### PR TITLE
Fix demo desktop app failing to launch

### DIFF
--- a/demo/desktop/src/main/kotlin/com/kitakkun/jetwhale/demo/main.kt
+++ b/demo/desktop/src/main/kotlin/com/kitakkun/jetwhale/demo/main.kt
@@ -1,4 +1,4 @@
-package com.kitakkun.jetwhale.demo.com.kitakkun.jetwhale.demo
+package com.kitakkun.jetwhale.demo
 
 import androidx.compose.ui.window.singleWindowApplication
 import com.kitakkun.jetwhale.demo.shared.App


### PR DESCRIPTION
After restructuring the demo app into per-target modules(#8), the Desktop demo app failed to launch due to an incorrect package declaration for the JVM entry point.

This PR fixes the issue by correcting the package of the `main.kt` file for the Desktop target.