### PR TITLE
Trigger Maven Central publish on v tags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,9 @@
 name: Publish
 
 on:
-  release:
-    types: [ released, prereleased ]
+  push:
+    tags:
+      - "v*"
 jobs:
   publish:
     name: Release build and publish


### PR DESCRIPTION
## Overview
- run the Maven Central publish workflow on v* tag pushes instead of release events
