### PR TITLE
Remove the jetwhale-protocol module to simplify API dependency management

### DIFF
--- a/jetwhale-agent-runtime/build.gradle.kts
+++ b/jetwhale-agent-runtime/build.gradle.kts
@@ -13,7 +13,8 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(projects.jetwhaleProtocol)
+            implementation(projects.jetwhaleProtocol.core)
+            implementation(projects.jetwhaleProtocol.agent)
             implementation(projects.jetwhaleAgentSdk)
 
             implementation(libs.bundles.ktorClient)

--- a/jetwhale-host/app/build.gradle.kts
+++ b/jetwhale-host/app/build.gradle.kts
@@ -55,7 +55,8 @@ kotlin {
 
 dependencies {
     implementation(projects.jetwhaleHostSdk)
-    implementation(projects.jetwhaleProtocol)
+    implementation(projects.jetwhaleProtocol.core)
+    implementation(projects.jetwhaleProtocol.host)
     implementation(projects.jetwhaleHost.feature.settings)
     implementation(projects.jetwhaleHost.feature.plugin)
     implementation(projects.jetwhaleHost.core.model)

--- a/jetwhale-host/core/data/build.gradle.kts
+++ b/jetwhale-host/core/data/build.gradle.kts
@@ -9,7 +9,8 @@ plugins {
 dependencies {
     implementation(projects.jetwhaleHostSdk)
     implementation(projects.jetwhaleHost.core.model)
-    implementation(projects.jetwhaleProtocol)
+    implementation(projects.jetwhaleProtocol.host)
+    implementation(projects.jetwhaleProtocol.core)
 
     implementation(compose.desktop.currentOs)
 

--- a/jetwhale-plugins/example/protocol/build.gradle.kts
+++ b/jetwhale-plugins/example/protocol/build.gradle.kts
@@ -8,6 +8,5 @@ kotlin {
 }
 
 dependencies {
-    commonMainImplementation(projects.jetwhaleProtocol)
     commonMainImplementation(libs.kotlinxSerializationJson)
 }

--- a/jetwhale-protocol/build.gradle.kts
+++ b/jetwhale-protocol/build.gradle.kts
@@ -1,30 +1,3 @@
-plugins {
-    alias(libs.plugins.multiplatform)
-    alias(libs.plugins.serialization)
-    alias(libs.plugins.publish)
-}
-
-kotlin {
-    androidLibrary.namespace = "com.kitakkun.jetwhale.protocol"
-
-    sourceSets {
-        commonMain.dependencies {
-            api(projects.jetwhaleProtocol.core)
-            api(projects.jetwhaleProtocol.agent)
-        }
-
-        jvmMain.dependencies {
-            api(projects.jetwhaleProtocol.host)
-        }
-    }
-}
-
 subprojects {
     group = "com.kitakkun.jetwhale.protocol"
-}
-
-jetwhalePublish {
-    artifactId = "jetwhale-protocol"
-    name = "JetWhale Protocol"
-    description = "Protocol libraries for JetWhale"
 }

--- a/jetwhale-protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/JetWhaleProtocolMarker.kt
+++ b/jetwhale-protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/JetWhaleProtocolMarker.kt
@@ -1,4 +1,0 @@
-package com.kitakkun.jetwhale.protocol
-
-// Internal marker to ensure a klib is produced for this meta module.
-internal object JetWhaleProtocolMarker

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,6 @@ dependencyResolutionManagement {
     }
 }
 
-include(":jetwhale-protocol")
 include(":jetwhale-protocol:core")
 include(":jetwhale-protocol:host")
 include(":jetwhale-protocol:agent")


### PR DESCRIPTION
As mentioned in #20, this PR completely removes the jetwhale-protocol module.