### PR TITLE
Fix: locate adb from common installation paths

### DIFF
--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDiagnosticsQueryKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDiagnosticsQueryKey.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.data.settings
 
+import com.kitakkun.jetwhale.host.data.util.findAdbPath
 import com.kitakkun.jetwhale.host.model.DebuggingToolsDiagnostics
 import com.kitakkun.jetwhale.host.model.DiagnosticsQueryKey
 import dev.zacsweers.metro.AppScope
@@ -13,16 +14,7 @@ import soil.query.buildQueryKey
 class DefaultDiagnosticsQueryKey : DiagnosticsQueryKey by buildQueryKey(
     id = QueryId("DefaultDiagnosticsQueryKey"),
     fetch = {
-        val adbPath: String
-        val adbPathDetectionProcess = ProcessBuilder()
-            .command("which", "adb")
-            .start()
-        adbPathDetectionProcess
-            .inputReader().useLines {
-                adbPath = it.firstOrNull().orEmpty()
-            }
-        adbPathDetectionProcess.waitFor()
-
+        val adbPath = findAdbPath()
         DebuggingToolsDiagnostics(adbPath = adbPath)
     }
 )

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/util/AdbUtil.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/util/AdbUtil.kt
@@ -1,0 +1,35 @@
+package com.kitakkun.jetwhale.host.data.util
+
+import java.io.File
+
+/**
+ * Finds the absolute path to the adb executable by checking common installation locations.
+ *
+ * This function checks the following locations in order:
+ * 1. /usr/bin/adb
+ * 2. /usr/local/bin/adb
+ * 3. $HOME/Android/Sdk/platform-tools/adb
+ * 4. $HOME/Library/Android/sdk/platform-tools/adb (macOS)
+ * 5. $ANDROID_HOME/platform-tools/adb
+ * 6. $ANDROID_SDK_ROOT/platform-tools/adb
+ *
+ * @return The absolute path to adb if found, otherwise "adb" as a fallback
+ */
+fun findAdbPath(): String {
+    val homeDir = System.getProperty("user.home")
+    val androidHome = System.getenv("ANDROID_HOME")
+    val androidSdkRoot = System.getenv("ANDROID_SDK_ROOT")
+
+    val candidatePaths = listOfNotNull(
+        "/usr/bin/adb",
+        "/usr/local/bin/adb",
+        homeDir?.let { "$it/Android/Sdk/platform-tools/adb" },
+        homeDir?.let { "$it/Library/Android/sdk/platform-tools/adb" },
+        androidHome?.let { "$it/platform-tools/adb" },
+        androidSdkRoot?.let { "$it/platform-tools/adb" },
+    )
+
+    return candidatePaths.firstOrNull { path ->
+        File(path).exists() && File(path).canExecute()
+    } ?: "adb" // Fallback to "adb" if not found
+}


### PR DESCRIPTION
## Overview

ProcessBuilder instances could not find the adb command because the PATH environment variable did not include paths from shell configuration files (e.g., .zshrc). This fix introduces a utility function that explicitly checks common adb installation locations in the following order:

- /usr/bin/adb
- /usr/local/bin/adb
- $HOME/Android/Sdk/platform-tools/adb
- $HOME/Library/Android/sdk/platform-tools/adb (macOS)
- $ANDROID_HOME/platform-tools/adb
- $ANDROID_SDK_ROOT/platform-tools/adb

This ensures adb can be found regardless of shell environment configuration.

## Links

- close #27 