### PR TITLE
Add java.sql module to desktop application packaging

### DIFF
--- a/jetwhale-host/app/build.gradle.kts
+++ b/jetwhale-host/app/build.gradle.kts
@@ -22,6 +22,7 @@ compose.desktop {
             // Fix runtime NoClassDefFoundError which occurs only on packaged application
             modules("jdk.unsupported")
             modules("java.naming")
+            modules("java.sql")
 
             targetFormats(
                 TargetFormat.Dmg,


### PR DESCRIPTION
## Summary
Added the `java.sql` module to the JVM modules included in the packaged desktop application to resolve potential runtime `NoClassDefFoundError` exceptions.

## Changes
- Added `modules("java.sql")` to the Compose Desktop build configuration in `jetwhale-host/app/build.gradle.kts`

## Details
The `java.sql` module is now explicitly included in the packaged application's JDK modules, alongside existing modules like `jdk.unsupported` and `java.naming`. This ensures that SQL-related classes are available at runtime in the packaged application, preventing `NoClassDefFoundError` that could occur when the application attempts to use JDBC or other SQL functionality.

## Links

- close #28