### PR TITLE
Expose jetwhale-agent-runtime dependencies as public API

### DIFF
--- a/jetwhale-agent-runtime/build.gradle.kts
+++ b/jetwhale-agent-runtime/build.gradle.kts
@@ -13,9 +13,9 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(projects.jetwhaleProtocol.core)
-            implementation(projects.jetwhaleProtocol.agent)
-            implementation(projects.jetwhaleAgentSdk)
+            api(projects.jetwhaleProtocol.core)
+            api(projects.jetwhaleProtocol.agent)
+            api(projects.jetwhaleAgentSdk)
 
             implementation(libs.bundles.ktorClient)
             implementation(libs.kotlinxCoroutinesCore)


### PR DESCRIPTION
## Summary
Changed the dependency configuration in `jetwhale-agent-runtime` to expose core protocol, agent protocol, and agent SDK as public API dependencies rather than internal implementation dependencies.

## Changes
- Changed `jetwhaleProtocol.core` from `implementation` to `api` configuration
- Changed `jetwhaleProtocol.agent` from `implementation` to `api` configuration
- Changed `jetwhaleAgentSdk` from `implementation` to `api` configuration

## Rationale
By exposing these dependencies as `api` instead of `implementation`, consumers of `jetwhale-agent-runtime` will have direct access to the protocol and SDK types without needing to declare separate dependencies. This improves the developer experience and ensures consistent versions across the dependency tree.