### PR TITLE
ci: run abi-check workflow only for modules with API dumps

### DIFF
--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -1,6 +1,13 @@
 name: ABI Check
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'jetwhale-host-sdk/**'
+      - 'jetwhale-agent-sdk/**'
+      - 'jetwhale-protocol/core/**'
+      - 'jetwhale-protocol/agent/**'
+      - 'jetwhale-protocol/host/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Overview
- Add path filters to abi-check workflow to run only when files in modules with API dumps are modified
- Targeted modules: `jetwhale-host-sdk`, `jetwhale-agent-sdk`, `jetwhale-protocol/core`, `jetwhale-protocol/agent`, `jetwhale-protocol/host`