### PR TITLE
docs: add plugin development documentation

### DIFF
--- a/docs/plugins/agent-plugin.md
+++ b/docs/plugins/agent-plugin.md
@@ -1,0 +1,283 @@
+# Agent Plugin Implementation Guide
+
+This guide explains how to implement an Agent Plugin that runs on the debuggee (application) side.
+
+## Overview
+
+Agent Plugins run within the debuggee application and are responsible for:
+
+- Sending events to the Host (debugger)
+- Receiving and handling method calls from the Host
+- Returning method results to the Host
+
+## Class Hierarchy
+
+JetWhale provides two base classes for Agent Plugins:
+
+| Class | Description |
+|-------|-------------|
+| `JetWhaleRawAgentPlugin` | Base class for raw string-based communication |
+| `JetWhaleAgentPlugin<Event, Method, MethodResult>` | Type-safe abstract class with protocol support |
+
+For most use cases, extend `JetWhaleAgentPlugin` for type-safe communication.
+
+## JetWhaleAgentPlugin
+
+### Class Definition
+
+```kotlin
+public abstract class JetWhaleAgentPlugin<Event, Method, MethodResult>
+    : JetWhaleRawAgentPlugin() {
+
+    // Type-safe communication protocol
+    protected abstract val protocol: JetWhaleAgentPluginProtocol<Event, Method, MethodResult>
+
+    // Handle method requests from the debugger
+    public abstract suspend fun onReceiveMethod(method: Method): MethodResult?
+
+    // Optional: Hook for event queueing (e.g., logging)
+    public open fun onEnqueueEvent(event: Event) {}
+
+    // Send event to the debugger
+    public fun enqueueEvent(event: Event)
+}
+```
+
+### Required Properties and Methods
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `pluginId` | `String` | Unique plugin identifier (reverse domain notation) |
+| `pluginVersion` | `String` | Plugin version string |
+| `protocol` | `JetWhaleAgentPluginProtocol` | Serialization protocol |
+| `onReceiveMethod()` | `suspend fun` | Handle incoming method calls |
+
+## Implementation Steps
+
+### Step 1: Define Protocol Types
+
+First, define the Event, Method, and MethodResult types in a shared module. See [Protocol Definition Guide](./protocol.md) for details.
+
+### Step 2: Create the Agent Plugin Class
+
+```kotlin
+class MyAgentPlugin : JetWhaleAgentPlugin<MyEvent, MyMethod, MyMethodResult>() {
+
+    // Unique plugin identifier - must match Host plugin
+    override val pluginId: String = "com.example.myplugin"
+
+    // Plugin version
+    override val pluginVersion: String = "1.0.0"
+
+    // Use kotlinx.serialization for type-safe JSON conversion
+    override val protocol: JetWhaleAgentPluginProtocol<MyEvent, MyMethod, MyMethodResult> =
+        kotlinxSerializationJetWhaleAgentPluginProtocol()
+
+    // Handle method calls from the Host
+    override suspend fun onReceiveMethod(method: MyMethod): MyMethodResult {
+        return when (method) {
+            is MyMethod.Ping -> MyMethodResult.Pong
+            is MyMethod.GetState -> MyMethodResult.StateResponse(currentState)
+            is MyMethod.UpdateValue -> {
+                updateValue(method.newValue)
+                MyMethodResult.Success
+            }
+        }
+    }
+}
+```
+
+### Step 3: Register the Plugin
+
+Register your plugin using the JetWhale DSL:
+
+```kotlin
+// In your application initialization code
+startJetWhale {
+    connection {
+        host = "localhost"  // Host address
+        port = 8080         // Port number
+    }
+    plugins {
+        register(MyAgentPlugin())
+    }
+}
+```
+
+## Sending Events
+
+Use `enqueueEvent()` to send events to the Host:
+
+```kotlin
+class MyAgentPlugin : JetWhaleAgentPlugin<MyEvent, MyMethod, MyMethodResult>() {
+    // ... required overrides ...
+
+    // Call this method to send events
+    fun notifyStateChanged(newState: String) {
+        enqueueEvent(MyEvent.StateChanged(newState))
+    }
+
+    fun notifyButtonClicked(buttonId: String) {
+        enqueueEvent(MyEvent.ButtonClicked(buttonId))
+    }
+}
+```
+
+### Event Queueing Behavior
+
+- Events are queued if the WebSocket connection is not established
+- Events are automatically flushed when the connection is established
+- The queue buffer size defaults to 100 (oldest events are dropped when exceeded)
+- Override `queueBufferSize()` to customize the buffer size
+
+```kotlin
+override fun queueBufferSize(): Int = 200  // Increase buffer size
+```
+
+## Handling Method Calls
+
+The `onReceiveMethod()` function is called when the Host sends a method request:
+
+```kotlin
+override suspend fun onReceiveMethod(method: MyMethod): MyMethodResult {
+    return when (method) {
+        is MyMethod.Ping -> {
+            // Simple response
+            MyMethodResult.Pong
+        }
+
+        is MyMethod.GetData -> {
+            // Return data from the application
+            val data = fetchData()
+            MyMethodResult.DataResponse(data)
+        }
+
+        is MyMethod.PerformAction -> {
+            // Perform an action and return result
+            try {
+                performAction(method.actionId)
+                MyMethodResult.Success
+            } catch (e: Exception) {
+                MyMethodResult.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+}
+```
+
+### Returning Null
+
+Return `null` if the method should not return a result:
+
+```kotlin
+override suspend fun onReceiveMethod(method: MyMethod): MyMethodResult? {
+    return when (method) {
+        is MyMethod.FireAndForget -> {
+            doSomething()
+            null  // No response sent
+        }
+        else -> handleMethod(method)
+    }
+}
+```
+
+## Event Logging Hook
+
+Override `onEnqueueEvent()` to add logging or additional processing when events are sent:
+
+```kotlin
+override fun onEnqueueEvent(event: MyEvent) {
+    Log.d("MyPlugin", "Sending event: $event")
+
+    // Update internal state for debugging
+    eventHistory.add(event)
+}
+```
+
+## JetWhaleRawAgentPlugin
+
+For advanced use cases requiring raw string handling, extend `JetWhaleRawAgentPlugin`:
+
+```kotlin
+abstract class JetWhaleRawAgentPlugin {
+    // Plugin identifier
+    abstract val pluginId: String
+
+    // Plugin version
+    abstract val pluginVersion: String
+
+    // Handle raw method messages
+    abstract suspend fun onRawMethod(message: String): String?
+
+    // Send raw event message
+    fun enqueueRawEvent(message: String)
+
+    // Message sender management
+    fun attachSender(sender: JetWhaleMessageSender)
+    fun detachSender()
+}
+```
+
+### Raw Plugin Example
+
+```kotlin
+class MyRawPlugin : JetWhaleRawAgentPlugin() {
+    override val pluginId = "com.example.rawplugin"
+    override val pluginVersion = "1.0.0"
+
+    override suspend fun onRawMethod(message: String): String? {
+        // Parse JSON manually
+        val json = Json.parseToJsonElement(message)
+        // Process and return raw JSON string
+        return """{"status": "ok"}"""
+    }
+}
+```
+
+## Complete Example
+
+```kotlin
+class ExampleAgentPlugin : JetWhaleAgentPlugin<ExampleEvent, ExampleMethod, ExampleMethodResult>() {
+
+    override val pluginId: String = "com.kitakkun.jetwhale.example"
+    override val pluginVersion: String = "1.0.0"
+
+    override val protocol: JetWhaleAgentPluginProtocol<ExampleEvent, ExampleMethod, ExampleMethodResult> =
+        kotlinxSerializationJetWhaleAgentPluginProtocol()
+
+    private val _eventLogsFlow = MutableStateFlow<List<String>>(emptyList())
+    val eventLogsFlow: StateFlow<List<String>> = _eventLogsFlow.asStateFlow()
+
+    override suspend fun onReceiveMethod(method: ExampleMethod): ExampleMethodResult {
+        return when (method) {
+            is ExampleMethod.Ping -> ExampleMethodResult.Pong
+        }
+    }
+
+    override fun onEnqueueEvent(event: ExampleEvent) {
+        _eventLogsFlow.update { it + "Event: $event" }
+    }
+
+    fun sendButtonClickedEvent(count: Int) {
+        enqueueEvent(ExampleEvent.ButtonClicked(count))
+    }
+}
+```
+
+## Best Practices
+
+1. **Use type-safe plugins**: Prefer `JetWhaleAgentPlugin` over `JetWhaleRawAgentPlugin` for compile-time safety
+
+2. **Keep method handlers fast**: `onReceiveMethod()` runs on the message processing thread; offload heavy work to coroutines
+
+3. **Use meaningful plugin IDs**: Follow reverse domain notation and keep IDs consistent between Agent and Host
+
+4. **Handle errors gracefully**: Return error results instead of throwing exceptions in `onReceiveMethod()`
+
+5. **Consider buffer size**: If your application generates many events rapidly, increase the queue buffer size
+
+## See Also
+
+- [Overview](./overview.md) - Plugin architecture overview
+- [Protocol Definition Guide](./protocol.md) - Defining Event, Method, and MethodResult types
+- [Host Plugin Implementation Guide](./host-plugin.md) - Implementing the Host-side plugin

--- a/docs/plugins/agent-plugin.md
+++ b/docs/plugins/agent-plugin.md
@@ -212,9 +212,9 @@ abstract class JetWhaleRawAgentPlugin {
     // Send raw event message
     fun enqueueRawEvent(message: String)
 
-    // Message sender management
-    fun attachSender(sender: JetWhaleMessageSender)
-    fun detachSender()
+    // Plugin lifecycle (called by JetWhale runtime)
+    fun activate(sender: JetWhaleMessageSender)
+    fun deactivate()
 }
 ```
 

--- a/docs/plugins/agent-plugin.md
+++ b/docs/plugins/agent-plugin.md
@@ -14,9 +14,9 @@ Agent Plugins run within the debuggee application and are responsible for:
 
 JetWhale provides two base classes for Agent Plugins:
 
-| Class | Description |
-|-------|-------------|
-| `JetWhaleRawAgentPlugin` | Base class for raw string-based communication |
+| Class                                              | Description                                    |
+|----------------------------------------------------|------------------------------------------------|
+| `JetWhaleRawAgentPlugin`                           | Base class for raw string-based communication  |
 | `JetWhaleAgentPlugin<Event, Method, MethodResult>` | Type-safe abstract class with protocol support |
 
 For most use cases, extend `JetWhaleAgentPlugin` for type-safe communication.
@@ -45,18 +45,19 @@ public abstract class JetWhaleAgentPlugin<Event, Method, MethodResult>
 
 ### Required Properties and Methods
 
-| Member | Type | Description |
-|--------|------|-------------|
-| `pluginId` | `String` | Unique plugin identifier (reverse domain notation) |
-| `pluginVersion` | `String` | Plugin version string |
-| `protocol` | `JetWhaleAgentPluginProtocol` | Serialization protocol |
-| `onReceiveMethod()` | `suspend fun` | Handle incoming method calls |
+| Member              | Type                          | Description                                        |
+|---------------------|-------------------------------|----------------------------------------------------|
+| `pluginId`          | `String`                      | Unique plugin identifier (reverse domain notation) |
+| `pluginVersion`     | `String`                      | Plugin version string                              |
+| `protocol`          | `JetWhaleAgentPluginProtocol` | Serialization protocol                             |
+| `onReceiveMethod()` | `suspend fun`                 | Handle incoming method calls                       |
 
 ## Implementation Steps
 
 ### Step 1: Define Protocol Types
 
-First, define the Event, Method, and MethodResult types in a shared module. See [Protocol Definition Guide](./protocol.md) for details.
+First, define the Event, Method, and MethodResult types in a shared module.
+See [Protocol Definition Guide](./protocol.md) for details.
 
 ### Step 2: Create the Agent Plugin Class
 
@@ -211,10 +212,6 @@ abstract class JetWhaleRawAgentPlugin {
 
     // Send raw event message
     fun enqueueRawEvent(message: String)
-
-    // Plugin lifecycle (called by JetWhale runtime)
-    fun activate(sender: JetWhaleMessageSender)
-    fun deactivate()
 }
 ```
 
@@ -266,15 +263,20 @@ class ExampleAgentPlugin : JetWhaleAgentPlugin<ExampleEvent, ExampleMethod, Exam
 
 ## Best Practices
 
-1. **Use type-safe plugins**: Prefer `JetWhaleAgentPlugin` over `JetWhaleRawAgentPlugin` for compile-time safety
+1. **Use type-safe plugins**: Prefer `JetWhaleAgentPlugin` over `JetWhaleRawAgentPlugin` for
+   compile-time safety
 
-2. **Keep method handlers fast**: `onReceiveMethod()` runs on the message processing thread; offload heavy work to coroutines
+2. **Keep method handlers fast**: `onReceiveMethod()` runs on the message processing thread; offload
+   heavy work to coroutines
 
-3. **Use meaningful plugin IDs**: Follow reverse domain notation and keep IDs consistent between Agent and Host
+3. **Use meaningful plugin IDs**: Follow reverse domain notation and keep IDs consistent between
+   Agent and Host
 
-4. **Handle errors gracefully**: Return error results instead of throwing exceptions in `onReceiveMethod()`
+4. **Handle errors gracefully**: Return error results instead of throwing exceptions in
+   `onReceiveMethod()`
 
-5. **Consider buffer size**: If your application generates many events rapidly, increase the queue buffer size
+5. **Consider buffer size**: If your application generates many events rapidly, increase the queue
+   buffer size
 
 ## See Also
 

--- a/docs/plugins/host-plugin.md
+++ b/docs/plugins/host-plugin.md
@@ -176,9 +176,11 @@ class MyPluginFactory : JetWhaleHostPluginFactory {
 ### Step 4: Implement the UI
 
 ```kotlin
+import androidx.compose.runtime.snapshots.SnapshotStateList
+
 @Composable
 fun MyPluginContent(
-    eventLogs: List<String>,
+    eventLogs: SnapshotStateList<String>,
     currentState: String,
     context: JetWhaleDebugOperationContext<MyMethod, MyMethodResult>,
 ) {
@@ -370,7 +372,7 @@ class ExampleHostPlugin : JetWhaleHostPlugin<ExampleEvent, ExampleMethod, Exampl
 // UI
 @Composable
 fun ExamplePluginUI(
-    eventLogs: List<String>,
+    eventLogs: SnapshotStateList<String>,
     context: JetWhaleDebugOperationContext<ExampleMethod, ExampleMethodResult>,
 ) {
     val scope = context.coroutineScope

--- a/docs/plugins/host-plugin.md
+++ b/docs/plugins/host-plugin.md
@@ -1,0 +1,469 @@
+# Host Plugin Implementation Guide
+
+This guide explains how to implement a Host Plugin that runs on the debugger (host) side.
+
+## Overview
+
+Host Plugins run within the JetWhale host application and are responsible for:
+
+- Receiving events from the Agent (debuggee)
+- Sending method calls to the Agent
+- Rendering the plugin UI using Jetpack Compose
+
+## Class Hierarchy
+
+JetWhale provides the following classes for Host Plugins:
+
+| Class | Description |
+|-------|-------------|
+| `JetWhaleRawHostPlugin` | Base class for raw string-based communication |
+| `JetWhaleHostPlugin<Event, Method, MethodResult>` | Type-safe abstract class with protocol support |
+| `JetWhaleHostPluginFactory` | Factory interface for plugin instantiation |
+
+## JetWhaleHostPluginFactory
+
+Every Host Plugin must provide a factory class for plugin discovery and instantiation.
+
+### Factory Interface
+
+```kotlin
+public interface JetWhaleHostPluginFactory {
+    // Plugin metadata (id, name, version)
+    val meta: JetWhalePluginMetaData
+
+    // Plugin icon (optional)
+    val icon: JetWhalePluginIcon get() = unspecifiedPluginIcon()
+
+    // Create plugin instance
+    fun createPlugin(): JetWhaleRawHostPlugin
+}
+```
+
+### Factory Implementation
+
+```kotlin
+@AutoService(JetWhaleHostPluginFactory::class)
+class MyPluginFactory : JetWhaleHostPluginFactory {
+
+    override val meta: JetWhalePluginMetaData = jetWhalePluginMetaData(
+        pluginId = "com.example.myplugin",
+        pluginName = "My Plugin",
+        version = "1.0.0",
+    )
+
+    override val icon: JetWhalePluginIcon = pluginIcon(
+        activeIconPath = "icons/my_plugin_active.svg",
+        inactiveIconPath = "icons/my_plugin_inactive.svg",
+    )
+
+    override fun createPlugin(): JetWhaleHostPlugin<*, *, *> {
+        return MyHostPlugin()
+    }
+}
+```
+
+### Plugin Metadata
+
+```kotlin
+public class JetWhalePluginMetaData(
+    val pluginId: String,     // Unique identifier (must match Agent plugin)
+    val pluginName: String,   // Display name in UI
+    val version: String,      // Plugin version
+)
+```
+
+### Plugin Icon
+
+```kotlin
+public class JetWhalePluginIcon(
+    val activeIconPath: String?,    // Icon when plugin tab is active
+    val inactiveIconPath: String?,  // Icon when plugin tab is inactive
+)
+```
+
+Icon paths are relative to the plugin JAR's resources directory. Supported formats: SVG, PNG, JPG.
+
+## JetWhaleHostPlugin
+
+### Class Definition
+
+```kotlin
+public abstract class JetWhaleHostPlugin<Event, Method, MethodResult>
+    : JetWhaleRawHostPlugin() {
+
+    // Type-safe communication protocol
+    protected abstract val protocol: JetWhaleHostPluginProtocol<Event, Method, MethodResult>
+
+    // Handle events from the debuggee
+    public abstract fun onEvent(event: Event)
+
+    // Render plugin UI
+    @Composable
+    public abstract fun Content(context: JetWhaleDebugOperationContext<Method, MethodResult>)
+
+    // Optional: Cleanup when plugin is disposed
+    public open fun onDispose() {}
+}
+```
+
+### Required Members
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `protocol` | `JetWhaleHostPluginProtocol` | Serialization protocol |
+| `onEvent()` | `fun` | Handle incoming events from Agent |
+| `Content()` | `@Composable` | Render the plugin UI |
+
+## Implementation Steps
+
+### Step 1: Define Protocol Types
+
+Define shared Event, Method, and MethodResult types. See [Protocol Definition Guide](./protocol.md).
+
+### Step 2: Create the Host Plugin Class
+
+```kotlin
+class MyHostPlugin : JetWhaleHostPlugin<MyEvent, MyMethod, MyMethodResult>() {
+
+    // Use kotlinx.serialization for type-safe JSON conversion
+    override val protocol: JetWhaleHostPluginProtocol<MyEvent, MyMethod, MyMethodResult> =
+        kotlinxSerializationJetWhaleHostPluginProtocol()
+
+    // State for UI
+    private val eventLogs = mutableStateListOf<String>()
+    private var currentState by mutableStateOf("Unknown")
+
+    // Handle events from the Agent
+    override fun onEvent(event: MyEvent) {
+        when (event) {
+            is MyEvent.StateChanged -> {
+                currentState = event.newState
+                eventLogs.add("State changed: ${event.newState}")
+            }
+            is MyEvent.ButtonClicked -> {
+                eventLogs.add("Button clicked: ${event.buttonId}")
+            }
+        }
+    }
+
+    // Render plugin UI
+    @Composable
+    override fun Content(context: JetWhaleDebugOperationContext<MyMethod, MyMethodResult>) {
+        MyPluginContent(
+            eventLogs = eventLogs,
+            currentState = currentState,
+            context = context,
+        )
+    }
+
+    // Optional: Cleanup resources
+    override fun onDispose() {
+        eventLogs.clear()
+    }
+}
+```
+
+### Step 3: Create the Factory Class
+
+```kotlin
+@AutoService(JetWhaleHostPluginFactory::class)
+class MyPluginFactory : JetWhaleHostPluginFactory {
+    override val meta = jetWhalePluginMetaData(
+        pluginId = "com.example.myplugin",  // Must match Agent plugin
+        pluginName = "My Plugin",
+        version = "1.0.0",
+    )
+
+    override fun createPlugin() = MyHostPlugin()
+}
+```
+
+### Step 4: Implement the UI
+
+```kotlin
+@Composable
+fun MyPluginContent(
+    eventLogs: List<String>,
+    currentState: String,
+    context: JetWhaleDebugOperationContext<MyMethod, MyMethodResult>,
+) {
+    val scope = context.coroutineScope
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("My Plugin") })
+        }
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding)) {
+            // Display current state
+            Text("Current State: $currentState")
+
+            // Button to send method to Agent
+            Button(onClick = {
+                scope.launch {
+                    val result = context.dispatch(MyMethod.Ping)
+                    when (result) {
+                        is MyMethodResult.Pong -> {
+                            // Handle pong response
+                        }
+                        else -> { /* Handle other results */ }
+                    }
+                }
+            }) {
+                Text("Send Ping")
+            }
+
+            // Display event logs
+            LazyColumn {
+                items(eventLogs) { log ->
+                    Text(log)
+                }
+            }
+        }
+    }
+}
+```
+
+## JetWhaleDebugOperationContext
+
+The `Content()` function receives a context object for interacting with the Agent:
+
+```kotlin
+public interface JetWhaleDebugOperationContext<Method, MethodResult> {
+    // CoroutineScope for launching async operations
+    val coroutineScope: CoroutineScope
+
+    // Send method to Agent and await result
+    suspend fun dispatch(method: Method): MethodResult?
+}
+```
+
+### Sending Methods
+
+Use `context.dispatch()` to send methods to the Agent:
+
+```kotlin
+@Composable
+fun Content(context: JetWhaleDebugOperationContext<MyMethod, MyMethodResult>) {
+    val scope = context.coroutineScope
+
+    Button(onClick = {
+        scope.launch {
+            // Send method and wait for result
+            val result = context.dispatch(MyMethod.GetData(id = 123))
+
+            when (result) {
+                is MyMethodResult.DataResponse -> {
+                    // Use the returned data
+                    processData(result.data)
+                }
+                is MyMethodResult.Error -> {
+                    // Handle error
+                    showError(result.message)
+                }
+                null -> {
+                    // No response (connection lost or timeout)
+                }
+            }
+        }
+    }) {
+        Text("Fetch Data")
+    }
+}
+```
+
+## Plugin Discovery
+
+Host Plugins are discovered using Java's Service Provider Interface (SPI).
+
+### Using AutoService (Recommended)
+
+Add the `@AutoService` annotation to your factory class:
+
+```kotlin
+@AutoService(JetWhaleHostPluginFactory::class)
+class MyPluginFactory : JetWhaleHostPluginFactory {
+    // ...
+}
+```
+
+Add the AutoService dependency:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    kapt("com.google.auto.service:auto-service:1.1.1")
+    implementation("com.google.auto.service:auto-service-annotations:1.1.1")
+}
+```
+
+### Manual SPI Configuration
+
+Alternatively, create the SPI configuration file manually:
+
+1. Create file: `src/main/resources/META-INF/services/com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory`
+2. Add the fully qualified class name of your factory:
+   ```
+   com.example.myplugin.MyPluginFactory
+   ```
+
+## JetWhaleRawHostPlugin
+
+For advanced use cases requiring raw string handling, extend `JetWhaleRawHostPlugin`:
+
+```kotlin
+public abstract class JetWhaleRawHostPlugin {
+    // Handle raw event messages
+    abstract fun onRawEvent(event: String)
+
+    // Cleanup when plugin is disposed
+    open fun onDispose() {}
+
+    // Render UI with raw string context
+    @Composable
+    abstract fun ContentRaw(context: JetWhaleDebugOperationContext<String, String>)
+}
+```
+
+## Complete Example
+
+```kotlin
+// Factory
+@AutoService(JetWhaleHostPluginFactory::class)
+class ExamplePluginFactory : JetWhaleHostPluginFactory {
+    override val meta = jetWhalePluginMetaData(
+        pluginId = "com.kitakkun.jetwhale.example",
+        pluginName = "Example Plugin",
+        version = "1.0.0",
+    )
+
+    override val icon = pluginIcon(
+        activeIconPath = "icons/window_filled.svg",
+        inactiveIconPath = "icons/window_outlined.svg",
+    )
+
+    override fun createPlugin() = ExampleHostPlugin()
+}
+
+// Plugin
+class ExampleHostPlugin : JetWhaleHostPlugin<ExampleEvent, ExampleMethod, ExampleMethodResult>() {
+
+    override val protocol: JetWhaleHostPluginProtocol<ExampleEvent, ExampleMethod, ExampleMethodResult> =
+        kotlinxSerializationJetWhaleHostPluginProtocol()
+
+    private val eventLogs = mutableStateListOf<String>()
+
+    override fun onEvent(event: ExampleEvent) {
+        when (event) {
+            is ExampleEvent.ButtonClicked -> {
+                eventLogs.add("Button clicked: count=${event.count}")
+            }
+        }
+    }
+
+    @Composable
+    override fun Content(context: JetWhaleDebugOperationContext<ExampleMethod, ExampleMethodResult>) {
+        ExamplePluginUI(eventLogs = eventLogs, context = context)
+    }
+
+    override fun onDispose() {
+        eventLogs.clear()
+    }
+}
+
+// UI
+@Composable
+fun ExamplePluginUI(
+    eventLogs: List<String>,
+    context: JetWhaleDebugOperationContext<ExampleMethod, ExampleMethodResult>,
+) {
+    val scope = context.coroutineScope
+    var pingResult by remember { mutableStateOf<String?>(null) }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Example Plugin") }) }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding)
+        ) {
+            stickyHeader {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = {
+                        scope.launch {
+                            val result = context.dispatch(ExampleMethod.Ping)
+                            pingResult = when (result) {
+                                is ExampleMethodResult.Pong -> "Pong received!"
+                                else -> "Unknown result"
+                            }
+                        }
+                    }) {
+                        Text("Send Ping")
+                    }
+                    pingResult?.let { Text(it) }
+                }
+            }
+
+            items(eventLogs) { log ->
+                Text(log, modifier = Modifier.padding(8.dp))
+            }
+        }
+    }
+}
+```
+
+## Building and Distributing
+
+### Build Configuration
+
+```kotlin
+// build.gradle.kts
+plugins {
+    kotlin("jvm")
+    kotlin("kapt")
+    kotlin("plugin.compose")
+    id("org.jetbrains.compose")
+}
+
+dependencies {
+    implementation("com.kitakkun.jetwhale:jetwhale-host-sdk:$version")
+    implementation("com.kitakkun.jetwhale:jetwhale-protocol-host:$version")
+
+    implementation(compose.desktop.currentOs)
+    implementation(compose.material3)
+
+    kapt("com.google.auto.service:auto-service:1.1.1")
+    implementation("com.google.auto.service:auto-service-annotations:1.1.1")
+}
+
+tasks.jar {
+    // Include all dependencies in the JAR for plugin distribution
+    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+```
+
+### Distribution
+
+1. Build the plugin JAR
+2. Place the JAR in the JetWhale host's plugins directory
+3. The host will automatically discover and load the plugin
+
+## Best Practices
+
+1. **Use Compose state properly**: Use `mutableStateOf` and `mutableStateListOf` for reactive UI updates
+
+2. **Handle null results**: `dispatch()` returns null if the connection is lost or the Agent doesn't respond
+
+3. **Cleanup in onDispose()**: Release resources and clear state when the plugin is disposed
+
+4. **Match plugin IDs**: Ensure `pluginId` matches between Agent and Host plugins
+
+5. **Keep UI responsive**: Use `context.coroutineScope.launch` for async operations
+
+6. **Provide meaningful icons**: Use distinct active/inactive icons for better UX
+
+## See Also
+
+- [Overview](./overview.md) - Plugin architecture overview
+- [Protocol Definition Guide](./protocol.md) - Defining Event, Method, and MethodResult types
+- [Agent Plugin Implementation Guide](./agent-plugin.md) - Implementing the Agent-side plugin

--- a/docs/plugins/host-plugin.md
+++ b/docs/plugins/host-plugin.md
@@ -155,11 +155,6 @@ class MyHostPlugin : JetWhaleHostPlugin<MyEvent, MyMethod, MyMethodResult>() {
             context = context,
         )
     }
-
-    // Optional: Cleanup resources
-    override fun onDispose() {
-        eventLogs.clear()
-    }
 }
 ```
 
@@ -369,10 +364,6 @@ class ExampleHostPlugin : JetWhaleHostPlugin<ExampleEvent, ExampleMethod, Exampl
     @Composable
     override fun Content(context: JetWhaleDebugOperationContext<ExampleMethod, ExampleMethodResult>) {
         ExamplePluginUI(eventLogs = eventLogs, context = context)
-    }
-
-    override fun onDispose() {
-        eventLogs.clear()
     }
 }
 

--- a/docs/plugins/host-plugin.md
+++ b/docs/plugins/host-plugin.md
@@ -176,11 +176,9 @@ class MyPluginFactory : JetWhaleHostPluginFactory {
 ### Step 4: Implement the UI
 
 ```kotlin
-import androidx.compose.runtime.snapshots.SnapshotStateList
-
 @Composable
 fun MyPluginContent(
-    eventLogs: SnapshotStateList<String>,
+    eventLogs: List<String>,
     currentState: String,
     context: JetWhaleDebugOperationContext<MyMethod, MyMethodResult>,
 ) {
@@ -372,7 +370,7 @@ class ExampleHostPlugin : JetWhaleHostPlugin<ExampleEvent, ExampleMethod, Exampl
 // UI
 @Composable
 fun ExamplePluginUI(
-    eventLogs: SnapshotStateList<String>,
+    eventLogs: List<String>,
     context: JetWhaleDebugOperationContext<ExampleMethod, ExampleMethodResult>,
 ) {
     val scope = context.coroutineScope

--- a/docs/plugins/host-plugin.md
+++ b/docs/plugins/host-plugin.md
@@ -56,7 +56,7 @@ class MyPluginFactory : JetWhaleHostPluginFactory {
         inactiveIconPath = "icons/my_plugin_inactive.svg",
     )
 
-    override fun createPlugin(): JetWhaleHostPlugin<*, *, *> {
+    override fun createPlugin(): JetWhaleRawHostPlugin {
         return MyHostPlugin()
     }
 }

--- a/docs/plugins/host-plugin.md
+++ b/docs/plugins/host-plugin.md
@@ -36,6 +36,9 @@ public interface JetWhaleHostPluginFactory {
 
     // Create plugin instance
     fun createPlugin(): JetWhaleRawHostPlugin
+
+    // Check compatibility with agent plugin version (optional)
+    fun isCompatibleWithAgentPlugin(agentVersion: String): Boolean = true
 }
 ```
 
@@ -321,7 +324,7 @@ public abstract class JetWhaleRawHostPlugin {
 
     // Render UI with raw string context
     @Composable
-    abstract fun ContentRaw(context: JetWhaleDebugOperationContext<String, String>)
+    abstract fun ContentRaw(context: JetWhaleRawDebugOperationContext)
 }
 ```
 

--- a/docs/plugins/host-plugin.md
+++ b/docs/plugins/host-plugin.md
@@ -287,12 +287,17 @@ class MyPluginFactory : JetWhaleHostPluginFactory {
 }
 ```
 
-Add the AutoService dependency:
+Add the AutoService dependency with KSP:
 
 ```kotlin
 // build.gradle.kts
+plugins {
+    // ...
+    id("com.google.devtools.ksp")
+}
+
 dependencies {
-    kapt("com.google.auto.service:auto-service:1.1.1")
+    ksp("dev.zacsweers.autoservice:auto-service-ksp:1.2.0")
     implementation("com.google.auto.service:auto-service-annotations:1.1.1")
 }
 ```
@@ -419,9 +424,9 @@ fun ExamplePluginUI(
 // build.gradle.kts
 plugins {
     kotlin("jvm")
-    kotlin("kapt")
     kotlin("plugin.compose")
     id("org.jetbrains.compose")
+    id("com.google.devtools.ksp")
 }
 
 dependencies {
@@ -431,7 +436,7 @@ dependencies {
     implementation(compose.desktop.currentOs)
     implementation(compose.material3)
 
-    kapt("com.google.auto.service:auto-service:1.1.1")
+    ksp("dev.zacsweers.autoservice:auto-service-ksp:1.2.0")
     implementation("com.google.auto.service:auto-service-annotations:1.1.1")
 }
 

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -10,7 +10,7 @@ JetWhale plugins consist of three components:
 |-----------|-------------|---------------------|
 | **Protocol** | Event, Method, and MethodResult definitions | Shared (Agent/Host) |
 | **Agent Plugin** | Plugin on the debuggee (application) side | Android/JVM/iOS/Web |
-| **Host Plugin** | Plugin on the host (debugger) side | Desktop/Android |
+| **Host Plugin** | Plugin on the host (debugger) side | Desktop (JVM) |
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -1,0 +1,200 @@
+# JetWhale Plugin Development Guide
+
+JetWhale is a Kotlin-based debugging tool with a plugin-based architecture. This guide explains how to develop JetWhale plugins.
+
+## Architecture Overview
+
+JetWhale plugins consist of three components:
+
+| Component | Description | Runtime Environment |
+|-----------|-------------|---------------------|
+| **Protocol** | Event, Method, and MethodResult definitions | Shared (Agent/Host) |
+| **Agent Plugin** | Plugin on the debuggee (application) side | Android/JVM/iOS/Web |
+| **Host Plugin** | Plugin on the host (debugger) side | Desktop/Android |
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        JetWhale Host                            │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │                    Host Plugin                            │  │
+│  │  - onEvent(event: Event)     ← Receive events            │  │
+│  │  - dispatch(method: Method)  → Send methods              │  │
+│  │  - Content()                 ← Render UI                 │  │
+│  └──────────────────────────────────────────────────────────┘  │
+└────────────────────────────┬────────────────────────────────────┘
+                             │ WebSocket (JSON)
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                   Debuggee Application                          │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │                   Agent Plugin                            │  │
+│  │  - enqueueEvent(event: Event)    → Send events           │  │
+│  │  - onReceiveMethod(method: Method) ← Receive methods     │  │
+│  └──────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Communication Flow
+
+### Event Sending (Agent → Host)
+
+1. Call `enqueueEvent(event)` on the Agent side
+2. Protocol serializes the event
+3. Send to Host via WebSocket
+4. `onEvent(event)` is called on the Host side
+
+### Method Invocation (Host → Agent)
+
+1. Call `context.dispatch(method)` on the Host side
+2. Protocol serializes the method
+3. Send to Agent via WebSocket
+4. `onReceiveMethod(method)` is called on the Agent side
+5. Return the result to Host
+
+## Plugin Development Workflow
+
+### 1. Protocol Definition
+
+First, define the data types shared between Agent and Host.
+
+```kotlin
+// Event: Agent → Host
+@Serializable
+sealed interface MyEvent {
+    @Serializable
+    data class StateChanged(val newState: String) : MyEvent
+}
+
+// Method: Host → Agent
+@Serializable
+sealed interface MyMethod {
+    @Serializable
+    data class UpdateState(val state: String) : MyMethod
+}
+
+// MethodResult: Agent → Host (response to Method)
+@Serializable
+sealed interface MyMethodResult {
+    @Serializable
+    data object Success : MyMethodResult
+
+    @Serializable
+    data class Error(val message: String) : MyMethodResult
+}
+```
+
+Details: [Protocol Definition Guide](./protocol.md)
+
+### 2. Agent Plugin Implementation
+
+Implement the plugin on the debuggee application side.
+
+```kotlin
+class MyAgentPlugin : JetWhaleAgentPlugin<MyEvent, MyMethod, MyMethodResult>() {
+    override val pluginId: String = "com.example.myplugin"
+    override val pluginVersion: String = "1.0.0"
+    override val protocol = kotlinxSerializationJetWhaleAgentPluginProtocol<MyEvent, MyMethod, MyMethodResult>()
+
+    override suspend fun onReceiveMethod(method: MyMethod): MyMethodResult {
+        return when (method) {
+            is MyMethod.UpdateState -> {
+                // Update state
+                MyMethodResult.Success
+            }
+        }
+    }
+}
+```
+
+Details: [Agent Plugin Implementation Guide](./agent-plugin.md)
+
+### 3. Host Plugin Implementation
+
+Implement the plugin on the host (debugger) side.
+
+```kotlin
+@AutoService(JetWhaleHostPluginFactory::class)
+class MyPluginFactory : JetWhaleHostPluginFactory {
+    override val meta = jetWhalePluginMetaData(
+        pluginId = "com.example.myplugin",
+        pluginName = "My Plugin",
+        version = "1.0.0",
+    )
+
+    override fun createPlugin() = MyHostPlugin()
+}
+
+class MyHostPlugin : JetWhaleHostPlugin<MyEvent, MyMethod, MyMethodResult>() {
+    override val protocol = kotlinxSerializationJetWhaleHostPluginProtocol<MyEvent, MyMethod, MyMethodResult>()
+
+    override fun onEvent(event: MyEvent) {
+        // Handle event
+    }
+
+    @Composable
+    override fun Content(context: JetWhaleDebugOperationContext<MyMethod, MyMethodResult>) {
+        // Render UI
+    }
+}
+```
+
+Details: [Host Plugin Implementation Guide](./host-plugin.md)
+
+## Plugin ID Convention
+
+The `pluginId` is a string that uniquely identifies a plugin. Follow these conventions:
+
+- Use reverse domain name notation (e.g., `com.example.myplugin`)
+- Use the same `pluginId` for both Agent and Host
+- Use lowercase letters only
+
+## Example Project Structure
+
+```
+my-jetwhale-plugin/
+├── protocol/                    # Protocol definitions (shared)
+│   └── src/commonMain/kotlin/
+│       ├── MyEvent.kt
+│       ├── MyMethod.kt
+│       └── MyMethodResult.kt
+├── agent/                       # Agent Plugin
+│   └── src/commonMain/kotlin/
+│       └── MyAgentPlugin.kt
+└── host/                        # Host Plugin
+    └── src/main/kotlin/
+        ├── MyHostPlugin.kt
+        └── MyPluginUI.kt
+```
+
+## Dependencies
+
+### Agent Plugin
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("com.kitakkun.jetwhale:jetwhale-agent-sdk:$version")
+    implementation("com.kitakkun.jetwhale:jetwhale-protocol-agent:$version")
+}
+```
+
+### Host Plugin
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("com.kitakkun.jetwhale:jetwhale-host-sdk:$version")
+    implementation("com.kitakkun.jetwhale:jetwhale-protocol-host:$version")
+
+    // AutoService (optional)
+    kapt("com.google.auto.service:auto-service:1.1.1")
+    implementation("com.google.auto.service:auto-service-annotations:1.1.1")
+}
+```
+
+## Next Steps
+
+- [Protocol Definition Guide](./protocol.md) - How to define Event, Method, and MethodResult
+- [Agent Plugin Implementation Guide](./agent-plugin.md) - Implementing debuggee-side plugins
+- [Host Plugin Implementation Guide](./host-plugin.md) - Implementing host-side plugins

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -189,12 +189,17 @@ dependencies {
 
 ```kotlin
 // build.gradle.kts
+plugins {
+    // ...
+    id("com.google.devtools.ksp")
+}
+
 dependencies {
     implementation("com.kitakkun.jetwhale:jetwhale-host-sdk:$version")
     implementation("com.kitakkun.jetwhale:jetwhale-protocol-host:$version")
 
-    // AutoService (optional)
-    kapt("com.google.auto.service:auto-service:1.1.1")
+    // AutoService with KSP
+    ksp("dev.zacsweers.autoservice:auto-service-ksp:1.2.0")
     implementation("com.google.auto.service:auto-service-annotations:1.1.1")
 }
 ```

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -58,10 +58,13 @@ JetWhale plugins consist of three components:
 
 First, define the data types shared between Agent and Host.
 
+> **Important**: Always use `@SerialName` on all sealed interface members. Without it, the fully qualified class name is embedded in JSON, which breaks protocol compatibility when refactoring.
+
 ```kotlin
 // Event: Agent → Host
 @Serializable
 sealed interface MyEvent {
+    @SerialName("state_changed")
     @Serializable
     data class StateChanged(val newState: String) : MyEvent
 }
@@ -69,6 +72,7 @@ sealed interface MyEvent {
 // Method: Host → Agent
 @Serializable
 sealed interface MyMethod {
+    @SerialName("update_state")
     @Serializable
     data class UpdateState(val state: String) : MyMethod
 }
@@ -76,9 +80,11 @@ sealed interface MyMethod {
 // MethodResult: Agent → Host (response to Method)
 @Serializable
 sealed interface MyMethodResult {
+    @SerialName("success")
     @Serializable
     data object Success : MyMethodResult
 
+    @SerialName("error")
     @Serializable
     data class Error(val message: String) : MyMethodResult
 }

--- a/docs/plugins/protocol.md
+++ b/docs/plugins/protocol.md
@@ -1,0 +1,507 @@
+# Protocol Definition Guide
+
+This guide explains how to define the communication protocol between Agent and Host plugins.
+
+## Overview
+
+JetWhale plugins communicate using three types of messages:
+
+| Type | Direction | Description |
+|------|-----------|-------------|
+| **Event** | Agent → Host | Notifications sent from the debuggee to the debugger |
+| **Method** | Host → Agent | Requests sent from the debugger to the debuggee |
+| **MethodResult** | Agent → Host | Responses to Method requests |
+
+All message types are serialized to JSON using [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization).
+
+## Project Structure
+
+Protocol types should be defined in a shared module that both Agent and Host plugins depend on:
+
+```
+my-plugin/
+├── protocol/                    # Shared protocol module
+│   ├── build.gradle.kts
+│   └── src/commonMain/kotlin/
+│       ├── MyEvent.kt
+│       ├── MyMethod.kt
+│       └── MyMethodResult.kt
+├── agent/                       # Depends on protocol
+│   └── ...
+└── host/                        # Depends on protocol
+    └── ...
+```
+
+## Defining Events
+
+Events are messages sent from the Agent (debuggee) to the Host (debugger). Use events to notify the Host about state changes, user interactions, or other occurrences in the application.
+
+### Basic Event Definition
+
+```kotlin
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@SerialName("my_event")
+@Serializable
+sealed interface MyEvent {
+
+    @SerialName("state_changed")
+    @Serializable
+    data class StateChanged(
+        val previousState: String,
+        val newState: String,
+    ) : MyEvent
+
+    @SerialName("button_clicked")
+    @Serializable
+    data class ButtonClicked(
+        val buttonId: String,
+        val clickCount: Int,
+    ) : MyEvent
+
+    @SerialName("error_occurred")
+    @Serializable
+    data class ErrorOccurred(
+        val errorMessage: String,
+        val stackTrace: String? = null,
+    ) : MyEvent
+}
+```
+
+### Event Design Guidelines
+
+- Use `sealed interface` for type-safe exhaustive handling
+- Annotate with `@Serializable` for JSON serialization
+- Use `@SerialName` to control JSON representation
+- Include all relevant data needed by the Host
+- Use optional parameters with defaults for backward compatibility
+
+## Defining Methods
+
+Methods are requests sent from the Host (debugger) to the Agent (debuggee). Use methods to query state, trigger actions, or modify the application.
+
+### Basic Method Definition
+
+```kotlin
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@SerialName("my_method")
+@Serializable
+sealed interface MyMethod {
+
+    // Simple method with no parameters
+    @SerialName("ping")
+    @Serializable
+    data object Ping : MyMethod
+
+    // Method with parameters
+    @SerialName("get_user")
+    @Serializable
+    data class GetUser(
+        val userId: String,
+    ) : MyMethod
+
+    // Method with multiple parameters
+    @SerialName("update_settings")
+    @Serializable
+    data class UpdateSettings(
+        val theme: String,
+        val fontSize: Int,
+        val notifications: Boolean,
+    ) : MyMethod
+
+    // Method with complex parameters
+    @SerialName("execute_action")
+    @Serializable
+    data class ExecuteAction(
+        val action: ActionType,
+        val parameters: Map<String, String> = emptyMap(),
+    ) : MyMethod
+}
+
+@Serializable
+enum class ActionType {
+    @SerialName("refresh") REFRESH,
+    @SerialName("reset") RESET,
+    @SerialName("export") EXPORT,
+}
+```
+
+### Method Design Guidelines
+
+- Use `data object` for methods with no parameters
+- Use `data class` for methods with parameters
+- Keep method names action-oriented (verbs)
+- Group related methods in the same sealed interface
+
+## Defining Method Results
+
+MethodResults are responses sent from the Agent back to the Host after processing a Method request.
+
+### Basic MethodResult Definition
+
+```kotlin
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@SerialName("my_method_result")
+@Serializable
+sealed interface MyMethodResult {
+
+    // Simple success response
+    @SerialName("pong")
+    @Serializable
+    data object Pong : MyMethodResult
+
+    // Success with data
+    @SerialName("user_data")
+    @Serializable
+    data class UserData(
+        val userId: String,
+        val userName: String,
+        val email: String,
+    ) : MyMethodResult
+
+    // Generic success
+    @SerialName("success")
+    @Serializable
+    data object Success : MyMethodResult
+
+    // Error response
+    @SerialName("error")
+    @Serializable
+    data class Error(
+        val code: Int,
+        val message: String,
+    ) : MyMethodResult
+
+    // Not found response
+    @SerialName("not_found")
+    @Serializable
+    data class NotFound(
+        val resourceId: String,
+    ) : MyMethodResult
+}
+```
+
+### MethodResult Design Guidelines
+
+- Always include error result types for proper error handling
+- Return meaningful data in success results
+- Use specific result types rather than generic ones when possible
+- Consider including error codes for programmatic handling
+
+## Serialization Configuration
+
+### Using kotlinx.serialization
+
+Add the serialization plugin and dependency:
+
+```kotlin
+// build.gradle.kts
+plugins {
+    kotlin("multiplatform") // or kotlin("jvm")
+    kotlin("plugin.serialization")
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+}
+```
+
+### SerialName Annotation
+
+Use `@SerialName` to control the JSON representation:
+
+```kotlin
+@SerialName("button_clicked")  // JSON: {"type": "button_clicked", ...}
+@Serializable
+data class ButtonClicked(val count: Int) : MyEvent
+```
+
+Without `@SerialName`, the class name is used as-is:
+
+```kotlin
+@Serializable
+data class ButtonClicked(val count: Int) : MyEvent  // JSON: {"type": "ButtonClicked", ...}
+```
+
+### JSON Format
+
+JetWhale uses polymorphic serialization with a discriminator field. The JSON format looks like:
+
+```json
+// Event
+{
+  "type": "button_clicked",
+  "count": 42
+}
+
+// Method
+{
+  "type": "get_user",
+  "userId": "user-123"
+}
+
+// MethodResult
+{
+  "type": "user_data",
+  "userId": "user-123",
+  "userName": "John Doe",
+  "email": "john@example.com"
+}
+```
+
+## Protocol Interfaces
+
+JetWhale provides protocol interfaces for both Agent and Host sides.
+
+### Agent Protocol
+
+```kotlin
+public interface JetWhaleAgentPluginProtocol<Event, Method, MethodResult> {
+    fun decodeMethod(value: String): Method
+    fun encodeMethodResult(value: MethodResult): String
+    fun encodeEvent(value: Event): String
+}
+```
+
+Usage in Agent Plugin:
+
+```kotlin
+override val protocol: JetWhaleAgentPluginProtocol<MyEvent, MyMethod, MyMethodResult> =
+    kotlinxSerializationJetWhaleAgentPluginProtocol()
+```
+
+### Host Protocol
+
+```kotlin
+public interface JetWhaleHostPluginProtocol<Event, Method, MethodResult> {
+    fun encodeMethod(value: Method): String
+    fun decodeMethodResult(value: String): MethodResult
+    fun decodeEvent(value: String): Event
+}
+```
+
+Usage in Host Plugin:
+
+```kotlin
+override val protocol: JetWhaleHostPluginProtocol<MyEvent, MyMethod, MyMethodResult> =
+    kotlinxSerializationJetWhaleHostPluginProtocol()
+```
+
+## Advanced Topics
+
+### Custom JSON Configuration
+
+If you need custom JSON settings, pass a configured `Json` instance:
+
+```kotlin
+val customJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+    prettyPrint = false
+}
+
+override val protocol = kotlinxSerializationJetWhaleAgentPluginProtocol<MyEvent, MyMethod, MyMethodResult>(
+    json = customJson
+)
+```
+
+### Nested Sealed Classes
+
+You can nest sealed classes for complex hierarchies:
+
+```kotlin
+@SerialName("my_event")
+@Serializable
+sealed interface MyEvent {
+
+    @Serializable
+    sealed interface UserEvent : MyEvent {
+        @SerialName("user_logged_in")
+        @Serializable
+        data class LoggedIn(val userId: String) : UserEvent
+
+        @SerialName("user_logged_out")
+        @Serializable
+        data object LoggedOut : UserEvent
+    }
+
+    @Serializable
+    sealed interface SystemEvent : MyEvent {
+        @SerialName("system_error")
+        @Serializable
+        data class Error(val message: String) : SystemEvent
+    }
+}
+```
+
+### Enum Serialization
+
+Use `@SerialName` on enum values for consistent JSON representation:
+
+```kotlin
+@Serializable
+enum class Priority {
+    @SerialName("low") LOW,
+    @SerialName("medium") MEDIUM,
+    @SerialName("high") HIGH,
+}
+
+@SerialName("task_created")
+@Serializable
+data class TaskCreated(
+    val taskId: String,
+    val priority: Priority,
+) : MyEvent
+```
+
+### Optional and Default Values
+
+Use default values for optional fields:
+
+```kotlin
+@SerialName("config_updated")
+@Serializable
+data class ConfigUpdated(
+    val key: String,
+    val value: String,
+    val timestamp: Long = System.currentTimeMillis(),  // Default value
+    val metadata: Map<String, String> = emptyMap(),    // Optional field
+) : MyEvent
+```
+
+### Collections and Maps
+
+kotlinx.serialization supports standard collections:
+
+```kotlin
+@SerialName("batch_update")
+@Serializable
+data class BatchUpdate(
+    val items: List<Item>,                    // List
+    val tags: Set<String>,                    // Set
+    val properties: Map<String, String>,      // Map
+) : MyMethod
+
+@Serializable
+data class Item(
+    val id: String,
+    val value: Int,
+)
+```
+
+## Complete Example
+
+```kotlin
+// ===== MyEvent.kt =====
+package com.example.myplugin.protocol
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@SerialName("my_event")
+@Serializable
+sealed interface MyEvent {
+
+    @SerialName("initialized")
+    @Serializable
+    data class Initialized(
+        val version: String,
+        val timestamp: Long,
+    ) : MyEvent
+
+    @SerialName("state_changed")
+    @Serializable
+    data class StateChanged(
+        val oldState: AppState,
+        val newState: AppState,
+    ) : MyEvent
+
+    @SerialName("action_performed")
+    @Serializable
+    data class ActionPerformed(
+        val actionId: String,
+        val success: Boolean,
+        val duration: Long,
+    ) : MyEvent
+}
+
+@Serializable
+enum class AppState {
+    @SerialName("idle") IDLE,
+    @SerialName("loading") LOADING,
+    @SerialName("ready") READY,
+    @SerialName("error") ERROR,
+}
+
+// ===== MyMethod.kt =====
+package com.example.myplugin.protocol
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@SerialName("my_method")
+@Serializable
+sealed interface MyMethod {
+
+    @SerialName("ping")
+    @Serializable
+    data object Ping : MyMethod
+
+    @SerialName("get_state")
+    @Serializable
+    data object GetState : MyMethod
+
+    @SerialName("set_state")
+    @Serializable
+    data class SetState(val state: AppState) : MyMethod
+
+    @SerialName("perform_action")
+    @Serializable
+    data class PerformAction(
+        val actionId: String,
+        val params: Map<String, String> = emptyMap(),
+    ) : MyMethod
+}
+
+// ===== MyMethodResult.kt =====
+package com.example.myplugin.protocol
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@SerialName("my_method_result")
+@Serializable
+sealed interface MyMethodResult {
+
+    @SerialName("pong")
+    @Serializable
+    data object Pong : MyMethodResult
+
+    @SerialName("current_state")
+    @Serializable
+    data class CurrentState(val state: AppState) : MyMethodResult
+
+    @SerialName("success")
+    @Serializable
+    data object Success : MyMethodResult
+
+    @SerialName("failure")
+    @Serializable
+    data class Failure(
+        val errorCode: Int,
+        val errorMessage: String,
+    ) : MyMethodResult
+}
+```
+
+## See Also
+
+- [Overview](./overview.md) - Plugin architecture overview
+- [Agent Plugin Implementation Guide](./agent-plugin.md) - Using protocol in Agent plugins
+- [Host Plugin Implementation Guide](./host-plugin.md) - Using protocol in Host plugins
+- [kotlinx.serialization Documentation](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serialization-guide.md)

--- a/docs/plugins/protocol.md
+++ b/docs/plugins/protocol.md
@@ -216,7 +216,7 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
 }
 ```
 

--- a/docs/plugins/protocol.md
+++ b/docs/plugins/protocol.md
@@ -14,11 +14,11 @@ JetWhale plugins communicate using three types of messages:
 
 All message types are serialized to JSON using [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization).
 
-> **Important: Always use `@SerialName`**
+> **Highly Recommended: Always use `@SerialName`**
 >
-> JetWhale uses `useClassDiscriminator = true` by default, which means the fully qualified class name (e.g., `com.example.MyEvent.StateChanged`) is embedded in the JSON if `@SerialName` is not specified. This creates a tight coupling between your class names/packages and the serialized protocol.
+> JetWhale uses `classDiscriminatorMode = ClassDiscriminatorMode.ALL_JSON_OBJECTS`, which adds a `"type"` field to all JSON objects. Without `@SerialName`, the fully qualified class name (e.g., `com.example.MyEvent.StateChanged`) is used as the type discriminator. This creates a tight coupling between your class names/packages and the serialized protocol.
 >
-> **Always specify `@SerialName` on all sealed interface members** to:
+> **It is highly recommended to specify `@SerialName` on all sealed interface members** to:
 > - Maintain protocol compatibility when refactoring (renaming classes, moving packages)
 > - Keep JSON payloads clean and readable
 > - Ensure binary compatibility between different versions of Agent and Host plugins
@@ -220,11 +220,11 @@ dependencies {
 }
 ```
 
-### SerialName Annotation (Required)
+### SerialName Annotation (Highly Recommended)
 
-**Always use `@SerialName`** on all Event, Method, and MethodResult types.
+**It is highly recommended to use `@SerialName`** on all Event, Method, and MethodResult types.
 
-JetWhale uses `useClassDiscriminator = true`, which means that without `@SerialName`, the **fully qualified class name** is used as the type discriminator:
+JetWhale uses `classDiscriminatorMode = ClassDiscriminatorMode.ALL_JSON_OBJECTS`, which means that without `@SerialName`, the **fully qualified class name** is used as the type discriminator:
 
 ```kotlin
 // WITHOUT @SerialName (NOT RECOMMENDED)


### PR DESCRIPTION
Add comprehensive documentation for JetWhale plugin developers covering:
- Overview of plugin architecture (Agent, Host, Protocol)
- Agent Plugin implementation guide
- Host Plugin implementation guide
- Protocol definition guide with kotlinx.serialization examples
