### PR TITLE
perf: run ABI check only on SDK modules

### DIFF
--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'jetwhale-host-sdk/**'
       - 'jetwhale-agent-sdk/**'
+      - 'jetwhale-annotations/**'
       - 'jetwhale-protocol/core/**'
       - 'jetwhale-protocol/agent/**'
       - 'jetwhale-protocol/host/**'
@@ -24,4 +25,11 @@ jobs:
       - uses: ./.github/actions/setup-java
 
       - name: Run ABI check
-        run: ./gradlew checkLegacyAbi
+        run: |
+          ./gradlew \
+            :jetwhale-host-sdk:checkLegacyAbi \
+            :jetwhale-agent-sdk:checkLegacyAbi \
+            :jetwhale-annotations:checkLegacyAbi \
+            :jetwhale-protocol:core:checkLegacyAbi \
+            :jetwhale-protocol:agent:checkLegacyAbi \
+            :jetwhale-protocol:host:checkLegacyAbi


### PR DESCRIPTION
## Summary

- Run `checkLegacyAbi` only on SDK modules instead of all modules
- Add `jetwhale-annotations` to path filter

## Problem

The ABI check workflow was running `./gradlew checkLegacyAbi` which configures and checks ALL modules including demos, host app, and example plugins. This caused:

- 6+ minute configuration phase after `gradle-conventions:jar`
- Unnecessary work on modules that don't need ABI validation

## Solution

Target only the SDK/library modules that actually need ABI checking:
- `jetwhale-host-sdk`
- `jetwhale-agent-sdk`
- `jetwhale-annotations`
- `jetwhale-protocol:core`
- `jetwhale-protocol:agent`
- `jetwhale-protocol:host`

## Additional plans

Enabling **merge queue** for this repository. It will:
1. Run CI checks before merging (quality gate)
2. Populate Gradle cache for future PR runs