### PR TITLE
ci: add test workflow for PRs and main branch pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-java
+
+      - name: Run tests
+        run: ./gradlew check


### PR DESCRIPTION
## Summary
- Add CI workflow to run tests on push to main branch and on pull requests
- Reuse existing `setup-java` action
- Execute `./gradlew check` to run tests