### PR TITLE
fix(demo:web): resolve ConcurrentModificationException during sync

### DIFF
--- a/demo/web/build.gradle.kts
+++ b/demo/web/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             commonWebpackConfig {
                 outputFileName = "demo.js"
             }
-            binaries.executable()
         }
+        binaries.executable()
     }
     wasmJs {
         browser {


### PR DESCRIPTION
## Summary
- Move `binaries.executable()` outside of `browser {}` block in demo/web to fix ConcurrentModificationException during Gradle sync
