### PR TITLE
Fix: prevent Window from being recreated when adding or removing NavKeys

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/WindowSceneStrategy.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/WindowSceneStrategy.kt
@@ -26,7 +26,7 @@ internal data class WindowEntry<T : Any>(
     val properties: WindowProperties,
 )
 
-internal data class WindowOverlayScene<T : Any>(
+internal class WindowOverlayScene<T : Any>(
     private val windowEntries: List<WindowEntry<T>>,
     override val previousEntries: List<NavEntry<T>>,
     override val overlaidEntries: List<NavEntry<T>>,
@@ -58,6 +58,32 @@ internal data class WindowOverlayScene<T : Any>(
     }
 
     override val entries: List<NavEntry<T>> = windowEntries.map { it.entry }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as WindowOverlayScene<*>
+
+        if (windowEntries != other.windowEntries) return false
+        if (previousEntries != other.previousEntries) return false
+        if (overlaidEntries != other.overlaidEntries) return false
+        if (key != other.key) return false
+        if (content != other.content) return false
+        if (entries != other.entries) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = windowEntries.hashCode()
+        result = 31 * result + previousEntries.hashCode()
+        result = 31 * result + overlaidEntries.hashCode()
+        result = 31 * result + key.hashCode()
+        result = 31 * result + content.hashCode()
+        result = 31 * result + entries.hashCode()
+        return result
+    }
 }
 
 class WindowSceneStrategy<T : Any>(


### PR DESCRIPTION
## Overview

This PR fixes unstable behavior in `WindowSceneStrategy` where adding or removing a NavKey triggered a full recomposition of composed Windows, resulting in unnecessary Window recreation.

## Requirements

- `jetbrainsCompose` must be updated to `1.11.0-alpha04+dev3732` or later.  
  Earlier versions are prone to frequent NPEs when a Window loses focus due to a bug in `SemanticsOwnerAccessibility.accessibleParentOf`.

- Additionally, the latest alpha version resolves crashes that could occur when using `SelectionContainer` in the JetWhale host application or plugin UIs.

## Video

This branch (tested with `1.11.0-alpha04+dev3732`):

<video src="https://github.com/user-attachments/assets/cddc16c3-0b86-45c0-b238-13f32583ed51"></video>

main branch (tested with `1.10.1`):

<video src="https://github.com/user-attachments/assets/7e2a0f9e-83a8-4a13-b6f9-0ea63ca7ad04"></video>

In the last part of the main branch video, the application crashes with an NPE in `SemanticsOwnerAccessibility.accessibleParentOf`.

