### PR TITLE
Improve shortcut key support

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.key
+import com.kitakkun.jetwhale.host.ui.isShortcutModifierPressed
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
@@ -50,7 +50,7 @@ fun main(args: Array<String>) = runBlocking {
             state = WindowState(position = WindowPosition.Aligned(Alignment.Center)),
             onCloseRequest = appGraph.applicationLifecycleOwner::shutdown,
             onPreviewKeyEvent = { keyEvent ->
-                if (keyEvent.isMetaPressed && keyEvent.key == Key.Q) {
+                if (keyEvent.isShortcutModifierPressed && keyEvent.key == Key.Q) {
                     appGraph.applicationLifecycleOwner.shutdown()
                     true
                 } else {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.key
-import com.kitakkun.jetwhale.host.ui.isShortcutModifierPressed
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
@@ -15,6 +14,7 @@ import com.kitakkun.jetwhale.host.cli.CommandLineArgumentsParser
 import com.kitakkun.jetwhale.host.component.InitializingDialog
 import com.kitakkun.jetwhale.host.component.ShuttingDownDialog
 import com.kitakkun.jetwhale.host.di.JetWhaleAppGraph
+import com.kitakkun.jetwhale.host.ui.isShortcutModifierPressed
 import dev.zacsweers.metro.createGraph
 import kotlinx.coroutines.runBlocking
 

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
@@ -5,7 +5,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
@@ -50,7 +52,7 @@ fun main(args: Array<String>) = runBlocking {
             state = WindowState(position = WindowPosition.Aligned(Alignment.Center)),
             onCloseRequest = appGraph.applicationLifecycleOwner::shutdown,
             onPreviewKeyEvent = { keyEvent ->
-                if (keyEvent.isShortcutModifierPressed && keyEvent.key == Key.Q) {
+                if (keyEvent.type == KeyEventType.KeyDown && keyEvent.isShortcutModifierPressed && keyEvent.key == Key.Q) {
                     appGraph.applicationLifecycleOwner.shutdown()
                     true
                 } else {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/WindowSceneStrategy.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/WindowSceneStrategy.kt
@@ -4,6 +4,8 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.key
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPlacement
@@ -14,6 +16,7 @@ import androidx.navigation3.scene.Scene
 import androidx.navigation3.scene.SceneStrategy
 import androidx.navigation3.scene.SceneStrategyScope
 import com.kitakkun.jetwhale.host.LocalComposeWindow
+import com.kitakkun.jetwhale.host.ui.isShortcutModifierPressed
 
 data class WindowProperties(
     val windowPlacement: WindowPlacement = WindowPlacement.Floating,
@@ -46,6 +49,14 @@ internal class WindowOverlayScene<T : Any>(
                 Window(
                     state = windowState,
                     onCloseRequest = { onCloseRequest(windowEntry.entry) },
+                    onPreviewKeyEvent = { keyEvent ->
+                        if (keyEvent.isShortcutModifierPressed && keyEvent.key == Key.W) {
+                            onCloseRequest(windowEntry.entry)
+                            true
+                        } else {
+                            false
+                        }
+                    },
                 ) {
                     CompositionLocalProvider(LocalComposeWindow provides this.window) {
                         Surface {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/WindowSceneStrategy.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/WindowSceneStrategy.kt
@@ -5,7 +5,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.key
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPlacement
@@ -50,7 +52,7 @@ internal class WindowOverlayScene<T : Any>(
                     state = windowState,
                     onCloseRequest = { onCloseRequest(windowEntry.entry) },
                     onPreviewKeyEvent = { keyEvent ->
-                        if (keyEvent.isShortcutModifierPressed && keyEvent.key == Key.W) {
+                        if (keyEvent.type == KeyEventType.KeyDown && keyEvent.isShortcutModifierPressed && keyEvent.key == Key.W) {
                             onCloseRequest(windowEntry.entry)
                             true
                         } else {

--- a/jetwhale-host/core/ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/KeyEventExtensions.kt
+++ b/jetwhale-host/core/ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/KeyEventExtensions.kt
@@ -1,0 +1,10 @@
+package com.kitakkun.jetwhale.host.ui
+
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+
+private val isMacOS: Boolean = System.getProperty("os.name").lowercase().contains("mac")
+
+val KeyEvent.isShortcutModifierPressed: Boolean
+    get() = if (isMacOS) isMetaPressed else isCtrlPressed

--- a/jetwhale-host/core/ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/KeyEventExtensions.kt
+++ b/jetwhale-host/core/ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/KeyEventExtensions.kt
@@ -3,8 +3,10 @@ package com.kitakkun.jetwhale.host.ui
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
+import java.util.Locale
 
-private val isMacOS: Boolean = System.getProperty("os.name").lowercase().contains("mac")
+private val isMacOS: Boolean =
+    System.getProperty("os.name")?.lowercase(Locale.ROOT)?.contains("mac") == true
 
 val KeyEvent.isShortcutModifierPressed: Boolean
     get() = if (isMacOS) isMetaPressed else isCtrlPressed

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,10 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 include(":jetwhale-annotations")
 include(":jetwhale-protocol:core")
 include(":jetwhale-protocol:host")


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                
- Add utility extension property `isShortcutModifierPressed` that detects the appropriate modifier key per OS (Command on macOS, Ctrl on Windows/Linux)
- Fix app quit shortcut (Command/Ctrl + Q) to work on all platforms
- Add shortcut key support (Command/Ctrl + W) for closing sub-windows opened via WindowSceneStrategy
- Apply the Foojay resolver plugin to simplify environment setup on new machines

Tested on macOS and Windows; both worked as expected.