### PR TITLE
fix: restore focus request for plugin canvas to fix text input

### DIFF
--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreen.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.pointer.PointerEvent
@@ -30,6 +32,11 @@ import soil.query.core.uuid
 fun PluginScreen(pluginComposeScene: PluginComposeScene) {
     val catchThrowHost = LocalCatchThrowHost.current
     var frameNanoTime by remember(pluginComposeScene) { mutableLongStateOf(0L) }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(pluginComposeScene) {
+        focusRequester.requestFocus()
+    }
 
     LaunchedEffect(pluginComposeScene) {
         while (true) {
@@ -58,6 +65,7 @@ fun PluginScreen(pluginComposeScene: PluginComposeScene) {
                     dpSize = with(density) { DpSize(it.width.toDp(), it.height.toDp()) },
                 )
             }
+            .focusRequester(focusRequester)
             .focusable()
             .pointerInput(Unit) {
                 awaitPointerEventScope {


### PR DESCRIPTION
## Summary

- Text input to plugins stopped working in 1.0.0-alpha04 due to PR #62, which removed `FocusRequester` and `LifecycleResumeEffect` from `PluginScreen` to fix popout crashes.
- Without an explicit focus request, the plugin `Canvas` never acquires keyboard focus, so `.onKeyEvent` never fires and `sendKeyEvent()` is never called — breaking all text input.
- This PR restores focus management using `LaunchedEffect(pluginComposeScene)` instead of `LifecycleResumeEffect`, so focus is requested once on initial composition (not on every lifecycle resume), avoiding the popout crash while restoring text input.

## Root Cause

```
LifecycleResumeEffect  →  requestFocus() called on every resume  →  crash on popout
```

PR #62 removed the entire block, leaving `.focusable()` + `.onKeyEvent` with no focus owner.

## Fix

```kotlin
val focusRequester = remember { FocusRequester() }

LaunchedEffect(pluginComposeScene) {
    focusRequester.requestFocus()  // runs once per plugin, not on every lifecycle resume
}

Canvas(
    modifier = Modifier
        ...
        .focusRequester(focusRequester)
        .focusable()
        ...
)
```

## Test Plan

- [x] Open a plugin that contains a `TextField`
- [x] Verify text can be typed without clicking first
- [x] Repeatedly use the popout feature and return to the main window — verify no crash
- [x] Verify text input still works after returning from popout