### PR TITLE
fix(demo:web): use ComposeViewport without document reference

### DIFF
--- a/demo/web/src/webMain/kotlin/com/kitakkun/jetwhale/demo/Main.kt
+++ b/demo/web/src/webMain/kotlin/com/kitakkun/jetwhale/demo/Main.kt
@@ -4,14 +4,11 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
 import com.kitakkun.jetwhale.demo.shared.App
 import com.kitakkun.jetwhale.demo.shared.initializeJetWhale
-import kotlinx.browser.document
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     initializeJetWhale()
-
-    val body = document.body ?: return
-    ComposeViewport(body) {
+    ComposeViewport {
         App()
     }
 }


### PR DESCRIPTION
## Summary

- `kotlinx.browser.document` is no longer available in the `webMain` intermediate source set metadata as of Kotlin 2.3.10, since it was removed from the stdlib
- Replaced `ComposeViewport(document.body) { ... }` with the no-arg `ComposeViewport { ... }` overload to avoid the platform-specific `document` reference in the shared `webMain` source set

## Test plan

- [x] Run `./gradlew :demo:web:build` and confirm it succeeds