### PR TITLE
refactor(host): concrete @Inject ScreenContext + PresenterContext (ToolingScaffold)

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -92,7 +92,7 @@ fun JetWhaleApp() {
                 JetWhaleTheme(theme.colorScheme) {
                     AppEnvironment(settings.appLanguage) {
                         Surface {
-                            context(rememberRetained { appGraph.createToolingScaffoldScreenContext() }) {
+                            context(rememberRetained { appGraph.toolingScaffoldScreenContext }) {
                                 ToolingScaffoldRoot(
                                     onClickSettings = { backStack.addSingleTop(SettingsNavKey()) },
                                     onClickPluginSettings = {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
@@ -28,12 +28,13 @@ import soil.query.SwrClientPlus
 interface JetWhaleAppGraph :
     PluginScreenContext.Factory,
     SettingsScreenContext.Factory,
-    ToolingScaffoldScreenContext.Factory,
     LicensesScreenContext.Factory,
     ScreenContext {
     val applicationLifecycleOwner: ApplicationLifecycleOwner
     val mcpServerService: McpServerService
     val swrClient: SwrClientPlus
+
+    val toolingScaffoldScreenContext: ToolingScaffoldScreenContext
 
     val themeSubscriptionKey: ThemeSubscriptionKey
     val appearanceSettingsSubscriptionKey: AppearanceSettingsSubscriptionKey

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -30,7 +30,7 @@ sealed interface ToolingScaffoldEffect {
 }
 
 @Composable
-context(screenContext: ToolingScaffoldScreenContext)
+context(presenterContext: ToolingScaffoldPresenterContext)
 fun toolingScaffoldPresenter(
     eventFlow: EventFlow<ToolingScaffoldEvent>,
     loadedPlugins: ImmutableList<PluginMetaData>,
@@ -44,7 +44,7 @@ fun toolingScaffoldPresenter(
         derivedStateOf { debugSessions.firstOrNull { it.id == selectedSessionId } }
     }
 
-    val setPluginEnabledMutation = rememberMutation(screenContext.setPluginEnabledMutationKey)
+    val setPluginEnabledMutation = rememberMutation(presenterContext.setPluginEnabledMutationKey)
 
     val plugins by remember(loadedPlugins, selectedSession, enabledPluginIds) {
         derivedStateOf {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -22,13 +22,15 @@ fun ToolingScaffoldRoot(
         state4 = rememberSubscription(screenContext.failedPluginJarPathsSubscriptionKey),
     ) { loadedPlugins, debugSessions, enabledPluginIds, failedJarPaths ->
         val eventFlow = rememberEventFlow<ToolingScaffoldEvent>()
-        val uiState = toolingScaffoldPresenter(
-            eventFlow = eventFlow,
-            loadedPlugins = loadedPlugins,
-            debugSessions = debugSessions,
-            enabledPluginIds = enabledPluginIds,
-            hasFailedJars = failedJarPaths.isNotEmpty(),
-        )
+        val uiState = context(screenContext.presenterContext) {
+            toolingScaffoldPresenter(
+                eventFlow = eventFlow,
+                loadedPlugins = loadedPlugins,
+                debugSessions = debugSessions,
+                enabledPluginIds = enabledPluginIds,
+                hasFailedJars = failedJarPaths.isNotEmpty(),
+            )
+        }
 
         ToolingScaffold(
             uiState = uiState,

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldScreenContext.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldScreenContext.kt
@@ -1,26 +1,31 @@
 package com.kitakkun.jetwhale.host.drawer
 
+import com.kitakkun.jetwhale.host.architecture.PresenterContext
 import com.kitakkun.jetwhale.host.architecture.ScreenContext
 import com.kitakkun.jetwhale.host.model.DebugSessionsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.EnabledPluginsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.FailedPluginJarPathsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.LoadedPluginsMetaDataSubscriptionKey
 import com.kitakkun.jetwhale.host.model.SetPluginEnabledMutationKey
-import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.GraphExtension
+import dev.zacsweers.metro.Inject
 
-@ContributesTo(AppScope::class)
-@GraphExtension
-interface ToolingScaffoldScreenContext : ScreenContext {
-    val loadedPluginsMetaDataSubscriptionKey: LoadedPluginsMetaDataSubscriptionKey
-    val debugSessionsSubscriptionKey: DebugSessionsSubscriptionKey
-    val enabledPluginsSubscriptionKey: EnabledPluginsSubscriptionKey
-    val failedPluginJarPathsSubscriptionKey: FailedPluginJarPathsSubscriptionKey
-    val setPluginEnabledMutationKey: SetPluginEnabledMutationKey
+/**
+ * Presenter-role context: only the dependencies the presenter consumes.
+ */
+@Inject
+class ToolingScaffoldPresenterContext(
+    val setPluginEnabledMutationKey: SetPluginEnabledMutationKey,
+) : PresenterContext
 
-    @GraphExtension.Factory
-    fun interface Factory {
-        fun createToolingScaffoldScreenContext(): ToolingScaffoldScreenContext
-    }
-}
+/**
+ * Screen-role context: the dependencies the Root consumes, plus the presenter context held
+ * by composition (has-a) so the presenter can be supplied a right-sized [PresenterContext].
+ */
+@Inject
+class ToolingScaffoldScreenContext(
+    val loadedPluginsMetaDataSubscriptionKey: LoadedPluginsMetaDataSubscriptionKey,
+    val debugSessionsSubscriptionKey: DebugSessionsSubscriptionKey,
+    val enabledPluginsSubscriptionKey: EnabledPluginsSubscriptionKey,
+    val failedPluginJarPathsSubscriptionKey: FailedPluginJarPathsSubscriptionKey,
+    val presenterContext: ToolingScaffoldPresenterContext,
+) : ScreenContext

--- a/jetwhale-host/core/architecture/src/main/kotlin/com/kitakkun/jetwhale/host/architecture/PresenterContext.kt
+++ b/jetwhale-host/core/architecture/src/main/kotlin/com/kitakkun/jetwhale/host/architecture/PresenterContext.kt
@@ -1,0 +1,12 @@
+package com.kitakkun.jetwhale.host.architecture
+
+/**
+ * Marker for the presenter-role context.
+ *
+ * A `<Feature>PresenterContext` is a concrete `@Inject` class that aggregates only the
+ * dependencies a presenter needs (e.g. MutationKey). A `<Feature>ScreenContext` holds it
+ * by composition (has-a), so the presenter requires only [PresenterContext] while the
+ * Root requires the full [ScreenContext]. This keeps the presenter's visible dependencies
+ * right-sized and enables capability gating of channel consumption.
+ */
+interface PresenterContext


### PR DESCRIPTION
## Summary

First step of adopting the new internal architecture in the debugger host, piloted on the **ToolingScaffold** screen.

Replaces the Metro `@GraphExtension` `ScreenContext` with a concrete `@Inject` class and introduces a role-context split:

- Add a `PresenterContext` marker to `core/architecture`.
- `ToolingScaffoldScreenContext` becomes a concrete `@Inject` class. The presenter-role dependency (`setPluginEnabledMutationKey`) is split into `ToolingScaffoldPresenterContext`, which the screen context **holds by composition (has-a)**.
- The presenter requires only `context(ToolingScaffoldPresenterContext)`; the Root requires the full `ScreenContext` and supplies the presenter context via `context(screenContext.presenterContext) { ... }`. This right-sizes the presenter's visible dependencies and sets up capability gating.
- `JetWhaleAppGraph` exposes a `toolingScaffoldScreenContext` accessor instead of the graph-extension factory.

`retain` (Rin → official Compose retain API) is intentionally **out of scope**: the official `runtime-retain` artifact is not on the Compose 1.10.2 classpath and its API is still evolving, so Rin is kept for now.

## Stack

This is PR 1/4 of a stacked series. Subsequent PRs build on this branch:
1. **this PR** — concrete ScreenContext + PresenterContext
2. `EventFlow` → `ScreenChannel`
3. `mutate` → `mutateAsync`
4. roll the patterns out to all remaining screens

## Verification

`./gradlew :jetwhale-host:app:compileKotlin` — BUILD SUCCESSFUL (Metro validates the DI graph at compile time).