### PR TITLE
refactor(host): mutate → mutateAsync with failure observation (ToolingScaffold)

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.kitakkun.jetwhale.host.architecture.ActionEffect
+import com.kitakkun.jetwhale.host.architecture.MutationErrorEffect
 import com.kitakkun.jetwhale.host.architecture.ScreenChannel
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.PluginAvailability
@@ -26,6 +27,7 @@ sealed interface ToolingScaffoldScreenAction {
 
 sealed interface ToolingScaffoldScreenActionResult {
     data class SessionClosed(val closedSessionIds: List<String>) : ToolingScaffoldScreenActionResult
+    data class SetPluginEnabledFailed(val error: Throwable) : ToolingScaffoldScreenActionResult
 }
 
 @Composable
@@ -90,9 +92,13 @@ fun toolingScaffoldPresenter(
             }
 
             is ToolingScaffoldScreenAction.SetPluginEnabled -> {
-                setPluginEnabledMutation.mutate(SetPluginEnabledParams(action.pluginId, action.enabled))
+                setPluginEnabledMutation.mutateAsync(SetPluginEnabledParams(action.pluginId, action.enabled))
             }
         }
+    }
+
+    MutationErrorEffect(setPluginEnabledMutation) { error ->
+        screenChannel.emit(ToolingScaffoldScreenActionResult.SetPluginEnabledFailed(error))
     }
 
     return ToolingScaffoldUiState(

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -28,6 +28,7 @@ fun ToolingScaffoldRoot(
                 // No message sink yet; results are routed through the channel so a future
                 // Root-side handler (e.g. a Snackbar) can surface them during the rollout.
                 is ToolingScaffoldScreenActionResult.SessionClosed -> Unit
+
                 is ToolingScaffoldScreenActionResult.SetPluginEnabledFailed -> Unit
             }
         }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -25,8 +25,10 @@ fun ToolingScaffoldRoot(
         val screenChannel = rememberScreenChannel<ToolingScaffoldScreenAction, ToolingScaffoldScreenActionResult>()
         ActionResultEffect(screenChannel) { result ->
             when (result) {
-                // No sink yet; routed through the channel so a future Root-side handler can surface it.
+                // No message sink yet; results are routed through the channel so a future
+                // Root-side handler (e.g. a Snackbar) can surface them during the rollout.
                 is ToolingScaffoldScreenActionResult.SessionClosed -> Unit
+                is ToolingScaffoldScreenActionResult.SetPluginEnabledFailed -> Unit
             }
         }
         val uiState = context(screenContext.presenterContext) {

--- a/jetwhale-host/core/architecture/src/main/kotlin/com/kitakkun/jetwhale/host/architecture/MutationErrorEffect.kt
+++ b/jetwhale-host/core/architecture/src/main/kotlin/com/kitakkun/jetwhale/host/architecture/MutationErrorEffect.kt
@@ -2,22 +2,71 @@ package com.kitakkun.jetwhale.host.architecture
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.autoSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.filterNotNull
+import soil.query.compose.MutationErrorObject
 import soil.query.compose.MutationObject
 
 /**
- * Failure counterpart to Soil's `MutatedEffect`.
+ * Failure counterpart to Soil's `MutatedEffect`: triggers [block] when a mutation fails.
  *
- * Observes the mutation's error state and invokes [block] once per new failure (keyed on
- * `errorUpdatedAt`). Pair it with `mutateAsync` so failures flow through the mutation state
- * instead of being swallowed by a fire-and-forget `mutate`.
+ * Modeled on `MutatedEffect`. It observes the error state via [snapshotFlow] and uses
+ * [keySelector] to identify whether a failure has already been handled, so [block] runs once
+ * per distinct failure (deduped across recompositions and restored state). Pair it with
+ * `mutateAsync` so failures flow through the mutation state instead of being swallowed by a
+ * fire-and-forget `mutate`.
+ *
+ * @param T Type of the return value from the mutation.
+ * @param U Type of the key to identify whether the failure has already been handled.
+ * @param mutation The MutationObject whose error will be observed.
+ * @param keySelector Calculates a key to identify whether the failure has already been handled.
+ * @param keySaver A Saver to persist and restore the last consumed key.
+ * @param block A callback to handle the error. Called only when the key differs from the previous one.
  */
 @Composable
-fun MutationErrorEffect(
-    mutation: MutationObject<*, *>,
-    block: suspend (Throwable) -> Unit,
+fun <T, U : Any> MutationErrorEffect(
+    mutation: MutationObject<T, *>,
+    keySelector: (MutationErrorObject<T, *>) -> U,
+    keySaver: Saver<U?, out Any> = autoSaver(),
+    block: suspend (error: Throwable) -> Unit,
 ) {
-    val error = mutation.error
-    LaunchedEffect(mutation.errorUpdatedAt) {
-        if (error != null) block(error)
+    val mutationState by rememberUpdatedState(mutation)
+    var lastConsumedKey by rememberSaveable(stateSaver = keySaver) { mutableStateOf(null) }
+    LaunchedEffect(Unit) {
+        snapshotFlow { mutationState as? MutationErrorObject }
+            .filterNotNull()
+            .collect {
+                val errorKey = keySelector(it)
+                if (lastConsumedKey != errorKey) {
+                    lastConsumedKey = errorKey
+                    block(it.error)
+                }
+            }
     }
+}
+
+/**
+ * A [MutationErrorEffect] keyed by `errorUpdatedAt`, so [block] is invoked once per new failure.
+ *
+ * @param T Type of the return value from the mutation.
+ * @param mutation The MutationObject whose error will be observed.
+ */
+@Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
+@Composable
+inline fun <T> MutationErrorEffect(
+    mutation: MutationObject<T, *>,
+    noinline block: suspend (error: Throwable) -> Unit,
+) {
+    MutationErrorEffect(
+        mutation = mutation,
+        keySelector = { it.errorUpdatedAt },
+        block = block,
+    )
 }

--- a/jetwhale-host/core/architecture/src/main/kotlin/com/kitakkun/jetwhale/host/architecture/MutationErrorEffect.kt
+++ b/jetwhale-host/core/architecture/src/main/kotlin/com/kitakkun/jetwhale/host/architecture/MutationErrorEffect.kt
@@ -1,0 +1,23 @@
+package com.kitakkun.jetwhale.host.architecture
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import soil.query.compose.MutationObject
+
+/**
+ * Failure counterpart to Soil's `MutatedEffect`.
+ *
+ * Observes the mutation's error state and invokes [block] once per new failure (keyed on
+ * `errorUpdatedAt`). Pair it with `mutateAsync` so failures flow through the mutation state
+ * instead of being swallowed by a fire-and-forget `mutate`.
+ */
+@Composable
+fun MutationErrorEffect(
+    mutation: MutationObject<*, *>,
+    block: suspend (Throwable) -> Unit,
+) {
+    val error = mutation.error
+    LaunchedEffect(mutation.errorUpdatedAt) {
+        if (error != null) block(error)
+    }
+}

--- a/jetwhale-host/core/architecture/src/main/kotlin/com/kitakkun/jetwhale/host/architecture/ScreenChannel.kt
+++ b/jetwhale-host/core/architecture/src/main/kotlin/com/kitakkun/jetwhale/host/architecture/ScreenChannel.kt
@@ -38,8 +38,8 @@ class ScreenChannel<Action, ActionResult>(
 fun <A, R> rememberScreenChannel(): ScreenChannel<A, R> = remember { ScreenChannel() }
 
 /** Consumes actions in the Presenter. Gated by [PresenterContext]. */
-context(_: PresenterContext)
 @Composable
+context(_: PresenterContext)
 fun <A> ActionEffect(
     screenChannel: ScreenChannel<A, *>,
     block: suspend (A) -> Unit,
@@ -50,8 +50,8 @@ fun <A> ActionEffect(
 }
 
 /** Consumes results in the Root. Gated by [ScreenContext]. */
-context(_: ScreenContext)
 @Composable
+context(_: ScreenContext)
 fun <R> ActionResultEffect(
     screenChannel: ScreenChannel<*, R>,
     block: suspend (R) -> Unit,


### PR DESCRIPTION
## Summary

Third step of the new architecture adoption (piloted on **ToolingScaffold**).

Stops firing `setPluginEnabledMutation` as a fire-and-forget `mutate` and routes its failures through the mutation state so they become observable:

- Add `MutationErrorEffect` to `core/architecture`: the failure counterpart to Soil's `MutatedEffect`, invoking its callback once per new error (keyed on `errorUpdatedAt`).
- ToolingScaffold uses `mutateAsync`; failures are emitted as `ToolingScaffoldScreenActionResult.SetPluginEnabledFailed` and consumed by the Root's `ActionResultEffect` (placeholder handler until a message sink lands).

Previously a failed toggle was silently swallowed; it is now observed and delivered to the Root, which is the architecturally correct place to surface it.

## Stack

PR 3/4. Base: `refactor/host-screen-channel` (#78).

## Verification

`./gradlew :jetwhale-host:app:compileKotlin` — BUILD SUCCESSFUL.