### PR TITLE
feat(host): follow the open plugin to the newly-selected session

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -18,6 +18,7 @@ import com.kitakkun.jetwhale.host.navigation.PluginNavKey
 import com.kitakkun.jetwhale.host.navigation.PluginPopoutNavKey
 import com.kitakkun.jetwhale.host.navigation.SettingsNavKey
 import com.kitakkun.jetwhale.host.navigation.addSingleTop
+import com.kitakkun.jetwhale.host.navigation.followPluginToSession
 import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
 import com.kitakkun.jetwhale.host.ui.AppEnvironment
 import com.kitakkun.jetwhale.host.ui.JetWhaleTheme
@@ -111,6 +112,17 @@ fun JetWhaleApp() {
                                                 sessionId = sessionId,
                                                 pluginName = pluginName,
                                             ),
+                                        )
+                                    },
+                                    onSelectedSessionChange = { selectedSession ->
+                                        // When the user switches the active session, make any plugin screen
+                                        // currently on top follow the newly-selected session instead of
+                                        // lingering on the previous one.
+                                        backStack.followPluginToSession(
+                                            newSessionId = selectedSession.id,
+                                            isPluginAvailableOnNewSession = { pluginId ->
+                                                selectedSession.installedPlugins.any { it.pluginId == pluginId }
+                                            },
                                         )
                                     },
                                 ) {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -1,9 +1,11 @@
 package com.kitakkun.jetwhale.host.drawer
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import com.kitakkun.jetwhale.host.architecture.ActionResultEffect
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
+import com.kitakkun.jetwhale.host.model.DebugSession
 import soil.query.compose.rememberSubscription
 
 @Composable
@@ -14,6 +16,7 @@ fun ToolingScaffoldRoot(
     onClickInfo: () -> Unit,
     onClickPlugin: (pluginId: String, sessionId: String) -> Unit,
     onClickPopout: (pluginId: String, pluginName: String, sessionId: String) -> Unit,
+    onSelectedSessionChange: (selectedSession: DebugSession) -> Unit,
     content: @Composable () -> Unit,
 ) {
     SoilDataBoundary(
@@ -40,6 +43,13 @@ fun ToolingScaffoldRoot(
                 enabledPluginIds = enabledPluginIds,
                 hasFailedJars = failedJarPaths.isNotEmpty(),
             )
+        }
+
+        // When the active/selected session changes, notify the host so that an open plugin
+        // screen can follow the newly-selected session instead of lingering on the old one.
+        LaunchedEffect(uiState.selectedSessionId) {
+            val selectedSession = uiState.selectedSession ?: return@LaunchedEffect
+            onSelectedSessionChange(selectedSession)
         }
 
         ToolingScaffold(

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
@@ -12,3 +12,27 @@ fun <T : NavKey> NavBackStack<T>.addSingleTop(index: Int, navKey: T) {
     removeIf { it == navKey }
     add(index, navKey)
 }
+
+/**
+ * Makes the plugin screen currently on top of the back stack follow a session switch.
+ *
+ * If the top entry is a [PluginNavKey] targeting a different session, it is replaced with a
+ * [PluginNavKey] for [newSessionId] so the same plugin is shown for the newly-selected session.
+ * If the plugin is not available on the new session (per [isPluginAvailableOnNewSession]), the old
+ * plugin entry is simply popped so the underlying (e.g. empty) screen is shown instead of a dead
+ * plugin screen.
+ *
+ * No-op when the top entry is not a [PluginNavKey] or already targets [newSessionId].
+ */
+fun NavBackStack<NavKey>.followPluginToSession(
+    newSessionId: String,
+    isPluginAvailableOnNewSession: (pluginId: String) -> Boolean,
+) {
+    val top = lastOrNull() as? PluginNavKey ?: return
+    if (top.sessionId == newSessionId) return
+
+    removeLastOrNull()
+    if (isPluginAvailableOnNewSession(top.pluginId)) {
+        addSingleTop(PluginNavKey(pluginId = top.pluginId, sessionId = newSessionId))
+    }
+}

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
@@ -33,6 +33,8 @@ fun NavBackStack<NavKey>.followPluginToSession(
 
     removeLastOrNull()
     if (isPluginAvailableOnNewSession(top.pluginId)) {
-        addSingleTop(PluginNavKey(pluginId = top.pluginId, sessionId = newSessionId))
+        // Plain add (not addSingleTop): we only replace the top entry, so earlier entries for the
+        // same plugin/session deeper in the back stack must be left intact.
+        add(PluginNavKey(pluginId = top.pluginId, sessionId = newSessionId))
     }
 }


### PR DESCRIPTION
## What

When switching the active debug session, a plugin screen on top of the back stack used to linger on the **previous** session. This makes the open plugin **follow** the session switch.

## How

- `NavBackStackExtensions.followPluginToSession(newSessionId, isPluginAvailableOnNewSession)` — if the top entry is a `PluginNavKey` targeting a different session, re-point it at the new session; if the plugin is not installed on the new session, pop it so the underlying screen shows instead of a dead plugin screen. No-op otherwise.
- `ToolingScaffoldRoot` — new `onSelectedSessionChange` callback, emitted from a `LaunchedEffect` keyed on the selected session id.
- `JetWhaleApp` — wires the callback using `DebugSession.installedPlugins` to decide availability.

## Verification

- `:jetwhale-host:app:compileKotlin` and `spotlessCheck` pass.
- ⚠️ Manual UI check pending: open a plugin, switch sessions, confirm the plugin re-points (or the screen clears when the plugin is absent on the target session).