### PR TITLE
build(network-inspector): publish agent-side artifacts to Maven Central

### DIFF
--- a/jetwhale-plugins/network/agent-ktor/build.gradle.kts
+++ b/jetwhale-plugins/network/agent-ktor/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
     alias(libs.plugins.multiplatform)
+    alias(libs.plugins.publish)
 }
 
 group = "com.kitakkun.jetwhale.plugins.network"
@@ -16,4 +17,10 @@ dependencies {
     commonMainApi(projects.jetwhalePlugins.network.agent)
     commonMainApi(libs.ktorClientCore)
     commonMainImplementation(libs.kotlinxCoroutinesCore)
+}
+
+jetwhalePublish {
+    artifactId = "jetwhale-network-inspector-agent-ktor"
+    name = "JetWhale Network Inspector Agent (Ktor)"
+    description = "Ktor client adapter that wires the JetWhale Network Inspector into an HttpClient."
 }

--- a/jetwhale-plugins/network/agent/build.gradle.kts
+++ b/jetwhale-plugins/network/agent/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 plugins {
     alias(libs.plugins.multiplatform)
     alias(libs.plugins.kotlinxSerialization)
+    alias(libs.plugins.publish)
 }
 
 // Distinct group so these plugin modules don't share coordinates with the `example` plugin
@@ -22,4 +23,10 @@ dependencies {
     commonMainImplementation(libs.kotlinxSerializationJson)
 
     commonTestImplementation(libs.kotlinTest)
+}
+
+jetwhalePublish {
+    artifactId = "jetwhale-network-inspector-agent"
+    name = "JetWhale Network Inspector Agent"
+    description = "Transport-agnostic agent core for the JetWhale Network Inspector (HTTP capture and mocking)."
 }

--- a/jetwhale-plugins/network/protocol/build.gradle.kts
+++ b/jetwhale-plugins/network/protocol/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 plugins {
     alias(libs.plugins.multiplatform)
     alias(libs.plugins.kotlinxSerialization)
+    alias(libs.plugins.publish)
 }
 
 // Distinct group so this module's coordinates don't collide with `example:protocol`.
@@ -16,4 +17,10 @@ kotlin {
 
 dependencies {
     commonMainImplementation(libs.kotlinxSerializationJson)
+}
+
+jetwhalePublish {
+    artifactId = "jetwhale-network-inspector-protocol"
+    name = "JetWhale Network Inspector Protocol"
+    description = "Transport-agnostic protocol types shared by the JetWhale Network Inspector agent and host."
 }


### PR DESCRIPTION
## Why

Right now the Network Inspector only works inside this repo's multi-module build (plugins depend on `projects.*`). To let **external app developers** use it, its agent-side artifacts must be consumable from Maven Central.

## What

Apply the existing `publish` (vanniktech) convention to the three agent-side modules so they are published as:

- `com.kitakkun.jetwhale:jetwhale-network-inspector-protocol`
- `com.kitakkun.jetwhale:jetwhale-network-inspector-agent`
- `com.kitakkun.jetwhale:jetwhale-network-inspector-agent-ktor`

These are picked up automatically by the existing tag-triggered `publish.yaml` workflow (`publishToMavenCentral`).

## Intended consumer usage (after a release)

```kotlin
// in the app being debugged
implementation("com.kitakkun.jetwhale:jetwhale-network-inspector-agent-ktor:<version>")

val client = HttpClient {
    install(networkAgentPlugin.ktorClientPlugin())
}
```
The host plugin jar (installed into `~/.jetwhale/plugins/`) is an end artifact and is distributed separately (e.g. a GitHub release), not via Maven.

## Notes / out of scope

- Stacked on #82 (the network modules only exist there); retarget to `main` once #82 merges.
- Nothing is on Maven Central yet for `com.kitakkun.jetwhale` — the **first actual publish requires a maintainer to push a release tag** (the workflow + secrets already exist).
- The SDK modules (agent-sdk/host-sdk/protocol) were already publish-configured; this PR only adds the Network Inspector modules.
- `:jetwhale-plugins:network:{protocol,agent,agent-ktor}:tasks --group publishing` show `publishToMavenCentral` after the change.