### PR TITLE
spike(host): Compose Hot Reload PoC for state-preserving plugin UI reload

### DIFF
--- a/jetwhale-plugins/example/dev-preview/README.md
+++ b/jetwhale-plugins/example/dev-preview/README.md
@@ -60,8 +60,20 @@ reload hook — a separate, deeper spike.
 ## Toward an external "dev-host" (for plugin authors outside this repo)
 
 This module proves the mechanism locally with project dependencies. The external-developer version
-would be a Gradle `hotdev` task that resolves a **published dev-host launcher** plus the developer's
-plugin module (as a source/compile dependency) and runs it under Compose Hot Reload on JBR.
+puts the **launch entry point on the plugin side**: the plugin author's own module embeds JetWhale as
+a dependency and launches it, so the **run target is the plugin module itself** and Compose Hot
+Reload recompiles/redefines the plugin's source:
+
+```kotlin
+// in the plugin author's module (provided by a published jetwhale-dev-host + a Gradle plugin)
+fun main() = launchJetWhaleDevHost()
+```
+```shell
+./gradlew :myPlugin:hotRun --auto   # run target = your plugin module -> your plugin hot-reloads
+```
+
+A Gradle `hotdev` task would wire this up: apply Compose Hot Reload, add the published `jetwhale-dev-host`
+dependency, set the main class, and run on JBR.
 
 Publishing notes:
 

--- a/jetwhale-plugins/example/dev-preview/README.md
+++ b/jetwhale-plugins/example/dev-preview/README.md
@@ -1,0 +1,54 @@
+# Example Plugin — Compose Hot Reload preview (PoC)
+
+A proof-of-concept harness that renders a JetWhale plugin's UI under **JetBrains Compose Hot
+Reload**, so plugin authors can edit UI code and see it reload **while Compose state is preserved**.
+
+## Why this exists / how it differs from the runtime hot reload
+
+The host app's runtime hot reload (`PluginHotReloadService`) reloads a plugin by loading its **jar
+in a new classloader** and rebuilding the Compose scene — which **loses all plugin UI state**.
+
+Compose Hot Reload instead **redefines the loaded classes in place** (JetBrains Runtime / DCEVM) and
+recomposes, **preserving `remember` state**. But it only reloads classes on the **application
+classpath** — it does not target dynamically loaded plugin jars. So this harness puts the plugin on
+the classpath as a direct dependency (`:jetwhale-plugins:example:host`) and renders its
+`ExamplePluginView` directly.
+
+## Run it
+
+Requires the **JetBrains Runtime (JBR, Java 21)**. Compose Hot Reload provisions a compatible JBR via
+the foojay toolchain resolver (already configured in `settings.gradle.kts`). Compose Hot Reload ships
+bundled with Compose Multiplatform 1.11.1, so no extra plugin is needed.
+
+```shell
+./gradlew :jetwhale-plugins:example:dev-preview:hotRun --auto
+```
+
+`--auto` enables Gradle continuous build, so saving a source file triggers a recompile + reload.
+
+## What to verify
+
+1. Click **"Send ping to debuggee"** a few times → the event log grows (this is the hoisted state).
+2. Edit `ExamplePluginView` in `:jetwhale-plugins:example:host` — e.g. change a button label or add a
+   `Text` — and save.
+3. The window updates with the new code **while the event log entries remain** (state preserved).
+
+## Known limits (what to expect)
+
+- **Requires JBR** to run; on a stock JDK only method-body changes redefine.
+- Method-body changes and (on JBR) adding/removing methods/fields reload fine; **changing a class's
+  supertype or adding brand-new top-level classes/files** generally cannot be redefined.
+- Restructuring a `@Composable` (changing the group structure) can reset the affected `remember`ed
+  state.
+- One plugin at a time (it is a direct classpath dependency here).
+
+## Relationship to the production plugin model
+
+Production loads plugins from external jars via isolated classloaders, which Compose Hot Reload does
+not cover. The recommended end state is a **hybrid**: use this state-preserving reload during UI
+development, and keep the classloader-based reload (state lost, but handles any change including new
+jars/dependencies) as the fallback for the installed-jar workflow.
+
+> Status: PoC. The setup compiles and the `hotRun`/`reload` tasks are available; the actual
+> state-preserving reload behavior must be confirmed on a machine with the JetBrains Runtime (the GUI
+> could not be run in CI).

--- a/jetwhale-plugins/example/dev-preview/README.md
+++ b/jetwhale-plugins/example/dev-preview/README.md
@@ -7,7 +7,9 @@ plugin authors can edit UI code and see it reload **while the plugin's Compose s
 
 Unlike a bare composable preview, the harness:
 
-1. instantiates the real plugin via `ExampleHostPluginFactory().createPlugin()`, and
+1. **discovers the plugin from the classpath via `ServiceLoader<JetWhaleHostPluginFactory>`** — the
+   same `@AutoService` mechanism the host uses (so it works for any plugin on the classpath, not just
+   the example), and
 2. renders it through the SDK's `ContentRaw` entry point — the **same path the host uses**.
 
 The plugin's state (its event-log `SnapshotStateList`) lives inside the plugin instance held by
@@ -54,6 +56,25 @@ So Compose Hot Reload is **not** a drop-in for the installed-jar reload.
 A fully state-preserving reload of the *installed-jar* path would require approach B: a JVM agent
 calling `Instrumentation.redefineClasses` on the plugin's loaded classes plus Compose's internal
 reload hook — a separate, deeper spike.
+
+## Toward an external "dev-host" (for plugin authors outside this repo)
+
+This module proves the mechanism locally with project dependencies. The external-developer version
+would be a Gradle `hotdev` task that resolves a **published dev-host launcher** plus the developer's
+plugin module (as a source/compile dependency) and runs it under Compose Hot Reload on JBR.
+
+Publishing notes:
+
+- The host runs as a **binary dependency** — only the plugin needs to be a source/compile dependency
+  to be hot-reloadable. So we publish the host to make it *runnable*, not reloadable.
+- Prefer a **thin `dev-host` aggregator library** published as a normal jar (`api`-depending on the
+  required host modules). The consumer adds **one** dependency and Gradle resolves the rest as normal
+  jars, so the Compose/Kotlin runtime stays **shared** with the plugin module.
+- Avoid a **shaded fat jar**: relocating Compose/Kotlin/coroutines breaks CHR (the plugin's Compose
+  classes must match the host's), and a non-relocated bundle risks duplicate-class conflicts with the
+  plugin's own transitive dependencies.
+- `:jetwhale-host:app` is a Compose Desktop *application* (resources, packaging, DI graph), not a
+  library — a dedicated minimal `dev-host` launcher module is the thing to publish, not `app`.
 
 ## Limits to expect
 

--- a/jetwhale-plugins/example/dev-preview/README.md
+++ b/jetwhale-plugins/example/dev-preview/README.md
@@ -1,54 +1,66 @@
 # Example Plugin — Compose Hot Reload preview (PoC)
 
-A proof-of-concept harness that renders a JetWhale plugin's UI under **JetBrains Compose Hot
-Reload**, so plugin authors can edit UI code and see it reload **while Compose state is preserved**.
+A proof-of-concept that renders a **real** JetWhale plugin under JetBrains **Compose Hot Reload**, so
+plugin authors can edit UI code and see it reload **while the plugin's Compose state is preserved**.
 
-## Why this exists / how it differs from the runtime hot reload
+## What it actually exercises
 
-The host app's runtime hot reload (`PluginHotReloadService`) reloads a plugin by loading its **jar
-in a new classloader** and rebuilding the Compose scene — which **loses all plugin UI state**.
+Unlike a bare composable preview, the harness:
 
-Compose Hot Reload instead **redefines the loaded classes in place** (JetBrains Runtime / DCEVM) and
-recomposes, **preserving `remember` state**. But it only reloads classes on the **application
-classpath** — it does not target dynamically loaded plugin jars. So this harness puts the plugin on
-the classpath as a direct dependency (`:jetwhale-plugins:example:host`) and renders its
-`ExamplePluginView` directly.
+1. instantiates the real plugin via `ExampleHostPluginFactory().createPlugin()`, and
+2. renders it through the SDK's `ContentRaw` entry point — the **same path the host uses**.
+
+The plugin's state (its event-log `SnapshotStateList`) lives inside the plugin instance held by
+`main()`. So the test is meaningful: does the **plugin instance's own state** survive a hot reload of
+its UI code?
 
 ## Run it
 
-Requires the **JetBrains Runtime (JBR, Java 21)**. Compose Hot Reload provisions a compatible JBR via
-the foojay toolchain resolver (already configured in `settings.gradle.kts`). Compose Hot Reload ships
-bundled with Compose Multiplatform 1.11.1, so no extra plugin is needed.
+Requires the **JetBrains Runtime (JBR, Java 21)**; Compose Hot Reload provisions a compatible JBR via
+the foojay resolver (already configured in `settings.gradle.kts`). Compose Hot Reload ships bundled
+with Compose Multiplatform 1.11.1, so no extra plugin is needed.
 
 ```shell
 ./gradlew :jetwhale-plugins:example:dev-preview:hotRun --auto
 ```
 
-`--auto` enables Gradle continuous build, so saving a source file triggers a recompile + reload.
+Then:
+1. Click **"Send ping to debuggee"** a few times → entries are added to the plugin's event log.
+2. Edit `ExamplePluginView` in `:jetwhale-plugins:example:host` (e.g. change a label) and save.
+3. The UI updates with the new code **while the event log is preserved**.
 
-## What to verify
+## The important caveat: this is the *compile-dependency* path, not the jar path
 
-1. Click **"Send ping to debuggee"** a few times → the event log grows (this is the hoisted state).
-2. Edit `ExamplePluginView` in `:jetwhale-plugins:example:host` — e.g. change a button label or add a
-   `Text` — and save.
-3. The window updates with the new code **while the event log entries remain** (state preserved).
+This works only because the plugin is a **compile-time classpath dependency**, so Compose Hot Reload
+recompiles and redefines it like ordinary app code.
 
-## Known limits (what to expect)
+Production is different: the host loads plugins from external jars (`~/.jetwhale/plugins/*.jar`) via
+**isolated child classloaders** at runtime. Compose Hot Reload **cannot reach those**, because:
+
+- its **continuous build recompiles the modules in the Gradle build**, not a plugin that is only
+  present as a prebuilt jar at runtime; and
+- its class redefinition targets classes on the **application (hot) classpath**, not classes loaded
+  by an unrelated child classloader from an external jar.
+
+So Compose Hot Reload is **not** a drop-in for the installed-jar reload.
+
+## Recommended end state: hybrid
+
+- **Plugin UI development** → develop the plugin as a compile dependency under Compose Hot Reload
+  (this harness), getting state-preserving reloads.
+- **Installed-jar workflow** → keep the classloader-based reload (loses state, but handles any change
+  including new jars/dependencies) as the fallback.
+
+A fully state-preserving reload of the *installed-jar* path would require approach B: a JVM agent
+calling `Instrumentation.redefineClasses` on the plugin's loaded classes plus Compose's internal
+reload hook — a separate, deeper spike.
+
+## Limits to expect
 
 - **Requires JBR** to run; on a stock JDK only method-body changes redefine.
-- Method-body changes and (on JBR) adding/removing methods/fields reload fine; **changing a class's
-  supertype or adding brand-new top-level classes/files** generally cannot be redefined.
-- Restructuring a `@Composable` (changing the group structure) can reset the affected `remember`ed
-  state.
-- One plugin at a time (it is a direct classpath dependency here).
+- Adding/removing methods/fields works on JBR; **changing a supertype or adding new top-level
+  classes/files** generally cannot be redefined.
+- Restructuring a `@Composable` (changing its group structure) can reset the affected state.
 
-## Relationship to the production plugin model
-
-Production loads plugins from external jars via isolated classloaders, which Compose Hot Reload does
-not cover. The recommended end state is a **hybrid**: use this state-preserving reload during UI
-development, and keep the classloader-based reload (state lost, but handles any change including new
-jars/dependencies) as the fallback for the installed-jar workflow.
-
-> Status: PoC. The setup compiles and the `hotRun`/`reload` tasks are available; the actual
-> state-preserving reload behavior must be confirmed on a machine with the JetBrains Runtime (the GUI
-> could not be run in CI).
+> Status: PoC. Compiles and the `hotRun` / `reload` tasks are available; the actual
+> state-preserving reload must be confirmed on a machine with the JetBrains Runtime (no GUI in CI).

--- a/jetwhale-plugins/example/dev-preview/build.gradle.kts
+++ b/jetwhale-plugins/example/dev-preview/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    alias(libs.plugins.jvm)
+    alias(libs.plugins.compose)
+}
+
+// Compose Hot Reload PoC: a tiny Compose Desktop harness that renders the example plugin's UI so it
+// can be hot-reloaded with state preserved. Run on JetBrains Runtime:
+//   ./gradlew :jetwhale-plugins:example:dev-preview:hotRun --auto
+// then edit ExamplePluginView and save. See README.md in this module.
+compose.desktop {
+    application {
+        mainClass = "com.kitakkun.jetwhale.plugins.example.devpreview.MainKt"
+    }
+}
+
+dependencies {
+    implementation(projects.jetwhalePlugins.example.host)
+    implementation(projects.jetwhaleHostSdk)
+    implementation(libs.kotlinxCoroutinesCore)
+}

--- a/jetwhale-plugins/example/dev-preview/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/devpreview/Main.kt
+++ b/jetwhale-plugins/example/dev-preview/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/devpreview/Main.kt
@@ -1,35 +1,48 @@
 package com.kitakkun.jetwhale.plugins.example.devpreview
 
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.window.singleWindowApplication
-import com.kitakkun.jetwhale.plugins.example.host.ExamplePluginView
+import com.kitakkun.jetwhale.host.sdk.JetWhaleRawDebugOperationContext
+import com.kitakkun.jetwhale.plugins.example.host.ExampleHostPluginFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 /**
- * Compose Hot Reload PoC harness for a JetWhale plugin's UI.
+ * Compose Hot Reload PoC harness that exercises the *real* plugin rendering path.
  *
- * This renders the example plugin's [ExamplePluginView] directly on the application classpath (not
- * via a loaded jar / separate classloader), so JetBrains Compose Hot Reload can redefine the
- * plugin's classes in place and recompose while preserving Compose state.
+ * Unlike a bare composable preview, this instantiates the actual plugin via its
+ * [com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory] and renders it through the SDK's
+ * `ContentRaw` entry point — the same path the host uses. The plugin's own state (its event log
+ * `SnapshotStateList`) lives inside the plugin instance held by [main], so we can observe whether it
+ * survives a hot reload of the plugin's UI code.
  *
- * Run on the JetBrains Runtime (see this module's README):
+ * Run on the JetBrains Runtime (see README):
  *   ./gradlew :jetwhale-plugins:example:dev-preview:hotRun --auto
- * Add a few log entries, then edit [ExamplePluginView] (e.g. change a button label) and save: the UI
- * updates while the `eventLogs` state below is preserved.
  *
- * Note: `DevelopmentEntryPoint` (from `org.jetbrains.compose.hot-reload:runtime-api`) can wrap the
- * content to scope reloads, but is not required — `hotRun` reloads the whole window composition.
+ * Then: click "Send ping" a few times (entries are added to the plugin's event log), edit
+ * `ExamplePluginView` in `:jetwhale-plugins:example:host` and save. The UI updates with the new code
+ * while the plugin instance — and its event log — is preserved.
+ *
+ * Caveat (the point of the PoC): this works because the plugin is a *compile-time classpath
+ * dependency*, so Compose Hot Reload recompiles and redefines it like app code. It does NOT cover
+ * the production model, where plugins are loaded from external jars via isolated classloaders — see
+ * README for why CHR cannot reach those and what the hybrid end state is.
  */
-fun main() = singleWindowApplication(title = "Example Plugin — Hot Reload Preview") {
-    MaterialTheme {
-        // State intentionally hoisted here (outside the reloaded composable) so we can observe that
-        // it survives a hot reload of ExamplePluginView.
-        val eventLogs = remember { mutableStateListOf<String>() }
-        ExamplePluginView(
-            eventLogs = eventLogs,
-            onClickSendPing = { eventLogs.add("ping #${eventLogs.size + 1}") },
-            onClickTriggerUIError = { eventLogs.add("error button clicked") },
-        )
+fun main() {
+    // Created once and kept alive across reloads; the plugin's state lives in this instance, exactly
+    // as it does inside the host.
+    val plugin = ExampleHostPluginFactory().createPlugin()
+
+    val context = object : JetWhaleRawDebugOperationContext {
+        override val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+
+        // No debuggee is attached in this harness, so method dispatch is a no-op.
+        override suspend fun dispatch(method: String): String? = null
+    }
+
+    singleWindowApplication(title = "Example Plugin — Hot Reload Preview") {
+        MaterialTheme {
+            plugin.ContentRaw(context)
+        }
     }
 }

--- a/jetwhale-plugins/example/dev-preview/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/devpreview/Main.kt
+++ b/jetwhale-plugins/example/dev-preview/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/devpreview/Main.kt
@@ -2,36 +2,38 @@ package com.kitakkun.jetwhale.plugins.example.devpreview
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.window.singleWindowApplication
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleRawDebugOperationContext
-import com.kitakkun.jetwhale.plugins.example.host.ExampleHostPluginFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import java.util.ServiceLoader
 
 /**
- * Compose Hot Reload PoC harness that exercises the *real* plugin rendering path.
+ * Compose Hot Reload "dev-host" spike.
  *
- * Unlike a bare composable preview, this instantiates the actual plugin via its
- * [com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory] and renders it through the SDK's
- * `ContentRaw` entry point — the same path the host uses. The plugin's own state (its event log
- * `SnapshotStateList`) lives inside the plugin instance held by [main], so we can observe whether it
- * survives a hot reload of the plugin's UI code.
+ * Instead of loading a plugin from an external jar via a child classloader (the production model,
+ * which Compose Hot Reload cannot reach), this discovers the plugin from the **application
+ * classpath** via [ServiceLoader] — the same `@AutoService(JetWhaleHostPluginFactory::class)`
+ * mechanism the host uses — and renders it through the SDK's `ContentRaw` entry point.
  *
- * Run on the JetBrains Runtime (see README):
+ * Because the plugin is a compile-time classpath dependency here, Compose Hot Reload can redefine it
+ * in place and recompose while preserving the plugin instance's state.
+ *
+ * This is the local proof of the "dev-host" approach: a plain dev JetWhale that finds plugins on its
+ * classpath and runs under CHR. The external-developer version would resolve a published dev-host
+ * launcher + the developer's plugin module via a Gradle `hotdev` task (see README).
+ *
+ * Run on the JetBrains Runtime:
  *   ./gradlew :jetwhale-plugins:example:dev-preview:hotRun --auto
- *
- * Then: click "Send ping" a few times (entries are added to the plugin's event log), edit
- * `ExamplePluginView` in `:jetwhale-plugins:example:host` and save. The UI updates with the new code
- * while the plugin instance — and its event log — is preserved.
- *
- * Caveat (the point of the PoC): this works because the plugin is a *compile-time classpath
- * dependency*, so Compose Hot Reload recompiles and redefines it like app code. It does NOT cover
- * the production model, where plugins are loaded from external jars via isolated classloaders — see
- * README for why CHR cannot reach those and what the hybrid end state is.
  */
 fun main() {
-    // Created once and kept alive across reloads; the plugin's state lives in this instance, exactly
-    // as it does inside the host.
-    val plugin = ExampleHostPluginFactory().createPlugin()
+    // Discover the plugin the same way the host does: ServiceLoader over the classpath. Whatever
+    // plugin module is on this app's classpath is picked up; here it is :jetwhale-plugins:example:host.
+    val factory = ServiceLoader.load(JetWhaleHostPluginFactory::class.java).firstOrNull()
+        ?: error("No JetWhaleHostPluginFactory found on the classpath")
+
+    // Created once and kept alive across reloads; the plugin's state lives in this instance.
+    val plugin = factory.createPlugin()
 
     val context = object : JetWhaleRawDebugOperationContext {
         override val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
@@ -40,7 +42,7 @@ fun main() {
         override suspend fun dispatch(method: String): String? = null
     }
 
-    singleWindowApplication(title = "Example Plugin — Hot Reload Preview") {
+    singleWindowApplication(title = "JetWhale dev-host — Hot Reload Preview") {
         MaterialTheme {
             plugin.ContentRaw(context)
         }

--- a/jetwhale-plugins/example/dev-preview/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/devpreview/Main.kt
+++ b/jetwhale-plugins/example/dev-preview/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/devpreview/Main.kt
@@ -1,0 +1,35 @@
+package com.kitakkun.jetwhale.plugins.example.devpreview
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.window.singleWindowApplication
+import com.kitakkun.jetwhale.plugins.example.host.ExamplePluginView
+
+/**
+ * Compose Hot Reload PoC harness for a JetWhale plugin's UI.
+ *
+ * This renders the example plugin's [ExamplePluginView] directly on the application classpath (not
+ * via a loaded jar / separate classloader), so JetBrains Compose Hot Reload can redefine the
+ * plugin's classes in place and recompose while preserving Compose state.
+ *
+ * Run on the JetBrains Runtime (see this module's README):
+ *   ./gradlew :jetwhale-plugins:example:dev-preview:hotRun --auto
+ * Add a few log entries, then edit [ExamplePluginView] (e.g. change a button label) and save: the UI
+ * updates while the `eventLogs` state below is preserved.
+ *
+ * Note: `DevelopmentEntryPoint` (from `org.jetbrains.compose.hot-reload:runtime-api`) can wrap the
+ * content to scope reloads, but is not required — `hotRun` reloads the whole window composition.
+ */
+fun main() = singleWindowApplication(title = "Example Plugin — Hot Reload Preview") {
+    MaterialTheme {
+        // State intentionally hoisted here (outside the reloaded composable) so we can observe that
+        // it survives a hot reload of ExamplePluginView.
+        val eventLogs = remember { mutableStateListOf<String>() }
+        ExamplePluginView(
+            eventLogs = eventLogs,
+            onClickSendPing = { eventLogs.add("ping #${eventLogs.size + 1}") },
+            onClickTriggerUIError = { eventLogs.add("error button clicked") },
+        )
+    }
+}

--- a/jetwhale-plugins/example/dev-preview/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/devpreview/Main.kt
+++ b/jetwhale-plugins/example/dev-preview/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/devpreview/Main.kt
@@ -1,50 +1,13 @@
 package com.kitakkun.jetwhale.plugins.example.devpreview
 
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.ui.window.singleWindowApplication
-import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
-import com.kitakkun.jetwhale.host.sdk.JetWhaleRawDebugOperationContext
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import java.util.ServiceLoader
-
 /**
- * Compose Hot Reload "dev-host" spike.
+ * Entry point for the dev-host hot reload spike.
  *
- * Instead of loading a plugin from an external jar via a child classloader (the production model,
- * which Compose Hot Reload cannot reach), this discovers the plugin from the **application
- * classpath** via [ServiceLoader] — the same `@AutoService(JetWhaleHostPluginFactory::class)`
- * mechanism the host uses — and renders it through the SDK's `ContentRaw` entry point.
- *
- * Because the plugin is a compile-time classpath dependency here, Compose Hot Reload can redefine it
- * in place and recompose while preserving the plugin instance's state.
- *
- * This is the local proof of the "dev-host" approach: a plain dev JetWhale that finds plugins on its
- * classpath and runs under CHR. The external-developer version would resolve a published dev-host
- * launcher + the developer's plugin module via a Gradle `hotdev` task (see README).
+ * This deliberately mirrors what a plugin author's own module would contain: a one-line `main` that
+ * delegates to the (future, published) [launchJetWhaleDevHost] launcher. The plugin to develop is
+ * picked up from this module's classpath dependency (`:jetwhale-plugins:example:host`).
  *
  * Run on the JetBrains Runtime:
  *   ./gradlew :jetwhale-plugins:example:dev-preview:hotRun --auto
  */
-fun main() {
-    // Discover the plugin the same way the host does: ServiceLoader over the classpath. Whatever
-    // plugin module is on this app's classpath is picked up; here it is :jetwhale-plugins:example:host.
-    val factory = ServiceLoader.load(JetWhaleHostPluginFactory::class.java).firstOrNull()
-        ?: error("No JetWhaleHostPluginFactory found on the classpath")
-
-    // Created once and kept alive across reloads; the plugin's state lives in this instance.
-    val plugin = factory.createPlugin()
-
-    val context = object : JetWhaleRawDebugOperationContext {
-        override val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
-
-        // No debuggee is attached in this harness, so method dispatch is a no-op.
-        override suspend fun dispatch(method: String): String? = null
-    }
-
-    singleWindowApplication(title = "JetWhale dev-host — Hot Reload Preview") {
-        MaterialTheme {
-            plugin.ContentRaw(context)
-        }
-    }
-}
+fun main() = launchJetWhaleDevHost()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,6 +45,7 @@ include(":jetwhale-host:feature:plugin")
 include(":jetwhale-plugins:example:host")
 include(":jetwhale-plugins:example:protocol")
 include(":jetwhale-plugins:example:agent")
+include(":jetwhale-plugins:example:dev-preview")
 
 include(":test-annotations")
 


### PR DESCRIPTION
## Goal

Verify (and start implementing) **state-preserving** plugin hot reload using JetBrains **Compose Hot Reload** — the runtime classloader reload loses all plugin UI state.

## What's here

A new `:jetwhale-plugins:example:dev-preview` Compose Desktop harness that renders the example plugin's `ExamplePluginView` **directly on the application classpath** (not via a loaded jar / separate classloader). That is the key: Compose Hot Reload redefines loaded classes in place (JBR/DCEVM) and recomposes while preserving `remember` state, but it only targets app-classpath classes — not dynamically loaded plugin jars.

- `build.gradle.kts` — Kotlin/JVM + the `compose` convention; `compose.desktop.application.mainClass` set.
- `Main.kt` — `singleWindowApplication { MaterialTheme { ExamplePluginView(eventLogs = remember { ... }, ...) } }`, with the state hoisted so it's observable across reloads.
- `README.md` — run/verify steps, limits, and the hybrid end state.

## Findings

- Compose Multiplatform **1.11.1 bundles** Compose Hot Reload — `hotRun` / `hotReloadMain` / `reload` tasks appear **with no extra plugin**. Confirmed via `:dev-preview:tasks`.
- Requires the **JetBrains Runtime (Java 21)**; CHR provisions it via the foojay resolver (already configured). Kotlin 2.4.0 is compatible.
- `DevelopmentEntryPoint` (runtime-api) is optional and not on the classpath by default; omitted (whole-window reload covers the PoC).

## How to run

```shell
./gradlew :jetwhale-plugins:example:dev-preview:hotRun --auto
```
Add log entries → edit `ExamplePluginView` → save → UI updates while `eventLogs` is preserved.

## Status / scope

- ✅ Compiles; CHR tasks configured.
- ⚠️ **Actual state-preserving reload not run** (needs JBR + GUI, unavailable in CI) — please verify locally.
- Out of scope: applying this to the **installed-jar** path (separate classloaders) — recommended end state is a hybrid (CHR for UI dev, classloader reload as fallback). Branched from `main`, independent of the network/hot-reload PRs.