### PR TITLE
fix: migrate retained state to Compose retain

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ material3Adaptive = "1.3.0-alpha07"
 navigation3 = "1.1.1"
 lifecycle = "2.11.0-beta01"
 soil = "1.0.0-alpha15"
-rin = "0.4.0"
 
 androidxDatastore = "1.2.1"
 metro = "1.1.1"
@@ -70,7 +69,6 @@ jetbrainsComposePreview = { module = "org.jetbrains.compose.ui:ui-tooling-previe
 jetbrainsComposeResources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "jetbrainsCompose" }
 jetbrainsComposeMaterialIconsExtended = { module = "org.jetbrains.compose.material:material-icons-extended", version = "1.7.3" }
 material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
-rin = { module = "io.github.takahirom.rin:rin", version.ref = "rin" }
 
 # navigation3
 navigation3Ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }

--- a/jetwhale-host/app/build.gradle.kts
+++ b/jetwhale-host/app/build.gradle.kts
@@ -103,7 +103,6 @@ dependencies {
     implementation(libs.kotlinxCollectionsImmutable)
     implementation(libs.soilQueryCompose)
     implementation(libs.androidxDatastorePreferences)
-    implementation(libs.rin)
     implementation(libs.material3)
     implementation(libs.aboutLibrariesCore)
 

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.host
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.retain.retain
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.savedstate.serialization.SavedStateConfiguration
@@ -21,7 +22,6 @@ import com.kitakkun.jetwhale.host.navigation.addSingleTop
 import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
 import com.kitakkun.jetwhale.host.ui.AppEnvironment
 import com.kitakkun.jetwhale.host.ui.JetWhaleTheme
-import io.github.takahirom.rin.rememberRetained
 import kotlinx.serialization.modules.SerializersModule
 import soil.query.compose.SwrClientProvider
 import soil.query.compose.rememberSubscription
@@ -92,7 +92,7 @@ fun JetWhaleApp() {
                 JetWhaleTheme(theme.colorScheme) {
                     AppEnvironment(settings.appLanguage) {
                         Surface {
-                            context(rememberRetained { appGraph.toolingScaffoldScreenContext }) {
+                            context(retain { appGraph.toolingScaffoldScreenContext }) {
                                 ToolingScaffoldRoot(
                                     onClickSettings = { backStack.addSingleTop(SettingsNavKey()) },
                                     onClickPluginSettings = {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ExpandedToolingDrawerView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ExpandedToolingDrawerView.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.retain.retain
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,7 +46,6 @@ import com.kitakkun.jetwhale.host.plugins
 import com.kitakkun.jetwhale.host.popout
 import com.kitakkun.jetwhale.host.puzzle_outlined
 import com.kitakkun.jetwhale.host.unavailable_plugins
-import io.github.takahirom.rin.rememberRetained
 import kotlinx.collections.immutable.ImmutableList
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -131,9 +131,9 @@ fun ExpandedToolingDrawerView(
                 }
 
                 else -> {
-                    var enabledPluginsExpanded by rememberRetained { mutableStateOf(true) }
-                    var disabledPluginsExpanded by rememberRetained { mutableStateOf(true) }
-                    var unavailablePluginsExpanded by rememberRetained { mutableStateOf(true) }
+                    var enabledPluginsExpanded by retain { mutableStateOf(true) }
+                    var disabledPluginsExpanded by retain { mutableStateOf(true) }
+                    var unavailablePluginsExpanded by retain { mutableStateOf(true) }
 
                     val enabledPlugins = remember(plugins) { plugins.filter { it.pluginAvailability == PluginAvailability.Enabled } }
                     val disabledPlugins = remember(plugins) { plugins.filter { it.pluginAvailability == PluginAvailability.Disabled } }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.retain.retain
 import androidx.compose.runtime.setValue
 import com.kitakkun.jetwhale.host.architecture.ActionEffect
 import com.kitakkun.jetwhale.host.architecture.MutationErrorEffect
@@ -14,7 +15,6 @@ import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.PluginAvailability
 import com.kitakkun.jetwhale.host.model.PluginMetaData
 import com.kitakkun.jetwhale.host.model.SetPluginEnabledParams
-import io.github.takahirom.rin.rememberRetained
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import soil.query.compose.rememberMutation
@@ -39,8 +39,8 @@ fun toolingScaffoldPresenter(
     enabledPluginIds: Set<String>,
     hasFailedJars: Boolean,
 ): ToolingScaffoldUiState {
-    var selectedSessionId by rememberRetained { mutableStateOf("") }
-    var selectedPluginId by rememberRetained { mutableStateOf("") }
+    var selectedSessionId by retain { mutableStateOf("") }
+    var selectedPluginId by retain { mutableStateOf("") }
     val selectedSession by remember(debugSessions, selectedSessionId) {
         derivedStateOf { debugSessions.firstOrNull { it.id == selectedSessionId } }
     }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavDisplay.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavDisplay.kt
@@ -51,6 +51,7 @@ fun JetWhaleNavDisplay(
         },
         entryDecorators = listOf(
             rememberSaveableStateHolderNavEntryDecorator(),
+            rememberRetainedNavEntryDecorator(),
             rememberViewModelStoreNavEntryDecorator(),
         ),
         entryProvider = entryProvider {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavEntries.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavEntries.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.retain.retain
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -22,7 +23,6 @@ import com.kitakkun.jetwhale.host.screen.InfoScreen
 import com.kitakkun.jetwhale.host.settings.SettingsScreenRoot
 import com.kitakkun.jetwhale.host.settings.licenses.LicensesScreenRoot
 import com.kitakkun.jetwhale.host.settings.logviewer.LogViewerScreenRoot
-import io.github.takahirom.rin.rememberRetained
 import org.jetbrains.compose.resources.stringResource
 
 fun EntryProviderScope<NavKey>.infoEntry(
@@ -50,7 +50,7 @@ fun EntryProviderScope<NavKey>.pluginEntries(
 ) {
     entry<PluginNavKey> { navKey ->
         context(
-            rememberRetained {
+            retain {
                 appGraph.pluginScreenContextFactory.create(
                     pluginId = navKey.pluginId,
                     sessionId = navKey.sessionId,
@@ -83,7 +83,7 @@ fun EntryProviderScope<NavKey>.pluginEntries(
         }
 
         context(
-            rememberRetained {
+            retain {
                 appGraph.pluginScreenContextFactory.create(
                     pluginId = navKey.pluginId,
                     sessionId = navKey.sessionId,
@@ -123,7 +123,7 @@ fun EntryProviderScope<NavKey>.settingsEntry(
         ),
     ) { navKey ->
         context(
-            rememberRetained {
+            retain {
                 appGraph.settingsScreenContext
             },
         ) {
@@ -148,7 +148,7 @@ fun EntryProviderScope<NavKey>.licensesEntry(
         ),
     ) {
         context(
-            rememberRetained {
+            retain {
                 appGraph.licensesScreenContext
             },
         ) {
@@ -177,7 +177,7 @@ fun EntryProviderScope<NavKey>.logViewerEntry() {
         }
 
         context(
-            rememberRetained {
+            retain {
                 appGraph.settingsScreenContext
             },
         ) {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/RetainedNavEntryDecorator.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/RetainedNavEntryDecorator.kt
@@ -1,0 +1,26 @@
+package com.kitakkun.jetwhale.host.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.retain.RetainedValuesStoreRegistry
+import androidx.compose.runtime.retain.retainRetainedValuesStoreRegistry
+import androidx.navigation3.runtime.NavEntryDecorator
+
+@Composable
+fun <T : Any> rememberRetainedNavEntryDecorator(): NavEntryDecorator<T> {
+    val registry = retainRetainedValuesStoreRegistry()
+    return remember(registry) { RetainedNavEntryDecorator(registry) }
+}
+
+private class RetainedNavEntryDecorator<T : Any>(
+    private val registry: RetainedValuesStoreRegistry,
+) : NavEntryDecorator<T>(
+    decorate = { entry ->
+        registry.LocalRetainedValuesStoreProvider(entry.contentKey) {
+            entry.Content()
+        }
+    },
+    onPop = { contentKey ->
+        registry.clearChild(contentKey)
+    },
+)

--- a/jetwhale-host/feature/settings/build.gradle.kts
+++ b/jetwhale-host/feature/settings/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
     implementation(projects.jetwhaleHost.core.architecture)
     implementation(libs.kotlinxCollectionsImmutable)
     implementation(libs.kotlinxDatetime)
-    implementation(libs.rin)
     implementation(libs.aboutLibrariesComposeM3)
 }
 

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldPresenter.kt
@@ -3,10 +3,10 @@ package com.kitakkun.jetwhale.host.settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.retain.retain
 import androidx.compose.runtime.setValue
 import com.kitakkun.jetwhale.host.architecture.ActionEffect
 import com.kitakkun.jetwhale.host.architecture.ScreenChannel
-import io.github.takahirom.rin.rememberRetained
 
 sealed interface SettingsScreenScaffoldAction {
     data class SelectMenu(val menu: SettingsScreenSegmentedMenu) : SettingsScreenScaffoldAction
@@ -18,7 +18,7 @@ fun settingsScreenScaffoldPresenter(
     screenChannel: ScreenChannel<SettingsScreenScaffoldAction, Nothing>,
     initialMenu: SettingsScreenSegmentedMenu,
 ): SettingsScreenScaffoldUiState {
-    var selectedMenu by rememberRetained { mutableStateOf(initialMenu) }
+    var selectedMenu by retain { mutableStateOf(initialMenu) }
 
     ActionEffect(screenChannel) { action ->
         when (action) {


### PR DESCRIPTION
## Overview

Migrate the navigation retained state from a custom implementation to Compose's `retain` API.

## Changes

- Add `RetainedNavEntryDecorator` to manage NavEntry retained state via Compose retain
- Adjust the `JetWhaleApp`, drawer, and settings presenters/views to the retain-based approach
- Remove dependencies that are no longer needed (`gradle/libs.versions.toml`, the affected `build.gradle.kts` files)

## Diff

10 files changed, 44 insertions(+), 21 deletions(-)