### PR TITLE
feat(host): state-preserving plugin hot reload (in-place class redefinition)

### DIFF
--- a/gradle-conventions/src/main/kotlin/jetwhale-plugin.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-plugin.gradle.kts
@@ -106,7 +106,12 @@ tasks.register<JavaExec>("runJetWhale") {
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
-            listOf("-Djetwhale.devPluginsDir=${devDirProvider.get()}")
+            listOf(
+                "-Djetwhale.devPluginsDir=${devDirProvider.get()}",
+                // Allow the dev hot-reload to self-attach a JVM agent (byte-buddy-agent) for in-place
+                // class redefinition; self-attach is disabled by default on JDK 9+.
+                "-Djdk.attach.allowAttachSelf=true",
+            )
         },
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kotlinxSerializationJson = "1.11.0"
 kotlinxCollectionsImmutable = "0.4.0"
 kotlinxCoroutines = "1.11.0"
 byteBuddy = "1.15.11"
+asm = "9.7.1"
 kotlinxDatetime = "0.8.0"
 
 # android
@@ -58,6 +59,7 @@ kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serializati
 kotlinxCollectionsImmutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 byteBuddyAgent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "byteBuddy" }
+asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 kotlinxDatetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 
 # androidx

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ kotlinDsl = "6.5.7"
 kotlinxSerializationJson = "1.11.0"
 kotlinxCollectionsImmutable = "0.4.0"
 kotlinxCoroutines = "1.11.0"
+byteBuddy = "1.15.11"
 kotlinxDatetime = "0.8.0"
 
 # android
@@ -56,6 +57,7 @@ kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotli
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinxCollectionsImmutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+byteBuddyAgent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "byteBuddy" }
 kotlinxDatetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 
 # androidx

--- a/jetwhale-host/core/data/build.gradle.kts
+++ b/jetwhale-host/core/data/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
     // Used in dev hot-reload to obtain a JVM Instrumentation handle (self-attach) for in-place class
     // redefinition. Dormant in production: only touched when the dev plugins directory is configured.
     implementation(libs.byteBuddyAgent)
+    // Reads @FunctionKeyMeta (BINARY-retention) group keys from redefined plugin bytecode so the
+    // dev hot-reload can invalidate exactly those Compose groups (state-preserving reload).
+    implementation(libs.asm)
     implementation(libs.bundles.ktorServer)
     implementation(libs.logbackClassic)
     implementation(libs.kotlinTest)

--- a/jetwhale-host/core/data/build.gradle.kts
+++ b/jetwhale-host/core/data/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     implementation(libs.androidxDatastorePreferences)
 
     implementation(libs.kotlinxSerializationJson)
+    // Used in dev hot-reload to obtain a JVM Instrumentation handle (self-attach) for in-place class
+    // redefinition. Dormant in production: only touched when the dev plugins directory is configured.
+    implementation(libs.byteBuddyAgent)
     implementation(libs.bundles.ktorServer)
     implementation(libs.logbackClassic)
     implementation(libs.kotlinTest)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -17,9 +17,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.serialization.json.Json
+import net.bytebuddy.agent.ByteBuddyAgent
+import java.lang.instrument.ClassDefinition
+import java.lang.instrument.Instrumentation
 import java.net.URLClassLoader
 import java.util.ServiceLoader
 import java.util.concurrent.ConcurrentHashMap
+import java.util.jar.JarFile
 import kotlin.io.path.Path
 
 @Inject
@@ -120,6 +124,47 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
         // reload (don't report stale success from a leftover jarPathToPluginId mapping).
         if (pluginJarPath in mutableFailedJarPathsFlow.value) return null
         return jarPathToPluginId[pluginJarPath]
+    }
+
+    override fun tryRedefinePlugin(pluginJarPath: String): String? {
+        val instrumentation = instrumentation ?: return null
+        val pluginId = jarPathToPluginId[pluginJarPath] ?: return null
+        val classLoader = classLoaders[pluginId] ?: return null
+
+        return try {
+            // Redefine every class this plugin's classloader has already loaded, using the rebuilt
+            // jar's bytecode. redefineClasses works on the loaded Class regardless of classloader, so
+            // this reaches the plugin's child-classloader classes (which Compose Hot Reload cannot).
+            val loadedClasses = instrumentation.allLoadedClasses.filter { it.classLoader === classLoader }
+            if (loadedClasses.isEmpty()) return null
+
+            val definitions = JarFile(pluginJarPath).use { jar ->
+                loadedClasses.mapNotNull { clazz ->
+                    val entry = jar.getJarEntry(clazz.name.replace('.', '/') + ".class") ?: return@mapNotNull null
+                    val bytes = jar.getInputStream(entry).use { it.readBytes() }
+                    ClassDefinition(clazz, bytes)
+                }
+            }
+            if (definitions.isEmpty()) return null
+
+            instrumentation.redefineClasses(*definitions.toTypedArray())
+            pluginId
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // UnsupportedOperationException (structural change without an enhanced runtime),
+            // LinkageError, etc. The caller falls back to a full reload.
+            println("In-place redefine failed for $pluginId: ${e.message}; falling back to full reload")
+            null
+        }
+    }
+
+    /**
+     * JVM Instrumentation handle, obtained lazily by self-attaching an agent the first time an
+     * in-place redefine is attempted (dev hot-reload only). Null if the agent cannot be installed.
+     */
+    private val instrumentation: Instrumentation? by lazy {
+        runCatching { ByteBuddyAgent.install() }.getOrNull()
     }
 
     companion object {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -2,6 +2,7 @@ package com.kitakkun.jetwhale.host.data.plugin
 
 import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
 import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.RedefinedPlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifest
 import dev.zacsweers.metro.AppScope
@@ -18,6 +19,11 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.serialization.json.Json
 import net.bytebuddy.agent.ByteBuddyAgent
+import org.objectweb.asm.AnnotationVisitor
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
 import java.io.File
 import java.lang.instrument.ClassDefinition
 import java.lang.instrument.Instrumentation
@@ -146,7 +152,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
         return jarPathToPluginId[pluginJarPath]
     }
 
-    override fun tryRedefinePlugin(pluginJarPath: String): String? {
+    override fun tryRedefinePlugin(pluginJarPath: String): RedefinedPlugin? {
         val instrumentation = instrumentation ?: return null
         val pluginId = jarPathToPluginId[pluginJarPath] ?: return null
         val classLoader = classLoaders[pluginId] ?: return null
@@ -158,17 +164,21 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             val loadedClasses = instrumentation.allLoadedClasses.filter { it.classLoader === classLoader }
             if (loadedClasses.isEmpty()) return null
 
+            val composableGroupKeys = mutableSetOf<Int>()
             val definitions = JarFile(pluginJarPath).use { jar ->
                 loadedClasses.mapNotNull { clazz ->
                     val entry = jar.getJarEntry(clazz.name.replace('.', '/') + ".class") ?: return@mapNotNull null
                     val bytes = jar.getInputStream(entry).use { it.readBytes() }
+                    // Collect the @Composable group keys so the caller can invalidate exactly those
+                    // groups for a state-preserving recompose.
+                    composableGroupKeys += readFunctionKeyMetaKeys(bytes)
                     ClassDefinition(clazz, bytes)
                 }
             }
             if (definitions.isEmpty()) return null
 
             instrumentation.redefineClasses(*definitions.toTypedArray())
-            pluginId
+            RedefinedPlugin(pluginId = pluginId, composableGroupKeys = composableGroupKeys.toList())
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
@@ -177,6 +187,55 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             println("In-place redefine failed for $pluginId: ${e.message}; falling back to full reload")
             null
         }
+    }
+
+    /**
+     * Reads the Compose group keys from every `@FunctionKeyMeta(key, ...)` in [classBytes] (on the
+     * class and its methods). The annotation has BINARY retention, so it is read from the bytecode
+     * with ASM rather than reflection. Kotlin's `@Repeatable` stores multiples in a `$Container`.
+     */
+    private fun readFunctionKeyMetaKeys(classBytes: ByteArray): Set<Int> {
+        val keys = mutableSetOf<Int>()
+        val keyReader = object : AnnotationVisitor(Opcodes.ASM9) {
+            override fun visit(name: String?, value: Any?) {
+                if (name == "key" && value is Int) keys += value
+            }
+        }
+        fun visitorFor(descriptor: String?): AnnotationVisitor? = when (descriptor) {
+            FUNCTION_KEY_META_DESC -> keyReader
+
+            FUNCTION_KEY_META_CONTAINER_DESC -> object : AnnotationVisitor(Opcodes.ASM9) {
+                override fun visitArray(name: String?): AnnotationVisitor? = if (name == "value") {
+                    object : AnnotationVisitor(Opcodes.ASM9) {
+                        override fun visitAnnotation(name: String?, descriptor: String?): AnnotationVisitor? = if (descriptor == FUNCTION_KEY_META_DESC) keyReader else null
+                    }
+                } else {
+                    null
+                }
+            }
+
+            else -> null
+        }
+        val classVisitor = object : ClassVisitor(Opcodes.ASM9) {
+            override fun visitAnnotation(descriptor: String?, visible: Boolean): AnnotationVisitor? = visitorFor(descriptor)
+
+            override fun visitMethod(
+                access: Int,
+                name: String?,
+                descriptor: String?,
+                signature: String?,
+                exceptions: Array<out String>?,
+            ): MethodVisitor = object : MethodVisitor(Opcodes.ASM9) {
+                override fun visitAnnotation(descriptor: String?, visible: Boolean): AnnotationVisitor? = visitorFor(descriptor)
+            }
+        }
+        runCatching {
+            ClassReader(classBytes).accept(
+                classVisitor,
+                ClassReader.SKIP_CODE or ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES,
+            )
+        }
+        return keys
     }
 
     /**
@@ -190,5 +249,9 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
     companion object {
         private const val MANIFEST_PATH = "META-INF/jetwhale/plugin-manifest.json"
         private val pluginManifestJson = Json { ignoreUnknownKeys = true }
+
+        private const val FUNCTION_KEY_META_DESC = "Landroidx/compose/runtime/internal/FunctionKeyMeta;"
+        private const val FUNCTION_KEY_META_CONTAINER_DESC =
+            "Landroidx/compose/runtime/internal/FunctionKeyMeta\$Container;"
     }
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.serialization.json.Json
 import net.bytebuddy.agent.ByteBuddyAgent
+import java.io.File
 import java.lang.instrument.ClassDefinition
 import java.lang.instrument.Instrumentation
 import java.net.URLClassLoader
@@ -48,9 +49,21 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
     /** Maps the absolute jar path a plugin was loaded from to its `pluginId`. */
     private val jarPathToPluginId: ConcurrentHashMap<String, String> = ConcurrentHashMap()
 
+    /**
+     * Private per-plugin copy of the jar that each classloader actually opens, keyed by `pluginId`.
+     * Loading from a copy lets the source (dev) jar be overwritten without corrupting the running
+     * classloader's open zip handle. Deleted when the plugin is replaced or unloaded.
+     */
+    private val runtimeJars: ConcurrentHashMap<String, File> = ConcurrentHashMap()
+
     override suspend fun loadPlugin(pluginJarPath: String) {
         try {
-            val classLoader = URLClassLoader(arrayOf(Path(pluginJarPath).toUri().toURL()))
+            // Open the classloader on a private copy of the jar so the source jar can be overwritten
+            // (e.g. by dev hot-reload restaging) without corrupting this classloader's open zip
+            // handle — which otherwise throws ZipException on later resource/class reads.
+            val runtimeJar = File.createTempFile("jetwhale-plugin-", ".jar").also { it.deleteOnExit() }
+            File(pluginJarPath).copyTo(runtimeJar, overwrite = true)
+            val classLoader = URLClassLoader(arrayOf(runtimeJar.toURI().toURL()))
 
             val manifestJson = classLoader
                 .getResourceAsStream(MANIFEST_PATH)
@@ -59,6 +72,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
                 ?: run {
                     println("Warning: $MANIFEST_PATH not found in $pluginJarPath")
                     classLoader.close()
+                    runtimeJar.delete()
                     mutableFailedJarPathsFlow.update { it + pluginJarPath }
                     return
                 }
@@ -70,6 +84,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
                 .singleOrNull()
                 ?: run {
                     classLoader.close()
+                    runtimeJar.delete()
                     error("Expected exactly one ${JetWhaleHostPluginFactory::class.java.simpleName} in $pluginJarPath")
                 }
 
@@ -77,6 +92,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             // we neither leak its classloader nor show a duplicate plugin.
             jarPathToPluginId[pluginJarPath]?.takeIf { it != manifest.pluginId }?.let { stalePluginId ->
                 classLoaders.remove(stalePluginId)?.close()
+                runtimeJars.remove(stalePluginId)?.delete()
                 mutablePluginsFlow.update { current ->
                     current.toMutableMap().apply { remove(stalePluginId) }.toPersistentMap()
                 }
@@ -85,6 +101,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             // Discard a previously loaded classloader for the same plugin id (e.g. a reload) so that
             // no stale classloader (and its classes) leaks.
             classLoaders.put(manifest.pluginId, classLoader)?.close()
+            runtimeJars.put(manifest.pluginId, runtimeJar)?.delete()
             // Remove any other jar-path entries that pointed at this plugin id (e.g. the jar was
             // renamed/moved or duplicated) so findPluginIdByJarPath never returns a stale path's id.
             jarPathToPluginId.entries.removeIf { it.value == manifest.pluginId && it.key != pluginJarPath }
@@ -110,6 +127,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             current.toMutableMap().apply { remove(pluginId) }.toPersistentMap()
         }
         classLoaders.remove(pluginId)?.close()
+        runtimeJars.remove(pluginId)?.delete()
         jarPathToPluginId.entries.removeIf { it.value == pluginId }
         println("Unloaded plugin: $pluginId")
     }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -52,7 +52,9 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
     /**
      * Private per-plugin copy of the jar that each classloader actually opens, keyed by `pluginId`.
      * Loading from a copy lets the source (dev) jar be overwritten without corrupting the running
-     * classloader's open zip handle. Deleted when the plugin is replaced or unloaded.
+     * classloader's open zip handle. Replaced copies are NOT deleted eagerly (cached resource URLs
+     * such as plugin icons may still point at them — deleting would throw NoSuchFileException); they
+     * are cleaned up on JVM exit via deleteOnExit.
      */
     private val runtimeJars: ConcurrentHashMap<String, File> = ConcurrentHashMap()
 
@@ -92,7 +94,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             // we neither leak its classloader nor show a duplicate plugin.
             jarPathToPluginId[pluginJarPath]?.takeIf { it != manifest.pluginId }?.let { stalePluginId ->
                 classLoaders.remove(stalePluginId)?.close()
-                runtimeJars.remove(stalePluginId)?.delete()
+                runtimeJars.remove(stalePluginId)
                 mutablePluginsFlow.update { current ->
                     current.toMutableMap().apply { remove(stalePluginId) }.toPersistentMap()
                 }
@@ -101,7 +103,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             // Discard a previously loaded classloader for the same plugin id (e.g. a reload) so that
             // no stale classloader (and its classes) leaks.
             classLoaders.put(manifest.pluginId, classLoader)?.close()
-            runtimeJars.put(manifest.pluginId, runtimeJar)?.delete()
+            runtimeJars.put(manifest.pluginId, runtimeJar)
             // Remove any other jar-path entries that pointed at this plugin id (e.g. the jar was
             // renamed/moved or duplicated) so findPluginIdByJarPath never returns a stale path's id.
             jarPathToPluginId.entries.removeIf { it.value == manifest.pluginId && it.key != pluginJarPath }
@@ -127,7 +129,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             current.toMutableMap().apply { remove(pluginId) }.toPersistentMap()
         }
         classLoaders.remove(pluginId)?.close()
-        runtimeJars.remove(pluginId)?.delete()
+        runtimeJars.remove(pluginId)
         jarPathToPluginId.entries.removeIf { it.value == pluginId }
         println("Unloaded plugin: $pluginId")
     }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
@@ -146,6 +146,20 @@ class DefaultPluginHotReloadService(
     private suspend fun reloadJar(jarPath: String) {
         if (!File(jarPath).exists()) return
 
+        // B1: try an in-place class redefinition first. On success the plugin's classloader and
+        // instances (and therefore their state) are kept; we only recreate the compose scenes so the
+        // redefined Content runs against the preserved instance state.
+        val redefinedPluginId = pluginFactoryRepository.tryRedefinePlugin(jarPath)
+        if (redefinedPluginId != null) {
+            withContext(Dispatchers.Main) {
+                pluginComposeSceneService.disposePluginScenesForPlugin(redefinedPluginId)
+            }
+            logger.info("Hot reloaded plugin in place (state preserved): $redefinedPluginId")
+            mutablePluginReloadedFlow.emit(redefinedPluginId)
+            return
+        }
+
+        // Fallback: full reload via a fresh classloader (plugin instance state is lost).
         // Capture the plugin id currently served by this jar (if any) so that we can dispose its
         // running instances and scenes before swapping in the new code.
         val previousPluginId = pluginFactoryRepository.findPluginIdByJarPath(jarPath)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
@@ -241,9 +241,10 @@ class DefaultPluginHotReloadService(
         private const val DEBOUNCE_MILLIS = 300L
 
         // B2 vs B1. When true, preserve composable-local remember via Compose's in-place hot reload
-        // (simulateHotReload); when false, recreate the plugin's compose scenes (instance state is
-        // still preserved, but remember resets). B2 relies on @InternalComposeApi and must be
-        // verified on the JetBrains Runtime — flip to false if a plugin's UI does not refresh.
-        private const val PRESERVE_REMEMBER_VIA_SIMULATE_HOT_RELOAD = true
+        // (simulateHotReload). NOTE: simulateHotReload recomposes EVERY running composition in the
+        // process — including the host UI — which can destabilize the host, so B1 is the default.
+        // When false, only the plugin's compose scenes are recreated (instance state preserved,
+        // remember reset). B2 relies on @InternalComposeApi and needs JetBrains Runtime verification.
+        private const val PRESERVE_REMEMBER_VIA_SIMULATE_HOT_RELOAD = false
     }
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
@@ -148,25 +148,34 @@ class DefaultPluginHotReloadService(
     private suspend fun reloadJar(jarPath: String) {
         if (!File(jarPath).exists()) return
 
-        // B1: try an in-place class redefinition first. On success the plugin's classloader and
-        // instances (and therefore their state) are kept; we only recreate the compose scenes so the
-        // redefined Content runs against the preserved instance state.
+        // Try an in-place class redefinition first. On success the plugin's classloader and instances
+        // (and therefore their state) are kept; how the UI is refreshed afterwards is configurable via
+        // [RELOAD_STRATEGY] so the remember-preservation approach can be experimented with.
         val redefinedPluginId = pluginFactoryRepository.tryRedefinePlugin(jarPath)
         if (redefinedPluginId != null) {
             withContext(Dispatchers.Main) {
-                if (PRESERVE_REMEMBER_VIA_SIMULATE_HOT_RELOAD) {
-                    // B2: ask Compose to recompose every running composition in place using its own
-                    // hot-reload mechanism, which preserves remember state. The plugin scene is not
-                    // recreated, so composable-local state (scroll, text input) is kept too.
-                    simulateHotReloadPreservingState()
-                } else {
-                    // B1: recreate only the compose scenes; the plugin instance (and its state) is
-                    // kept, but composable-local remember is reset.
-                    pluginComposeSceneService.disposePluginScenesForPlugin(redefinedPluginId)
-                    mutablePluginReloadedFlow.emit(redefinedPluginId)
+                when (RELOAD_STRATEGY) {
+                    ReloadStrategy.SCENE_RECREATE -> {
+                        // Recreate only the plugin's compose scenes. Instance state is preserved, but
+                        // composable-local remember is reset. Most robust; does not touch the host.
+                        pluginComposeSceneService.disposePluginScenesForPlugin(redefinedPluginId)
+                        mutablePluginReloadedFlow.emit(redefinedPluginId)
+                    }
+
+                    ReloadStrategy.SIMULATE_HOT_RELOAD -> {
+                        // Compose's own hot reload: recomposes every running composition in place,
+                        // preserving remember. Note it also recomposes the host UI.
+                        simulateHotReloadPreservingState()
+                    }
+
+                    ReloadStrategy.NONE -> {
+                        // Do nothing and rely on Compose's live-edit auto-invalidation (active when an
+                        // agent is attached) to recompose the redefined composables in place, keeping
+                        // remember. The cheapest path if Compose picks up our redefineClasses itself.
+                    }
                 }
             }
-            logger.info("Hot reloaded plugin in place (state preserved): $redefinedPluginId")
+            logger.info("Hot reloaded plugin in place via $RELOAD_STRATEGY (state preserved): $redefinedPluginId")
             return
         }
 
@@ -240,11 +249,21 @@ class DefaultPluginHotReloadService(
     companion object {
         private const val DEBOUNCE_MILLIS = 300L
 
-        // B2 vs B1. When true, preserve composable-local remember via Compose's in-place hot reload
-        // (simulateHotReload). NOTE: simulateHotReload recomposes EVERY running composition in the
-        // process — including the host UI — which can destabilize the host, so B1 is the default.
-        // When false, only the plugin's compose scenes are recreated (instance state preserved,
-        // remember reset). B2 relies on @InternalComposeApi and needs JetBrains Runtime verification.
-        private const val PRESERVE_REMEMBER_VIA_SIMULATE_HOT_RELOAD = false
+        // How the plugin UI is refreshed after a successful in-place class redefinition. Switch this
+        // to experiment with preserving composable-local remember state (see [ReloadStrategy]).
+        // SCENE_RECREATE is the safe default (instance state kept, remember reset).
+        private val RELOAD_STRATEGY = ReloadStrategy.SCENE_RECREATE
     }
+}
+
+/** How the plugin UI is refreshed after an in-place class redefinition (see [DefaultPluginHotReloadService]). */
+private enum class ReloadStrategy {
+    /** Recreate the plugin's compose scenes. Instance state kept, composable-local remember reset. */
+    SCENE_RECREATE,
+
+    /** Compose's simulateHotReload: keeps remember, but recomposes the whole host process. */
+    SIMULATE_HOT_RELOAD,
+
+    /** Do nothing; rely on Compose live-edit auto-invalidation to recompose the redefined code. */
+    NONE,
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.host.data.plugin
 
 import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.invalidateGroupsWithKey
 import androidx.compose.runtime.simulateHotReload
 import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
 import com.kitakkun.jetwhale.host.model.DebugSessionRepository
@@ -151,20 +152,30 @@ class DefaultPluginHotReloadService(
         // Try an in-place class redefinition first. On success the plugin's classloader and instances
         // (and therefore their state) are kept; how the UI is refreshed afterwards is configurable via
         // [RELOAD_STRATEGY] so the remember-preservation approach can be experimented with.
-        val redefinedPluginId = pluginFactoryRepository.tryRedefinePlugin(jarPath)
-        if (redefinedPluginId != null) {
+        val redefined = pluginFactoryRepository.tryRedefinePlugin(jarPath)
+        if (redefined != null) {
             withContext(Dispatchers.Main) {
                 when (RELOAD_STRATEGY) {
+                    ReloadStrategy.INVALIDATE_GROUPS -> {
+                        // Invalidate exactly the redefined @Composable groups (by their compiler group
+                        // key). Compose recomposes them in place against the new code WITHOUT disposing
+                        // the composition, so remember state is preserved and the rest of the UI —
+                        // including the host — is untouched. This is the same primitive Compose's own
+                        // live edit uses.
+                        invalidateRedefinedGroups(redefined.composableGroupKeys)
+                    }
+
                     ReloadStrategy.SCENE_RECREATE -> {
                         // Recreate only the plugin's compose scenes. Instance state is preserved, but
                         // composable-local remember is reset. Most robust; does not touch the host.
-                        pluginComposeSceneService.disposePluginScenesForPlugin(redefinedPluginId)
-                        mutablePluginReloadedFlow.emit(redefinedPluginId)
+                        pluginComposeSceneService.disposePluginScenesForPlugin(redefined.pluginId)
+                        mutablePluginReloadedFlow.emit(redefined.pluginId)
                     }
 
                     ReloadStrategy.SIMULATE_HOT_RELOAD -> {
-                        // Compose's own hot reload: recomposes every running composition in place,
-                        // preserving remember. Note it also recomposes the host UI.
+                        // Compose's save/dispose/restore hot reload. NOTE: it DISPOSES every running
+                        // composition (host included) and recomposes — observed to reset the whole UI,
+                        // so it is not recommended. Kept for comparison.
                         simulateHotReloadPreservingState()
                     }
 
@@ -175,7 +186,10 @@ class DefaultPluginHotReloadService(
                     }
                 }
             }
-            logger.info("Hot reloaded plugin in place via $RELOAD_STRATEGY (state preserved): $redefinedPluginId")
+            logger.info(
+                "Hot reloaded plugin in place via $RELOAD_STRATEGY (state preserved): " +
+                    "${redefined.pluginId} (${redefined.composableGroupKeys.size} composable groups)",
+            )
             return
         }
 
@@ -201,6 +215,14 @@ class DefaultPluginHotReloadService(
 
         logger.info("Hot reloaded plugin: $reloadedPluginId")
         mutablePluginReloadedFlow.emit(reloadedPluginId)
+    }
+
+    @OptIn(InternalComposeApi::class)
+    private fun invalidateRedefinedGroups(groupKeys: List<Int>) {
+        // Invalidate-only (no dispose): Compose marks the groups with these keys dirty and recomposes
+        // them against the redefined code, keeping the slot table — and therefore remember state —
+        // intact. Only groups with these keys (the redefined plugin composables) are affected.
+        groupKeys.forEach { key -> invalidateGroupsWithKey(key) }
     }
 
     @OptIn(InternalComposeApi::class)
@@ -249,19 +271,26 @@ class DefaultPluginHotReloadService(
     companion object {
         private const val DEBOUNCE_MILLIS = 300L
 
-        // How the plugin UI is refreshed after a successful in-place class redefinition. Switch this
-        // to experiment with preserving composable-local remember state (see [ReloadStrategy]).
-        // SCENE_RECREATE is the safe default (instance state kept, remember reset).
-        private val RELOAD_STRATEGY = ReloadStrategy.SCENE_RECREATE
+        // How the plugin UI is refreshed after a successful in-place class redefinition (see
+        // [ReloadStrategy]). INVALIDATE_GROUPS is the state-preserving default; SCENE_RECREATE is the
+        // robust fallback if a target runtime does not support group invalidation as expected.
+        private val RELOAD_STRATEGY = ReloadStrategy.INVALIDATE_GROUPS
     }
 }
 
 /** How the plugin UI is refreshed after an in-place class redefinition (see [DefaultPluginHotReloadService]). */
 private enum class ReloadStrategy {
+    /**
+     * Invalidate exactly the redefined @Composable groups (by their @FunctionKeyMeta group key) so
+     * Compose recomposes them in place without disposing — preserving remember and leaving the host
+     * untouched. The theoretically-grounded, state-preserving default (same primitive as live edit).
+     */
+    INVALIDATE_GROUPS,
+
     /** Recreate the plugin's compose scenes. Instance state kept, composable-local remember reset. */
     SCENE_RECREATE,
 
-    /** Compose's simulateHotReload: keeps remember, but recomposes the whole host process. */
+    /** Compose's simulateHotReload: DISPOSES every composition (resets the whole UI). Not recommended. */
     SIMULATE_HOT_RELOAD,
 
     /** Do nothing; rely on Compose live-edit auto-invalidation to recompose the redefined code. */

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
@@ -1,5 +1,7 @@
 package com.kitakkun.jetwhale.host.data.plugin
 
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.simulateHotReload
 import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
 import com.kitakkun.jetwhale.host.model.DebugSessionRepository
 import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
@@ -152,10 +154,19 @@ class DefaultPluginHotReloadService(
         val redefinedPluginId = pluginFactoryRepository.tryRedefinePlugin(jarPath)
         if (redefinedPluginId != null) {
             withContext(Dispatchers.Main) {
-                pluginComposeSceneService.disposePluginScenesForPlugin(redefinedPluginId)
+                if (PRESERVE_REMEMBER_VIA_SIMULATE_HOT_RELOAD) {
+                    // B2: ask Compose to recompose every running composition in place using its own
+                    // hot-reload mechanism, which preserves remember state. The plugin scene is not
+                    // recreated, so composable-local state (scroll, text input) is kept too.
+                    simulateHotReloadPreservingState()
+                } else {
+                    // B1: recreate only the compose scenes; the plugin instance (and its state) is
+                    // kept, but composable-local remember is reset.
+                    pluginComposeSceneService.disposePluginScenesForPlugin(redefinedPluginId)
+                    mutablePluginReloadedFlow.emit(redefinedPluginId)
+                }
             }
             logger.info("Hot reloaded plugin in place (state preserved): $redefinedPluginId")
-            mutablePluginReloadedFlow.emit(redefinedPluginId)
             return
         }
 
@@ -181,6 +192,13 @@ class DefaultPluginHotReloadService(
 
         logger.info("Hot reloaded plugin: $reloadedPluginId")
         mutablePluginReloadedFlow.emit(reloadedPluginId)
+    }
+
+    @OptIn(InternalComposeApi::class)
+    private fun simulateHotReloadPreservingState() {
+        // Compose's own hot-reload entry point: saves the state of all running compositions, disposes
+        // them, and recomposes against the freshly redefined code — preserving remember state.
+        simulateHotReload(Unit)
     }
 
     private fun disposePlugin(pluginId: String) {
@@ -221,5 +239,11 @@ class DefaultPluginHotReloadService(
 
     companion object {
         private const val DEBOUNCE_MILLIS = 300L
+
+        // B2 vs B1. When true, preserve composable-local remember via Compose's in-place hot reload
+        // (simulateHotReload); when false, recreate the plugin's compose scenes (instance state is
+        // still preserved, but remember resets). B2 relies on @InternalComposeApi and must be
+        // verified on the JetBrains Runtime — flip to false if a plugin's UI does not refresh.
+        private const val PRESERVE_REMEMBER_VIA_SIMULATE_HOT_RELOAD = true
     }
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginFactoryRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginFactoryRepository.kt
@@ -35,10 +35,25 @@ interface PluginFactoryRepository {
      * already-loaded classes are redefined from the rebuilt jar **without** dropping the classloader
      * or recreating the plugin instance, so the plugin instance's state is preserved.
      *
-     * Returns the `pluginId` on success, or `null` when an in-place swap is not possible (no JVM
+     * Returns a [RedefinedPlugin] on success (including the Compose group keys of the redefined
+     * `@Composable` functions, so the caller can invalidate exactly those groups for a
+     * state-preserving recompose), or `null` when an in-place swap is not possible (no JVM
      * Instrumentation available, an unsupported/structural change without an enhanced runtime such as
      * the JetBrains Runtime, etc.). On `null` the caller should fall back to [reloadPlugin], which
      * does a full reload at the cost of losing state.
      */
-    fun tryRedefinePlugin(pluginJarPath: String): String?
+    fun tryRedefinePlugin(pluginJarPath: String): RedefinedPlugin?
 }
+
+/**
+ * Result of a successful in-place plugin redefinition.
+ *
+ * @property pluginId the plugin that was redefined.
+ * @property composableGroupKeys the Compose group keys (`@FunctionKeyMeta.key`) of the redefined
+ *   `@Composable` functions. Passing these to `invalidateGroupsWithKey` recomposes exactly those
+ *   groups in place, preserving `remember` state and leaving the rest of the UI untouched.
+ */
+data class RedefinedPlugin(
+    val pluginId: String,
+    val composableGroupKeys: List<Int>,
+)

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginFactoryRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginFactoryRepository.kt
@@ -29,4 +29,16 @@ interface PluginFactoryRepository {
      * that was (re)loaded, or `null` if loading failed.
      */
     suspend fun reloadPlugin(pluginJarPath: String): String?
+
+    /**
+     * Attempts an in-place hot swap of the plugin served by [pluginJarPath]: the plugin's
+     * already-loaded classes are redefined from the rebuilt jar **without** dropping the classloader
+     * or recreating the plugin instance, so the plugin instance's state is preserved.
+     *
+     * Returns the `pluginId` on success, or `null` when an in-place swap is not possible (no JVM
+     * Instrumentation available, an unsupported/structural change without an enhanced runtime such as
+     * the JetBrains Runtime, etc.). On `null` the caller should fall back to [reloadPlugin], which
+     * does a full reload at the cost of losing state.
+     */
+    fun tryRedefinePlugin(pluginJarPath: String): String?
 }


### PR DESCRIPTION
Follow-up to #84 (merged). Adds **state-preserving** hot reload for installed-jar plugins running in the full host — something Compose Hot Reload cannot do for jar/child-classloader plugins.

## B1 — in-place class redefinition (instance state preserved)
- `PluginFactoryRepository.tryRedefinePlugin()`: redefines the plugin's already-loaded classes from the rebuilt jar via `Instrumentation.redefineClasses` (works across the plugin's **child classloader**), keeping the classloader and the plugin **instance** (and its state).
- `Instrumentation` obtained by self-attaching `byte-buddy-agent` (dev only, lazy).
- `DefaultPluginHotReloadService`: try redefine first → recreate only the compose scenes → fall back to the full classloader reload (state lost) when redefine is unsupported.
- `runJetWhale` passes `-Djdk.attach.allowAttachSelf=true` for the self-attach.

## B2 — preserve `remember` too (Compose simulateHotReload)
- After a successful redefine, recompose all running compositions via `androidx.compose.runtime.simulateHotReload` (`@InternalComposeApi`), preserving composable-local `remember` (scroll, text input). Toggle `PRESERVE_REMEMBER_VIA_SIMULATE_HOT_RELOAD` (B2 on by default; false = B1 scene-recreate).

## Verification status
- ✅ Compiles (API existence confirmed against Compose Multiplatform 1.11.1: `simulateHotReload`, `redefineClasses`, byte-buddy resolve; app unaffected).
- ⚠️ **Runtime verification pending (needs JetBrains Runtime + GUI, unavailable in CI):**
  - structural changes (add/remove methods/fields/classes) need JBR/DCEVM; on a stock JDK only method-body changes redefine, others fall back to full reload.
  - confirm `simulateHotReload` reaches the plugin's separate ComposeScene; if not, set the flag to false (B1).
  - `runJetWhale` currently launches on the default toolchain (17); running on JBR is needed to exercise structural redefines.

## How to verify
`runJetWhale` (host) + `stageDevPlugin -t` (rebuild/restage) in two terminals, connect the demo debuggee, open the example plugin, then edit `ExamplePluginView` and confirm state survives the reload.