### PR TITLE
feat(host): preserve plugin instance state on hot reload via in-place class redefinition

### DIFF
--- a/gradle-conventions/src/main/kotlin/jetwhale-plugin.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-plugin.gradle.kts
@@ -106,7 +106,12 @@ tasks.register<JavaExec>("runJetWhale") {
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
-            listOf("-Djetwhale.devPluginsDir=${devDirProvider.get()}")
+            listOf(
+                "-Djetwhale.devPluginsDir=${devDirProvider.get()}",
+                // Allow the dev hot-reload to self-attach a JVM agent (byte-buddy-agent) for in-place
+                // class redefinition; self-attach is disabled by default on JDK 9+.
+                "-Djdk.attach.allowAttachSelf=true",
+            )
         },
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ kotlinDsl = "6.5.7"
 kotlinxSerializationJson = "1.11.0"
 kotlinxCollectionsImmutable = "0.4.0"
 kotlinxCoroutines = "1.11.0"
+byteBuddy = "1.15.11"
 kotlinxDatetime = "0.8.0"
 
 # android
@@ -55,6 +56,7 @@ kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotli
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinxCollectionsImmutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+byteBuddyAgent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "byteBuddy" }
 kotlinxDatetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 
 # androidx

--- a/jetwhale-host/core/data/build.gradle.kts
+++ b/jetwhale-host/core/data/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     implementation(libs.androidxDatastorePreferences)
 
     implementation(libs.kotlinxSerializationJson)
+    // Used in dev hot-reload to obtain a JVM Instrumentation handle (self-attach) for in-place class
+    // redefinition. Dormant in production: only touched when the dev plugins directory is configured.
+    implementation(libs.byteBuddyAgent)
     implementation(libs.bundles.ktorServer)
     implementation(libs.logbackClassic)
     implementation(libs.kotlinTest)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.data.plugin
 
+import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
 import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
 import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
@@ -27,10 +28,11 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.jar.JarFile
 import kotlin.io.path.Path
 
-@Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
-class DefaultPluginFactoryRepository : PluginFactoryRepository {
+class DefaultPluginFactoryRepository @Inject constructor(
+    private val appDataDirectoryProvider: AppDataDirectoryProvider,
+) : PluginFactoryRepository {
     private val mutablePluginsFlow: MutableStateFlow<ImmutableMap<String, LoadedHostPlugin>> =
         MutableStateFlow(persistentMapOf())
     override val loadedPluginsFlow: Flow<Map<String, LoadedHostPlugin>> = mutablePluginsFlow
@@ -63,9 +65,8 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             // Open the classloader on a private copy of the jar so the source jar can be overwritten
             // (e.g. by dev hot-reload restaging) without corrupting this classloader's open zip
             // handle — which otherwise throws ZipException on later resource/class reads.
-            val runtimeJar = File.createTempFile("jetwhale-plugin-", ".jar").also { it.deleteOnExit() }
-            File(pluginJarPath).copyTo(runtimeJar, overwrite = true)
-            val classLoader = URLClassLoader(arrayOf(runtimeJar.toURI().toURL()))
+            val runtimeJar: File? = createRuntimeCopyIfDevJar(pluginJarPath)
+            val classLoader = URLClassLoader(arrayOf((runtimeJar ?: File(pluginJarPath)).toURI().toURL()))
 
             val manifestJson = classLoader
                 .getResourceAsStream(MANIFEST_PATH)
@@ -74,7 +75,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
                 ?: run {
                     println("Warning: $MANIFEST_PATH not found in $pluginJarPath")
                     classLoader.close()
-                    runtimeJar.delete()
+                    runtimeJar?.delete()
                     mutableFailedJarPathsFlow.update { it + pluginJarPath }
                     return
                 }
@@ -86,7 +87,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
                 .singleOrNull()
                 ?: run {
                     classLoader.close()
-                    runtimeJar.delete()
+                    runtimeJar?.delete()
                     error("Expected exactly one ${JetWhaleHostPluginFactory::class.java.simpleName} in $pluginJarPath")
                 }
 
@@ -103,7 +104,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             // Discard a previously loaded classloader for the same plugin id (e.g. a reload) so that
             // no stale classloader (and its classes) leaks.
             classLoaders.put(manifest.pluginId, classLoader)?.close()
-            runtimeJars.put(manifest.pluginId, runtimeJar)
+            runtimeJar?.let { runtimeJars[manifest.pluginId] = it }
             // Remove any other jar-path entries that pointed at this plugin id (e.g. the jar was
             // renamed/moved or duplicated) so findPluginIdByJarPath never returns a stale path's id.
             jarPathToPluginId.entries.removeIf { it.value == manifest.pluginId && it.key != pluginJarPath }
@@ -121,6 +122,23 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             if (e is CancellationException) throw e
             println("Failed to load plugin from $pluginJarPath: ${e.message}")
             mutableFailedJarPathsFlow.update { it + pluginJarPath }
+        }
+    }
+
+    /**
+     * Returns a private temp copy of [pluginJarPath] when it lives under the dev plugins directory
+     * (so the dev jar can be restaged without corrupting the running classloader's open zip handle),
+     * or `null` for stable installed jars, which are loaded directly without an extra copy.
+     */
+    private fun createRuntimeCopyIfDevJar(pluginJarPath: String): File? {
+        val devDir = appDataDirectoryProvider.getDevPluginsDir() ?: return null
+        val underDevDir = runCatching {
+            File(pluginJarPath).canonicalFile.toPath().startsWith(File(devDir).canonicalFile.toPath())
+        }.getOrDefault(false)
+        if (!underDevDir) return null
+        return File.createTempFile("jetwhale-plugin-", ".jar").also {
+            it.deleteOnExit()
+            File(pluginJarPath).copyTo(it, overwrite = true)
         }
     }
 
@@ -155,17 +173,22 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             // Redefine every class this plugin's classloader has already loaded, using the rebuilt
             // jar's bytecode. redefineClasses works on the loaded Class regardless of classloader, so
             // this reaches the plugin's child-classloader classes (which Compose Hot Reload cannot).
-            val loadedClasses = instrumentation.allLoadedClasses.filter { it.classLoader === classLoader }
+            // Array and hidden classes (e.g. invokedynamic lambdas) have no class file and are not
+            // redefinable, so they are skipped.
+            val loadedClasses = instrumentation.allLoadedClasses
+                .filter { it.classLoader === classLoader && !it.isArray && !it.isHidden }
             if (loadedClasses.isEmpty()) return null
 
-            val definitions = JarFile(pluginJarPath).use { jar ->
-                loadedClasses.mapNotNull { clazz ->
-                    val entry = jar.getJarEntry(clazz.name.replace('.', '/') + ".class") ?: return@mapNotNull null
-                    val bytes = jar.getInputStream(entry).use { it.readBytes() }
-                    ClassDefinition(clazz, bytes)
+            val definitions = ArrayList<ClassDefinition>(loadedClasses.size)
+            JarFile(pluginJarPath).use { jar ->
+                for (clazz in loadedClasses) {
+                    // A loaded (non-hidden, non-array) class with no class file in the rebuilt jar
+                    // would leave stale bytecode behind — a partial redefine. Bail out so the caller
+                    // does a full reload instead of reporting a misleading success.
+                    val entry = jar.getJarEntry(clazz.name.replace('.', '/') + ".class") ?: return null
+                    definitions += ClassDefinition(clazz, jar.getInputStream(entry).use { it.readBytes() })
                 }
             }
-            if (definitions.isEmpty()) return null
 
             instrumentation.redefineClasses(*definitions.toTypedArray())
             pluginId

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -12,16 +12,19 @@ import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import net.bytebuddy.agent.ByteBuddyAgent
+import java.io.File
+import java.lang.instrument.ClassDefinition
+import java.lang.instrument.Instrumentation
 import java.net.URLClassLoader
 import java.util.ServiceLoader
 import java.util.concurrent.ConcurrentHashMap
+import java.util.jar.JarFile
 import kotlin.io.path.Path
 
 @Inject
@@ -46,9 +49,23 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
     /** Maps the absolute jar path a plugin was loaded from to its `pluginId`. */
     private val jarPathToPluginId: ConcurrentHashMap<String, String> = ConcurrentHashMap()
 
+    /**
+     * Private per-plugin copy of the jar that each classloader actually opens, keyed by `pluginId`.
+     * Loading from a copy lets the source (dev) jar be overwritten without corrupting the running
+     * classloader's open zip handle. Replaced copies are NOT deleted eagerly (cached resource URLs
+     * such as plugin icons may still point at them — deleting would throw NoSuchFileException); they
+     * are cleaned up on JVM exit via deleteOnExit.
+     */
+    private val runtimeJars: ConcurrentHashMap<String, File> = ConcurrentHashMap()
+
     override suspend fun loadPlugin(pluginJarPath: String) {
         try {
-            val classLoader = URLClassLoader(arrayOf(Path(pluginJarPath).toUri().toURL()))
+            // Open the classloader on a private copy of the jar so the source jar can be overwritten
+            // (e.g. by dev hot-reload restaging) without corrupting this classloader's open zip
+            // handle — which otherwise throws ZipException on later resource/class reads.
+            val runtimeJar = File.createTempFile("jetwhale-plugin-", ".jar").also { it.deleteOnExit() }
+            File(pluginJarPath).copyTo(runtimeJar, overwrite = true)
+            val classLoader = URLClassLoader(arrayOf(runtimeJar.toURI().toURL()))
 
             val manifestJson = classLoader
                 .getResourceAsStream(MANIFEST_PATH)
@@ -57,6 +74,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
                 ?: run {
                     println("Warning: $MANIFEST_PATH not found in $pluginJarPath")
                     classLoader.close()
+                    runtimeJar.delete()
                     mutableFailedJarPathsFlow.update { it + pluginJarPath }
                     return
                 }
@@ -68,6 +86,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
                 .singleOrNull()
                 ?: run {
                     classLoader.close()
+                    runtimeJar.delete()
                     error("Expected exactly one ${JetWhaleHostPluginFactory::class.java.simpleName} in $pluginJarPath")
                 }
 
@@ -75,6 +94,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             // we neither leak its classloader nor show a duplicate plugin.
             jarPathToPluginId[pluginJarPath]?.takeIf { it != manifest.pluginId }?.let { stalePluginId ->
                 classLoaders.remove(stalePluginId)?.close()
+                runtimeJars.remove(stalePluginId)
                 mutablePluginsFlow.update { current ->
                     current.toMutableMap().apply { remove(stalePluginId) }.toPersistentMap()
                 }
@@ -82,11 +102,8 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
 
             // Discard a previously loaded classloader for the same plugin id (e.g. a reload) so that
             // no stale classloader (and its classes) leaks.
-            classLoaders.put(manifest.pluginId, classLoader)?.also { oldClassLoader ->
-                withContext(Dispatchers.IO) {
-                    oldClassLoader.close()
-                }
-            }
+            classLoaders.put(manifest.pluginId, classLoader)?.close()
+            runtimeJars.put(manifest.pluginId, runtimeJar)
             // Remove any other jar-path entries that pointed at this plugin id (e.g. the jar was
             // renamed/moved or duplicated) so findPluginIdByJarPath never returns a stale path's id.
             jarPathToPluginId.entries.removeIf { it.value == manifest.pluginId && it.key != pluginJarPath }
@@ -112,6 +129,7 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
             current.toMutableMap().apply { remove(pluginId) }.toPersistentMap()
         }
         classLoaders.remove(pluginId)?.close()
+        runtimeJars.remove(pluginId)
         jarPathToPluginId.entries.removeIf { it.value == pluginId }
         println("Unloaded plugin: $pluginId")
     }
@@ -126,6 +144,47 @@ class DefaultPluginFactoryRepository : PluginFactoryRepository {
         // reload (don't report stale success from a leftover jarPathToPluginId mapping).
         if (pluginJarPath in mutableFailedJarPathsFlow.value) return null
         return jarPathToPluginId[pluginJarPath]
+    }
+
+    override fun tryRedefinePlugin(pluginJarPath: String): String? {
+        val instrumentation = instrumentation ?: return null
+        val pluginId = jarPathToPluginId[pluginJarPath] ?: return null
+        val classLoader = classLoaders[pluginId] ?: return null
+
+        return try {
+            // Redefine every class this plugin's classloader has already loaded, using the rebuilt
+            // jar's bytecode. redefineClasses works on the loaded Class regardless of classloader, so
+            // this reaches the plugin's child-classloader classes (which Compose Hot Reload cannot).
+            val loadedClasses = instrumentation.allLoadedClasses.filter { it.classLoader === classLoader }
+            if (loadedClasses.isEmpty()) return null
+
+            val definitions = JarFile(pluginJarPath).use { jar ->
+                loadedClasses.mapNotNull { clazz ->
+                    val entry = jar.getJarEntry(clazz.name.replace('.', '/') + ".class") ?: return@mapNotNull null
+                    val bytes = jar.getInputStream(entry).use { it.readBytes() }
+                    ClassDefinition(clazz, bytes)
+                }
+            }
+            if (definitions.isEmpty()) return null
+
+            instrumentation.redefineClasses(*definitions.toTypedArray())
+            pluginId
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // UnsupportedOperationException (structural change without an enhanced runtime),
+            // LinkageError, etc. The caller falls back to a full reload.
+            println("In-place redefine failed for $pluginId: ${e.message}; falling back to full reload")
+            null
+        }
+    }
+
+    /**
+     * JVM Instrumentation handle, obtained lazily by self-attaching an agent the first time an
+     * in-place redefine is attempted (dev hot-reload only). Null if the agent cannot be installed.
+     */
+    private val instrumentation: Instrumentation? by lazy {
+        runCatching { ByteBuddyAgent.install() }.getOrNull()
     }
 
     companion object {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
@@ -146,6 +146,22 @@ class DefaultPluginHotReloadService(
     private suspend fun reloadJar(jarPath: String) {
         if (!File(jarPath).exists()) return
 
+        // Try an in-place class redefinition first. On success the plugin's classloader and instance
+        // are kept (so the plugin instance's state survives), and we recreate only its compose scenes
+        // so the redefined Content runs against that preserved state. Composable-local `remember` is
+        // reset (the scene is rebuilt); state that must survive a reload should live in the plugin
+        // instance. Reaches the plugin's child-classloader classes, which Compose Hot Reload cannot.
+        val redefinedPluginId = pluginFactoryRepository.tryRedefinePlugin(jarPath)
+        if (redefinedPluginId != null) {
+            withContext(Dispatchers.Main) {
+                pluginComposeSceneService.disposePluginScenesForPlugin(redefinedPluginId)
+            }
+            logger.info("Hot reloaded plugin in place (instance state preserved): $redefinedPluginId")
+            mutablePluginReloadedFlow.emit(redefinedPluginId)
+            return
+        }
+
+        // Fallback: full reload via a fresh classloader (plugin instance state is lost).
         // Capture the plugin id currently served by this jar (if any) so that we can dispose its
         // running instances and scenes before swapping in the new code.
         val previousPluginId = pluginFactoryRepository.findPluginIdByJarPath(jarPath)

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginFactoryRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginFactoryRepository.kt
@@ -29,4 +29,16 @@ interface PluginFactoryRepository {
      * that was (re)loaded, or `null` if loading failed.
      */
     suspend fun reloadPlugin(pluginJarPath: String): String?
+
+    /**
+     * Attempts an in-place hot swap of the plugin served by [pluginJarPath]: the plugin's
+     * already-loaded classes are redefined from the rebuilt jar **without** dropping the classloader
+     * or recreating the plugin instance, so the plugin instance's state is preserved.
+     *
+     * Returns the `pluginId` on success, or `null` when an in-place swap is not possible (no JVM
+     * Instrumentation available, an unsupported/structural change without an enhanced runtime such as
+     * the JetBrains Runtime, etc.). On `null` the caller should fall back to [reloadPlugin], which
+     * does a full reload at the cost of losing the plugin's state.
+     */
+    fun tryRedefinePlugin(pluginJarPath: String): String?
 }


### PR DESCRIPTION
## What

On dev hot-reload, before doing the full classloader reload (which recreates the plugin instance and **loses its state**), try an **in-place JVM class redefinition**: the plugin's already-loaded classes are redefined from the rebuilt jar via `Instrumentation.redefineClasses`, keeping the classloader and the **plugin instance (and its state)**. Only the plugin's compose scenes are recreated so the new code runs against the preserved state.

This means state held in the plugin instance (e.g. the Network Inspector's captured traffic and mock rules) **survives a reload**, instead of being wiped on every code change.

## How

- `PluginFactoryRepository.tryRedefinePlugin()` — redefines the plugin's loaded classes (works across the plugin's **child classloader**, which the standard Compose hot reload cannot reach). Returns `null` on any unsupported change, so the caller falls back to the existing full `reloadPlugin`.
- `Instrumentation` is obtained lazily by self-attaching `byte-buddy-agent` (dev only); `runJetWhale` passes `-Djdk.attach.allowAttachSelf=true`.
- Each plugin classloader is opened on a **private copy of the jar**, so restaging the dev jar can't corrupt the running classloader's open zip handle (avoids `ZipException`).

## Limits

- Structural changes (new methods/fields/classes) need an **enhanced runtime (JetBrains Runtime)**; otherwise only method-body changes redefine and anything else falls back to a full reload.
- Composable-local `remember` is reset (scenes are recreated). State that must survive a reload should live in the **plugin instance** — preserving Compose `remember` across a code swap is out of scope (not achievable reliably; even Compose Live Edit re-calculates the edited scope's remember).

## Verification

- ✅ Compiles (`:jetwhale-host:core:data` and `:jetwhale-host:app`); `spotlessCheck` clean.
- Runtime confirmed on the JetBrains Runtime: editing a plugin and restaging keeps the plugin instance's state across the reload.

Replaces the earlier exploratory PR #88 (kept for the experimentation history).