### PR TITLE
feat(plugin-dev): runIde-style fetch-and-run host for external plugin authors

### DIFF
--- a/.github/workflows/distribute-desktop-app.yaml
+++ b/.github/workflows/distribute-desktop-app.yaml
@@ -13,29 +13,45 @@ jobs:
       matrix:
         include:
           - os: macOS-latest
-            gradleTask: packageDmg
-            artifactGlob: jetwhale-host/app/build/compose/binaries/main/dmg/*.dmg
-            artifactName: macos-dmg
+            osArch: macos-arm64
+            installerTask: packageDmg
+            installerGlob: jetwhale-host/app/build/compose/binaries/main/dmg/*.dmg
+            installerExt: dmg
           - os: ubuntu-latest
-            gradleTask: packageDeb
-            artifactGlob: jetwhale-host/app/build/compose/binaries/main/deb/*.deb
-            artifactName: linux-deb
+            osArch: linux-x64
+            installerTask: packageDeb
+            installerGlob: jetwhale-host/app/build/compose/binaries/main/deb/*.deb
+            installerExt: deb
           - os: windows-latest
-            gradleTask: packageMsi
-            artifactGlob: jetwhale-host/app/build/compose/binaries/main/msi/*.msi
-            artifactName: windows-msi
+            osArch: windows-x64
+            installerTask: packageMsi
+            installerGlob: jetwhale-host/app/build/compose/binaries/main/msi/*.msi
+            installerExt: msi
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
-      - name: Build Distributable
-        run: ./gradlew :jetwhale-host:app:${{ matrix.gradleTask }}
-      - name: Upload Distributable Artifact
+      - name: Build installer and runnable uber jar
+        run: ./gradlew :jetwhale-host:app:${{ matrix.installerTask }} :jetwhale-host:app:packageUberJarForCurrentOS
+      # Rename assets to a predictable scheme that includes the FULL tag version (e.g. -alpha04),
+      # which the installer's own packageVersion drops. No manual renaming needed afterwards, and the
+      # uber-jar name matches what the `downloadJetWhaleHost` Gradle task expects.
+      - name: Collect and rename release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          version="${GITHUB_REF_NAME}"
+          installer=$(ls ${{ matrix.installerGlob }} | head -n 1)
+          cp "$installer" "dist/jetwhale-debugger-${version}-${{ matrix.osArch }}.${{ matrix.installerExt }}"
+          uberjar=$(ls jetwhale-host/app/build/compose/jars/*.jar | head -n 1)
+          cp "$uberjar" "dist/jetwhale-host-${version}-${{ matrix.osArch }}.jar"
+      - name: Upload release assets
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifactName }}
-          path: ${{ matrix.artifactGlob }}
+          name: ${{ matrix.osArch }}
+          path: dist/*
           if-no-files-found: error
   release:
     name: Create Draft Release and Attach Artifacts
@@ -51,8 +67,5 @@ jobs:
         with:
           draft: true
           generate_release_notes: true
-          files: |
-            dist/**/*.dmg
-            dist/**/*.deb
-            dist/**/*.msi
+          files: dist/**/*
           fail_on_unmatched_files: true

--- a/docs/developing-plugins.md
+++ b/docs/developing-plugins.md
@@ -33,3 +33,34 @@ dev directory and hot-reloads whenever the jar is re-staged:
 
 When the `jetwhale.devPluginsDir` system property is absent (i.e. a normal production launch), dev
 mode and hot reload are completely inert — behaviour is unchanged.
+
+## Developing a plugin outside this repository
+
+In-repo, `runJetWhale` builds the host from the local `:jetwhale-host:app` project. Plugin authors
+working in their **own** repository don't have that project, so they download a released host and run
+it, via `runJetWhaleFromRelease` (the JetWhale equivalent of IntelliJ's `runIde`):
+
+1. Depend on the published SDK to compile the plugin (compile-time only — the host itself is not a
+   library dependency):
+   ```kotlin
+   // host module
+   compileOnly("com.kitakkun.jetwhale:jetwhale-host-sdk:<version>")
+   // agent module, in the app being debugged
+   implementation("com.kitakkun.jetwhale:jetwhale-agent-sdk:<version>")
+   ```
+2. Apply the convention and pin which released host to run against:
+   ```kotlin
+   plugins { id("jetwhale-plugin") }
+   jetwhalePlugin { hostVersion.set("<version>") }
+   ```
+3. Run it (two terminals, same live-reload model as in-repo):
+   ```shell
+   ./gradlew :myPlugin:runJetWhaleFromRelease   # downloads the host uber jar for your OS + launches it
+   ./gradlew :myPlugin:stageDevPlugin -t        # rebuild & re-stage on change
+   ```
+
+`runJetWhaleFromRelease` downloads the runnable host uber jar for `hostVersion` and the current
+OS/architecture from the GitHub release (cached under `~/.jetwhale/dev-host/`), stages your plugin,
+and launches it with hot reload — no manual install of JetWhale needed. State-preserving in-place
+reload of method-body changes works on a stock JDK; structural changes fall back to a full reload
+(the JetBrains Runtime is needed to redefine those in place).

--- a/gradle-conventions/src/main/kotlin/jetwhale-plugin.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-plugin.gradle.kts
@@ -119,48 +119,73 @@ tasks.register<JavaExec>("runJetWhale") {
 // ---------------------------------------------------------------------------
 // runJetWhaleFromRelease: download a released host and launch it with this plugin, for plugin
 // authors developing OUTSIDE this repository (the `:jetwhale-host:app` project is not available to
-// them). Set `jetwhalePlugin.hostVersion` to choose which released host to run against.
+// them). Set `jetwhalePlugin.hostVersion` to choose which released host to run against, or pass
+// `-PjetwhaleHostJar=<path>` to launch a locally built host uber jar (useful before a release exists).
 // ---------------------------------------------------------------------------
 
-// "<os>-<arch>" of the current machine, matching the host uber-jar release asset names.
-val currentOsArch: String = run {
-    val osName = System.getProperty("os.name").lowercase()
-    val os = when {
-        osName.contains("mac") || osName.contains("darwin") -> "macos"
-        osName.contains("win") -> "windows"
-        else -> "linux"
+// "<os>-<arch>" of the current machine (resolved lazily), matching the host uber-jar release asset
+// names. Fails clearly for OS/architectures we don't publish assets for.
+val currentOsArch: Provider<String> =
+    providers.systemProperty("os.name").zip(providers.systemProperty("os.arch")) { osName, archName ->
+        val os = when {
+            osName.contains("mac", ignoreCase = true) || osName.contains("darwin", ignoreCase = true) -> "macos"
+            osName.contains("win", ignoreCase = true) -> "windows"
+            osName.contains("nux", ignoreCase = true) || osName.contains("nix", ignoreCase = true) -> "linux"
+            else -> error("Unsupported OS for runJetWhaleFromRelease: $osName")
+        }
+        val arch = when (archName.lowercase()) {
+            "aarch64", "arm64" -> "arm64"
+            "x86_64", "amd64", "x64" -> "x64"
+            else -> error("Unsupported architecture for runJetWhaleFromRelease: $archName")
+        }
+        "$os-$arch"
     }
-    val archName = System.getProperty("os.arch").lowercase()
-    val arch = if (archName.contains("aarch64") || archName.contains("arm")) "arm64" else "x64"
-    "$os-$arch"
-}
 
-// Downloaded host jars are cached here, shared across plugin projects and keyed by version + os/arch.
-val devHostCacheDir = File(System.getProperty("user.home"), ".jetwhale/dev-host")
+// A locally built host uber jar to launch instead of downloading (e.g. the output of
+// `:jetwhale-host:app:packageUberJarForCurrentOS`). When set it overrides hostVersion.
+val localHostJar: Provider<String> = providers.gradleProperty("jetwhaleHostJar")
 
-// Path of the cached host uber jar for the configured version (has a value only when hostVersion set).
-val hostReleaseJar = pluginExtension.hostVersion.map { version ->
-    File(devHostCacheDir, "$version/jetwhale-host-$version-$currentOsArch.jar")
-}
+// Path of the cached host uber jar for the configured version (resolved lazily, value only when set).
+val hostReleaseJar: Provider<File> =
+    pluginExtension.hostVersion.zip(currentOsArch) { version, osArch ->
+        File(
+            providers.systemProperty("user.home").get(),
+            ".jetwhale/dev-host/$version/jetwhale-host-$version-$osArch.jar",
+        )
+    }
 
 val downloadJetWhaleHost = tasks.register("downloadJetWhaleHost") {
     group = "jetwhale"
     description = "Downloads the released JetWhale host uber jar (jetwhalePlugin.hostVersion) for the current OS."
 
     val versionProvider = pluginExtension.hostVersion
+    val osArchProvider = currentOsArch
     val jarProvider = hostReleaseJar
-    val osArch = currentOsArch
-    onlyIf { versionProvider.isPresent }
+    val localJarProvider = localHostJar
+    // Nothing to download when launching a local jar, or when no version is configured.
+    onlyIf { versionProvider.isPresent && !localJarProvider.isPresent }
     doLast {
-        val version = versionProvider.get()
         val jar = jarProvider.get()
         if (jar.exists() && jar.length() > 0) return@doLast
         jar.parentFile.mkdirs()
-        val url = "https://github.com/kitakkun/jetwhale/releases/download/$version/jetwhale-host-$version-$osArch.jar"
-        logger.lifecycle("Downloading JetWhale host $version ($osArch) from $url")
+        val version = versionProvider.get()
+        val url = "https://github.com/kitakkun/jetwhale/releases/download/$version/jetwhale-host-$version-${osArchProvider.get()}.jar"
+        logger.lifecycle("Downloading JetWhale host $version from $url")
         val tmp = File.createTempFile("jetwhale-host-", ".jar", jar.parentFile)
-        java.net.URI(url).toURL().openStream().use { input -> tmp.outputStream().use(input::copyTo) }
-        check(tmp.renameTo(jar)) { "Failed to move downloaded host jar into place: $jar" }
+        try {
+            val connection = java.net.URI(url).toURL().openConnection().apply {
+                connectTimeout = 30_000
+                readTimeout = 60_000
+            }
+            connection.getInputStream().use { input -> tmp.outputStream().use(input::copyTo) }
+            java.nio.file.Files.move(
+                tmp.toPath(),
+                jar.toPath(),
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+            )
+        } finally {
+            tmp.delete()
+        }
     }
 }
 
@@ -169,15 +194,27 @@ tasks.register<JavaExec>("runJetWhaleFromRelease") {
     description = "Downloads the released JetWhale host (jetwhalePlugin.hostVersion) and launches it with this plugin."
 
     val hostVersionProvider = pluginExtension.hostVersion
+    val releaseJarProvider = hostReleaseJar
+    val localJarProvider = localHostJar
     dependsOn(stageDevPlugin, downloadJetWhaleHost)
-    classpath = files(hostReleaseJar)
+    // Resolved in doFirst (after validation) so an unset hostVersion gives a clear error instead of
+    // a "no value present" failure from resolving the classpath provider too early.
+    classpath = files()
     mainClass.set("com.kitakkun.jetwhale.host.MainKt")
 
     doFirst {
-        require(hostVersionProvider.isPresent) {
-            "Set jetwhalePlugin.hostVersion to the released JetWhale host version to run against " +
-                "(or use the in-repo `runJetWhale` task)."
+        val hostJar = when {
+            localJarProvider.isPresent -> File(localJarProvider.get())
+
+            hostVersionProvider.isPresent -> releaseJarProvider.get()
+
+            else -> error(
+                "Set jetwhalePlugin.hostVersion to the released JetWhale host version, or pass " +
+                    "-PjetwhaleHostJar=<path> to launch a local host jar (or use the in-repo `runJetWhale`).",
+            )
         }
+        require(hostJar.exists()) { "JetWhale host jar not found: $hostJar" }
+        classpath = files(hostJar)
     }
 
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }

--- a/gradle-conventions/src/main/kotlin/jetwhale-plugin.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-plugin.gradle.kts
@@ -116,6 +116,83 @@ tasks.register<JavaExec>("runJetWhale") {
     )
 }
 
+// ---------------------------------------------------------------------------
+// runJetWhaleFromRelease: download a released host and launch it with this plugin, for plugin
+// authors developing OUTSIDE this repository (the `:jetwhale-host:app` project is not available to
+// them). Set `jetwhalePlugin.hostVersion` to choose which released host to run against.
+// ---------------------------------------------------------------------------
+
+// "<os>-<arch>" of the current machine, matching the host uber-jar release asset names.
+val currentOsArch: String = run {
+    val osName = System.getProperty("os.name").lowercase()
+    val os = when {
+        osName.contains("mac") || osName.contains("darwin") -> "macos"
+        osName.contains("win") -> "windows"
+        else -> "linux"
+    }
+    val archName = System.getProperty("os.arch").lowercase()
+    val arch = if (archName.contains("aarch64") || archName.contains("arm")) "arm64" else "x64"
+    "$os-$arch"
+}
+
+// Downloaded host jars are cached here, shared across plugin projects and keyed by version + os/arch.
+val devHostCacheDir = File(System.getProperty("user.home"), ".jetwhale/dev-host")
+
+// Path of the cached host uber jar for the configured version (has a value only when hostVersion set).
+val hostReleaseJar = pluginExtension.hostVersion.map { version ->
+    File(devHostCacheDir, "$version/jetwhale-host-$version-$currentOsArch.jar")
+}
+
+val downloadJetWhaleHost = tasks.register("downloadJetWhaleHost") {
+    group = "jetwhale"
+    description = "Downloads the released JetWhale host uber jar (jetwhalePlugin.hostVersion) for the current OS."
+
+    val versionProvider = pluginExtension.hostVersion
+    val jarProvider = hostReleaseJar
+    val osArch = currentOsArch
+    onlyIf { versionProvider.isPresent }
+    doLast {
+        val version = versionProvider.get()
+        val jar = jarProvider.get()
+        if (jar.exists() && jar.length() > 0) return@doLast
+        jar.parentFile.mkdirs()
+        val url = "https://github.com/kitakkun/jetwhale/releases/download/$version/jetwhale-host-$version-$osArch.jar"
+        logger.lifecycle("Downloading JetWhale host $version ($osArch) from $url")
+        val tmp = File.createTempFile("jetwhale-host-", ".jar", jar.parentFile)
+        java.net.URI(url).toURL().openStream().use { input -> tmp.outputStream().use(input::copyTo) }
+        check(tmp.renameTo(jar)) { "Failed to move downloaded host jar into place: $jar" }
+    }
+}
+
+tasks.register<JavaExec>("runJetWhaleFromRelease") {
+    group = "jetwhale"
+    description = "Downloads the released JetWhale host (jetwhalePlugin.hostVersion) and launches it with this plugin."
+
+    val hostVersionProvider = pluginExtension.hostVersion
+    dependsOn(stageDevPlugin, downloadJetWhaleHost)
+    classpath = files(hostReleaseJar)
+    mainClass.set("com.kitakkun.jetwhale.host.MainKt")
+
+    doFirst {
+        require(hostVersionProvider.isPresent) {
+            "Set jetwhalePlugin.hostVersion to the released JetWhale host version to run against " +
+                "(or use the in-repo `runJetWhale` task)."
+        }
+    }
+
+    val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
+    jvmArgumentProviders.add(
+        CommandLineArgumentProvider {
+            listOf(
+                "-Djetwhale.devPluginsDir=${devDirProvider.get()}",
+                // Self-attach for the dev hot-reload's in-place class redefinition (disabled by
+                // default on JDK 9+). Structural changes still need the JetBrains Runtime.
+                "-Djdk.attach.allowAttachSelf=true",
+            )
+        },
+    )
+}
+
 // Make sure `packagePlugin` participates in the standard `assemble`/`build` lifecycle so authors get
 // the distributable artifact without invoking the task by name.
 tasks.named("assemble") {

--- a/gradle-conventions/src/main/kotlin/jetwhale-plugin.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-plugin.gradle.kts
@@ -197,12 +197,11 @@ tasks.register<JavaExec>("runJetWhaleFromRelease") {
     val releaseJarProvider = hostReleaseJar
     val localJarProvider = localHostJar
     dependsOn(stageDevPlugin, downloadJetWhaleHost)
-    // Resolved in doFirst (after validation) so an unset hostVersion gives a clear error instead of
-    // a "no value present" failure from resolving the classpath provider too early.
-    classpath = files()
-    mainClass.set("com.kitakkun.jetwhale.host.MainKt")
 
-    doFirst {
+    // Resolve the host jar lazily so JavaExec reads it at execution (after downloadJetWhaleHost has
+    // run). A provider is required: reassigning `classpath` in doFirst is lost under the configuration
+    // cache, leaving an empty classpath and a cryptic "could not find main class" failure.
+    val hostJarProvider = providers.provider {
         val hostJar = when {
             localJarProvider.isPresent -> File(localJarProvider.get())
 
@@ -213,9 +212,11 @@ tasks.register<JavaExec>("runJetWhaleFromRelease") {
                     "-PjetwhaleHostJar=<path> to launch a local host jar (or use the in-repo `runJetWhale`).",
             )
         }
-        require(hostJar.exists()) { "JetWhale host jar not found: $hostJar" }
-        classpath = files(hostJar)
+        check(hostJar.exists()) { "JetWhale host jar not found: $hostJar" }
+        hostJar
     }
+    classpath = files(hostJarProvider)
+    mainClass.set("com.kitakkun.jetwhale.host.MainKt")
 
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
     jvmArgumentProviders.add(

--- a/gradle-conventions/src/main/kotlin/util/JetWhalePluginExtension.kt
+++ b/gradle-conventions/src/main/kotlin/util/JetWhalePluginExtension.kt
@@ -25,4 +25,15 @@ interface JetWhalePluginExtension {
      * distribution of the host (so external builds can resolve it) is out of scope for now.
      */
     val hostApplicationProject: Property<String>
+
+    /**
+     * Version of the released JetWhale host to download and launch with `runJetWhaleFromRelease`,
+     * for plugin authors developing **outside** this repository.
+     *
+     * When set, `runJetWhaleFromRelease` fetches the matching host application (a runnable uber jar)
+     * for the current OS/architecture from the GitHub release of that version, instead of building
+     * it from [hostApplicationProject]. Leave unset for in-repo development (use `runJetWhale`, which
+     * builds the host from the local project).
+     */
+    val hostVersion: Property<String>
 }


### PR DESCRIPTION
## What

Lets plugin authors **outside this repository** develop against a released JetWhale host without building it from the (unavailable) `:jetwhale-host:app` project — the JetWhale equivalent of IntelliJ's `runIde`.

- New `jetwhalePlugin { hostVersion }` selects which released host to run against.
- New **`runJetWhaleFromRelease`** task: downloads the runnable host **uber jar** for `hostVersion` and the current OS/arch from the GitHub release (cached under `~/.jetwhale/dev-host/`), stages the plugin, and launches it with hot reload.
- New `downloadJetWhaleHost` task fetches + caches the uber jar.
- The author compiles against the **published SDK**; the host is an **opaque runnable artifact** (no need to publish the host's internal modules — same split as IntelliJ: SDK to compile, distribution to run).
- In-repo `runJetWhale` (project-based) is unchanged.

## CI (`distribute-desktop-app`)

- Also builds and attaches the **runnable uber jar per OS** to the release.
- **Renames every release asset to a predictable name with the FULL tag version** (e.g. `-alpha04`). The native installer's own `packageVersion` drops the pre-release suffix, which previously required **manual filename fixups** — this removes that, and the uber-jar name matches the URL `downloadJetWhaleHost` expects.

## Docs

`docs/developing-plugins.md` documents the external "develop a plugin outside this repo" flow.

## Verification

- ✅ `:jetwhale-plugins:example:host:tasks --group jetwhale` shows `runJetWhaleFromRelease` / `downloadJetWhaleHost`; convention compiles; `spotlessCheck` clean.
- ⚠️ End-to-end download+launch needs a release to exist (cut a tag → CI publishes SDK + uber jars). Until then, the download URL/asset-name scheme is verifiable by inspection; runtime launch is confirmable locally against a `packageUberJarForCurrentOS` build.

## Notes

- Uber jar is OS/arch specific; the task picks the current machine's asset (mac arm64 / linux x64 / windows x64 in the CI matrix). More arch runners can be added later.
- Structural in-place redefine needs the JetBrains Runtime; on a stock JRE only method-body changes redefine, the rest fall back to a full reload.
- SDK publishing is the compile-time prerequisite — a single release tag publishes the SDK (publish.yaml) and the uber jars together.