### PR TITLE
ci: manual SNAPSHOT publishing (Maven snapshots + host pre-release)

### DIFF
--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -47,7 +47,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
       - id: ver
-        run: echo "version=$(grep -m1 '^jetwhale = ' gradle/libs.versions.toml | cut -d'"' -f2)-SNAPSHOT" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "version=$(grep -m1 '^jetwhale = ' gradle/libs.versions.toml | cut -d'"' -f2)-SNAPSHOT" >> "$GITHUB_OUTPUT"
+          echo "built=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
       - name: Publish SDK snapshot to Maven Central
         run: ./gradlew publishToMavenCentral -PjetwhaleSnapshot --no-configuration-cache
         env:
@@ -70,8 +72,16 @@ jobs:
       - name: Attach host uber jars to a pre-release
         uses: softprops/action-gh-release@v2
         with:
+          # The tag stays `<version>-SNAPSHOT` so runJetWhaleFromRelease always resolves the latest
+          # snapshot; the build number / commit / timestamp below identify which build it currently is.
           tag_name: ${{ steps.ver.outputs.version }}
-          name: ${{ steps.ver.outputs.version }}
+          name: ${{ steps.ver.outputs.version }} (build ${{ github.run_number }})
           prerelease: true
+          body: |
+            Development snapshot — overwritten on each publish; `runJetWhaleFromRelease` resolves this latest build.
+
+            - Build: #${{ github.run_number }}
+            - Commit: ${{ github.sha }}
+            - Built (UTC): ${{ steps.ver.outputs.built }}
           files: dist/**/*.jar
           fail_on_unmatched_files: true

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -1,0 +1,77 @@
+name: Publish Snapshot
+# Manually publish a development SNAPSHOT: the SDK and Gradle plugin go to the Central snapshots
+# repository (overwritable), and the host uber jars are attached to a `<version>-SNAPSHOT` GitHub
+# pre-release so `runJetWhaleFromRelease` (hostVersion = "<version>-SNAPSHOT") can download them.
+on:
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  host-uberjar:
+    name: Build host uber jar (${{ matrix.osArch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macOS-latest
+            osArch: macos-arm64
+          - os: ubuntu-latest
+            osArch: linux-x64
+          - os: windows-latest
+            osArch: windows-x64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-java
+      - name: Build host uber jar
+        run: ./gradlew :jetwhale-host:app:packageUberJarForCurrentOS -PjetwhaleSnapshot
+      - name: Rename uber jar with the snapshot version
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          version="$(grep -m1 '^jetwhale = ' gradle/libs.versions.toml | cut -d'"' -f2)-SNAPSHOT"
+          uberjar=$(ls jetwhale-host/app/build/compose/jars/*.jar | head -n 1)
+          cp "$uberjar" "dist/jetwhale-host-${version}-${{ matrix.osArch }}.jar"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: host-${{ matrix.osArch }}
+          path: dist/*
+          if-no-files-found: error
+  publish:
+    name: Publish snapshots
+    needs: host-uberjar
+    runs-on: macOS-latest
+    environment: Publish
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-java
+      - id: ver
+        run: echo "version=$(grep -m1 '^jetwhale = ' gradle/libs.versions.toml | cut -d'"' -f2)-SNAPSHOT" >> "$GITHUB_OUTPUT"
+      - name: Publish SDK snapshot to Maven Central
+        run: ./gradlew publishToMavenCentral -PjetwhaleSnapshot --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+      - name: Publish Gradle plugin snapshot to Maven Central
+        run: ./gradlew -p jetwhale-gradle-plugin publishToMavenCentral -PjetwhaleSnapshot --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - name: Attach host uber jars to a pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.version }}
+          name: ${{ steps.ver.outputs.version }}
+          prerelease: true
+          files: dist/**/*.jar
+          fail_on_unmatched_files: true

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -24,6 +24,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
       - name: Build host uber jar
+        # Force bash so the POSIX `./gradlew` runs identically on the Windows matrix entry
+        # (the default Windows shell is PowerShell), matching the Rename step below.
+        shell: bash
         run: ./gradlew :jetwhale-host:app:packageUberJarForCurrentOS -PjetwhaleSnapshot
       - name: Rename uber jar with the snapshot version
         shell: bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,5 +34,8 @@ spotless {
 
 allprojects {
     group = "com.kitakkun.jetwhale"
-    version = rootProject.libs.versions.jetwhale.get()
+    // Pass -PjetwhaleSnapshot to publish a SNAPSHOT of the current version (overwritable, goes to the
+    // Central snapshots repo) instead of a release.
+    version = rootProject.libs.versions.jetwhale.get() +
+        if (rootProject.hasProperty("jetwhaleSnapshot")) "-SNAPSHOT" else ""
 }

--- a/jetwhale-gradle-plugin/build.gradle.kts
+++ b/jetwhale-gradle-plugin/build.gradle.kts
@@ -11,7 +11,8 @@ plugins {
 }
 
 group = "com.kitakkun.jetwhale"
-version = libs.versions.jetwhale.get()
+// Pass -PjetwhaleSnapshot to publish a SNAPSHOT of the current version instead of a release.
+version = libs.versions.jetwhale.get() + if (hasProperty("jetwhaleSnapshot")) "-SNAPSHOT" else ""
 
 jetwhalePublish {
     artifactId = "jetwhale-gradle-plugin"

--- a/jetwhale-gradle-plugin/src/main/kotlin/jetwhale-plugin.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/jetwhale-plugin.gradle.kts
@@ -167,24 +167,49 @@ val downloadJetWhaleHost = tasks.register("downloadJetWhaleHost") {
     doLast {
         val jar = jarProvider.get()
         val version = versionProvider.get()
-        // Releases are immutable, so a cached jar is reused. SNAPSHOTs are overwritten on each publish,
-        // so always re-download them to avoid running a stale host.
-        if (!version.endsWith("-SNAPSHOT") && jar.exists() && jar.length() > 0) return@doLast
+        val isSnapshot = version.endsWith("-SNAPSHOT")
+        val cached = jar.exists() && jar.length() > 0
+        // Immutable releases never change, so a present cache is always valid (no network needed).
+        if (!isSnapshot && cached) return@doLast
         jar.parentFile.mkdirs()
         val url = "https://github.com/kitakkun/jetwhale/releases/download/$version/jetwhale-host-$version-${osArchProvider.get()}.jar"
+        // Sidecar storing the downloaded asset's ETag, used to detect whether a SNAPSHOT changed.
+        val etagFile = File(jar.parentFile, "${jar.name}.etag")
+
+        fun open(method: String) = (java.net.URI(url).toURL().openConnection() as java.net.HttpURLConnection).apply {
+            requestMethod = method
+            connectTimeout = 30_000
+            readTimeout = 60_000
+        }
+
+        // SNAPSHOTs are overwritten on each publish; re-download only when the asset's ETag changed.
+        if (isSnapshot && cached && etagFile.exists()) {
+            val remoteETag = runCatching {
+                val head = open("HEAD")
+                try {
+                    head.getHeaderField("ETag")
+                } finally {
+                    head.disconnect()
+                }
+            }.getOrNull()
+            if (remoteETag != null && remoteETag == etagFile.readText()) {
+                logger.lifecycle("JetWhale host $version is up to date; using cached jar.")
+                return@doLast
+            }
+        }
+
         logger.lifecycle("Downloading JetWhale host $version from $url")
         val tmp = File.createTempFile("jetwhale-host-", ".jar", jar.parentFile)
         try {
-            val connection = java.net.URI(url).toURL().openConnection().apply {
-                connectTimeout = 30_000
-                readTimeout = 60_000
-            }
+            val connection = open("GET")
             connection.getInputStream().use { input -> tmp.outputStream().use(input::copyTo) }
             java.nio.file.Files.move(
                 tmp.toPath(),
                 jar.toPath(),
                 java.nio.file.StandardCopyOption.REPLACE_EXISTING,
             )
+            // Record the new ETag so the next run can skip an unchanged download.
+            connection.getHeaderField("ETag")?.let { etagFile.writeText(it) }
         } finally {
             tmp.delete()
         }

--- a/jetwhale-gradle-plugin/src/main/kotlin/jetwhale-plugin.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/jetwhale-plugin.gradle.kts
@@ -166,9 +166,11 @@ val downloadJetWhaleHost = tasks.register("downloadJetWhaleHost") {
     onlyIf { versionProvider.isPresent && !localJarProvider.isPresent }
     doLast {
         val jar = jarProvider.get()
-        if (jar.exists() && jar.length() > 0) return@doLast
-        jar.parentFile.mkdirs()
         val version = versionProvider.get()
+        // Releases are immutable, so a cached jar is reused. SNAPSHOTs are overwritten on each publish,
+        // so always re-download them to avoid running a stale host.
+        if (!version.endsWith("-SNAPSHOT") && jar.exists() && jar.length() > 0) return@doLast
+        jar.parentFile.mkdirs()
         val url = "https://github.com/kitakkun/jetwhale/releases/download/$version/jetwhale-host-$version-${osArchProvider.get()}.jar"
         logger.lifecycle("Downloading JetWhale host $version from $url")
         val tmp = File.createTempFile("jetwhale-host-", ".jar", jar.parentFile)


### PR DESCRIPTION
## Why
For dev / hot-reload verification we want to publish overwritable dev builds without cutting a real release (Maven Central releases are permanent and can't be re-published).

## What
A manual `workflow_dispatch` **Publish Snapshot** workflow + a `-PjetwhaleSnapshot` flag (appends `-SNAPSHOT` to the version):

- **SDK + Gradle plugin** -> Central **snapshots** repo (vanniktech auto-routes `-SNAPSHOT`), overwritable, no tag.
- **Host uber jars** -> a `<version>-SNAPSHOT` GitHub **pre-release**, so `runJetWhaleFromRelease` (`hostVersion = "<version>-SNAPSHOT"`) can download the host for hot-reload checks — not just the Maven artifacts. (Purely local dev still works via `-PjetwhaleHostJar`.)

## Consuming a snapshot
```kotlin
// settings.gradle.kts
pluginManagement { repositories { mavenCentral(); maven("https://central.sonatype.com/repository/maven-snapshots/") } }
dependencyResolutionManagement { repositories { mavenCentral(); maven("https://central.sonatype.com/repository/maven-snapshots/") } }
// build
plugins { id("jetwhale-plugin") version "1.0.0-alpha04-SNAPSHOT" }
jetwhalePlugin { hostVersion.set("1.0.0-alpha04-SNAPSHOT") }
```

## Verification
- ✅ `-PjetwhaleSnapshot` makes both the root modules and the gradle-plugin build report `1.0.0-alpha04-SNAPSHOT` (release version unchanged without the flag).
- ✅ spotless clean.
- ⚠️ The actual dispatch (Central snapshot upload + pre-release) needs to run on CI with the existing Publish secrets.