### PR TITLE
fix(plugin-dev): don't break external Gradle sync when the in-repo host project is absent

### DIFF
--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.gradle.kts
@@ -85,12 +85,27 @@ val jetwhaleHostRuntime = configurations.create("jetwhaleHostRuntime") {
     isCanBeResolved = true
 }
 
-// Wire the host project dependency lazily (no afterEvaluate, so it stays configuration-cache safe)
-// while still honoring any override of `hostApplicationProject` set in the consumer's build script.
-dependencies.addProvider(
-    "jetwhaleHostRuntime",
-    pluginExtension.hostApplicationProject.map { projectPath -> dependencies.project(projectPath) },
-)
+// `runJetWhale` launches the in-repo `:jetwhale-host:app` project, so it only works inside the
+// JetWhale repository. Wire its host dependency only when that project actually exists: otherwise the
+// resolvable `jetwhaleHostRuntime` configuration would reference a missing project and break
+// configuration / IDE sync for external plugin authors (who use `runJetWhaleFromRelease` instead).
+afterEvaluate {
+    val projectPath = pluginExtension.hostApplicationProject.orNull
+    if (projectPath != null && rootProject.findProject(projectPath) != null) {
+        dependencies.add("jetwhaleHostRuntime", dependencies.project(projectPath))
+    } else {
+        // Keep the task present but fail with actionable guidance if it is actually invoked.
+        tasks.named("runJetWhale").configure {
+            doFirst {
+                error(
+                    "`runJetWhale` requires the in-repo host project '$projectPath', which does not " +
+                        "exist in this build. When developing a plugin OUTSIDE the JetWhale repository, " +
+                        "set `jetwhalePlugin.hostVersion` and run `runJetWhaleFromRelease` instead.",
+                )
+            }
+        }
+    }
+}
 
 tasks.register<JavaExec>("runJetWhale") {
     group = "jetwhale"


### PR DESCRIPTION
## Symptom
In a plugin project **outside** the JetWhale repo, Gradle **sync fails**:
```
Project with path ':jetwhale-host:app' could not be found.
```

## Cause
`runJetWhale` launches the in-repo `:jetwhale-host:app` via a **resolvable** `jetwhaleHostRuntime` configuration, and the project dependency was wired **unconditionally**. IDE sync resolves all resolvable configurations, so referencing the missing project breaks the whole import. (`runJetWhaleFromRelease`, the external path, was already fine.)

## Fix
Wire the host project dependency **only when that project exists** (checked in `afterEvaluate`). External projects configure/sync cleanly; running `runJetWhale` there now fails with actionable guidance pointing at `runJetWhaleFromRelease`.

## Verification
Reproduced with a standalone external plugin project (own wrapper, plugin + SDK from Central snapshots):
- ❌ before: `dependencies --configuration jetwhaleHostRuntime` / sync → "Project ':jetwhale-host:app' could not be found".
- ✅ after: that configuration resolves to **No dependencies**; `runJetWhale --dry-run` no longer fails at configuration; `runJetWhaleFromRelease --dry-run` works **with config cache** (entry stored).
- ✅ in-repo unchanged: `:jetwhale-plugins:example:host` `jetwhaleHostRuntime` still contains `project :jetwhale-host:app`; `runJetWhale` resolves.
- ✅ external `runJetWhale` (real run) now fails with: *"...requires the in-repo host project ':jetwhale-host:app'... use runJetWhaleFromRelease instead."*

Needs a new snapshot publish for external consumers to pick up.