### PR TITLE
refactor(plugin-dev): move in-repo runJetWhale out of the published plugin

### DIFF
--- a/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
@@ -1,0 +1,50 @@
+import org.gradle.process.CommandLineArgumentProvider
+
+/**
+ * In-repo-only companion to the published `com.kitakkun.jetwhale` plugin.
+ *
+ * Adds `runJetWhale`, the IntelliJ-`runIde`-equivalent that launches the locally built host project
+ * (`:jetwhale-host:app`) with this plugin staged for hot reload. It lives here, and is NOT published,
+ * because it depends on the JetWhale repository's own host project — which external plugin authors
+ * don't have. They use `runJetWhaleFromRelease` from the published plugin instead.
+ *
+ * Apply this alongside `com.kitakkun.jetwhale`: it reuses that plugin's `stageDevPlugin` task and its
+ * dev plugins directory.
+ */
+
+// Must match the dev directory used by the `com.kitakkun.jetwhale` plugin's `stageDevPlugin` task.
+val devPluginsDir = layout.buildDirectory.dir("jetwhale/devPlugins")
+
+// Resolve the host application (classes + runtime dependencies) so we can launch its main class
+// directly with the dev system property set.
+val jetwhaleHostRuntime = configurations.create("jetwhaleHostRuntime") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+dependencies.add("jetwhaleHostRuntime", dependencies.project(":jetwhale-host:app"))
+
+tasks.register<JavaExec>("runJetWhale") {
+    group = "jetwhale"
+    description = "Launches the local JetWhale host project with this plugin loaded for development (hot reload)."
+
+    // `stageDevPlugin` is contributed by the `com.kitakkun.jetwhale` plugin applied to the same module.
+    // Referenced by name (not tasks.named) so plugin application order doesn't matter.
+    dependsOn("stageDevPlugin")
+
+    classpath = jetwhaleHostRuntime
+    mainClass.set("com.kitakkun.jetwhale.host.MainKt")
+
+    // Point the host at the dev plugins directory; this enables dev-mode loading + hot reload.
+    // Supplied lazily via a CommandLineArgumentProvider so the task stays configuration-cache safe.
+    val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
+    jvmArgumentProviders.add(
+        CommandLineArgumentProvider {
+            listOf(
+                "-Djetwhale.devPluginsDir=${devDirProvider.get()}",
+                // Allow the dev hot-reload to self-attach a JVM agent (byte-buddy-agent) for in-place
+                // class redefinition; self-attach is disabled by default on JDK 9+.
+                "-Djdk.attach.allowAttachSelf=true",
+            )
+        },
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -172,3 +172,5 @@ serialization = { id = "serialization" }
 debuggerComposeFeature = { id = "debugger-compose-feature" }
 publish = { id = "publish" }
 jetwhalePlugin = { id = "com.kitakkun.jetwhale" }
+# In-repo only: adds `runJetWhale` (launches the local :jetwhale-host:app). Not published.
+jetwhaleHostLaunch = { id = "jetwhale-host-launch" }

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.gradle.kts
@@ -12,17 +12,19 @@ import util.JetWhalePluginExtension
  *   the hand-written `tasks.jar { from(configurations.runtimeClasspath.map(::zipTree)) ... }` that
  *   each plugin used to repeat.
  * - `installPlugin` — copies the packaged fat-jar into `~/.jetwhale/plugins/`.
- * - `runJetWhale` — the IntelliJ-`runIde`-equivalent: packages the plugin, places it in a private
- *   dev directory and launches the JetWhale host with `-Djetwhale.devPluginsDir=<dir>` so the host
- *   loads and hot-reloads the plugin under development. For live reload, run `runJetWhale` (which
- *   blocks while the host is open) in one terminal and `stageDevPlugin -t` in another — the host
- *   hot-reloads whenever the jar is re-staged. (Do not use `runJetWhale -t`: a blocking JavaExec
- *   never lets Gradle continuous mode start the next build.)
+ * - `stageDevPlugin` — copies the packaged fat-jar into a private dev directory the host watches for
+ *   hot reload.
+ * - `runJetWhaleFromRelease` — downloads the released JetWhale host (see `jetwhalePlugin.hostVersion`)
+ *   for the current OS/architecture and launches it with this plugin staged for development. For live
+ *   reload, run it in one terminal and `stageDevPlugin -t` in another — the host hot-reloads whenever
+ *   the jar is re-staged.
+ *
+ * The in-repo host launcher (`runJetWhale`, which runs the local `:jetwhale-host:app` project) lives
+ * in the separate, non-published `jetwhale-host-launch` convention.
  */
 
 val pluginExtension = extensions.create("jetwhalePlugin", JetWhalePluginExtension::class.java).apply {
     pluginArchiveName.convention(project.name)
-    hostApplicationProject.convention(":jetwhale-host:app")
 }
 
 // ---------------------------------------------------------------------------
@@ -62,58 +64,21 @@ tasks.register<Copy>("installPlugin") {
 }
 
 // ---------------------------------------------------------------------------
-// runJetWhale: launch the host with this plugin loaded from a dev directory.
+// stageDevPlugin: stage the packaged plugin into a dev directory the host hot-reloads from.
 // ---------------------------------------------------------------------------
 
 // A private dev directory under the module's build folder. The host watches it and hot-reloads the
 // plugin jar whenever it is re-staged (e.g. by running `stageDevPlugin -t` in a separate terminal).
+// NOTE: the in-repo `jetwhale-host-launch` convention reuses this exact path, so keep them in sync.
 val devPluginsDir = layout.buildDirectory.dir("jetwhale/devPlugins")
 
-// Stage the freshly packaged plugin into the dev directory before launching the host.
+// Stage the freshly packaged plugin into the dev directory.
 val stageDevPlugin = tasks.register<Copy>("stageDevPlugin") {
     group = "jetwhale"
     description = "Copies the packaged plugin jar into the host dev plugins directory."
 
     from(packagePlugin)
     into(devPluginsDir)
-}
-
-// Resolve the host application (classes + runtime dependencies) from the configured host project so
-// we can launch its main class directly with the dev system property set.
-val jetwhaleHostRuntime = configurations.create("jetwhaleHostRuntime") {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-}
-
-// Wire the host project dependency lazily (no afterEvaluate, so it stays configuration-cache safe)
-// while still honoring any override of `hostApplicationProject` set in the consumer's build script.
-dependencies.addProvider(
-    "jetwhaleHostRuntime",
-    pluginExtension.hostApplicationProject.map { projectPath -> dependencies.project(projectPath) },
-)
-
-tasks.register<JavaExec>("runJetWhale") {
-    group = "jetwhale"
-    description = "Launches the JetWhale host with this plugin loaded for development (hot reload)."
-
-    dependsOn(stageDevPlugin)
-
-    classpath = jetwhaleHostRuntime
-    mainClass.set("com.kitakkun.jetwhale.host.MainKt")
-
-    // Point the host at the dev plugins directory; this enables dev-mode loading + hot reload.
-    // Supplied lazily via a CommandLineArgumentProvider so the task stays configuration-cache safe.
-    val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
-    jvmArgumentProviders.add(
-        CommandLineArgumentProvider {
-            listOf(
-                "-Djetwhale.devPluginsDir=${devDirProvider.get()}",
-                // Allow the dev hot-reload to self-attach a JVM agent (byte-buddy-agent) for in-place
-                // class redefinition; self-attach is disabled by default on JDK 9+.
-                "-Djdk.attach.allowAttachSelf=true",
-            )
-        },
-    )
 }
 
 // ---------------------------------------------------------------------------

--- a/jetwhale-gradle-plugin/src/main/kotlin/util/JetWhalePluginExtension.kt
+++ b/jetwhale-gradle-plugin/src/main/kotlin/util/JetWhalePluginExtension.kt
@@ -3,10 +3,10 @@ package util
 import org.gradle.api.provider.Property
 
 /**
- * Configuration for the `jetwhale-plugin` convention.
+ * Configuration for the `com.kitakkun.jetwhale` plugin.
  *
- * Plugin authors apply the `jetwhale-plugin` convention and (optionally) tweak these values to
- * control how the distributable plugin jar is packaged and how `runJetWhale` launches the host.
+ * Plugin authors apply the plugin and (optionally) tweak these values to control how the
+ * distributable plugin jar is packaged and which released host `runJetWhaleFromRelease` runs against.
  */
 interface JetWhalePluginExtension {
     /**
@@ -16,24 +16,11 @@ interface JetWhalePluginExtension {
     val pluginArchiveName: Property<String>
 
     /**
-     * Gradle project path of the JetWhale host application used by `runJetWhale`.
-     *
-     * Defaults to `:jetwhale-host:app`. The referenced project must apply the Compose Desktop
-     * application plugin and expose `com.kitakkun.jetwhale.host.MainKt` as its main class.
-     *
-     * Note: this assumes the host is available as a project in the same Gradle build. A full Maven
-     * distribution of the host (so external builds can resolve it) is out of scope for now.
-     */
-    val hostApplicationProject: Property<String>
-
-    /**
-     * Version of the released JetWhale host to download and launch with `runJetWhaleFromRelease`,
-     * for plugin authors developing **outside** this repository.
+     * Version of the released JetWhale host to download and launch with `runJetWhaleFromRelease`.
      *
      * When set, `runJetWhaleFromRelease` fetches the matching host application (a runnable uber jar)
-     * for the current OS/architecture from the GitHub release of that version, instead of building
-     * it from [hostApplicationProject]. Leave unset for in-repo development (use `runJetWhale`, which
-     * builds the host from the local project).
+     * for the current OS/architecture from the GitHub release of that version. Pass
+     * `-PjetwhaleHostJar=<path>` to launch a locally built host uber jar instead.
      */
     val hostVersion: Property<String>
 }

--- a/jetwhale-plugins/example/host/build.gradle.kts
+++ b/jetwhale-plugins/example/host/build.gradle.kts
@@ -2,8 +2,10 @@ plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.compose)
     alias(libs.plugins.ksp)
-    // Provides packagePlugin / installPlugin / runJetWhale tasks (see the jetwhale-plugin convention).
+    // Provides packagePlugin / installPlugin / stageDevPlugin / runJetWhaleFromRelease (published).
     alias(libs.plugins.jetwhalePlugin)
+    // In-repo only: adds runJetWhale, which launches the local :jetwhale-host:app project.
+    alias(libs.plugins.jetwhaleHostLaunch)
 }
 
 dependencies {


### PR DESCRIPTION
## Why
The published `com.kitakkun.jetwhale` plugin carried JetWhale-repo-internal build logic: `runJetWhale` launched the local `:jetwhale-host:app` project via a **resolvable** configuration. That has no meaning for external plugin authors and **broke their Gradle sync** (the resolvable config referenced a project they don't have). This removes the root cause (vs #94, which only guarded the symptom).

## What
- **Published plugin** keeps only external-facing tasks: `packagePlugin`, `installPlugin`, `stageDevPlugin`, `downloadJetWhaleHost`, `runJetWhaleFromRelease` (+ `hostVersion`). No `:jetwhale-host:app` reference → external projects configure/sync cleanly **by construction**.
- **New non-published convention** `jetwhale-host-launch` (in `gradle-conventions`) adds `runJetWhale` (local host launch), applied only by in-repo host modules (`example/host`). Reuses the published plugin's `stageDevPlugin` + dev dir.
- Drop `hostApplicationProject` from the extension (never overridden).

## Verification
- ✅ in-repo `example:host`: both `runJetWhale` (resolves `:jetwhale-host:app`) and `runJetWhaleFromRelease` present.
- ✅ external project (plugin from mavenLocal): **no `runJetWhale`**, no `:jetwhale-host:app` reference; `runJetWhaleFromRelease --dry-run` works **with config cache**.

Supersedes #94. Needs a new snapshot publish for external consumers.