### PR TITLE
chore: bump version to 1.0.0-alpha05

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jetwhale = "1.0.0-alpha04"
+jetwhale = "1.0.0-alpha05"
 mavenPublish = "0.36.0"
 
 # kotlin


### PR DESCRIPTION
`1.0.0-alpha04` is released on Maven Central, so the repo's dev version should point at the **next** target.

- Dev snapshots now publish as **`1.0.0-alpha05-SNAPSHOT`** (via `-PjetwhaleSnapshot`), which sorts correctly *after* the released `1.0.0-alpha04`.
- The next release tags `1.0.0-alpha05` (no `-SNAPSHOT`); bump again afterwards.

(Was `1.0.0-alpha04`, i.e. an already-released version — its snapshot would have sorted *before* the release.)