### PR TITLE
feat(plugin-dev): rename runJetWhaleFromRelease to runJetWhale + add runJetWhaleHot

### DIFF
--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -1,7 +1,7 @@
 name: Publish Snapshot
 # Manually publish a development SNAPSHOT: the SDK and Gradle plugin go to the Central snapshots
 # repository (overwritable), and the host uber jars are attached to a `<version>-SNAPSHOT` GitHub
-# pre-release so `runJetWhaleFromRelease` (hostVersion = "<version>-SNAPSHOT") can download them.
+# pre-release so `runJetWhale` (hostVersion = "<version>-SNAPSHOT") can download them.
 on:
   workflow_dispatch:
 permissions:
@@ -75,13 +75,13 @@ jobs:
       - name: Attach host uber jars to a pre-release
         uses: softprops/action-gh-release@v2
         with:
-          # The tag stays `<version>-SNAPSHOT` so runJetWhaleFromRelease always resolves the latest
+          # The tag stays `<version>-SNAPSHOT` so runJetWhale always resolves the latest
           # snapshot; the build number / commit / timestamp below identify which build it currently is.
           tag_name: ${{ steps.ver.outputs.version }}
           name: ${{ steps.ver.outputs.version }} (build ${{ github.run_number }})
           prerelease: true
           body: |
-            Development snapshot — overwritten on each publish; `runJetWhaleFromRelease` resolves this latest build.
+            Development snapshot — overwritten on each publish; `runJetWhale` resolves this latest build.
 
             - Build: #${{ github.run_number }}
             - Commit: ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Thanks to its Kotlin-first design, JetWhale can be introduced with a minimal lea
 
 - 🔥 **Hot-Reloadable Plugin Development**
     - Build your own plugins in your **own** repository against the published SDK — no fork needed
-    - `runJetWhaleFromRelease` downloads a real JetWhale host and launches it with your plugin loaded;
+    - `runJetWhale` downloads a real JetWhale host and launches it with your plugin loaded;
       edit your plugin, re-stage, and the host **hot-reloads** it — no restart
     - See [Developing plugins](docs/developing-plugins.md)
 
@@ -52,7 +52,7 @@ JetWhale's debugging tools are plugins, and you can build your own in your **own
 fast, **hot-reload** dev loop:
 
 - Apply the published `com.kitakkun.jetwhale.host` Gradle plugin and compile against the published SDK.
-- Run a real host with `./gradlew :myPlugin:runJetWhaleFromRelease` (it downloads the host for your
+- Run a real host with `./gradlew :myPlugin:runJetWhale` (it downloads the host for your
   OS — no manual install).
 - Re-stage on save with `./gradlew :myPlugin:stageDevPlugin -t`; the host reloads your plugin without
   a restart — keeping its state for simple (method-body) edits, and recreating it for structural

--- a/docs/developing-plugins.md
+++ b/docs/developing-plugins.md
@@ -12,7 +12,8 @@ The `com.kitakkun.jetwhale.host` plugin gives your plugin's module these tasks:
 | `packagePlugin`          | Builds the distributable plugin fat-jar (the artifact you drop into `~/.jetwhale/plugins/`).          |
 | `installPlugin`          | Copies the packaged fat-jar into `~/.jetwhale/plugins/`.                                              |
 | `stageDevPlugin`         | Stages the packaged fat-jar into a private dev directory the host watches for hot reload.             |
-| `runJetWhaleFromRelease` | Downloads a released JetWhale host for your OS and launches it with your plugin loaded.|
+| `runJetWhale`            | Downloads a released JetWhale host for your OS and launches it with your plugin loaded.|
+| `runJetWhaleHot`         | Like `runJetWhale`, but runs the host on the JetBrains Runtime so structural changes hot-reload in place (see [Limitations](#limitations)).|
 
 ## Set up
 
@@ -79,7 +80,7 @@ manifest. See `jetwhale-plugins/example/host` for a complete, working example:
 
 ## Hot reload (the live dev loop)
 
-`runJetWhaleFromRelease` starts the host with `-Djetwhale.devPluginsDir=<dir>` pointing at a dev
+`runJetWhale` starts the host with `-Djetwhale.devPluginsDir=<dir>` pointing at a dev
 directory under your module's `build` folder. The host loads plugins from that directory **in addition
 to** `~/.jetwhale/plugins/` and watches it: whenever the plugin jar is re-staged, the host reloads it
 and refreshes the open plugin screen — **no host restart needed**. For simple edits it redefines your
@@ -90,17 +91,17 @@ Run the host in one terminal and continuous re-staging in another:
 
 ```shell
 # Terminal 1 — download + launch the host (stays running)
-./gradlew :myPlugin:runJetWhaleFromRelease
+./gradlew :myPlugin:runJetWhale
 
 # Terminal 2 — rebuild & re-stage the plugin jar on every source change
 ./gradlew :myPlugin:stageDevPlugin -t
 ```
 
-> Do **not** add `-t` to `runJetWhaleFromRelease`: it is a long-running process (it blocks until you
+> Do **not** add `-t` to `runJetWhale`: it is a long-running process (it blocks until you
 > close the host), and Gradle continuous mode only starts a new build once the current task graph
 > finishes. Keep the host in one terminal and `stageDevPlugin -t` in another.
 
-`runJetWhaleFromRelease` downloads the runnable host uber jar for `hostVersion` and the current
+`runJetWhale` downloads the runnable host uber jar for `hostVersion` and the current
 OS/architecture from the GitHub release (cached under `~/.jetwhale/dev-host/`) — no manual install of
 JetWhale needed. Pass `-PjetwhaleHostJar=<path>` to launch a locally built host uber jar instead.
 
@@ -120,8 +121,15 @@ Compose-specific: restructuring a `@Composable` (changing its group structure) c
 held by that part of the UI even when the rest of the plugin is preserved.
 
 On a **stock JDK**, only method-body edits are redefined in place; everything else falls back to a
-full reload. Preserving state across **structural** changes too would require running the host on the
-**JetBrains Runtime (JBR)**.
+full reload. To preserve state across **structural** changes too, launch with **`runJetWhaleHot`**,
+which runs the host on the **JetBrains Runtime (JBR)** with enhanced class redefinition. JBR is
+provisioned via Gradle toolchains — add the
+[foojay resolver](https://github.com/gradle/foojay-toolchains) to your `settings.gradle.kts` so it
+can be downloaded automatically:
+
+```kotlin
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0" }
+```
 
 So: a change that can't be redefined in place costs you the plugin's in-memory state — never a host
 restart.
@@ -139,11 +147,11 @@ maven("https://central.sonatype.com/repository/maven-snapshots/")
 ## Developing inside this repository
 
 In-repo plugin modules (e.g. `jetwhale-plugins/example/host`) don't download a host — they launch the
-local `:jetwhale-host:app` project directly via `runJetWhale`, which is added by the internal,
+local `:jetwhale-host:app` project directly via `runJetWhaleLocal`, which is added by the internal,
 non-published `jetwhale-host-launch` convention applied alongside `com.kitakkun.jetwhale.host`:
 
 ```shell
-./gradlew :jetwhale-plugins:example:host:runJetWhale      # builds + launches the local host
+./gradlew :jetwhale-plugins:example:host:runJetWhaleLocal   # builds + launches the local host
 ./gradlew :jetwhale-plugins:example:host:stageDevPlugin -t
 ```
 

--- a/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
@@ -3,10 +3,10 @@ import org.gradle.process.CommandLineArgumentProvider
 /**
  * In-repo-only companion to the published `com.kitakkun.jetwhale.host` plugin.
  *
- * Adds `runJetWhale`, the IntelliJ-`runIde`-equivalent that launches the locally built host project
- * (`:jetwhale-host:app`) with this plugin staged for hot reload. It lives here, and is NOT published,
- * because it depends on the JetWhale repository's own host project — which external plugin authors
- * don't have. They use `runJetWhaleFromRelease` from the published plugin instead.
+ * Adds `runJetWhaleLocal`, which launches the locally built host project (`:jetwhale-host:app`) with
+ * this plugin staged for hot reload. It lives here, and is NOT published, because it depends on the
+ * JetWhale repository's own host project — which external plugin authors don't have. They use
+ * `runJetWhale` from the published plugin instead.
  *
  * Apply this alongside `com.kitakkun.jetwhale.host`: it reuses that plugin's `stageDevPlugin` task and its
  * dev plugins directory.
@@ -23,7 +23,7 @@ val jetwhaleHostRuntime = configurations.create("jetwhaleHostRuntime") {
 }
 dependencies.add("jetwhaleHostRuntime", dependencies.project(":jetwhale-host:app"))
 
-tasks.register<JavaExec>("runJetWhale") {
+tasks.register<JavaExec>("runJetWhaleLocal") {
     group = "jetwhale"
     description = "Launches the local JetWhale host project with this plugin loaded for development (hot reload)."
 

--- a/jetwhale-gradle-plugin/build.gradle.kts
+++ b/jetwhale-gradle-plugin/build.gradle.kts
@@ -17,5 +17,5 @@ version = libs.versions.jetwhale.get() + if (hasProperty("jetwhaleSnapshot")) "-
 jetwhalePublish {
     artifactId = "jetwhale-gradle-plugin"
     name = "JetWhale Gradle Plugin"
-    description = "Gradle plugin for developing JetWhale host plugins (packagePlugin, runJetWhale, runJetWhaleFromRelease)."
+    description = "Gradle plugin for developing JetWhale host plugins (packagePlugin, runJetWhale, runJetWhaleHot)."
 }

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -205,8 +205,7 @@ fun registerRunTask(name: String, taskDescription: String, hot: Boolean) = tasks
 
             else -> error(
                 "Set jetwhalePlugin.hostVersion to the released JetWhale host version, or pass " +
-                    "-PjetwhaleHostJar=<path> to launch a local host jar (or use the in-repo " +
-                    "`runJetWhaleLocal`).",
+                    "-PjetwhaleHostJar=<path> to launch a locally built host uber jar.",
             )
         }
         check(hostJar.exists()) { "JetWhale host jar not found: $hostJar" }

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -1,4 +1,7 @@
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.process.CommandLineArgumentProvider
 import util.JetWhalePluginExtension
 
@@ -181,27 +184,27 @@ val downloadJetWhaleHost = tasks.register("downloadJetWhaleHost") {
     }
 }
 
-tasks.register<JavaExec>("runJetWhaleFromRelease") {
+// `runJetWhale` and `runJetWhaleHot` share the same launch config. `hot` runs the host on the
+// JetBrains Runtime with enhanced class redefinition, so structural code changes (added/removed
+// members, etc.) are redefined in place instead of triggering a full, state-resetting reload.
+fun registerRunTask(name: String, taskDescription: String, hot: Boolean) = tasks.register<JavaExec>(name) {
     group = "jetwhale"
-    description = "Downloads the released JetWhale host (jetwhalePlugin.hostVersion) and launches it with this plugin."
-
-    val hostVersionProvider = pluginExtension.hostVersion
-    val releaseJarProvider = hostReleaseJar
-    val localJarProvider = localHostJar
+    description = taskDescription
     dependsOn(stageDevPlugin, downloadJetWhaleHost)
 
     // Resolve the host jar lazily so JavaExec reads it at execution (after downloadJetWhaleHost has
-    // run). A provider is required: reassigning `classpath` in doFirst is lost under the configuration
-    // cache, leaving an empty classpath and a cryptic "could not find main class" failure.
+    // run). A provider is required: reassigning `classpath` in doFirst is lost under the
+    // configuration cache, leaving an empty classpath and a cryptic "could not find main class".
     val hostJarProvider = providers.provider {
         val hostJar = when {
-            localJarProvider.isPresent -> File(localJarProvider.get())
+            localHostJar.isPresent -> File(localHostJar.get())
 
-            hostVersionProvider.isPresent -> releaseJarProvider.get()
+            pluginExtension.hostVersion.isPresent -> hostReleaseJar.get()
 
             else -> error(
                 "Set jetwhalePlugin.hostVersion to the released JetWhale host version, or pass " +
-                    "-PjetwhaleHostJar=<path> to launch a local host jar (or use the in-repo `runJetWhale`).",
+                    "-PjetwhaleHostJar=<path> to launch a local host jar (or use the in-repo " +
+                    "`runJetWhaleLocal`).",
             )
         }
         check(hostJar.exists()) { "JetWhale host jar not found: $hostJar" }
@@ -210,18 +213,42 @@ tasks.register<JavaExec>("runJetWhaleFromRelease") {
     classpath = files(hostJarProvider)
     mainClass.set("com.kitakkun.jetwhale.host.MainKt")
 
+    // Run the host on the JetBrains Runtime (provisioned via Gradle toolchains; add the foojay
+    // resolver to settings to auto-download it) so it can redefine structural changes in place.
+    if (hot) {
+        javaLauncher.set(
+            project.extensions.getByType(JavaToolchainService::class.java).launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(21))
+                vendor.set(JvmVendorSpec.JETBRAINS)
+            },
+        )
+    }
+
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
-            listOf(
-                "-Djetwhale.devPluginsDir=${devDirProvider.get()}",
-                // Self-attach for the dev hot-reload's in-place class redefinition (disabled by
-                // default on JDK 9+). Structural changes still need the JetBrains Runtime.
-                "-Djdk.attach.allowAttachSelf=true",
-            )
+            buildList {
+                add("-Djetwhale.devPluginsDir=${devDirProvider.get()}")
+                // Self-attach for the dev hot-reload's in-place class redefinition (off by default
+                // on JDK 9+).
+                add("-Djdk.attach.allowAttachSelf=true")
+                // On the JetBrains Runtime, allow redefining structural changes in place too.
+                if (hot) add("-XX:+AllowEnhancedClassRedefinition")
+            }
         },
     )
 }
+
+registerRunTask(
+    name = "runJetWhale",
+    taskDescription = "Downloads the released JetWhale host (jetwhalePlugin.hostVersion) and launches it with this plugin.",
+    hot = false,
+)
+registerRunTask(
+    name = "runJetWhaleHot",
+    taskDescription = "Like runJetWhale, but runs the host on the JetBrains Runtime so structural code changes hot-reload in place (requires a JBR toolchain).",
+    hot = true,
+)
 
 // Make sure `packagePlugin` participates in the standard `assemble`/`build` lifecycle so authors get
 // the distributable artifact without invoking the task by name.

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -17,13 +17,15 @@ import util.JetWhalePluginExtension
  * - `installPlugin` — copies the packaged fat-jar into `~/.jetwhale/plugins/`.
  * - `stageDevPlugin` — copies the packaged fat-jar into a private dev directory the host watches for
  *   hot reload.
- * - `runJetWhaleFromRelease` — downloads the released JetWhale host (see `jetwhalePlugin.hostVersion`)
- *   for the current OS/architecture and launches it with this plugin staged for development. For live
- *   reload, run it in one terminal and `stageDevPlugin -t` in another — the host hot-reloads whenever
- *   the jar is re-staged.
+ * - `runJetWhale` — downloads the released JetWhale host (see `jetwhalePlugin.hostVersion`) for the
+ *   current OS/architecture and launches it with this plugin staged for development. For live reload,
+ *   run it in one terminal and `stageDevPlugin -t` in another — the host hot-reloads whenever the jar
+ *   is re-staged.
+ * - `runJetWhaleHot` — the same, but runs the host on the JetBrains Runtime so structural code changes
+ *   hot-reload in place too (requires a JBR toolchain).
  *
- * The in-repo host launcher (`runJetWhale`, which runs the local `:jetwhale-host:app` project) lives
- * in the separate, non-published `jetwhale-host-launch` convention.
+ * The in-repo host launcher (`runJetWhaleLocal`, which runs the local `:jetwhale-host:app` project)
+ * lives in the separate, non-published `jetwhale-host-launch` convention.
  */
 
 val pluginExtension = extensions.create("jetwhalePlugin", JetWhalePluginExtension::class.java).apply {
@@ -85,7 +87,7 @@ val stageDevPlugin = tasks.register<Copy>("stageDevPlugin") {
 }
 
 // ---------------------------------------------------------------------------
-// runJetWhaleFromRelease: download a released host and launch it with this plugin, for plugin
+// runJetWhale: download a released host and launch it with this plugin, for plugin
 // authors developing OUTSIDE this repository (the `:jetwhale-host:app` project is not available to
 // them). Set `jetwhalePlugin.hostVersion` to choose which released host to run against, or pass
 // `-PjetwhaleHostJar=<path>` to launch a locally built host uber jar (useful before a release exists).
@@ -99,12 +101,12 @@ val currentOsArch: Provider<String> =
             osName.contains("mac", ignoreCase = true) || osName.contains("darwin", ignoreCase = true) -> "macos"
             osName.contains("win", ignoreCase = true) -> "windows"
             osName.contains("nux", ignoreCase = true) || osName.contains("nix", ignoreCase = true) -> "linux"
-            else -> error("Unsupported OS for runJetWhaleFromRelease: $osName")
+            else -> error("Unsupported OS for runJetWhale: $osName")
         }
         val arch = when (archName.lowercase()) {
             "aarch64", "arm64" -> "arm64"
             "x86_64", "amd64", "x64" -> "x64"
-            else -> error("Unsupported architecture for runJetWhaleFromRelease: $archName")
+            else -> error("Unsupported architecture for runJetWhale: $archName")
         }
         "$os-$arch"
     }

--- a/jetwhale-gradle-plugin/src/main/kotlin/util/JetWhalePluginExtension.kt
+++ b/jetwhale-gradle-plugin/src/main/kotlin/util/JetWhalePluginExtension.kt
@@ -3,10 +3,10 @@ package util
 import org.gradle.api.provider.Property
 
 /**
- * Configuration for the `com.kitakkun.jetwhale` plugin.
+ * Configuration for the `com.kitakkun.jetwhale.host` plugin.
  *
  * Plugin authors apply the plugin and (optionally) tweak these values to control how the
- * distributable plugin jar is packaged and which released host `runJetWhaleFromRelease` runs against.
+ * distributable plugin jar is packaged and which released host `runJetWhale` runs against.
  */
 interface JetWhalePluginExtension {
     /**
@@ -16,9 +16,9 @@ interface JetWhalePluginExtension {
     val pluginArchiveName: Property<String>
 
     /**
-     * Version of the released JetWhale host to download and launch with `runJetWhaleFromRelease`.
+     * Version of the released JetWhale host to download and launch with `runJetWhale`.
      *
-     * When set, `runJetWhaleFromRelease` fetches the matching host application (a runnable uber jar)
+     * When set, `runJetWhale` fetches the matching host application (a runnable uber jar)
      * for the current OS/architecture from the GitHub release of that version. Pass
      * `-PjetwhaleHostJar=<path>` to launch a locally built host uber jar instead.
      */

--- a/jetwhale-plugins/example/host/build.gradle.kts
+++ b/jetwhale-plugins/example/host/build.gradle.kts
@@ -2,9 +2,9 @@ plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.compose)
     alias(libs.plugins.ksp)
-    // Provides packagePlugin / installPlugin / stageDevPlugin / runJetWhaleFromRelease (published).
+    // Provides packagePlugin / installPlugin / stageDevPlugin / runJetWhale / runJetWhaleHot (published).
     alias(libs.plugins.jetwhalePlugin)
-    // In-repo only: adds runJetWhale, which launches the local :jetwhale-host:app project.
+    // In-repo only: adds runJetWhaleLocal, which launches the local :jetwhale-host:app project.
     alias(libs.plugins.jetwhaleHostLaunch)
 }
 


### PR DESCRIPTION
## Task naming
- The published `com.kitakkun.jetwhale.host` plugin's external launch task is now just **`runJetWhale`** (was the verbose `runJetWhaleFromRelease`).
- The in-repo `jetwhale-host-launch` convention's local-launch task is renamed **`runJetWhale` → `runJetWhaleLocal`** to avoid colliding with the published `runJetWhale` when both are applied (e.g. `example/host`).

## New: `runJetWhaleHot`
`runJetWhaleHot` is like `runJetWhale` but runs the downloaded host on the **JetBrains Runtime** (Gradle toolchain, `vendor = JETBRAINS`, Java 21) with `-XX:+AllowEnhancedClassRedefinition`. That lets the host redefine **structural** code changes (added/removed members, etc.) **in place**, so plugin state is preserved across them instead of triggering a full reload. JBR is provisioned via Gradle toolchains (add the foojay resolver to settings).

## Also
- Docs: task table + a `runJetWhaleHot`/JBR/foojay note in Limitations + in-repo section uses `runJetWhaleLocal`; README + example/host comments + extension KDoc + POM description updated.

## Verification
- ✅ `:jetwhale-plugins:example:host` exposes `runJetWhale` / `runJetWhaleHot` / `runJetWhaleLocal` with **no task-name collision**; configures under the configuration cache; spotless clean.
- ⚠️ The actual JBR launch (toolchain download + enhanced redefinition) needs a JBR + GUI and was **not** verified headlessly.