### PR TITLE
feat(plugin-dev): make runJetWhaleHot auto re-stage the plugin

### DIFF
--- a/docs/developing-plugins.md
+++ b/docs/developing-plugins.md
@@ -13,7 +13,7 @@ The `com.kitakkun.jetwhale.host` plugin gives your plugin's module these tasks:
 | `installPlugin`          | Copies the packaged fat-jar into `~/.jetwhale/plugins/`.                                              |
 | `stageDevPlugin`         | Stages the packaged fat-jar into a private dev directory the host watches for hot reload.             |
 | `runJetWhale`            | Downloads a released JetWhale host for your OS and launches it with your plugin loaded.|
-| `runJetWhaleHot`         | Like `runJetWhale`, but runs the host on the JetBrains Runtime so structural changes hot-reload in place (see [Limitations](#limitations)).|
+| `runJetWhaleHot`         | Like `runJetWhale`, but runs the host on the JetBrains Runtime so structural changes hot-reload in place (see [Limitations](#limitations)), and auto re-stages your plugin in the background — the whole hot-reload loop in one command. |
 
 ## Set up
 
@@ -87,7 +87,22 @@ and refreshes the open plugin screen — **no host restart needed**. For simple 
 classes in place and keeps the plugin's state; for changes it can't apply that way it recreates the
 plugin from a fresh classloader (see [Limitations](#limitations) below).
 
-Run the host in one terminal and continuous re-staging in another:
+The simplest loop is a single command — `runJetWhaleHot` launches the host **and** keeps re-staging
+your plugin for you:
+
+```shell
+# Launches the host and re-stages on every source change, all in one terminal.
+./gradlew :myPlugin:runJetWhaleHot
+```
+
+It runs the host in the foreground and, in the background, a `stageDevPlugin -t` that re-packages and
+re-stages the jar whenever you edit a source file; the host then hot-reloads it. The background
+re-staging stops automatically when you stop the host (close it, or press Ctrl+C). `runJetWhaleHot`
+also runs the host on the JetBrains Runtime so structural changes hot-reload in place — see
+[Limitations](#limitations).
+
+If you prefer a plain JDK (no JBR toolchain), use `runJetWhale` instead and drive the re-staging
+yourself from a second terminal:
 
 ```shell
 # Terminal 1 — download + launch the host (stays running)
@@ -97,9 +112,10 @@ Run the host in one terminal and continuous re-staging in another:
 ./gradlew :myPlugin:stageDevPlugin -t
 ```
 
-> Do **not** add `-t` to `runJetWhale`: it is a long-running process (it blocks until you
-> close the host), and Gradle continuous mode only starts a new build once the current task graph
-> finishes. Keep the host in one terminal and `stageDevPlugin -t` in another.
+> Do **not** add `-t` to `runJetWhale`/`runJetWhaleHot`: they are long-running processes (they block
+> until you close the host), and Gradle continuous mode only starts a new build once the current task
+> graph finishes. `runJetWhaleHot` already runs the watcher for you; for `runJetWhale`, keep the host
+> in one terminal and `stageDevPlugin -t` in another.
 
 `runJetWhale` downloads the runnable host uber jar for `hostVersion` and the current
 OS/architecture from the GitHub release (cached under `~/.jetwhale/dev-host/`) — no manual install of

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -105,10 +105,22 @@ val stopHotStaging = tasks.register("stopHotStaging") {
         val pidFile = pidFileProvider.get().asFile
         if (!pidFile.exists()) return@doLast
         pidFile.readText().trim().toLongOrNull()?.let { pid ->
-            ProcessHandle.of(pid).ifPresent { handle ->
-                handle.descendants().forEach { it.destroy() }
-                handle.destroy()
-            }
+            ProcessHandle.of(pid)
+                // Guard against PID reuse: a stale pid file left by a crashed run could otherwise point
+                // at an unrelated process that inherited the id. The watcher was started by this same
+                // Gradle daemon (doFirst runs in it), so only act when the process is still our child.
+                .filter { handle -> handle.parent().map { it.pid() == ProcessHandle.current().pid() }.orElse(false) }
+                .ifPresent { handle ->
+                    // Stop it gracefully first, then — if it has not exited shortly — force it so the
+                    // watcher is never left running.
+                    handle.descendants().forEach { it.destroy() }
+                    handle.destroy()
+                    runCatching { handle.onExit().get(3, java.util.concurrent.TimeUnit.SECONDS) }
+                    if (handle.isAlive) {
+                        handle.descendants().forEach { it.destroyForcibly() }
+                        handle.destroyForcibly()
+                    }
+                }
         }
         pidFile.delete()
     }

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -21,8 +21,9 @@ import util.JetWhalePluginExtension
  *   current OS/architecture and launches it with this plugin staged for development. For live reload,
  *   run it in one terminal and `stageDevPlugin -t` in another — the host hot-reloads whenever the jar
  *   is re-staged.
- * - `runJetWhaleHot` — the same, but runs the host on the JetBrains Runtime so structural code changes
- *   hot-reload in place too (requires a JBR toolchain).
+ * - `runJetWhaleHot` — the same, but runs the host on the JetBrains Runtime (so structural code changes
+ *   hot-reload in place too; requires a JBR toolchain) AND keeps the plugin re-staged in the background,
+ *   so a single command is the whole hot-reload loop — no separate `stageDevPlugin -t` terminal needed.
  *
  * The in-repo host launcher (`runJetWhaleLocal`, which runs the local `:jetwhale-host:app` project)
  * lives in the separate, non-published `jetwhale-host-launch` convention.
@@ -84,6 +85,33 @@ val stageDevPlugin = tasks.register<Copy>("stageDevPlugin") {
 
     from(packagePlugin)
     into(devPluginsDir)
+}
+
+// ---------------------------------------------------------------------------
+// Continuous re-staging for runJetWhaleHot.
+// ---------------------------------------------------------------------------
+
+// runJetWhaleHot starts a background `stageDevPlugin -t` so a single command is the whole hot-reload
+// loop (see registerRunTask). The watcher's PID is handed from the run task's doFirst to the finalizer
+// below through this file: the configuration cache does not preserve a shared field across task actions,
+// and a finalizer (unlike doLast) also runs when the host exits with a non-zero status.
+val hotStagingPidFile = layout.buildDirectory.file("jetwhale/hot-staging.pid")
+
+val stopHotStaging = tasks.register("stopHotStaging") {
+    description = "Stops the background continuous-staging watcher started by runJetWhaleHot."
+
+    val pidFileProvider = hotStagingPidFile
+    doLast {
+        val pidFile = pidFileProvider.get().asFile
+        if (!pidFile.exists()) return@doLast
+        pidFile.readText().trim().toLongOrNull()?.let { pid ->
+            ProcessHandle.of(pid).ifPresent { handle ->
+                handle.descendants().forEach { it.destroy() }
+                handle.destroy()
+            }
+        }
+        pidFile.delete()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -238,6 +266,61 @@ fun registerRunTask(name: String, taskDescription: String, hot: Boolean) = tasks
             }
         },
     )
+
+    // Make `runJetWhaleHot` the whole hot-reload loop in one command: while the host runs in the
+    // foreground (and hot-reloads from the dev directory), a background `stageDevPlugin -t` re-packages
+    // and re-stages the plugin on every source change — so authors no longer need a second terminal.
+    // The host is launched in the foreground here; `dependsOn(stageDevPlugin)` already staged it once
+    // before this watcher takes over re-staging on change.
+    if (hot) {
+        // stopHotStaging is a finalizer (not doLast) so the watcher is also stopped when the host exits
+        // non-zero; on an interactive Ctrl+C the watcher additionally receives the terminal's SIGINT
+        // because it shares this command's process group.
+        finalizedBy(stopHotStaging)
+
+        val rootProjectDir = project.rootDir
+        val stageTaskPath = if (project.path == ":") ":stageDevPlugin" else "${project.path}:stageDevPlugin"
+        val osNameProvider = providers.systemProperty("os.name")
+        val pidFileProvider = hotStagingPidFile
+
+        doFirst {
+            val isWindows = osNameProvider.getOrElse("").startsWith("Windows", ignoreCase = true)
+            val gradlew = File(rootProjectDir, if (isWindows) "gradlew.bat" else "gradlew")
+            if (!gradlew.exists()) {
+                logger.warn(
+                    "JetWhale: Gradle wrapper not found at $gradlew; not auto-re-staging. " +
+                        "Run `./gradlew $stageTaskPath -t` in another terminal to hot-reload code changes.",
+                )
+                return@doFirst
+            }
+            // On Windows a .bat must be launched through cmd; elsewhere the wrapper is executed directly.
+            val command = buildList {
+                if (isWindows) addAll(listOf("cmd", "/c"))
+                add(gradlew.absolutePath)
+                addAll(listOf(stageTaskPath, "-t", "--console=plain"))
+            }
+            logger.lifecycle("JetWhale: continuously re-staging the plugin on source changes (${command.joinToString(" ")}).")
+            val process = ProcessBuilder(command)
+                .directory(rootProjectDir)
+                .redirectErrorStream(true)
+                .start()
+            val pidFile = pidFileProvider.get().asFile
+            pidFile.parentFile.mkdirs()
+            pidFile.writeText(process.pid().toString())
+            // The task action runs inside the Gradle daemon, whose streams are not the user's console,
+            // so a raw INHERIT would hide re-staging progress and (critically) any compile errors.
+            // Pump the watcher's output through this task's logger so it surfaces on the console.
+            val watcherLogger = logger
+            Thread(
+                {
+                    process.inputStream.bufferedReader().useLines { lines ->
+                        lines.forEach { watcherLogger.lifecycle("[stageDevPlugin] $it") }
+                    }
+                },
+                "jetwhale-hot-staging-watcher",
+            ).also { it.isDaemon = true }.start()
+        }
+    }
 }
 
 registerRunTask(
@@ -247,7 +330,8 @@ registerRunTask(
 )
 registerRunTask(
     name = "runJetWhaleHot",
-    taskDescription = "Like runJetWhale, but runs the host on the JetBrains Runtime so structural code changes hot-reload in place (requires a JBR toolchain).",
+    taskDescription = "Like runJetWhale, but runs the host on the JetBrains Runtime (structural changes hot-reload in " +
+        "place; requires a JBR toolchain) and auto re-stages the plugin in the background — the whole hot-reload loop in one command.",
     hot = true,
 )
 


### PR DESCRIPTION
## Summary

`runJetWhaleHot` is now the **whole hot-reload loop in a single command**. It launches the host in the foreground and, in the background, runs a `stageDevPlugin -t` that re-packages and re-stages the plugin on every source change — so the host hot-reloads it without the author having to open a second terminal.

Previously `runJetWhaleHot` only staged the plugin **once** (via `dependsOn(stageDevPlugin)`) before launch; to actually get live reload you had to run `./gradlew :myPlugin:stageDevPlugin -t` yourself in another terminal (as the docs instructed). Now the "Hot" task owns the full loop.

`runJetWhale` (non-hot) is intentionally unchanged: a one-shot launch for a plain JDK, with the manual two-terminal flow still documented.

## How it works

- While the host runs in the foreground (and hot-reloads from the dev directory), a background Gradle continuous build (`stageDevPlugin -t`) re-packages and re-stages the jar on every change. This is the same two-process workflow the docs already recommended, just automated.
- **Lifecycle:** the watcher's PID is handed from the run task's `doFirst` to a finalizer through a file, because the configuration cache does not preserve a shared field across task actions. A **finalizer** (not `doLast`) stops the watcher even when the host exits with a non-zero status; an interactive **Ctrl+C** also reaches the watcher because it shares the command's process group.
- **Output:** the watcher's output is pumped through the task logger so re-staging progress and (critically) compile errors surface on the console — a raw `INHERIT` would go to the Gradle daemon's streams, not the user's terminal.
- **Cross-platform:** on Windows the wrapper is launched via `cmd /c`; the wrapper's absence is handled with a clear warning (falls back to staging once).

## Notes for reviewers

- Configuration cache is enabled in this repo (`org.gradle.configuration-cache=true`); the implementation only captures serializable values (`File`/`String`/`Provider`) into the task actions, never `Project`.
- Compiles cleanly: `./gradlew :jetwhale-gradle-plugin:compileKotlin` (Java 21).

## Docs

`docs/developing-plugins.md` updated to present `runJetWhaleHot` as the one-command loop and keep the two-terminal flow for `runJetWhale`.