### PR TITLE
feat(plugins): allow one module to declare multiple plugins

### DIFF
--- a/docs/developing-plugins.md
+++ b/docs/developing-plugins.md
@@ -69,14 +69,35 @@ implementation("com.kitakkun.jetwhale:jetwhale-agent-sdk:<version>")
 
 ### 3. Write the plugin
 
-Implement `JetWhaleHostPluginFactory` and register it for `ServiceLoader` discovery, and add a plugin
-manifest. See `jetwhale-plugins/example/host` for a complete, working example:
+Implement `JetWhaleHostPluginFactory` and declare it in a plugin manifest. The host loads each plugin
+by the `factoryClass` you list in the manifest, so **no `ServiceLoader`/`@AutoService` registration is
+needed**. See `jetwhale-plugins/example/host` for a complete, working example:
 
 - `src/main/kotlin/.../MyPluginFactory.kt` — a `JetWhaleHostPluginFactory` returning your
-  `JetWhaleRawHostPlugin` (or the typed `JetWhaleHostPlugin<Event, Method, MethodResult>`).
-- `src/main/resources/META-INF/services/com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory` —
-  one line with your factory's fully-qualified name (or use `@AutoService`).
-- `src/main/resources/META-INF/jetwhale/plugin-manifest.json` — `pluginId`, `pluginName`, `version`.
+  `JetWhaleRawHostPlugin` (or the typed `JetWhaleHostPlugin<Event, Method, MethodResult>`). It needs a
+  public no-arg constructor so the host can instantiate it.
+- `src/main/resources/META-INF/jetwhale/plugin-manifest.json` — one entry per plugin under `plugins`,
+  each with `pluginId`, `pluginName`, `version`, and `factoryClass` (the fully-qualified name of the
+  factory above):
+
+  ```json
+  {
+    "plugins": [
+      {
+        "pluginId": "com.example.myplugin",
+        "pluginName": "My Plugin",
+        "version": "1.0.0",
+        "factoryClass": "com.example.MyPluginFactory"
+      }
+    ]
+  }
+  ```
+
+#### Multiple plugins in one module
+
+A single module's jar can ship several plugins: add one entry per plugin to the `plugins` array, each
+pointing at its own `factoryClass`. The plugins share the jar (and its classloader), and are loaded,
+reloaded, and hot-redefined together.
 
 ## Hot reload (the live dev loop)
 

--- a/docs/developing-plugins.md
+++ b/docs/developing-plugins.md
@@ -70,8 +70,8 @@ implementation("com.kitakkun.jetwhale:jetwhale-agent-sdk:<version>")
 ### 3. Write the plugin
 
 Implement `JetWhaleHostPluginFactory` and declare it in a plugin manifest. The host loads each plugin
-by the `factoryClass` you list in the manifest, so **no `ServiceLoader`/`@AutoService` registration is
-needed**. See `jetwhale-plugins/example/host` for a complete, working example:
+by instantiating the `factoryClass` named in the manifest. See `jetwhale-plugins/example/host` for a
+complete, working example:
 
 - `src/main/kotlin/.../MyPluginFactory.kt` — a `JetWhaleHostPluginFactory` returning your
   `JetWhaleRawHostPlugin` (or the typed `JetWhaleHostPlugin<Event, Method, MethodResult>`). It needs a

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,9 +17,6 @@ androidGradlePlugin = "9.2.0"
 androidxCoreKtx = "1.18.0"
 androidxActivity = "1.13.0"
 
-autoServiceKsp = "1.2.0"
-autoServiceAnnotations = "1.1.1"
-
 jetbrainsCompose = "1.11.1"
 material3 = "1.11.0-alpha07"
 material3Adaptive = "1.3.0-alpha07"
@@ -109,9 +106,6 @@ kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 
 aboutLibrariesComposeM3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutLibraries" }
 aboutLibrariesCore = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutLibraries" }
-
-autoServiceKsp = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "autoServiceKsp" }
-autoServiceAnnotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoServiceAnnotations" }
 
 [bundles]
 gradlePlugins = [

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -23,17 +23,19 @@ public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugi
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest {
 	public static final field $stable I
 	public static final field Companion Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;
-	public final fun component5 ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;
-	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;
+	public final fun component6 ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAgentVersionRange ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;
+	public final fun getFactoryClass ()Ljava/lang/String;
 	public final fun getIcon ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;
 	public final fun getPluginId ()Ljava/lang/String;
 	public final fun getPluginName ()Ljava/lang/String;
@@ -121,6 +123,35 @@ public final synthetic class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginMa
 }
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile {
+	public static final field $stable I
+	public static final field Companion Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlugins ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest.kt
@@ -2,11 +2,28 @@ package com.kitakkun.jetwhale.host.sdk
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Top-level shape of `META-INF/jetwhale/plugin-manifest.json`. A single plugin JAR may declare
+ * several plugins, so the manifest is a list — one [JetWhaleHostPluginManifest] entry per plugin.
+ * Each entry names its own [JetWhaleHostPluginFactory] implementation via
+ * [JetWhaleHostPluginManifest.factoryClass], which is how a single JAR can ship several plugins.
+ */
+@Serializable
+public data class JetWhaleHostPluginManifestFile(
+    public val plugins: List<JetWhaleHostPluginManifest>,
+)
+
 @Serializable
 public data class JetWhaleHostPluginManifest(
     public val pluginId: String,
     public val pluginName: String,
     public val version: String,
+    /**
+     * Fully-qualified name of this plugin's [JetWhaleHostPluginFactory] implementation. The host loads
+     * this class from the plugin JAR and instantiates it (via its no-arg constructor) to obtain the
+     * plugin. Each entry pointing at its own factory is what lets one JAR provide multiple plugins.
+     */
+    public val factoryClass: String,
     public val agentVersionRange: AgentVersionRange? = null,
     public val icon: Icon? = null,
 ) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -233,8 +233,7 @@ class DefaultPluginFactoryRepository @Inject constructor(
         println("Unloaded plugin: $pluginId")
     }
 
-    override fun findPluginIdsByJarPath(pluginJarPath: String): List<String> =
-        jarPathToPluginIds[pluginJarPath].orEmpty()
+    override fun findPluginIdsByJarPath(pluginJarPath: String): List<String> = jarPathToPluginIds[pluginJarPath].orEmpty()
 
     override suspend fun reloadPlugin(pluginJarPath: String): List<String> = loadMutex.withLock {
         // loadPlugin already closes and replaces the previous classloader for this jar, dropping the

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import net.bytebuddy.agent.ByteBuddyAgent
 import java.io.File
@@ -59,7 +61,19 @@ class DefaultPluginFactoryRepository @Inject constructor(
      */
     private val runtimeJars: ConcurrentHashMap<String, File> = ConcurrentHashMap()
 
-    override suspend fun loadPlugin(pluginJarPath: String) {
+    /**
+     * Serializes load/unload/reload: each performs compound read-modify-write across several maps
+     * ([classLoaders], [jarPathToPluginIds], [runtimeJars], [mutablePluginsFlow]), which per-map
+     * atomicity alone does not make safe. `loadPlugin` is invoked from the initial load, the install
+     * flow, and the hot-reload watcher, so these can overlap.
+     */
+    private val loadMutex = Mutex()
+
+    override suspend fun loadPlugin(pluginJarPath: String): Unit = loadMutex.withLock {
+        loadPluginUnderLock(pluginJarPath)
+    }
+
+    private fun loadPluginUnderLock(pluginJarPath: String) {
         var classLoader: URLClassLoader? = null
         var runtimeJar: File? = null
         try {
@@ -191,7 +205,11 @@ class DefaultPluginFactoryRepository @Inject constructor(
         }
     }
 
-    override suspend fun unloadPlugin(pluginId: String) {
+    override suspend fun unloadPlugin(pluginId: String): Unit = loadMutex.withLock {
+        unloadPluginUnderLock(pluginId)
+    }
+
+    private fun unloadPluginUnderLock(pluginId: String) {
         mutablePluginsFlow.update { current ->
             current.toMutableMap().apply { remove(pluginId) }.toPersistentMap()
         }
@@ -214,14 +232,18 @@ class DefaultPluginFactoryRepository @Inject constructor(
     override fun findPluginIdsByJarPath(pluginJarPath: String): List<String> =
         jarPathToPluginIds[pluginJarPath].orEmpty()
 
-    override suspend fun reloadPlugin(pluginJarPath: String): List<String> {
+    override suspend fun reloadPlugin(pluginJarPath: String): List<String> = loadMutex.withLock {
         // loadPlugin already closes and replaces the previous classloader for this jar, dropping the
-        // stale classes. We simply re-run it and report the resulting plugin ids.
-        loadPlugin(pluginJarPath)
+        // stale classes. We simply re-run it (under the same lock, so the result read below is
+        // consistent with it) and report the resulting plugin ids.
+        loadPluginUnderLock(pluginJarPath)
         // loadPlugin records the path in failedJarPaths on failure; treat that as an unsuccessful
         // reload (don't report stale success from a leftover jarPathToPluginIds mapping).
-        if (pluginJarPath in mutableFailedJarPathsFlow.value) return emptyList()
-        return jarPathToPluginIds[pluginJarPath].orEmpty()
+        if (pluginJarPath in mutableFailedJarPathsFlow.value) {
+            emptyList()
+        } else {
+            jarPathToPluginIds[pluginJarPath].orEmpty()
+        }
     }
 
     override fun tryRedefinePlugin(pluginJarPath: String): List<String> {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -110,7 +110,10 @@ class DefaultPluginFactoryRepository @Inject constructor(
             val loaded = ArrayList<LoadedHostPlugin>(manifests.size)
             for (manifest in manifests) {
                 val factory = try {
-                    classLoader.loadClass(manifest.factoryClass).getDeclaredConstructor().newInstance()
+                    // getConstructor (not getDeclaredConstructor): the contract is a *public* no-arg
+                    // constructor, so a non-public one fails clearly with NoSuchMethodException rather
+                    // than an IllegalAccessException at newInstance().
+                    classLoader.loadClass(manifest.factoryClass).getConstructor().newInstance()
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Throwable) {
@@ -165,7 +168,8 @@ class DefaultPluginFactoryRepository @Inject constructor(
     private fun failJar(pluginJarPath: String, classLoader: URLClassLoader?, runtimeJar: File?) {
         classLoader?.close()
         runtimeJar?.delete()
-        mutableFailedJarPathsFlow.update { it + pluginJarPath }
+        // Avoid accumulating duplicates across repeated failed loads (e.g. a hot-reload rebuild loop).
+        mutableFailedJarPathsFlow.update { if (pluginJarPath in it) it else it + pluginJarPath }
     }
 
     /**

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -74,74 +74,29 @@ class DefaultPluginFactoryRepository @Inject constructor(
     }
 
     private fun loadPluginUnderLock(pluginJarPath: String) {
-        var classLoader: URLClassLoader? = null
-        var runtimeJar: File? = null
+        // Open the classloader on a private copy of the jar so the source jar can be overwritten
+        // (e.g. by dev hot-reload restaging) without corrupting this classloader's open zip handle —
+        // which otherwise throws ZipException on later resource/class reads. Every plugin declared by
+        // the jar shares this single classloader.
+        val runtimeJar = createRuntimeCopyIfDevJar(pluginJarPath)
+        val classLoader = URLClassLoader(arrayOf((runtimeJar ?: File(pluginJarPath)).toURI().toURL()))
+
+        // Once the classloader is handed to `classLoaders`, the map owns it and the `finally` below
+        // must not close it; until then it (and its temp copy) is ours to discard on any failure.
+        var committed = false
         try {
-            // Open the classloader on a private copy of the jar so the source jar can be overwritten
-            // (e.g. by dev hot-reload restaging) without corrupting this classloader's open zip
-            // handle — which otherwise throws ZipException on later resource/class reads. Every plugin
-            // declared by the jar shares this single classloader.
-            runtimeJar = createRuntimeCopyIfDevJar(pluginJarPath)
-            classLoader = URLClassLoader(arrayOf((runtimeJar ?: File(pluginJarPath)).toURI().toURL()))
-
-            val manifestJson = classLoader
-                .getResourceAsStream(MANIFEST_PATH)
-                ?.bufferedReader()
-                ?.use { it.readText() }
-                ?: run {
-                    println("Warning: $MANIFEST_PATH not found in $pluginJarPath")
-                    return failJar(pluginJarPath, classLoader, runtimeJar)
-                }
-
-            val manifests = pluginManifestJson.decodeFromString<JetWhaleHostPluginManifestFile>(manifestJson).plugins
-            if (manifests.isEmpty()) {
-                println("Warning: $MANIFEST_PATH in $pluginJarPath declares no plugins")
-                return failJar(pluginJarPath, classLoader, runtimeJar)
-            }
-            manifests.groupingBy { it.pluginId }.eachCount().filterValues { it > 1 }.keys.takeIf { it.isNotEmpty() }
-                ?.let { duplicates ->
-                    println("Warning: $MANIFEST_PATH in $pluginJarPath declares duplicate pluginId(s): ${duplicates.joinToString()}")
-                    return failJar(pluginJarPath, classLoader, runtimeJar)
-                }
-
-            // Instantiate each plugin's factory by the fully-qualified class name it declares in the
-            // manifest (no ServiceLoader): this is what pairs every manifest entry with its factory and
-            // lets a single jar provide several plugins.
-            val loaded = ArrayList<LoadedHostPlugin>(manifests.size)
-            for (manifest in manifests) {
-                val factory = try {
-                    // getConstructor (not getDeclaredConstructor): the contract is a *public* no-arg
-                    // constructor, so a non-public one fails clearly with NoSuchMethodException rather
-                    // than an IllegalAccessException at newInstance().
-                    classLoader.loadClass(manifest.factoryClass).getConstructor().newInstance()
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Throwable) {
-                    println(
-                        "Failed to instantiate factory '${manifest.factoryClass}' for plugin " +
-                            "'${manifest.pluginId}' in $pluginJarPath: ${e.message}",
-                    )
-                    return failJar(pluginJarPath, classLoader, runtimeJar)
-                }
-                if (factory !is JetWhaleHostPluginFactory) {
-                    println(
-                        "Factory '${manifest.factoryClass}' for plugin '${manifest.pluginId}' in " +
-                            "$pluginJarPath is not a ${JetWhaleHostPluginFactory::class.java.simpleName}",
-                    )
-                    return failJar(pluginJarPath, classLoader, runtimeJar)
-                }
-                loaded += LoadedHostPlugin(manifest = manifest, factory = factory)
-            }
-
-            val newPluginIds = manifests.map { it.pluginId }
+            val loaded = loadDeclaredPlugins(pluginJarPath, classLoader)
+            val newPluginIds = loaded.map { it.manifest.pluginId }
 
             // Detach any of these plugin ids that another jar currently provides, so we neither leak
             // that jar's classloader nor show a duplicate plugin (e.g. a plugin moved between jars).
             detachPluginIdsFromOtherJars(newPluginIds.toSet(), keepJarPath = pluginJarPath)
 
-            // Discard the previously loaded classloader for this jar (e.g. a reload) so that no stale
-            // classloader (and its classes) leaks; record this load's runtime copy.
-            classLoaders.put(pluginJarPath, classLoader)?.close()
+            // Hand the new classloader to the map (discarding the previous one for this jar, e.g. a
+            // reload, so no stale classloader and its classes leak) and record this load's runtime copy.
+            val previousClassLoader = classLoaders.put(pluginJarPath, classLoader)
+            committed = true
+            previousClassLoader?.close()
             if (runtimeJar != null) runtimeJars[pluginJarPath] = runtimeJar else runtimeJars.remove(pluginJarPath)
 
             // Plugin ids this jar provided before but no longer does (removed/renamed across a rebuild).
@@ -157,19 +112,56 @@ class DefaultPluginFactoryRepository @Inject constructor(
             loaded.forEach { println("Loaded plugin: ${it.manifest.pluginId} v${it.manifest.version}") }
             // A previously failed jar may now succeed (e.g. after a rebuild); clear it from failures.
             mutableFailedJarPathsFlow.update { it.filterNot { path -> path == pluginJarPath } }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Throwable) {
-            if (e is CancellationException) throw e
             println("Failed to load plugin from $pluginJarPath: ${e.message}")
-            failJar(pluginJarPath, classLoader, runtimeJar)
+            // Avoid accumulating duplicates across repeated failed loads (e.g. a hot-reload rebuild loop).
+            mutableFailedJarPathsFlow.update { if (pluginJarPath in it) it else it + pluginJarPath }
+        } finally {
+            if (!committed) {
+                classLoader.close()
+                runtimeJar?.delete()
+            }
         }
     }
 
-    /** Closes the freshly opened [classLoader]/[runtimeJar] and records [pluginJarPath] as failed. */
-    private fun failJar(pluginJarPath: String, classLoader: URLClassLoader?, runtimeJar: File?) {
-        classLoader?.close()
-        runtimeJar?.delete()
-        // Avoid accumulating duplicates across repeated failed loads (e.g. a hot-reload rebuild loop).
-        mutableFailedJarPathsFlow.update { if (pluginJarPath in it) it else it + pluginJarPath }
+    /**
+     * Reads the manifest from [classLoader] and instantiates every plugin the jar declares, pairing
+     * each manifest entry with the factory class it names (no ServiceLoader) — which is what lets a
+     * single jar provide several plugins. Throws on any problem (manifest missing, empty, or with
+     * duplicate ids; a factory class that is missing, lacks a public no-arg constructor, or is not a
+     * [JetWhaleHostPluginFactory]). The caller owns [classLoader]'s lifecycle.
+     */
+    private fun loadDeclaredPlugins(pluginJarPath: String, classLoader: ClassLoader): List<LoadedHostPlugin> {
+        val manifestJson = classLoader.getResourceAsStream(MANIFEST_PATH)?.bufferedReader()?.use { it.readText() }
+            ?: error("$MANIFEST_PATH not found in $pluginJarPath")
+
+        val manifests = pluginManifestJson.decodeFromString<JetWhaleHostPluginManifestFile>(manifestJson).plugins
+        require(manifests.isNotEmpty()) { "$MANIFEST_PATH in $pluginJarPath declares no plugins" }
+        val duplicateIds = manifests.groupingBy { it.pluginId }.eachCount().filterValues { it > 1 }.keys
+        require(duplicateIds.isEmpty()) {
+            "$MANIFEST_PATH in $pluginJarPath declares duplicate pluginId(s): ${duplicateIds.joinToString()}"
+        }
+
+        return manifests.map { manifest ->
+            val factory = try {
+                // getConstructor (not getDeclaredConstructor): the contract is a *public* no-arg
+                // constructor, so a non-public/missing one fails clearly with NoSuchMethodException.
+                classLoader.loadClass(manifest.factoryClass).getConstructor().newInstance()
+            } catch (e: ReflectiveOperationException) {
+                throw IllegalStateException(
+                    "Could not load factory '${manifest.factoryClass}' for plugin '${manifest.pluginId}' " +
+                        "in $pluginJarPath: ${e.message}",
+                    e,
+                )
+            }
+            require(factory is JetWhaleHostPluginFactory) {
+                "Factory '${manifest.factoryClass}' for plugin '${manifest.pluginId}' in $pluginJarPath " +
+                    "is not a ${JetWhaleHostPluginFactory::class.java.simpleName}"
+            }
+            LoadedHostPlugin(manifest = manifest, factory = factory)
+        }
     }
 
     /**

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -4,7 +4,7 @@ import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
 import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
 import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
-import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifest
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifestFile
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -23,7 +23,6 @@ import java.io.File
 import java.lang.instrument.ClassDefinition
 import java.lang.instrument.Instrumentation
 import java.net.URLClassLoader
-import java.util.ServiceLoader
 import java.util.concurrent.ConcurrentHashMap
 import java.util.jar.JarFile
 import kotlin.io.path.Path
@@ -42,17 +41,17 @@ class DefaultPluginFactoryRepository @Inject constructor(
     override val failedJarPathsFlow: Flow<List<String>> = mutableFailedJarPathsFlow.asStateFlow()
 
     /**
-     * The classloader that owns each loaded plugin, keyed by `pluginId`. Each plugin gets its own
-     * [URLClassLoader] so that, on reload, the previous loader can be closed and discarded together
-     * with all of the plugin's stale classes.
+     * The classloader that owns each loaded jar, keyed by absolute jar path. A single jar may declare
+     * several plugins; they all share this one classloader, so that on reload the previous loader can
+     * be closed and discarded together with all of the jar's stale classes.
      */
     private val classLoaders: ConcurrentHashMap<String, URLClassLoader> = ConcurrentHashMap()
 
-    /** Maps the absolute jar path a plugin was loaded from to its `pluginId`. */
-    private val jarPathToPluginId: ConcurrentHashMap<String, String> = ConcurrentHashMap()
+    /** Maps the absolute jar path a plugin was loaded from to the `pluginId`s it provides. */
+    private val jarPathToPluginIds: ConcurrentHashMap<String, List<String>> = ConcurrentHashMap()
 
     /**
-     * Private per-plugin copy of the jar that each classloader actually opens, keyed by `pluginId`.
+     * Private per-jar copy of the jar that each classloader actually opens, keyed by absolute jar path.
      * Loading from a copy lets the source (dev) jar be overwritten without corrupting the running
      * classloader's open zip handle. Replaced copies are NOT deleted eagerly (cached resource URLs
      * such as plugin icons may still point at them — deleting would throw NoSuchFileException); they
@@ -61,12 +60,15 @@ class DefaultPluginFactoryRepository @Inject constructor(
     private val runtimeJars: ConcurrentHashMap<String, File> = ConcurrentHashMap()
 
     override suspend fun loadPlugin(pluginJarPath: String) {
+        var classLoader: URLClassLoader? = null
+        var runtimeJar: File? = null
         try {
             // Open the classloader on a private copy of the jar so the source jar can be overwritten
             // (e.g. by dev hot-reload restaging) without corrupting this classloader's open zip
-            // handle — which otherwise throws ZipException on later resource/class reads.
-            val runtimeJar: File? = createRuntimeCopyIfDevJar(pluginJarPath)
-            val classLoader = URLClassLoader(arrayOf((runtimeJar ?: File(pluginJarPath)).toURI().toURL()))
+            // handle — which otherwise throws ZipException on later resource/class reads. Every plugin
+            // declared by the jar shares this single classloader.
+            runtimeJar = createRuntimeCopyIfDevJar(pluginJarPath)
+            classLoader = URLClassLoader(arrayOf((runtimeJar ?: File(pluginJarPath)).toURI().toURL()))
 
             val manifestJson = classLoader
                 .getResourceAsStream(MANIFEST_PATH)
@@ -74,54 +76,101 @@ class DefaultPluginFactoryRepository @Inject constructor(
                 ?.use { it.readText() }
                 ?: run {
                     println("Warning: $MANIFEST_PATH not found in $pluginJarPath")
-                    classLoader.close()
-                    runtimeJar?.delete()
-                    mutableFailedJarPathsFlow.update { it + pluginJarPath }
-                    return
+                    return failJar(pluginJarPath, classLoader, runtimeJar)
                 }
 
-            val manifest = pluginManifestJson.decodeFromString<JetWhaleHostPluginManifest>(manifestJson)
-
-            val factory = ServiceLoader.load(JetWhaleHostPluginFactory::class.java, classLoader)
-                .toList()
-                .singleOrNull()
-                ?: run {
-                    classLoader.close()
-                    runtimeJar?.delete()
-                    error("Expected exactly one ${JetWhaleHostPluginFactory::class.java.simpleName} in $pluginJarPath")
+            val manifests = pluginManifestJson.decodeFromString<JetWhaleHostPluginManifestFile>(manifestJson).plugins
+            if (manifests.isEmpty()) {
+                println("Warning: $MANIFEST_PATH in $pluginJarPath declares no plugins")
+                return failJar(pluginJarPath, classLoader, runtimeJar)
+            }
+            manifests.groupingBy { it.pluginId }.eachCount().filterValues { it > 1 }.keys.takeIf { it.isNotEmpty() }
+                ?.let { duplicates ->
+                    println("Warning: $MANIFEST_PATH in $pluginJarPath declares duplicate pluginId(s): ${duplicates.joinToString()}")
+                    return failJar(pluginJarPath, classLoader, runtimeJar)
                 }
 
-            // If this jar previously loaded under a *different* plugin id, drop that stale entry so
-            // we neither leak its classloader nor show a duplicate plugin.
-            jarPathToPluginId[pluginJarPath]?.takeIf { it != manifest.pluginId }?.let { stalePluginId ->
-                classLoaders.remove(stalePluginId)?.close()
-                runtimeJars.remove(stalePluginId)
-                mutablePluginsFlow.update { current ->
-                    current.toMutableMap().apply { remove(stalePluginId) }.toPersistentMap()
+            // Instantiate each plugin's factory by the fully-qualified class name it declares in the
+            // manifest (no ServiceLoader): this is what pairs every manifest entry with its factory and
+            // lets a single jar provide several plugins.
+            val loaded = ArrayList<LoadedHostPlugin>(manifests.size)
+            for (manifest in manifests) {
+                val factory = try {
+                    classLoader.loadClass(manifest.factoryClass).getDeclaredConstructor().newInstance()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    println(
+                        "Failed to instantiate factory '${manifest.factoryClass}' for plugin " +
+                            "'${manifest.pluginId}' in $pluginJarPath: ${e.message}",
+                    )
+                    return failJar(pluginJarPath, classLoader, runtimeJar)
                 }
+                if (factory !is JetWhaleHostPluginFactory) {
+                    println(
+                        "Factory '${manifest.factoryClass}' for plugin '${manifest.pluginId}' in " +
+                            "$pluginJarPath is not a ${JetWhaleHostPluginFactory::class.java.simpleName}",
+                    )
+                    return failJar(pluginJarPath, classLoader, runtimeJar)
+                }
+                loaded += LoadedHostPlugin(manifest = manifest, factory = factory)
             }
 
-            // Discard a previously loaded classloader for the same plugin id (e.g. a reload) so that
-            // no stale classloader (and its classes) leaks.
-            classLoaders.put(manifest.pluginId, classLoader)?.close()
-            runtimeJar?.let { runtimeJars[manifest.pluginId] = it }
-            // Remove any other jar-path entries that pointed at this plugin id (e.g. the jar was
-            // renamed/moved or duplicated) so findPluginIdByJarPath never returns a stale path's id.
-            jarPathToPluginId.entries.removeIf { it.value == manifest.pluginId && it.key != pluginJarPath }
-            jarPathToPluginId[pluginJarPath] = manifest.pluginId
+            val newPluginIds = manifests.map { it.pluginId }
+
+            // Detach any of these plugin ids that another jar currently provides, so we neither leak
+            // that jar's classloader nor show a duplicate plugin (e.g. a plugin moved between jars).
+            detachPluginIdsFromOtherJars(newPluginIds.toSet(), keepJarPath = pluginJarPath)
+
+            // Discard the previously loaded classloader for this jar (e.g. a reload) so that no stale
+            // classloader (and its classes) leaks; record this load's runtime copy.
+            classLoaders.put(pluginJarPath, classLoader)?.close()
+            if (runtimeJar != null) runtimeJars[pluginJarPath] = runtimeJar else runtimeJars.remove(pluginJarPath)
+
+            // Plugin ids this jar provided before but no longer does (removed/renamed across a rebuild).
+            val removedPluginIds = jarPathToPluginIds[pluginJarPath].orEmpty() - newPluginIds.toSet()
+            jarPathToPluginIds[pluginJarPath] = newPluginIds
 
             mutablePluginsFlow.update { current ->
                 current.toMutableMap().apply {
-                    put(manifest.pluginId, LoadedHostPlugin(manifest = manifest, factory = factory))
-                    println("Loaded plugin: ${manifest.pluginId} v${manifest.version}")
+                    removedPluginIds.forEach { remove(it) }
+                    loaded.forEach { put(it.manifest.pluginId, it) }
                 }.toPersistentMap()
             }
+            loaded.forEach { println("Loaded plugin: ${it.manifest.pluginId} v${it.manifest.version}") }
             // A previously failed jar may now succeed (e.g. after a rebuild); clear it from failures.
             mutableFailedJarPathsFlow.update { it.filterNot { path -> path == pluginJarPath } }
         } catch (e: Throwable) {
             if (e is CancellationException) throw e
             println("Failed to load plugin from $pluginJarPath: ${e.message}")
-            mutableFailedJarPathsFlow.update { it + pluginJarPath }
+            failJar(pluginJarPath, classLoader, runtimeJar)
+        }
+    }
+
+    /** Closes the freshly opened [classLoader]/[runtimeJar] and records [pluginJarPath] as failed. */
+    private fun failJar(pluginJarPath: String, classLoader: URLClassLoader?, runtimeJar: File?) {
+        classLoader?.close()
+        runtimeJar?.delete()
+        mutableFailedJarPathsFlow.update { it + pluginJarPath }
+    }
+
+    /**
+     * Removes [pluginIds] from every jar other than [keepJarPath] that currently provides them; a jar
+     * left with no plugins has its classloader closed and dropped. Their `loadedPlugins` entries are
+     * left for the caller to overwrite with the new jar's plugins.
+     */
+    private fun detachPluginIdsFromOtherJars(pluginIds: Set<String>, keepJarPath: String) {
+        for ((jarPath, ids) in jarPathToPluginIds) {
+            if (jarPath == keepJarPath) continue
+            val remaining = ids.filterNot { it in pluginIds }
+            if (remaining.size == ids.size) continue
+            if (remaining.isEmpty()) {
+                jarPathToPluginIds.remove(jarPath)
+                classLoaders.remove(jarPath)?.close()
+                runtimeJars.remove(jarPath)
+            } else {
+                jarPathToPluginIds[jarPath] = remaining
+            }
         }
     }
 
@@ -146,38 +195,49 @@ class DefaultPluginFactoryRepository @Inject constructor(
         mutablePluginsFlow.update { current ->
             current.toMutableMap().apply { remove(pluginId) }.toPersistentMap()
         }
-        classLoaders.remove(pluginId)?.close()
-        runtimeJars.remove(pluginId)
-        jarPathToPluginId.entries.removeIf { it.value == pluginId }
+        // Drop the plugin from its jar; close the jar's shared classloader only once its last plugin
+        // is gone (other plugins from the same jar must keep working).
+        val jarPath = jarPathToPluginIds.entries.firstOrNull { pluginId in it.value }?.key
+        if (jarPath != null) {
+            val remaining = jarPathToPluginIds.getValue(jarPath).filterNot { it == pluginId }
+            if (remaining.isEmpty()) {
+                jarPathToPluginIds.remove(jarPath)
+                classLoaders.remove(jarPath)?.close()
+                runtimeJars.remove(jarPath)
+            } else {
+                jarPathToPluginIds[jarPath] = remaining
+            }
+        }
         println("Unloaded plugin: $pluginId")
     }
 
-    override fun findPluginIdByJarPath(pluginJarPath: String): String? = jarPathToPluginId[pluginJarPath]
+    override fun findPluginIdsByJarPath(pluginJarPath: String): List<String> =
+        jarPathToPluginIds[pluginJarPath].orEmpty()
 
-    override suspend fun reloadPlugin(pluginJarPath: String): String? {
-        // loadPlugin already closes and replaces the previous classloader for the same plugin id,
-        // dropping the stale classes. We simply re-run it and report the resulting plugin id.
+    override suspend fun reloadPlugin(pluginJarPath: String): List<String> {
+        // loadPlugin already closes and replaces the previous classloader for this jar, dropping the
+        // stale classes. We simply re-run it and report the resulting plugin ids.
         loadPlugin(pluginJarPath)
         // loadPlugin records the path in failedJarPaths on failure; treat that as an unsuccessful
-        // reload (don't report stale success from a leftover jarPathToPluginId mapping).
-        if (pluginJarPath in mutableFailedJarPathsFlow.value) return null
-        return jarPathToPluginId[pluginJarPath]
+        // reload (don't report stale success from a leftover jarPathToPluginIds mapping).
+        if (pluginJarPath in mutableFailedJarPathsFlow.value) return emptyList()
+        return jarPathToPluginIds[pluginJarPath].orEmpty()
     }
 
-    override fun tryRedefinePlugin(pluginJarPath: String): String? {
-        val instrumentation = instrumentation ?: return null
-        val pluginId = jarPathToPluginId[pluginJarPath] ?: return null
-        val classLoader = classLoaders[pluginId] ?: return null
+    override fun tryRedefinePlugin(pluginJarPath: String): List<String> {
+        val instrumentation = instrumentation ?: return emptyList()
+        val pluginIds = jarPathToPluginIds[pluginJarPath]?.takeIf { it.isNotEmpty() } ?: return emptyList()
+        val classLoader = classLoaders[pluginJarPath] ?: return emptyList()
 
         return try {
-            // Redefine every class this plugin's classloader has already loaded, using the rebuilt
-            // jar's bytecode. redefineClasses works on the loaded Class regardless of classloader, so
-            // this reaches the plugin's child-classloader classes (which Compose Hot Reload cannot).
-            // Array and hidden classes (e.g. invokedynamic lambdas) have no class file and are not
-            // redefinable, so they are skipped.
+            // Redefine every class this jar's classloader has already loaded, using the rebuilt jar's
+            // bytecode. redefineClasses works on the loaded Class regardless of classloader, so this
+            // reaches the plugin's child-classloader classes (which Compose Hot Reload cannot). Because
+            // all plugins in the jar share this classloader, one redefine covers every plugin. Array
+            // and hidden classes (e.g. invokedynamic lambdas) have no class file and are skipped.
             val loadedClasses = instrumentation.allLoadedClasses
                 .filter { it.classLoader === classLoader && !it.isArray && !it.isHidden }
-            if (loadedClasses.isEmpty()) return null
+            if (loadedClasses.isEmpty()) return emptyList()
 
             val definitions = ArrayList<ClassDefinition>(loadedClasses.size)
             JarFile(pluginJarPath).use { jar ->
@@ -185,20 +245,20 @@ class DefaultPluginFactoryRepository @Inject constructor(
                     // A loaded (non-hidden, non-array) class with no class file in the rebuilt jar
                     // would leave stale bytecode behind — a partial redefine. Bail out so the caller
                     // does a full reload instead of reporting a misleading success.
-                    val entry = jar.getJarEntry(clazz.name.replace('.', '/') + ".class") ?: return null
+                    val entry = jar.getJarEntry(clazz.name.replace('.', '/') + ".class") ?: return emptyList()
                     definitions += ClassDefinition(clazz, jar.getInputStream(entry).use { it.readBytes() })
                 }
             }
 
             instrumentation.redefineClasses(*definitions.toTypedArray())
-            pluginId
+            pluginIds
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
             // UnsupportedOperationException (structural change without an enhanced runtime),
             // LinkageError, etc. The caller falls back to a full reload.
-            println("In-place redefine failed for $pluginId: ${e.message}; falling back to full reload")
-            null
+            println("In-place redefine failed for ${pluginIds.joinToString()}: ${e.message}; falling back to full reload")
+            emptyList()
         }
     }
 

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
@@ -146,43 +146,42 @@ class DefaultPluginHotReloadService(
     private suspend fun reloadJar(jarPath: String) {
         if (!File(jarPath).exists()) return
 
-        // Try an in-place class redefinition first. On success the plugin's classloader and instance
-        // are kept (so the plugin instance's state survives), and we recreate only its compose scenes
-        // so the redefined Content runs against that preserved state. Composable-local `remember` is
+        // Try an in-place class redefinition first. On success the plugins' classloader and instances
+        // are kept (so plugin instance state survives), and we recreate only their compose scenes so
+        // the redefined Content runs against that preserved state. Composable-local `remember` is
         // reset (the scene is rebuilt); state that must survive a reload should live in the plugin
-        // instance. Reaches the plugin's child-classloader classes, which Compose Hot Reload cannot.
-        val redefinedPluginId = pluginFactoryRepository.tryRedefinePlugin(jarPath)
-        if (redefinedPluginId != null) {
+        // instance. Reaches the plugins' child-classloader classes, which Compose Hot Reload cannot.
+        // One jar may provide several plugins, so this works on the full set the jar redefined.
+        val redefinedPluginIds = pluginFactoryRepository.tryRedefinePlugin(jarPath)
+        if (redefinedPluginIds.isNotEmpty()) {
             withContext(Dispatchers.Main) {
-                pluginComposeSceneService.disposePluginScenesForPlugin(redefinedPluginId)
+                redefinedPluginIds.forEach { pluginComposeSceneService.disposePluginScenesForPlugin(it) }
             }
-            logger.info("Hot reloaded plugin in place (instance state preserved): $redefinedPluginId")
-            mutablePluginReloadedFlow.emit(redefinedPluginId)
+            logger.info("Hot reloaded plugin(s) in place (instance state preserved): ${redefinedPluginIds.joinToString()}")
+            redefinedPluginIds.forEach { mutablePluginReloadedFlow.emit(it) }
             return
         }
 
         // Fallback: full reload via a fresh classloader (plugin instance state is lost).
-        // Capture the plugin id currently served by this jar (if any) so that we can dispose its
-        // running instances and scenes before swapping in the new code.
-        val previousPluginId = pluginFactoryRepository.findPluginIdByJarPath(jarPath)
-        previousPluginId?.let { disposePlugin(it) }
+        // Capture the plugin ids currently served by this jar so that we can dispose their running
+        // instances and scenes before swapping in the new code.
+        val previousPluginIds = pluginFactoryRepository.findPluginIdsByJarPath(jarPath)
+        previousPluginIds.forEach { disposePlugin(it) }
 
-        val reloadedPluginId = pluginFactoryRepository.reloadPlugin(jarPath)
-        if (reloadedPluginId == null) {
+        val reloadedPluginIds = pluginFactoryRepository.reloadPlugin(jarPath)
+        if (reloadedPluginIds.isEmpty()) {
             logger.warning("Failed to reload plugin from $jarPath")
             return
         }
 
-        // The plugin id may have changed if its manifest id changed across the rebuild; make sure the
-        // previously loaded instances are gone in that case too.
-        if (previousPluginId != null && previousPluginId != reloadedPluginId) {
-            disposePlugin(previousPluginId)
-        }
+        // Some plugin ids may have disappeared if the jar's manifest changed across the rebuild
+        // (a plugin removed/renamed); make sure their previously loaded instances are gone too.
+        (previousPluginIds - reloadedPluginIds.toSet()).forEach { disposePlugin(it) }
 
-        reinitializeInstances(reloadedPluginId)
+        reloadedPluginIds.forEach { reinitializeInstances(it) }
 
-        logger.info("Hot reloaded plugin: $reloadedPluginId")
-        mutablePluginReloadedFlow.emit(reloadedPluginId)
+        logger.info("Hot reloaded plugin(s): ${reloadedPluginIds.joinToString()}")
+        reloadedPluginIds.forEach { mutablePluginReloadedFlow.emit(it) }
     }
 
     private fun disposePlugin(pluginId: String) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
@@ -171,6 +171,13 @@ class DefaultPluginHotReloadService(
         val reloadedPluginIds = pluginFactoryRepository.reloadPlugin(jarPath)
         if (reloadedPluginIds.isEmpty()) {
             logger.warning("Failed to reload plugin from $jarPath")
+            // A failed reload (e.g. a compile error in the rebuilt jar) leaves the previously loaded
+            // code intact in the repository, so restore the instances/scenes we disposed above instead
+            // of leaving active sessions without the plugin until the next successful build.
+            previousPluginIds.forEach {
+                reinitializeInstances(it)
+                mutablePluginReloadedFlow.emit(it)
+            }
             return
         }
 

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginFactoryRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginFactoryRepository.kt
@@ -18,27 +18,29 @@ interface PluginFactoryRepository {
     suspend fun unloadPlugin(pluginId: String)
 
     /**
-     * Returns the `pluginId` currently loaded from [pluginJarPath], or `null` if no plugin from that
-     * jar is loaded. Used by hot reload to map a changed jar file back to the plugin it provides.
+     * Returns the `pluginId`s currently loaded from [pluginJarPath] (a single jar may provide several
+     * plugins), or an empty list if no plugin from that jar is loaded. Used by hot reload to map a
+     * changed jar file back to the plugins it provides.
      */
-    fun findPluginIdByJarPath(pluginJarPath: String): String?
+    fun findPluginIdsByJarPath(pluginJarPath: String): List<String>
 
     /**
-     * Reloads the plugin from [pluginJarPath]: the previous classloader for that jar is closed and
-     * discarded, then the factory is loaded again from a fresh classloader. Returns the `pluginId`
-     * that was (re)loaded, or `null` if loading failed.
+     * Reloads every plugin from [pluginJarPath]: the previous classloader for that jar is closed and
+     * discarded, then the factories are loaded again from a fresh classloader. Returns the `pluginId`s
+     * that were (re)loaded, or an empty list if loading failed.
      */
-    suspend fun reloadPlugin(pluginJarPath: String): String?
+    suspend fun reloadPlugin(pluginJarPath: String): List<String>
 
     /**
-     * Attempts an in-place hot swap of the plugin served by [pluginJarPath]: the plugin's
-     * already-loaded classes are redefined from the rebuilt jar **without** dropping the classloader
-     * or recreating the plugin instance, so the plugin instance's state is preserved.
+     * Attempts an in-place hot swap of the plugins served by [pluginJarPath]: the jar's already-loaded
+     * classes are redefined from the rebuilt jar **without** dropping the classloader or recreating the
+     * plugin instances, so plugin instance state is preserved. Because all plugins in a jar share one
+     * classloader, this covers every plugin the jar provides at once.
      *
-     * Returns the `pluginId` on success, or `null` when an in-place swap is not possible (no JVM
-     * Instrumentation available, an unsupported/structural change without an enhanced runtime such as
-     * the JetBrains Runtime, etc.). On `null` the caller should fall back to [reloadPlugin], which
-     * does a full reload at the cost of losing the plugin's state.
+     * Returns the redefined `pluginId`s on success, or an empty list when an in-place swap is not
+     * possible (no JVM Instrumentation available, an unsupported/structural change without an enhanced
+     * runtime such as the JetBrains Runtime, etc.). On an empty result the caller should fall back to
+     * [reloadPlugin], which does a full reload at the cost of losing the plugins' state.
      */
-    fun tryRedefinePlugin(pluginJarPath: String): String?
+    fun tryRedefinePlugin(pluginJarPath: String): List<String>
 }

--- a/jetwhale-plugins/example/host/build.gradle.kts
+++ b/jetwhale-plugins/example/host/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.compose)
-    alias(libs.plugins.ksp)
     // Provides packagePlugin / installPlugin / stageDevPlugin / runJetWhale / runJetWhaleHot (published).
     alias(libs.plugins.jetwhalePlugin)
     // In-repo only: adds runJetWhaleLocal, which launches the local :jetwhale-host:app project.
@@ -9,9 +8,6 @@ plugins {
 }
 
 dependencies {
-    ksp(libs.autoServiceKsp)
-    implementation(libs.autoServiceAnnotations)
-
     compileOnly(projects.jetwhaleHostSdk)
     compileOnly(libs.material3)
     compileOnly(libs.kotlinxSerializationJson)

--- a/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostPluginFactory.kt
+++ b/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostPluginFactory.kt
@@ -3,7 +3,6 @@ package com.kitakkun.jetwhale.plugins.example.host
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import com.google.auto.service.AutoService
 import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleDebugOperationContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
@@ -22,8 +21,8 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
 
+// Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
 @Suppress("UNUSED")
-@AutoService(JetWhaleHostPluginFactory::class)
 class ExampleHostPluginFactory : JetWhaleHostPluginFactory {
     override fun createPlugin(): JetWhaleRawHostPlugin = ExampleHostPlugin()
 }

--- a/jetwhale-plugins/example/host/src/main/resources/META-INF/jetwhale/plugin-manifest.json
+++ b/jetwhale-plugins/example/host/src/main/resources/META-INF/jetwhale/plugin-manifest.json
@@ -1,14 +1,19 @@
 {
   "$schema": "../../../../../../../../../../schemas/plugin-manifest.schema.json",
-  "pluginId": "com.kitakkun.jetwhale.example",
-  "pluginName": "Example JetWhale Plugin",
-  "version": "1.0.0",
-  "agentVersionRange": {
-    "min": "1.0.0",
-    "max": "1.0.0"
-  },
-  "icon": {
-    "activePath": "icons/window_filled.svg",
-    "inactivePath": "icons/window_outlined.svg"
-  }
+  "plugins": [
+    {
+      "pluginId": "com.kitakkun.jetwhale.example",
+      "pluginName": "Example JetWhale Plugin",
+      "version": "1.0.0",
+      "factoryClass": "com.kitakkun.jetwhale.plugins.example.host.ExampleHostPluginFactory",
+      "agentVersionRange": {
+        "min": "1.0.0",
+        "max": "1.0.0"
+      },
+      "icon": {
+        "activePath": "icons/window_filled.svg",
+        "inactivePath": "icons/window_outlined.svg"
+      }
+    }
+  ]
 }

--- a/jetwhale-plugins/network/host/build.gradle.kts
+++ b/jetwhale-plugins/network/host/build.gradle.kts
@@ -1,16 +1,12 @@
 plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.compose)
-    alias(libs.plugins.ksp)
 }
 
 // Distinct group so this module's coordinates don't collide with `example:host`.
 group = "com.kitakkun.jetwhale.plugins.network"
 
 dependencies {
-    ksp(libs.autoServiceKsp)
-    implementation(libs.autoServiceAnnotations)
-
     compileOnly(projects.jetwhaleHostSdk)
     compileOnly(libs.material3)
     compileOnly(libs.kotlinxSerializationJson)

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import com.google.auto.service.AutoService
 import com.kitakkun.jetwhale.host.sdk.JetWhaleDebugOperationContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
@@ -19,8 +18,8 @@ import com.kitakkun.jetwhale.protocol.host.JetWhaleHostPluginProtocol
 import com.kitakkun.jetwhale.protocol.host.kotlinxSerializationJetWhaleHostPluginProtocol
 import kotlinx.coroutines.launch
 
+// Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
 @Suppress("UNUSED")
-@AutoService(JetWhaleHostPluginFactory::class)
 class NetworkHostPluginFactory : JetWhaleHostPluginFactory {
     override fun createPlugin(): JetWhaleRawHostPlugin = NetworkHostPlugin()
 }

--- a/jetwhale-plugins/network/host/src/main/resources/META-INF/jetwhale/plugin-manifest.json
+++ b/jetwhale-plugins/network/host/src/main/resources/META-INF/jetwhale/plugin-manifest.json
@@ -1,14 +1,19 @@
 {
   "$schema": "../../../../../../../../../../schemas/plugin-manifest.schema.json",
-  "pluginId": "com.kitakkun.jetwhale.network",
-  "pluginName": "Network Inspector",
-  "version": "1.0.0",
-  "agentVersionRange": {
-    "min": "1.0.0",
-    "max": "1.0.0"
-  },
-  "icon": {
-    "activePath": "icons/network_filled.svg",
-    "inactivePath": "icons/network_outlined.svg"
-  }
+  "plugins": [
+    {
+      "pluginId": "com.kitakkun.jetwhale.network",
+      "pluginName": "Network Inspector",
+      "version": "1.0.0",
+      "factoryClass": "com.kitakkun.jetwhale.plugins.network.host.NetworkHostPluginFactory",
+      "agentVersionRange": {
+        "min": "1.0.0",
+        "max": "1.0.0"
+      },
+      "icon": {
+        "activePath": "icons/network_filled.svg",
+        "inactivePath": "icons/network_outlined.svg"
+      }
+    }
+  ]
 }

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -2,50 +2,66 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/kitakkun/JetWhale/schemas/plugin-manifest.schema.json",
   "title": "JetWhale Host Plugin Manifest",
-  "description": "Manifest file for a JetWhale host plugin JAR. Place at META-INF/jetwhale/plugin-manifest.json.",
+  "description": "Manifest file for a JetWhale host plugin JAR. Place at META-INF/jetwhale/plugin-manifest.json. A single JAR may declare multiple plugins.",
   "type": "object",
-  "required": ["pluginId", "pluginName", "version"],
+  "required": ["plugins"],
   "additionalProperties": false,
   "properties": {
-    "pluginId": {
-      "type": "string",
-      "description": "Unique identifier for the plugin (e.g. com.example.myplugin)."
-    },
-    "pluginName": {
-      "type": "string",
-      "description": "Human-readable display name of the plugin."
-    },
-    "version": {
-      "type": "string",
-      "description": "Plugin version string (e.g. 1.0.0)."
-    },
-    "agentVersionRange": {
-      "type": "object",
-      "description": "Specifies the range of agent plugin versions this host plugin is compatible with. Omit to allow all agent versions.",
-      "additionalProperties": false,
-      "properties": {
-        "min": {
-          "type": ["string", "null"],
-          "description": "Minimum compatible agent version (inclusive). Null means no lower bound."
-        },
-        "max": {
-          "type": ["string", "null"],
-          "description": "Maximum compatible agent version (inclusive). Null means no upper bound."
-        }
-      }
-    },
-    "icon": {
-      "type": "object",
-      "description": "Icon paths relative to the JAR root.",
-      "additionalProperties": false,
-      "properties": {
-        "activePath": {
-          "type": ["string", "null"],
-          "description": "Path to the icon used when the plugin is active."
-        },
-        "inactivePath": {
-          "type": ["string", "null"],
-          "description": "Path to the icon used when the plugin is inactive."
+    "plugins": {
+      "type": "array",
+      "description": "The plugins declared by this JAR. Each entry names its own factory class, so one JAR can provide several plugins.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["pluginId", "pluginName", "version", "factoryClass"],
+        "additionalProperties": false,
+        "properties": {
+          "pluginId": {
+            "type": "string",
+            "description": "Unique identifier for the plugin (e.g. com.example.myplugin)."
+          },
+          "pluginName": {
+            "type": "string",
+            "description": "Human-readable display name of the plugin."
+          },
+          "version": {
+            "type": "string",
+            "description": "Plugin version string (e.g. 1.0.0)."
+          },
+          "factoryClass": {
+            "type": "string",
+            "description": "Fully-qualified name of this plugin's JetWhaleHostPluginFactory implementation (e.g. com.example.MyPluginFactory). The host loads and instantiates it from the JAR."
+          },
+          "agentVersionRange": {
+            "type": "object",
+            "description": "Specifies the range of agent plugin versions this host plugin is compatible with. Omit to allow all agent versions.",
+            "additionalProperties": false,
+            "properties": {
+              "min": {
+                "type": ["string", "null"],
+                "description": "Minimum compatible agent version (inclusive). Null means no lower bound."
+              },
+              "max": {
+                "type": ["string", "null"],
+                "description": "Maximum compatible agent version (inclusive). Null means no upper bound."
+              }
+            }
+          },
+          "icon": {
+            "type": "object",
+            "description": "Icon paths relative to the JAR root.",
+            "additionalProperties": false,
+            "properties": {
+              "activePath": {
+                "type": ["string", "null"],
+                "description": "Path to the icon used when the plugin is active."
+              },
+              "inactivePath": {
+                "type": ["string", "null"],
+                "description": "Path to the icon used when the plugin is inactive."
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

A single plugin module's jar can now ship **multiple plugins**. The plugin manifest (`META-INF/jetwhale/plugin-manifest.json`) becomes a list, and each entry names its own factory by fully-qualified class name:

```json
{
  "plugins": [
    {
      "pluginId": "com.example.a",
      "pluginName": "Plugin A",
      "version": "1.0.0",
      "factoryClass": "com.example.PluginAFactory"
    },
    {
      "pluginId": "com.example.b",
      "pluginName": "Plugin B",
      "version": "1.0.0",
      "factoryClass": "com.example.PluginBFactory"
    }
  ]
}
```

The host loads each plugin by instantiating the class named in `factoryClass` (reflection, public no-arg constructor), so **`ServiceLoader` / `@AutoService` registration is no longer needed**. This is the same approach IntelliJ plugins (`plugin.xml`'s `implementation-class`) and similar extension-point systems use: the manifest entry points at its implementation, which removes the ambiguity of "which factory belongs to which manifest entry" that ServiceLoader had.

## Design

- **`JetWhaleHostPluginManifestFile`** (new) wraps the per-plugin `JetWhaleHostPluginManifest` list; the per-plugin entry gains a required **`factoryClass`**.
- **One classloader per jar**, shared by all the plugins it declares. `DefaultPluginFactoryRepository` now keys its classloader and runtime jar copy by **jar path** (not plugin id) and tracks `jarPath -> [pluginId]`. On reload the jar's single classloader is closed and replaced, dropping every plugin's stale classes together.
- **Repository API** returns all of a jar's plugins: `findPluginIdByJarPath -> findPluginIdsByJarPath`, and `reloadPlugin` / `tryRedefinePlugin` now return `List<String>`. Hot reload disposes, reloads, and in-place-redefines every plugin a jar provides together.
- **Concurrency:** `loadPlugin` / `unloadPlugin` / `reloadPlugin` each do compound read-modify-write across several maps and can overlap (initial load, install flow, hot-reload watcher). Per-map `ConcurrentHashMap` atomicity doesn't make those sequences safe, so a `Mutex` now serializes the mutation regions (the read-only `findPluginIdsByJarPath` / `tryRedefinePlugin` stay lock-free).
- Plugins no longer need `@AutoService`; the `ksp` + `auto-service` dependencies are dropped from the two plugin modules and the version catalog.

## Breaking change

Existing single-object manifests and `ServiceLoader`-based factory discovery are no longer supported. Plugin authors must wrap their entries in a `plugins` array and add `factoryClass`. This rides on the `1.0.0-alpha06` bump.

## Validation

- `./gradlew :jetwhale-host-sdk:compileKotlin :jetwhale-host:core:data:compileKotlin :jetwhale-plugins:example:host:compileKotlin :jetwhale-plugins:network:host:compileKotlin :jetwhale-host:core:mcp:test` — all green (Java 21).
- `packagePlugin` for the example module produces a jar whose bundled manifest has the new shape and `factoryClass`, the factory class is present, and there is no leftover `META-INF/services` entry.
- Two independent self-review passes; the only open item is a pre-existing limitation (the in-place redefine path does not re-read the manifest), unchanged by this PR.

## Docs

`docs/developing-plugins.md` updated: the manifest format, `factoryClass`, dropping `ServiceLoader`/`@AutoService`, and a "multiple plugins in one module" section.