### PR TITLE
fix(plugin-dev): make downloadJetWhaleHost configuration-cache compatible

### DIFF
--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -115,14 +115,17 @@ val currentOsArch: Provider<String> =
 // `:jetwhale-host:app:packageUberJarForCurrentOS`). When set it overrides hostVersion.
 val localHostJar: Provider<String> = providers.gradleProperty("jetwhaleHostJar")
 
+// Resolve user.home as a provider OUTSIDE the combiner below. Reading it via `providers` inside the
+// zip lambda would make the lambda capture the enclosing script object (its `this$0`), which the
+// configuration cache cannot serialize ("cannot serialize Gradle script object references").
+val userHome: Provider<String> = providers.systemProperty("user.home")
+
 // Path of the cached host uber jar for the configured version (resolved lazily, value only when set).
 val hostReleaseJar: Provider<File> =
-    pluginExtension.hostVersion.zip(currentOsArch) { version, osArch ->
-        File(
-            providers.systemProperty("user.home").get(),
-            ".jetwhale/dev-host/$version/jetwhale-host-$version-$osArch.jar",
-        )
-    }
+    pluginExtension.hostVersion.zip(currentOsArch) { version, osArch -> version to osArch }
+        .zip(userHome) { (version, osArch), home ->
+            File(home, ".jetwhale/dev-host/$version/jetwhale-host-$version-$osArch.jar")
+        }
 
 val downloadJetWhaleHost = tasks.register("downloadJetWhaleHost") {
     group = "jetwhale"


### PR DESCRIPTION
## Problem

Running `downloadJetWhaleHost` (and therefore `runJetWhale` / `runJetWhaleHot`, which depend on it) breaks the configuration cache:

```
1 problem was found storing the configuration cache.
- Task `:jetwhale-plugins:example:host:downloadJetWhaleHost` of type `org.gradle.api.DefaultTask`:
  cannot serialize Gradle script object references as these are not supported with the configuration cache.
```

## Root cause

The configuration-cache report traces the failure to the `hostReleaseJar` provider:

```
downloadJetWhaleHost task action
  → $jarProvider (= hostReleaseJar)
    → BiProvider.combiner → hostReleaseJar$1 lambda
      → field "this$0" → Com_kitakkun_jetwhale_host_gradle   ← the script object
```

`hostReleaseJar` resolved `user.home` via `providers.systemProperty(...)` **inside** its `zip` combiner lambda. Referencing `providers` (a member of the precompiled script object) from inside the lambda forced it to capture the enclosing script instance as `this$0`, which the configuration cache cannot serialize.

`currentOsArch` did not hit this because it reads its system properties *outside* the combiner (they are passed in as the `zip` operands).

## Fix

Pull `user.home` out into a top-level `userHome` provider and `zip` it in, so the combiner no longer references `providers`:

```kotlin
val userHome: Provider<String> = providers.systemProperty("user.home")

val hostReleaseJar: Provider<File> =
    pluginExtension.hostVersion.zip(currentOsArch) { version, osArch -> version to osArch }
        .zip(userHome) { (version, osArch), home ->
            File(home, ".jetwhale/dev-host/$version/jetwhale-host-$version-$osArch.jar")
        }
```

This mirrors the existing `currentOsArch` pattern.

## Verification

```
$ ./gradlew :jetwhale-plugins:example:host:downloadJetWhaleHost --configuration-cache
...
BUILD SUCCESSFUL
Configuration cache entry stored.

# second run
Reusing configuration cache.
Configuration cache entry reused.
```

No more "Configuration cache problems found".

> [!NOTE]
> This is a pre-existing bug on `main`, independent of the `runJetWhaleHot` auto-staging work, so it is split into its own PR.