### PR TITLE
fix(plugin-dev): validate host jar at execution time so runJetWhale(Hot) downloads it

### DIFF
--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -342,7 +342,11 @@ fun registerRunTask(name: String, taskDescription: String, hot: Boolean) = tasks
     // Registered last so that, with doFirst's LIFO ordering, it runs before the hot-staging watcher above.
     doFirst {
         val hostJar = hostJarProvider.get()
-        check(hostJar.exists()) { "JetWhale host jar not found: $hostJar" }
+        // Require a real, non-empty file: a directory (e.g. a misconfigured -PjetwhaleHostJar) or an
+        // empty file would otherwise pass and fail later with a cryptic JVM "could not find main class".
+        check(hostJar.isFile && hostJar.length() > 0) {
+            "JetWhale host jar is missing, empty, or not a regular file: $hostJar"
+        }
     }
 }
 

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -241,7 +241,7 @@ fun registerRunTask(name: String, taskDescription: String, hot: Boolean) = tasks
     // run). A provider is required: reassigning `classpath` in doFirst is lost under the
     // configuration cache, leaving an empty classpath and a cryptic "could not find main class".
     val hostJarProvider = providers.provider {
-        val hostJar = when {
+        when {
             localHostJar.isPresent -> File(localHostJar.get())
 
             pluginExtension.hostVersion.isPresent -> hostReleaseJar.get()
@@ -251,8 +251,6 @@ fun registerRunTask(name: String, taskDescription: String, hot: Boolean) = tasks
                     "-PjetwhaleHostJar=<path> to launch a locally built host uber jar.",
             )
         }
-        check(hostJar.exists()) { "JetWhale host jar not found: $hostJar" }
-        hostJar
     }
     classpath = files(hostJarProvider)
     mainClass.set("com.kitakkun.jetwhale.host.MainKt")
@@ -335,6 +333,16 @@ fun registerRunTask(name: String, taskDescription: String, hot: Boolean) = tasks
                 "jetwhale-hot-staging-watcher",
             ).also { it.isDaemon = true }.start()
         }
+    }
+
+    // Verify the resolved host jar exists at EXECUTION time — after downloadJetWhaleHost (a dependency)
+    // has had a chance to download it. Checking this inside hostJarProvider instead would evaluate it
+    // while Gradle resolves the classpath's dependencies during task-graph configuration, before the
+    // jar is downloaded, failing with the cryptic "Could not determine the dependencies of task".
+    // Registered last so that, with doFirst's LIFO ordering, it runs before the hot-staging watcher above.
+    doFirst {
+        val hostJar = hostJarProvider.get()
+        check(hostJar.exists()) { "JetWhale host jar not found: $hostJar" }
     }
 }
 


### PR DESCRIPTION
## Problem

`runJetWhale` / `runJetWhaleHot` failed before ever downloading the host jar when no cached jar was present:

```
Could not determine the dependencies of task ':...:runJetWhaleHot'.
> JetWhale host jar not found: ~/.jetwhale/dev-host/<version>/jetwhale-host-<version>-<os>-<arch>.jar
```

The run tasks resolve the host jar via `classpath = files(hostJarProvider)`, and the provider also asserted the jar exists. That assertion was evaluated while Gradle resolves the task's classpath dependencies **during task-graph configuration** — before the dependent `downloadJetWhaleHost` task runs. With no cached jar the build aborted at configuration time, so the host was never downloaded. `dependsOn(downloadJetWhaleHost)` only orders *execution*, which the configuration-time check ran ahead of.

## Fix

Move the existence check out of the provider into a `doFirst`, which runs at execution time after `downloadJetWhaleHost`. It is registered last so `doFirst`'s LIFO ordering keeps it ahead of the hot-staging watcher.

## Verification

Ran `./gradlew :jetwhale-plugins:example:host:runJetWhaleHot` with no cached jar:
`Downloading JetWhale host 1.0.0-alpha05 ...` → host launches → `Wiring ADB reverse for device emulator-5554`.