### PR TITLE
feat(sdk)!: split plugin UI (Content) into a separate interface

### DIFF
--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -9,8 +9,6 @@ public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleDebugOper
 public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin : com/kitakkun/jetwhale/host/sdk/JetWhaleRawHostPlugin {
 	public static final field $stable I
 	public fun <init> ()V
-	public abstract fun Content (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleDebugOperationContext;Landroidx/compose/runtime/Composer;I)V
-	public final fun ContentRaw (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleRawDebugOperationContext;Landroidx/compose/runtime/Composer;I)V
 	protected abstract fun getProtocol ()Lcom/kitakkun/jetwhale/protocol/host/JetWhaleHostPluginProtocol;
 	public abstract fun onEvent (Ljava/lang/Object;)V
 	public final fun onRawEvent (Ljava/lang/String;)V
@@ -202,8 +200,18 @@ public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleRawDebugO
 public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleRawHostPlugin {
 	public static final field $stable I
 	public fun <init> ()V
-	public abstract fun ContentRaw (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleRawDebugOperationContext;Landroidx/compose/runtime/Composer;I)V
 	public fun onDispose ()V
 	public abstract fun onRawEvent (Ljava/lang/String;)V
+}
+
+public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleRawUiHostPlugin {
+	public abstract fun ContentRaw (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleRawDebugOperationContext;Landroidx/compose/runtime/Composer;I)V
+}
+
+public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleUiHostPlugin : com/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin, com/kitakkun/jetwhale/host/sdk/JetWhaleRawUiHostPlugin {
+	public static final field $stable I
+	public fun <init> ()V
+	public abstract fun Content (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleDebugOperationContext;Landroidx/compose/runtime/Composer;I)V
+	public final fun ContentRaw (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleRawDebugOperationContext;Landroidx/compose/runtime/Composer;I)V
 }
 

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin.kt
@@ -1,11 +1,13 @@
 package com.kitakkun.jetwhale.host.sdk
 
-import androidx.compose.runtime.Composable
 import com.kitakkun.jetwhale.protocol.host.JetWhaleHostPluginProtocol
-import kotlinx.coroutines.CoroutineScope
 
 /**
- * Plugin interface for JetWhale.
+ * Base class for typed JetWhale host plugins: it decodes raw event strings into [Event]s via
+ * [protocol] and hands them to [onEvent].
+ *
+ * This base is **headless** (no UI). For a plugin that renders a UI, extend [JetWhaleUiHostPlugin]
+ * instead, which adds the [JetWhaleUiHostPlugin.Content] composable.
  */
 public abstract class JetWhaleHostPlugin<Event, Method, MethodResult> : JetWhaleRawHostPlugin() {
     /**
@@ -20,41 +22,11 @@ public abstract class JetWhaleHostPlugin<Event, Method, MethodResult> : JetWhale
     public abstract fun onEvent(event: Event)
 
     /**
-     * Composable function that represents the UI of the plugin
-     *
-     * Composition will be kept as long as the plugin instance is alive.
-     * Even if the tab is switched, the composition will be kept.
-     *
-     * @param context The context to perform debug operations
-     */
-    @Composable
-    public abstract fun Content(context: JetWhaleDebugOperationContext<Method, MethodResult>)
-
-    /**
      * Handles a raw event message received from the debuggee.
      * Decodes the message and processes it.
      */
     final override fun onRawEvent(event: String) {
         val decodedEvent = protocol.decodeEvent(event)
         onEvent(decodedEvent)
-    }
-
-    /**
-     * Composable function that adapts raw string-based context to typed context
-     * and calls the typed Content function.
-     * @param context The raw debug operation context
-     */
-    @Composable
-    final override fun ContentRaw(context: JetWhaleRawDebugOperationContext) {
-        val typedContext = object : JetWhaleDebugOperationContext<Method, MethodResult> {
-            override val coroutineScope: CoroutineScope = context.coroutineScope
-            override suspend fun <MR : MethodResult> dispatch(method: Method): MR? {
-                val encodedMethod = protocol.encodeMethod(method)
-                val rawResult = context.dispatch(encodedMethod)
-                @Suppress("UNCHECKED_CAST")
-                return rawResult?.let { protocol.decodeMethodResult(it) } as? MR
-            }
-        }
-        Content(context = typedContext)
     }
 }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleRawHostPlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleRawHostPlugin.kt
@@ -1,9 +1,11 @@
 package com.kitakkun.jetwhale.host.sdk
 
-import androidx.compose.runtime.Composable
-
 /**
  * Base class for JetWhale Host Plugins that handle raw events from the debuggee.
+ *
+ * This base is **headless**: it carries no UI. A plugin that renders a UI additionally implements
+ * [JetWhaleRawUiHostPlugin] (or, for the typed variant, extends [JetWhaleUiHostPlugin] instead of
+ * [JetWhaleHostPlugin]).
  */
 public abstract class JetWhaleRawHostPlugin {
     /**
@@ -16,14 +18,4 @@ public abstract class JetWhaleRawHostPlugin {
      * Called when the plugin instance is disposed
      */
     public open fun onDispose() {}
-
-    /**
-     * Composable content for the plugin UI with raw String operations context
-     * This function is internally used by the JetWhale Host Application.
-     * Do not call this function directly.
-     *
-     * @param context The context for dispatching debug operations
-     */
-    @Composable
-    public abstract fun ContentRaw(context: JetWhaleRawDebugOperationContext)
 }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleRawUiHostPlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleRawUiHostPlugin.kt
@@ -1,0 +1,23 @@
+package com.kitakkun.jetwhale.host.sdk
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Optional UI capability for a [JetWhaleRawHostPlugin]: a plugin that renders a UI implements this in
+ * addition to extending [JetWhaleRawHostPlugin]. Plugins that don't implement it are headless and the
+ * host renders no scene for them.
+ *
+ * Most plugins use the typed [JetWhaleUiHostPlugin] (which implements this for you) rather than this
+ * raw interface directly.
+ */
+public interface JetWhaleRawUiHostPlugin {
+    /**
+     * Composable content for the plugin UI with raw String operations context.
+     * This function is internally used by the JetWhale Host Application.
+     * Do not call this function directly.
+     *
+     * @param context The context for dispatching debug operations
+     */
+    @Composable
+    public fun ContentRaw(context: JetWhaleRawDebugOperationContext)
+}

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleUiHostPlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleUiHostPlugin.kt
@@ -1,0 +1,46 @@
+package com.kitakkun.jetwhale.host.sdk
+
+import androidx.compose.runtime.Composable
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Base class for typed JetWhale host plugins that render a UI. It is a [JetWhaleHostPlugin] that also
+ * provides a Compose [Content], adapting the host's raw [JetWhaleRawDebugOperationContext] to the
+ * typed [JetWhaleDebugOperationContext] for you.
+ *
+ * Extend this instead of [JetWhaleHostPlugin] when the plugin has a UI; extend [JetWhaleHostPlugin]
+ * directly for a headless plugin.
+ */
+public abstract class JetWhaleUiHostPlugin<Event, Method, MethodResult> :
+    JetWhaleHostPlugin<Event, Method, MethodResult>(),
+    JetWhaleRawUiHostPlugin {
+    /**
+     * Composable function that represents the UI of the plugin
+     *
+     * Composition will be kept as long as the plugin instance is alive.
+     * Even if the tab is switched, the composition will be kept.
+     *
+     * @param context The context to perform debug operations
+     */
+    @Composable
+    public abstract fun Content(context: JetWhaleDebugOperationContext<Method, MethodResult>)
+
+    /**
+     * Composable function that adapts raw string-based context to typed context
+     * and calls the typed Content function.
+     * @param context The raw debug operation context
+     */
+    @Composable
+    final override fun ContentRaw(context: JetWhaleRawDebugOperationContext) {
+        val typedContext = object : JetWhaleDebugOperationContext<Method, MethodResult> {
+            override val coroutineScope: CoroutineScope = context.coroutineScope
+            override suspend fun <MR : MethodResult> dispatch(method: Method): MR? {
+                val encodedMethod = protocol.encodeMethod(method)
+                val rawResult = context.dispatch(encodedMethod)
+                @Suppress("UNCHECKED_CAST")
+                return rawResult?.let { protocol.decodeMethodResult(it) } as? MR
+            }
+        }
+        Content(context = typedContext)
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
@@ -17,6 +17,7 @@ import com.kitakkun.jetwhale.host.model.PluginComposeSceneService
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.model.WindowInfoUpdater
 import com.kitakkun.jetwhale.host.sdk.JetWhaleRawDebugOperationContext
+import com.kitakkun.jetwhale.host.sdk.JetWhaleRawUiHostPlugin
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -64,7 +65,8 @@ class DefaultPluginComposeSceneService(
 
                 composeScene.setContent {
                     pluginBridgeProvider.PluginEntryPoint {
-                        pluginInstance.ContentRaw(context = debugOperationContext)
+                        // Headless plugins (not a JetWhaleRawUiHostPlugin) render no content.
+                        (pluginInstance as? JetWhaleRawUiHostPlugin)?.ContentRaw(context = debugOperationContext)
                     }
                 }
 

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -1,6 +1,5 @@
 package com.kitakkun.jetwhale.host.mcp
 
-import androidx.compose.runtime.Composable
 import com.kitakkun.jetwhale.host.model.LoadedPluginInstance
 import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
@@ -8,7 +7,6 @@ import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpParameterDescriptor
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
-import com.kitakkun.jetwhale.host.sdk.JetWhaleRawDebugOperationContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleRawHostPlugin
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -221,9 +219,6 @@ private class FakeMcpCapablePlugin :
     JetWhaleRawHostPlugin(),
     JetWhaleMcpCapablePlugin {
     override fun onRawEvent(event: String) = Unit
-
-    @Composable
-    override fun ContentRaw(context: JetWhaleRawDebugOperationContext) = Unit
 
     override fun mcpTools() = listOf(
         JetWhaleMcpToolDescriptor(

--- a/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostPluginFactory.kt
+++ b/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostPluginFactory.kt
@@ -5,12 +5,12 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleDebugOperationContext
-import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpParameterDescriptor
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
 import com.kitakkun.jetwhale.host.sdk.JetWhaleRawHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleUiHostPlugin
 import com.kitakkun.jetwhale.plugins.example.protocol.ExampleEvent
 import com.kitakkun.jetwhale.plugins.example.protocol.ExampleMethod
 import com.kitakkun.jetwhale.plugins.example.protocol.ExampleMethodResult
@@ -29,7 +29,7 @@ class ExampleHostPluginFactory : JetWhaleHostPluginFactory {
 
 @OptIn(ExperimentalJetWhaleApi::class)
 private class ExampleHostPlugin :
-    JetWhaleHostPlugin<ExampleEvent, ExampleMethod, ExampleMethodResult>(),
+    JetWhaleUiHostPlugin<ExampleEvent, ExampleMethod, ExampleMethodResult>(),
     JetWhaleMcpCapablePlugin {
 
     override val protocol: JetWhaleHostPluginProtocol<ExampleEvent, ExampleMethod, ExampleMethodResult> = kotlinxSerializationJetWhaleHostPluginProtocol()

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
@@ -7,9 +7,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.kitakkun.jetwhale.host.sdk.JetWhaleDebugOperationContext
-import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleRawHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleUiHostPlugin
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.plugins.network.protocol.NetworkEvent
 import com.kitakkun.jetwhale.plugins.network.protocol.NetworkMethod
@@ -26,7 +26,7 @@ class NetworkHostPluginFactory : JetWhaleHostPluginFactory {
 
 private const val MAX_TRANSACTIONS = 500
 
-private class NetworkHostPlugin : JetWhaleHostPlugin<NetworkEvent, NetworkMethod, NetworkMethodResult>() {
+private class NetworkHostPlugin : JetWhaleUiHostPlugin<NetworkEvent, NetworkMethod, NetworkMethodResult>() {
 
     override val protocol: JetWhaleHostPluginProtocol<NetworkEvent, NetworkMethod, NetworkMethodResult> =
         kotlinxSerializationJetWhaleHostPluginProtocol()


### PR DESCRIPTION
## Summary

Make **headless plugins** possible by removing the UI from the base plugin types and moving it to opt-in UI types. Until now every plugin had to implement a `Content`/`ContentRaw` composable, so a plugin with no UI (e.g. one that only contributes MCP tools) was impossible.

This is the first step toward headless plugins: it only separates the UI-bearing plugin into its own interface; nothing about the existing UI behavior changes.

## New shape

```
JetWhaleRawHostPlugin (abstract class)      // headless base: onRawEvent / onDispose, no UI
JetWhaleRawUiHostPlugin (interface)         // opt-in UI: @Composable ContentRaw(rawCtx)

JetWhaleHostPlugin<E,M,R> (abstract class)  // typed base, headless (decodes events -> onEvent)
JetWhaleUiHostPlugin<E,M,R> (abstract class)// typed + UI: adds @Composable Content + raw->typed adapter
```

- `JetWhaleRawHostPlugin` no longer declares `ContentRaw`; it is now headless.
- New `JetWhaleRawUiHostPlugin` interface carries the `@Composable` `ContentRaw`.
- `JetWhaleHostPlugin<E,M,R>` keeps only event handling (`protocol`, `onEvent`, the final `onRawEvent`).
- New `JetWhaleUiHostPlugin<E,M,R>` adds the typed `@Composable` `Content` and the raw→typed context adapter (it owns `protocol` via its superclass).

## Host

`DefaultPluginComposeSceneService` now renders `ContentRaw` only when the instance is a `JetWhaleRawUiHostPlugin`; headless plugins get no content rendered. The in-repo `example` and `network` plugins extend `JetWhaleUiHostPlugin`. The MCP test's fake plugin is now headless (no `ContentRaw` override).

> Note: this PR keeps the scope to the interface split. Follow-ups (e.g. the UI not opening a plugin screen for headless plugins, marking a plugin as headless in the model/UI) come separately.

## Breaking change

Plugins with a UI must extend `JetWhaleUiHostPlugin` instead of `JetWhaleHostPlugin` (or, at the raw level, implement `JetWhaleRawUiHostPlugin` alongside `JetWhaleRawHostPlugin`). Targets `1.0.0-alpha07`.

## Validation

- `./gradlew :jetwhale-host-sdk:compileKotlin :jetwhale-host:core:data:compileKotlin :jetwhale-plugins:example:host:compileKotlin :jetwhale-plugins:network:host:compileKotlin :jetwhale-host:core:mcp:test` — green (Java 21).
- `spotlessApply` + `:jetwhale-host-sdk:updateKotlinAbi` applied (the SDK ABI dump is updated for the new/removed members).