### PR TITLE
fix(coroutines): re-throw CancellationException at suspend try-catch boundaries

### DIFF
--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/NetworkTestScreen.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/NetworkTestScreen.kt
@@ -27,6 +27,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Lets the user point the monitored Ktor client at any server and fire sample requests.
@@ -44,10 +45,14 @@ internal fun NetworkTestScreen() {
     fun fire(label: String, block: suspend (baseUrl: String) -> String) {
         val target = baseUrl.trimEnd('/')
         scope.launch {
-            val line = runCatching { block(target) }.fold(
-                onSuccess = { "$label → $it" },
-                onFailure = { "$label → error: ${it.message}" },
-            )
+            val line = try {
+                "$label → ${block(target)}"
+            } catch (e: CancellationException) {
+                // Never swallow cancellation: re-throw so the coroutine cancellation mechanism keeps working.
+                throw e
+            } catch (e: Throwable) {
+                "$label → error: ${e.message}"
+            }
             log.add(0, line)
         }
     }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultClientSessionNegotiationStrategy.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultClientSessionNegotiationStrategy.kt
@@ -7,6 +7,7 @@ import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleProtocolVersion
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.receiveDeserialized
 import io.ktor.client.plugins.websocket.sendSerialized
+import kotlin.coroutines.cancellation.CancellationException
 
 internal class DefaultClientSessionNegotiationStrategy(private val plugins: List<AgentPlugin>) : ClientSessionNegotiationStrategy {
     private var sessionId: String? = null
@@ -22,6 +23,9 @@ internal class DefaultClientSessionNegotiationStrategy(private val plugins: List
         val response = negotiatePlugins(plugins)
 
         ClientSessionNegotiationResult.Success(availablePluginIds = response.availablePlugins.map { it.pluginId })
+    } catch (e: CancellationException) {
+        // Never swallow cancellation: re-throw so the coroutine cancellation mechanism keeps working.
+        throw e
     } catch (e: Throwable) {
         ClientSessionNegotiationResult.Failure(reason = e.message ?: "Unknown error during negotiation")
     }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/KtorWebSocketServer.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/KtorWebSocketServer.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * A Ktor-based WebSocket server for handling debug sessions.
@@ -78,6 +79,9 @@ class KtorWebSocketServer(
                 it.startSuspend()
                 embeddedServer = it
             }
+        } catch (e: CancellationException) {
+            // Never swallow cancellation: re-throw so the coroutine cancellation mechanism keeps working.
+            throw e
         } catch (e: Throwable) {
             mutableStatusFlow.update { DebugWebSocketServerStatus.Error(e.message ?: "Unknown error") }
         }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/negotiation/DefaultServerSessionNegotiationStrategy.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/negotiation/DefaultServerSessionNegotiationStrategy.kt
@@ -5,6 +5,7 @@ import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import io.ktor.server.websocket.DefaultWebSocketServerSession
 import io.ktor.util.logging.Logger
+import kotlin.coroutines.cancellation.CancellationException
 
 @Inject
 @ContributesBinding(AppScope::class)
@@ -29,6 +30,9 @@ class DefaultServerSessionNegotiationStrategy(
                 session = session,
                 plugin = plugin,
             )
+        } catch (e: CancellationException) {
+            // Never swallow cancellation: re-throw so the coroutine cancellation mechanism keeps working.
+            throw e
         } catch (e: Throwable) {
             return ServerSessionNegotiationResult.Failure(e)
         }


### PR DESCRIPTION
## Summary

Stop swallowing `CancellationException` in a few `suspend` try-catch boundaries. A broad `catch (Throwable)` / `runCatching` around suspending calls also catches the `CancellationException` that the coroutines machinery throws to unwind a cancelled coroutine — swallowing it breaks structured-concurrency cancellation (the coroutine keeps running / reports a normal failure instead of cancelling).

Rationale: ["CancellationException はなぜ catch してはいけないのか" (kitakkun)](https://qiita.com/kitakkun/items/253540215f057a5933b4).

## Changes

Each broad catch now re-throws `CancellationException` first:

- `DefaultClientSessionNegotiationStrategy.negotiate()` — wraps `sendSerialized`/`receiveDeserialized`.
- `DefaultServerSessionNegotiationStrategy.negotiate()` — server-side counterpart.
- `KtorWebSocketServer.start()` — wraps `startSuspend()`.
- `NetworkTestScreen` (demo) — `runCatching { block(target) }` (where `block` is `suspend`) replaced with a try-catch that re-throws cancellation; the success/error log behavior is unchanged.

```kotlin
} catch (e: CancellationException) {
    throw e
} catch (e: Throwable) {
    // ...existing failure handling...
}
```

## Scope / notes

These were the genuine violations found in a sweep; broad catches around **non-suspending** code (e.g. synchronous `decodeFromStringOrNull` helpers) and catches that already re-throw cancellation were left as-is.

One borderline case was intentionally left out for discussion: `DefaultMcpServerService.start()` has a `catch (Exception)`, but it only wraps the non-suspending `server.start(wait = false)`, so no `CancellationException` is actually thrown there.

## Validation

Compiled the affected modules with Java 21 (`:jetwhale-host:core:data`, `:jetwhale-agent-runtime` JVM, `:demo:shared` metadata + JVM) and ran `spotlessApply` (no changes) — all green.