### PR TITLE
feat(host)!: load only user-approved plugin jars

### DIFF
--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -21,3 +21,24 @@ The JetWhale host's behavior is configured from its **Settings** screen.
 Installed plugins live in `~/.jetwhale/plugins/` as fat-jars. Drop a plugin jar there (or run
 `./gradlew installPlugin` from a plugin project) and the host picks it up. See
 [Developing Plugins](/guide/developing-plugins) for building your own.
+
+### Plugin trust
+
+Plugin jars are arbitrary code running inside the host process, so JetWhale only loads jars you
+have explicitly approved. Approvals are recorded in `~/.jetwhale/trusted-plugins.json`, with each
+jar pinned to the SHA-256 hash of its content at approval time. On startup:
+
+- Jars whose current content still matches their pinned hash are loaded.
+- Jars that were never approved, or whose content changed since approval, are **not** loaded and
+  appear in the **Unverified Plugins** section of the settings screen for review.
+
+Installing a plugin through the file picker counts as approval; jars dropped into the directory by
+anything else must be approved manually. Revoking trust unloads the plugin immediately.
+
+::: warning Threat model
+This is an entry-side defense: it stops JetWhale from executing jars you never vouched for, and
+detects jars swapped out after approval. It does **not** defend against malicious software already
+running with your user privileges — such software can rewrite the trust registry (or JetWhale
+itself) directly. Protecting against an attacker who already controls your user account is outside
+the scope of this mechanism.
+:::

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/ApplicationLifecycleOwner.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/ApplicationLifecycleOwner.kt
@@ -1,11 +1,10 @@
 package com.kitakkun.jetwhale.host
 
-import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
 import com.kitakkun.jetwhale.host.mcp.McpServerService
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
 import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
-import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
 import com.kitakkun.jetwhale.host.model.PluginHotReloadService
+import com.kitakkun.jetwhale.host.model.PluginTrustService
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -21,8 +20,7 @@ import kotlinx.coroutines.launch
 class ApplicationLifecycleOwner(
     private val server: DebugWebSocketServer,
     private val mcpServerService: McpServerService,
-    private val appDataDirectoryProvider: AppDataDirectoryProvider,
-    private val pluginFactoryRepository: PluginFactoryRepository,
+    private val pluginTrustService: PluginTrustService,
     private val pluginHotReloadService: PluginHotReloadService,
     private val settingsRepository: DebuggerSettingsRepository,
 ) {
@@ -51,9 +49,11 @@ class ApplicationLifecycleOwner(
                 port = settingsRepository.readMcpServerPort(),
             )
 
-            appDataDirectoryProvider.getAllPluginJarFilePaths().forEach {
-                pluginFactoryRepository.loadPlugin(it)
-            }
+            // Load only jars the user has explicitly approved (pinned by content hash). Anything else
+            // in the plugins directory — a jar that was never approved, or one whose bytes changed
+            // after approval — is surfaced for review instead of being executed. This is what stops a
+            // malicious jar dropped into ~/.jetwhale/plugins from auto-running in the host process.
+            pluginTrustService.loadTrustedPlugins()
 
             // Loads dev plugins (if any) and starts watching the dev directory for hot reload.
             // No-op unless the jetwhale.devPluginsDir system property is set.

--- a/jetwhale-host/core/data/build.gradle.kts
+++ b/jetwhale-host/core/data/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.metro)
+    alias(libs.plugins.kotlinxSerialization)
     alias(libs.plugins.mokkery)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.jetbrainsCompose)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
@@ -19,6 +19,13 @@ class AppDataDirectoryProvider {
 
     fun getAppDataPath(): String = "~/.jetwhale"
 
+    /**
+     * The file backing the plugin trust registry (the list of jars the user has explicitly approved,
+     * each pinned to the content hash it had at approval time). Lives directly under the app data
+     * directory so it is created and read before any plugin jar is touched.
+     */
+    fun getTrustRegistryFile(): File = File(appDataDir, "trusted-plugins.json")
+
     fun createAppDataDirectoriesIfNeeded() {
         val appDataDirectory = File(appDataDir)
         if (!appDataDirectory.exists()) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
@@ -26,6 +26,22 @@ class AppDataDirectoryProvider {
      */
     fun getTrustRegistryFile(): File = File(appDataDir, "trusted-plugins.json")
 
+    /**
+     * True only for a `.jar` file directly inside the managed plugins directory. Paths are compared
+     * canonically so `..` segments or symlinked aliases cannot smuggle in a jar from elsewhere. This
+     * is the precondition for trusting a jar: the plugins directory is the security boundary, and
+     * only files placed there through the explicit install flow may be approved.
+     */
+    fun isManagedPluginJarPath(jarPath: String): Boolean {
+        val file = File(jarPath)
+        if (file.extension != "jar") return false
+        return try {
+            file.canonicalFile.parentFile == File(pluginDir).canonicalFile
+        } catch (e: java.io.IOException) {
+            false
+        }
+    }
+
     fun createAppDataDirectoriesIfNeeded() {
         val appDataDirectory = File(appDataDir)
         if (!appDataDirectory.exists()) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallMutationKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallMutationKey.kt
@@ -1,8 +1,8 @@
 package com.kitakkun.jetwhale.host.data.plugin
 
 import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
-import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
 import com.kitakkun.jetwhale.host.model.PluginInstallMutationKey
+import com.kitakkun.jetwhale.host.model.PluginTrustService
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -12,13 +12,15 @@ import soil.query.buildMutationKey
 @Inject
 @ContributesBinding(AppScope::class)
 class DefaultPluginInstallMutationKey(
-    private val pluginFactoryRepository: PluginFactoryRepository,
+    private val pluginTrustService: PluginTrustService,
     private val appDataDirectoryProvider: AppDataDirectoryProvider,
 ) : PluginInstallMutationKey by buildMutationKey(
     id = MutationId("pluginInstall"),
     mutate = { jarUrlString: String ->
         appDataDirectoryProvider.createAppDataDirectoriesIfNeeded()
         val copiedJarFilePath = appDataDirectoryProvider.copyJarFileToAppDataDirectory(jarUrlString)
-        pluginFactoryRepository.loadPlugin(copiedJarFilePath)
+        // Installing via the file picker is the user's explicit consent: approve (pin the content
+        // hash) and load. A jar that merely appears in the directory by other means is not trusted.
+        pluginTrustService.trustAndLoad(copiedJarFilePath)
     },
 )

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepository.kt
@@ -1,0 +1,110 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
+import com.kitakkun.jetwhale.host.model.PluginTrustRepository
+import com.kitakkun.jetwhale.host.model.TrustedPluginEntry
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+
+/**
+ * JSON-file-backed trust registry stored at `~/.jetwhale/trusted-plugins.json`. Reads itself once on
+ * construction so the trust decision is available before any plugin jar is loaded; every mutation
+ * updates the in-memory snapshot and rewrites the file under a mutex.
+ *
+ * The JSON is built and parsed with the [JsonObject] tree API rather than `@Serializable` classes on
+ * purpose: this module does not apply the kotlinx.serialization compiler plugin, so a generated
+ * serializer for a local data class would not exist and `encodeToString` would fail at runtime.
+ */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+@Inject
+class DefaultPluginTrustRepository(
+    private val appDataDirectoryProvider: AppDataDirectoryProvider,
+) : PluginTrustRepository {
+    private val writeMutex = Mutex()
+
+    private val mutableEntriesFlow: MutableStateFlow<Map<String, TrustedPluginEntry>> =
+        MutableStateFlow(readFromDisk())
+    override val trustedEntriesFlow: Flow<Map<String, TrustedPluginEntry>> = mutableEntriesFlow.asStateFlow()
+
+    override suspend fun trustedEntry(jarPath: String): TrustedPluginEntry? = mutableEntriesFlow.value[jarPath]
+
+    override suspend fun trust(jarPath: String, sha256: String): Unit = writeMutex.withLock {
+        val updated = mutableEntriesFlow.value + (jarPath to TrustedPluginEntry(jarPath, sha256, System.currentTimeMillis()))
+        persist(updated)
+        mutableEntriesFlow.value = updated
+    }
+
+    override suspend fun revoke(jarPath: String): Unit = writeMutex.withLock {
+        if (jarPath !in mutableEntriesFlow.value) return@withLock
+        val updated = mutableEntriesFlow.value - jarPath
+        persist(updated)
+        mutableEntriesFlow.value = updated
+    }
+
+    private fun readFromDisk(): Map<String, TrustedPluginEntry> {
+        val file = appDataDirectoryProvider.getTrustRegistryFile()
+        if (!file.exists()) return emptyMap()
+        return try {
+            val root = json.parseToJsonElement(file.readText()).jsonObject
+            val entries = root[ENTRIES_KEY]?.jsonObject ?: return emptyMap()
+            entries.mapValues { (path, element) ->
+                val entry = element.jsonObject
+                TrustedPluginEntry(
+                    jarPath = path,
+                    sha256 = entry.getValue(SHA256_KEY).jsonPrimitive.content,
+                    trustedAtEpochMillis = entry.getValue(TRUSTED_AT_KEY).jsonPrimitive.long,
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // A corrupt or unreadable registry must fail safe: treat everything as untrusted rather
+            // than risk loading a jar we cannot prove was approved.
+            println("Failed to read plugin trust registry, treating all plugins as untrusted: ${e.message}")
+            emptyMap()
+        }
+    }
+
+    private fun persist(entries: Map<String, TrustedPluginEntry>) {
+        val file = appDataDirectoryProvider.getTrustRegistryFile()
+        file.parentFile?.mkdirs()
+        val root = buildJsonObject {
+            put(
+                ENTRIES_KEY,
+                JsonObject(
+                    entries.mapValues { (_, entry) ->
+                        buildJsonObject {
+                            put(SHA256_KEY, entry.sha256)
+                            put(TRUSTED_AT_KEY, entry.trustedAtEpochMillis)
+                        }
+                    },
+                ),
+            )
+        }
+        file.writeText(json.encodeToString(JsonElement.serializer(), root))
+    }
+
+    companion object {
+        private const val ENTRIES_KEY = "entries"
+        private const val SHA256_KEY = "sha256"
+        private const val TRUSTED_AT_KEY = "trustedAtEpochMillis"
+        private val json = Json { prettyPrint = true }
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepository.kt
@@ -10,7 +10,6 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.Serializable
@@ -33,23 +32,22 @@ class DefaultPluginTrustRepository(
 ) : PluginTrustRepository {
     private val writeMutex = Mutex()
 
-    private val mutableEntriesFlow: MutableStateFlow<Map<String, TrustedPluginEntry>> =
-        MutableStateFlow(readFromDisk())
-    override val trustedEntriesFlow: Flow<Map<String, TrustedPluginEntry>> = mutableEntriesFlow.asStateFlow()
+    override val trustedEntriesFlow: Flow<Map<String, TrustedPluginEntry>>
+        field = MutableStateFlow(readFromDisk())
 
-    override suspend fun trustedEntry(jarPath: String): TrustedPluginEntry? = mutableEntriesFlow.value[jarPath]
+    override suspend fun trustedEntry(jarPath: String): TrustedPluginEntry? = trustedEntriesFlow.value[jarPath]
 
     override suspend fun trust(jarPath: String, sha256: String): Unit = writeMutex.withLock {
-        val updated = mutableEntriesFlow.value + (jarPath to TrustedPluginEntry(jarPath, sha256, System.currentTimeMillis()))
+        val updated = trustedEntriesFlow.value + (jarPath to TrustedPluginEntry(jarPath, sha256, System.currentTimeMillis()))
         persist(updated)
-        mutableEntriesFlow.value = updated
+        trustedEntriesFlow.value = updated
     }
 
     override suspend fun revoke(jarPath: String): Unit = writeMutex.withLock {
-        if (jarPath !in mutableEntriesFlow.value) return@withLock
-        val updated = mutableEntriesFlow.value - jarPath
+        if (jarPath !in trustedEntriesFlow.value) return@withLock
+        val updated = trustedEntriesFlow.value - jarPath
         persist(updated)
-        mutableEntriesFlow.value = updated
+        trustedEntriesFlow.value = updated
     }
 
     private fun readFromDisk(): Map<String, TrustedPluginEntry> {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepository.kt
@@ -13,14 +13,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.long
-import kotlinx.serialization.json.put
 import java.io.File
 import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
@@ -30,10 +24,6 @@ import java.nio.file.StandardCopyOption
  * JSON-file-backed trust registry stored at `~/.jetwhale/trusted-plugins.json`. Reads itself once on
  * construction so the trust decision is available before any plugin jar is loaded; every mutation
  * updates the in-memory snapshot and rewrites the file under a mutex.
- *
- * The JSON is built and parsed with the [JsonObject] tree API rather than `@Serializable` classes on
- * purpose: this module does not apply the kotlinx.serialization compiler plugin, so a generated
- * serializer for a local data class would not exist and `encodeToString` would fail at runtime.
  */
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
@@ -66,14 +56,12 @@ class DefaultPluginTrustRepository(
         val file = appDataDirectoryProvider.getTrustRegistryFile()
         if (!file.exists()) return emptyMap()
         return try {
-            val root = json.parseToJsonElement(file.readText()).jsonObject
-            val entries = root[ENTRIES_KEY]?.jsonObject ?: return emptyMap()
-            entries.mapValues { (path, element) ->
-                val entry = element.jsonObject
+            val registry = json.decodeFromString<TrustRegistryFile>(file.readText())
+            registry.entries.mapValues { (path, entry) ->
                 TrustedPluginEntry(
                     jarPath = path,
-                    sha256 = entry.getValue(SHA256_KEY).jsonPrimitive.content,
-                    trustedAtEpochMillis = entry.getValue(TRUSTED_AT_KEY).jsonPrimitive.long,
+                    sha256 = entry.sha256,
+                    trustedAtEpochMillis = entry.trustedAtEpochMillis,
                 )
             }
         } catch (e: CancellationException) {
@@ -89,23 +77,18 @@ class DefaultPluginTrustRepository(
     private fun persist(entries: Map<String, TrustedPluginEntry>) {
         val file = appDataDirectoryProvider.getTrustRegistryFile()
         file.parentFile?.mkdirs()
-        val root = buildJsonObject {
-            put(
-                ENTRIES_KEY,
-                JsonObject(
-                    entries.mapValues { (_, entry) ->
-                        buildJsonObject {
-                            put(SHA256_KEY, entry.sha256)
-                            put(TRUSTED_AT_KEY, entry.trustedAtEpochMillis)
-                        }
-                    },
-                ),
-            )
-        }
+        val registry = TrustRegistryFile(
+            entries = entries.mapValues { (_, entry) ->
+                StoredTrustedPluginEntry(
+                    sha256 = entry.sha256,
+                    trustedAtEpochMillis = entry.trustedAtEpochMillis,
+                )
+            },
+        )
         // Write to a sibling temp file and move it into place so an interrupted write can never
         // leave a truncated registry behind (which would fail-safe but wipe all trust decisions).
         val tempFile = File(file.parentFile, "${file.name}.tmp")
-        tempFile.writeText(json.encodeToString(JsonElement.serializer(), root))
+        tempFile.writeText(json.encodeToString(registry))
         try {
             Files.move(tempFile.toPath(), file.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
         } catch (e: AtomicMoveNotSupportedException) {
@@ -113,10 +96,18 @@ class DefaultPluginTrustRepository(
         }
     }
 
+    @Serializable
+    private data class TrustRegistryFile(
+        val entries: Map<String, StoredTrustedPluginEntry>,
+    )
+
+    @Serializable
+    private data class StoredTrustedPluginEntry(
+        val sha256: String,
+        val trustedAtEpochMillis: Long,
+    )
+
     companion object {
-        private const val ENTRIES_KEY = "entries"
-        private const val SHA256_KEY = "sha256"
-        private const val TRUSTED_AT_KEY = "trustedAtEpochMillis"
         private val json = Json { prettyPrint = true }
     }
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepository.kt
@@ -21,6 +21,10 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
 import kotlinx.serialization.json.put
+import java.io.File
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 /**
  * JSON-file-backed trust registry stored at `~/.jetwhale/trusted-plugins.json`. Reads itself once on
@@ -98,7 +102,15 @@ class DefaultPluginTrustRepository(
                 ),
             )
         }
-        file.writeText(json.encodeToString(JsonElement.serializer(), root))
+        // Write to a sibling temp file and move it into place so an interrupted write can never
+        // leave a truncated registry behind (which would fail-safe but wipe all trust decisions).
+        val tempFile = File(file.parentFile, "${file.name}.tmp")
+        tempFile.writeText(json.encodeToString(JsonElement.serializer(), root))
+        try {
+            Files.move(tempFile.toPath(), file.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        } catch (e: AtomicMoveNotSupportedException) {
+            Files.move(tempFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
     }
 
     companion object {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustService.kt
@@ -8,6 +8,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -42,6 +43,9 @@ class DefaultPluginTrustService(
     }
 
     override suspend fun trustAndLoad(jarPath: String) {
+        require(appDataDirectoryProvider.isManagedPluginJarPath(jarPath)) {
+            "Refusing to trust a jar outside the managed plugins directory: $jarPath"
+        }
         pluginTrustRepository.trust(jarPath, computeSha256(jarPath))
         mutableUntrustedJarPathsFlow.update { it - jarPath }
         pluginFactoryRepository.loadPlugin(jarPath)
@@ -60,7 +64,17 @@ class DefaultPluginTrustService(
     /** True only if [jarPath] has a trusted entry whose pinned hash matches the jar's current bytes. */
     private suspend fun isTrusted(jarPath: String): Boolean {
         val entry = pluginTrustRepository.trustedEntry(jarPath) ?: return false
-        return entry.sha256 == computeSha256(jarPath)
+        val currentSha256 = try {
+            computeSha256(jarPath)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // A jar we cannot read is a jar we cannot verify: fail safe as untrusted instead of
+            // letting an IO error abort loading of every other plugin.
+            println("Failed to hash plugin jar, treating as untrusted: $jarPath (${e.message})")
+            return false
+        }
+        return entry.sha256 == currentSha256
     }
 
     private suspend fun computeSha256(jarPath: String): String = withContext(Dispatchers.IO) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustService.kt
@@ -1,0 +1,78 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
+import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.PluginTrustRepository
+import com.kitakkun.jetwhale.host.model.PluginTrustService
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.security.MessageDigest
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+@Inject
+class DefaultPluginTrustService(
+    private val appDataDirectoryProvider: AppDataDirectoryProvider,
+    private val pluginTrustRepository: PluginTrustRepository,
+    private val pluginFactoryRepository: PluginFactoryRepository,
+) : PluginTrustService {
+    private val mutableUntrustedJarPathsFlow: MutableStateFlow<List<String>> = MutableStateFlow(emptyList())
+    override val untrustedJarPathsFlow: Flow<List<String>> = mutableUntrustedJarPathsFlow.asStateFlow()
+
+    override suspend fun loadTrustedPlugins() {
+        val untrusted = mutableListOf<String>()
+        for (jarPath in appDataDirectoryProvider.getAllPluginJarFilePaths()) {
+            if (isTrusted(jarPath)) {
+                pluginFactoryRepository.loadPlugin(jarPath)
+            } else {
+                println("Skipping untrusted plugin jar (not approved or content changed): $jarPath")
+                untrusted += jarPath
+            }
+        }
+        mutableUntrustedJarPathsFlow.value = untrusted
+    }
+
+    override suspend fun trustAndLoad(jarPath: String) {
+        pluginTrustRepository.trust(jarPath, computeSha256(jarPath))
+        mutableUntrustedJarPathsFlow.update { it - jarPath }
+        pluginFactoryRepository.loadPlugin(jarPath)
+    }
+
+    override suspend fun revokeTrust(jarPath: String) {
+        pluginTrustRepository.revoke(jarPath)
+        // Unload everything this jar provided so revoking trust takes effect immediately, without a
+        // restart. The jar file itself stays in the directory, so it becomes untrusted-but-present.
+        pluginFactoryRepository.findPluginIdsByJarPath(jarPath).forEach { pluginFactoryRepository.unloadPlugin(it) }
+        if (File(jarPath).exists()) {
+            mutableUntrustedJarPathsFlow.update { if (jarPath in it) it else it + jarPath }
+        }
+    }
+
+    /** True only if [jarPath] has a trusted entry whose pinned hash matches the jar's current bytes. */
+    private suspend fun isTrusted(jarPath: String): Boolean {
+        val entry = pluginTrustRepository.trustedEntry(jarPath) ?: return false
+        return entry.sha256 == computeSha256(jarPath)
+    }
+
+    private suspend fun computeSha256(jarPath: String): String = withContext(Dispatchers.IO) {
+        val digest = MessageDigest.getInstance("SHA-256")
+        File(jarPath).inputStream().use { stream ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = stream.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        digest.digest().joinToString("") { "%02x".format(it) }
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustService.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -26,8 +25,8 @@ class DefaultPluginTrustService(
     private val pluginTrustRepository: PluginTrustRepository,
     private val pluginFactoryRepository: PluginFactoryRepository,
 ) : PluginTrustService {
-    private val mutableUntrustedJarPathsFlow: MutableStateFlow<List<String>> = MutableStateFlow(emptyList())
-    override val untrustedJarPathsFlow: Flow<List<String>> = mutableUntrustedJarPathsFlow.asStateFlow()
+    override val untrustedJarPathsFlow: Flow<List<String>>
+        field = MutableStateFlow(emptyList())
 
     override suspend fun loadTrustedPlugins() {
         val untrusted = mutableListOf<String>()
@@ -39,7 +38,7 @@ class DefaultPluginTrustService(
                 untrusted += jarPath
             }
         }
-        mutableUntrustedJarPathsFlow.value = untrusted
+        untrustedJarPathsFlow.value = untrusted
     }
 
     override suspend fun trustAndLoad(jarPath: String) {
@@ -47,7 +46,7 @@ class DefaultPluginTrustService(
             "Refusing to trust a jar outside the managed plugins directory: $jarPath"
         }
         pluginTrustRepository.trust(jarPath, computeSha256(jarPath))
-        mutableUntrustedJarPathsFlow.update { it - jarPath }
+        untrustedJarPathsFlow.update { it - jarPath }
         pluginFactoryRepository.loadPlugin(jarPath)
     }
 
@@ -57,7 +56,7 @@ class DefaultPluginTrustService(
         // restart. The jar file itself stays in the directory, so it becomes untrusted-but-present.
         pluginFactoryRepository.findPluginIdsByJarPath(jarPath).forEach { pluginFactoryRepository.unloadPlugin(it) }
         if (File(jarPath).exists()) {
-            mutableUntrustedJarPathsFlow.update { if (jarPath in it) it else it + jarPath }
+            untrustedJarPathsFlow.update { if (jarPath in it) it else it + jarPath }
         }
     }
 

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultTrustPluginMutationKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultTrustPluginMutationKey.kt
@@ -1,0 +1,21 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.model.PluginTrustService
+import com.kitakkun.jetwhale.host.model.TrustPluginMutationKey
+import com.kitakkun.jetwhale.host.model.TrustPluginRequest
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import soil.query.MutationId
+import soil.query.buildMutationKey
+
+@Inject
+@ContributesBinding(AppScope::class)
+class DefaultTrustPluginMutationKey(
+    private val pluginTrustService: PluginTrustService,
+) : TrustPluginMutationKey by buildMutationKey(
+    id = MutationId("trust_plugin"),
+    mutate = { request: TrustPluginRequest ->
+        pluginTrustService.trustAndLoad(request.jarPath)
+    },
+)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultUntrustedPluginJarPathsSubscriptionKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultUntrustedPluginJarPathsSubscriptionKey.kt
@@ -1,0 +1,23 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.model.PluginTrustService
+import com.kitakkun.jetwhale.host.model.UntrustedPluginJarPathsSubscriptionKey
+import com.kitakkun.jetwhale.host.model.UntrustedPluginJars
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.map
+import soil.query.SubscriptionId
+import soil.query.buildSubscriptionKey
+
+@Inject
+@ContributesBinding(AppScope::class)
+class DefaultUntrustedPluginJarPathsSubscriptionKey(
+    private val pluginTrustService: PluginTrustService,
+) : UntrustedPluginJarPathsSubscriptionKey by buildSubscriptionKey(
+    id = SubscriptionId("default_untrusted_plugin_jar_paths_subscription_key"),
+    subscribe = {
+        pluginTrustService.untrustedJarPathsFlow.map { UntrustedPluginJars(it.toPersistentList()) }
+    },
+)

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepositoryTest.kt
@@ -1,0 +1,58 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DefaultPluginTrustRepositoryTest {
+    private val originalUserHome: String? = System.getProperty("user.home")
+    private val tempHome: File = File.createTempFile("jetwhale-home-", "").apply {
+        delete()
+        mkdirs()
+    }
+
+    init {
+        // AppDataDirectoryProvider resolves its paths from user.home in field initializers, so point
+        // it at an isolated temp home before any provider is constructed in a test.
+        System.setProperty("user.home", tempHome.absolutePath)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        if (originalUserHome != null) System.setProperty("user.home", originalUserHome)
+        tempHome.deleteRecursively()
+    }
+
+    // A fresh repository each time so we exercise the on-disk read path, not just the in-memory cache.
+    private fun newRepository() = DefaultPluginTrustRepository(AppDataDirectoryProvider())
+
+    @Test
+    fun trustedEntriesSurviveAReadBackFromDisk() = runBlocking {
+        // Regression guard for the original bug: persisting the registry must actually write valid
+        // JSON. It previously threw a SerializationException at runtime (no serializer was generated
+        // for the @Serializable model because this module lacks the serialization plugin); the
+        // mutation swallowed it, so approving an untrusted jar silently did nothing.
+        newRepository().apply {
+            trust("/plugins/a.jar", "hash-a")
+            trust("/plugins/b.jar", "hash-b")
+        }
+
+        val reloaded = newRepository()
+        assertEquals("hash-a", reloaded.trustedEntry("/plugins/a.jar")?.sha256)
+        assertEquals("hash-b", reloaded.trustedEntry("/plugins/b.jar")?.sha256)
+    }
+
+    @Test
+    fun revokeRemovesTheEntryAndPersists() = runBlocking {
+        newRepository().apply {
+            trust("/plugins/a.jar", "hash-a")
+            revoke("/plugins/a.jar")
+        }
+
+        assertNull(newRepository().trustedEntry("/plugins/a.jar"))
+    }
+}

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepositoryTest.kt
@@ -36,10 +36,6 @@ class DefaultPluginTrustRepositoryTest {
 
     @Test
     fun trustedEntriesSurviveAReadBackFromDisk() = runBlocking {
-        // Regression guard for the original bug: persisting the registry must actually write valid
-        // JSON. It previously threw a SerializationException at runtime (no serializer was generated
-        // for the @Serializable model because this module lacks the serialization plugin); the
-        // mutation swallowed it, so approving an untrusted jar silently did nothing.
         newRepository().apply {
             trust("/plugins/a.jar", "hash-a")
             trust("/plugins/b.jar", "hash-b")

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepositoryTest.kt
@@ -4,26 +4,30 @@ import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
 import kotlinx.coroutines.runBlocking
 import java.io.File
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class DefaultPluginTrustRepositoryTest {
-    private val originalUserHome: String? = System.getProperty("user.home")
-    private val tempHome: File = File.createTempFile("jetwhale-home-", "").apply {
-        delete()
-        mkdirs()
-    }
+    private var originalUserHome: String? = null
+    private lateinit var tempHome: File
 
-    init {
+    @BeforeTest
+    fun setUp() {
         // AppDataDirectoryProvider resolves its paths from user.home in field initializers, so point
         // it at an isolated temp home before any provider is constructed in a test.
+        originalUserHome = System.getProperty("user.home")
+        tempHome = File.createTempFile("jetwhale-home-", "").apply {
+            delete()
+            mkdirs()
+        }
         System.setProperty("user.home", tempHome.absolutePath)
     }
 
     @AfterTest
     fun cleanup() {
-        if (originalUserHome != null) System.setProperty("user.home", originalUserHome)
+        originalUserHome?.let { System.setProperty("user.home", it) }
         tempHome.deleteRecursively()
     }
 

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepositoryTest.kt
@@ -35,7 +35,7 @@ class DefaultPluginTrustRepositoryTest {
     private fun newRepository() = DefaultPluginTrustRepository(AppDataDirectoryProvider())
 
     @Test
-    fun trustedEntriesSurviveAReadBackFromDisk() = runBlocking {
+    fun `trusted entries survive a read back from disk`() = runBlocking {
         newRepository().apply {
             trust("/plugins/a.jar", "hash-a")
             trust("/plugins/b.jar", "hash-b")
@@ -47,7 +47,7 @@ class DefaultPluginTrustRepositoryTest {
     }
 
     @Test
-    fun revokeRemovesTheEntryAndPersists() = runBlocking {
+    fun `revoke removes the entry and persists`() = runBlocking {
         newRepository().apply {
             trust("/plugins/a.jar", "hash-a")
             revoke("/plugins/a.jar")

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustServiceTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustServiceTest.kt
@@ -46,7 +46,7 @@ class DefaultPluginTrustServiceTest {
     }
 
     @Test
-    fun trustAndLoadAcceptsAJarInsideThePluginsDirectory() = runBlocking {
+    fun `trustAndLoad accepts a jar inside the plugins directory`() = runBlocking {
         val jar = File(pluginsDir, "plugin.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
 
         service.trustAndLoad(jar.absolutePath)
@@ -56,7 +56,7 @@ class DefaultPluginTrustServiceTest {
     }
 
     @Test
-    fun trustAndLoadRejectsAJarOutsideThePluginsDirectory() = runBlocking {
+    fun `trustAndLoad rejects a jar outside the plugins directory`() = runBlocking {
         val outsideJar = File(tempHome, "evil.jar").apply { writeBytes(byteArrayOf(1)) }
 
         assertFailsWith<IllegalArgumentException> { service.trustAndLoad(outsideJar.absolutePath) }
@@ -65,7 +65,7 @@ class DefaultPluginTrustServiceTest {
     }
 
     @Test
-    fun trustAndLoadRejectsAPathEscapingThePluginsDirectoryViaDotDot() = runBlocking {
+    fun `trustAndLoad rejects a path escaping the plugins directory via dot-dot`() = runBlocking {
         val outsideJar = File(tempHome, "evil.jar").apply { writeBytes(byteArrayOf(1)) }
         val sneakyPath = "${pluginsDir.absolutePath}/../../${outsideJar.name}"
 
@@ -74,7 +74,7 @@ class DefaultPluginTrustServiceTest {
     }
 
     @Test
-    fun trustAndLoadRejectsANonJarFile() = runBlocking {
+    fun `trustAndLoad rejects a non-jar file`() = runBlocking {
         val notAJar = File(pluginsDir, "plugin.zip").apply { writeBytes(byteArrayOf(1)) }
 
         assertFailsWith<IllegalArgumentException> { service.trustAndLoad(notAJar.absolutePath) }
@@ -82,7 +82,7 @@ class DefaultPluginTrustServiceTest {
     }
 
     @Test
-    fun loadTrustedPluginsTreatsAnUnhashableJarAsUntrustedInsteadOfAborting() = runBlocking {
+    fun `loadTrustedPlugins treats an unhashable jar as untrusted instead of aborting`() = runBlocking {
         val readable = File(pluginsDir, "good.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
         service.trustAndLoad(readable.absolutePath)
         factoryRepository.loadedJarPaths.clear()

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustServiceTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustServiceTest.kt
@@ -1,0 +1,133 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
+import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
+import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.PluginTrustRepository
+import com.kitakkun.jetwhale.host.model.TrustedPluginEntry
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DefaultPluginTrustServiceTest {
+    private var originalUserHome: String? = null
+    private lateinit var tempHome: File
+    private lateinit var pluginsDir: File
+
+    private lateinit var trustRepository: FakePluginTrustRepository
+    private lateinit var factoryRepository: FakePluginFactoryRepository
+    private lateinit var service: DefaultPluginTrustService
+
+    @BeforeTest
+    fun setUp() {
+        originalUserHome = System.getProperty("user.home")
+        tempHome = File.createTempFile("jetwhale-home-", "").apply {
+            delete()
+            mkdirs()
+        }
+        System.setProperty("user.home", tempHome.absolutePath)
+        pluginsDir = File(tempHome, ".jetwhale/plugins").apply { mkdirs() }
+
+        trustRepository = FakePluginTrustRepository()
+        factoryRepository = FakePluginFactoryRepository()
+        service = DefaultPluginTrustService(AppDataDirectoryProvider(), trustRepository, factoryRepository)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        originalUserHome?.let { System.setProperty("user.home", it) }
+        tempHome.deleteRecursively()
+    }
+
+    @Test
+    fun trustAndLoadAcceptsAJarInsideThePluginsDirectory() = runBlocking {
+        val jar = File(pluginsDir, "plugin.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+
+        service.trustAndLoad(jar.absolutePath)
+
+        assertEquals(listOf(jar.absolutePath), factoryRepository.loadedJarPaths)
+        assertEquals(setOf(jar.absolutePath), trustRepository.entries.keys)
+    }
+
+    @Test
+    fun trustAndLoadRejectsAJarOutsideThePluginsDirectory() = runBlocking {
+        val outsideJar = File(tempHome, "evil.jar").apply { writeBytes(byteArrayOf(1)) }
+
+        assertFailsWith<IllegalArgumentException> { service.trustAndLoad(outsideJar.absolutePath) }
+        assertEquals(emptyList(), factoryRepository.loadedJarPaths)
+        assertEquals(emptySet(), trustRepository.entries.keys)
+    }
+
+    @Test
+    fun trustAndLoadRejectsAPathEscapingThePluginsDirectoryViaDotDot() = runBlocking {
+        val outsideJar = File(tempHome, "evil.jar").apply { writeBytes(byteArrayOf(1)) }
+        val sneakyPath = "${pluginsDir.absolutePath}/../../${outsideJar.name}"
+
+        assertFailsWith<IllegalArgumentException> { service.trustAndLoad(sneakyPath) }
+        assertEquals(emptyList(), factoryRepository.loadedJarPaths)
+    }
+
+    @Test
+    fun trustAndLoadRejectsANonJarFile() = runBlocking {
+        val notAJar = File(pluginsDir, "plugin.zip").apply { writeBytes(byteArrayOf(1)) }
+
+        assertFailsWith<IllegalArgumentException> { service.trustAndLoad(notAJar.absolutePath) }
+        assertEquals(emptyList(), factoryRepository.loadedJarPaths)
+    }
+
+    @Test
+    fun loadTrustedPluginsTreatsAnUnhashableJarAsUntrustedInsteadOfAborting() = runBlocking {
+        val readable = File(pluginsDir, "good.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        service.trustAndLoad(readable.absolutePath)
+        factoryRepository.loadedJarPaths.clear()
+
+        // A directory named *.jar is enumerated as a plugin jar but cannot be opened as a stream,
+        // so hashing it fails — the failure must skip this entry, not abort the whole load.
+        val unhashable = File(pluginsDir, "broken.jar").apply { mkdirs() }
+        trustRepository.entries[unhashable.absolutePath] = TrustedPluginEntry(unhashable.absolutePath, "irrelevant", 0L)
+
+        service.loadTrustedPlugins()
+
+        assertEquals(listOf(readable.absolutePath), factoryRepository.loadedJarPaths)
+    }
+
+    private class FakePluginTrustRepository : PluginTrustRepository {
+        val entries = mutableMapOf<String, TrustedPluginEntry>()
+        override val trustedEntriesFlow: Flow<Map<String, TrustedPluginEntry>> = MutableStateFlow(emptyMap())
+
+        override suspend fun trustedEntry(jarPath: String): TrustedPluginEntry? = entries[jarPath]
+
+        override suspend fun trust(jarPath: String, sha256: String) {
+            entries[jarPath] = TrustedPluginEntry(jarPath, sha256, 0L)
+        }
+
+        override suspend fun revoke(jarPath: String) {
+            entries.remove(jarPath)
+        }
+    }
+
+    private class FakePluginFactoryRepository : PluginFactoryRepository {
+        val loadedJarPaths = mutableListOf<String>()
+        override val loadedPluginsFlow: Flow<Map<String, LoadedHostPlugin>> = MutableStateFlow(emptyMap())
+        override val loadedPlugins: Map<String, LoadedHostPlugin> = emptyMap()
+        override val failedJarPathsFlow: Flow<List<String>> = MutableStateFlow(emptyList())
+
+        override suspend fun loadPlugin(pluginJarPath: String) {
+            loadedJarPaths.add(pluginJarPath)
+        }
+
+        override suspend fun unloadPlugin(pluginId: String) = Unit
+
+        override fun findPluginIdsByJarPath(pluginJarPath: String): List<String> = emptyList()
+
+        override suspend fun reloadPlugin(pluginJarPath: String): List<String> = emptyList()
+
+        override fun tryRedefinePlugin(pluginJarPath: String): List<String> = emptyList()
+    }
+}

--- a/jetwhale-host/core/model/build.gradle.kts
+++ b/jetwhale-host/core/model/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.jvm)
+    alias(libs.plugins.kotlinxSerialization)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.metro)
@@ -7,6 +8,7 @@ plugins {
 
 dependencies {
     implementation(projects.jetwhaleHostSdk)
+    implementation(libs.kotlinxSerializationJson)
     implementation(libs.soilQueryCore)
     implementation(libs.kotlinxCollectionsImmutable)
     implementation(libs.kotlinxDatetime)

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/JetWhaleColorSchemeId.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/JetWhaleColorSchemeId.kt
@@ -1,5 +1,8 @@
 package com.kitakkun.jetwhale.host.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 @JvmInline
 value class JetWhaleColorSchemeId private constructor(val id: String) {
     companion object {

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginTrustRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginTrustRepository.kt
@@ -1,0 +1,33 @@
+package com.kitakkun.jetwhale.host.model
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A jar the user has explicitly approved for loading, pinned to the content hash it had at the
+ * moment of approval. On startup only jars whose current content still matches their pinned
+ * [sha256] are loaded; anything else (a jar that was never approved, or one whose bytes changed
+ * after approval) is treated as untrusted and is not executed.
+ */
+data class TrustedPluginEntry(
+    val jarPath: String,
+    val sha256: String,
+    val trustedAtEpochMillis: Long,
+)
+
+/**
+ * Persists the plugin trust registry: the set of jars the user has explicitly approved, each pinned
+ * to its content hash (see [TrustedPluginEntry]). This is the single data source backing the trust
+ * decision; the business logic that compares a jar's current hash against its pinned value lives in
+ * [PluginTrustService].
+ */
+interface PluginTrustRepository {
+    val trustedEntriesFlow: Flow<Map<String, TrustedPluginEntry>>
+
+    suspend fun trustedEntry(jarPath: String): TrustedPluginEntry?
+
+    /** Records (or replaces) the trusted entry for a jar, pinning [sha256] as its approved content. */
+    suspend fun trust(jarPath: String, sha256: String)
+
+    /** Removes any trusted entry for [jarPath]. */
+    suspend fun revoke(jarPath: String)
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginTrustService.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginTrustService.kt
@@ -1,0 +1,43 @@
+package com.kitakkun.jetwhale.host.model
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * The security boundary in front of dynamic plugin loading.
+ *
+ * JetWhale loads plugin jars from `~/.jetwhale/plugins`, and loading a jar executes attacker-
+ * controlled code (the factory constructor, the plugin's Compose content). Because any process
+ * running as the user can drop a jar into that directory, blindly loading every jar there is a code-
+ * execution hole. This service closes it by loading **only** jars the user has explicitly approved,
+ * each pinned to the content hash it had at approval time (see [PluginTrustRepository]): a jar that
+ * was never approved — or whose bytes changed after approval — is surfaced for review instead of
+ * being executed.
+ *
+ * This is an entry-side defense by design. Once untrusted code is loaded into the JVM it cannot be
+ * reliably sandboxed (the `SecurityManager` is removed in modern JDKs), so the only effective control
+ * is to never load code the user did not vouch for.
+ */
+interface PluginTrustService {
+    /**
+     * Jars currently present in the plugins directory that are **not** trusted: either never approved,
+     * or approved under a different content hash (i.e. the jar was replaced/tampered after approval).
+     * These are not loaded; the UI surfaces them so the user can review and approve them.
+     */
+    val untrustedJarPathsFlow: Flow<List<String>>
+
+    /**
+     * Loads every trusted jar from the plugins directory and records the rest as untrusted (see
+     * [untrustedJarPathsFlow]). Call once on startup in place of loading the directory wholesale.
+     */
+    suspend fun loadTrustedPlugins()
+
+    /**
+     * Approves [jarPath]: pins its current content hash in the trust registry and loads it. This is
+     * the consent point — call it only in response to an explicit user action (installing a jar via
+     * the file picker, or approving a surfaced untrusted jar).
+     */
+    suspend fun trustAndLoad(jarPath: String)
+
+    /** Revokes approval for [jarPath], unloads the plugins it provided, and re-flags it as untrusted. */
+    suspend fun revokeTrust(jarPath: String)
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/TrustPluginMutationKey.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/TrustPluginMutationKey.kt
@@ -1,0 +1,12 @@
+package com.kitakkun.jetwhale.host.model
+
+import soil.query.MutationKey
+
+/**
+ * The absolute jar path to approve. A distinct type (rather than a bare `String`) so this mutation
+ * key does not collide with [PluginInstallMutationKey] in dependency injection.
+ */
+data class TrustPluginRequest(val jarPath: String)
+
+/** Approves a surfaced untrusted jar: pins its content hash and loads it. */
+typealias TrustPluginMutationKey = MutationKey<Unit, TrustPluginRequest>

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/UntrustedPluginJarPathsSubscriptionKey.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/UntrustedPluginJarPathsSubscriptionKey.kt
@@ -1,0 +1,18 @@
+package com.kitakkun.jetwhale.host.model
+
+import kotlinx.collections.immutable.ImmutableList
+import soil.query.SubscriptionKey
+
+/**
+ * Wrapper around the untrusted jar paths. A distinct type (rather than a bare
+ * `ImmutableList<String>`) so this subscription key does not collide with
+ * [FailedPluginJarPathsSubscriptionKey] in dependency injection.
+ */
+data class UntrustedPluginJars(val paths: ImmutableList<String>)
+
+/**
+ * Jars present in the plugins directory that were not loaded because they are not trusted (never
+ * approved, or their content changed after approval). Surfaced so the user can review and approve
+ * them. See [PluginTrustService].
+ */
+typealias UntrustedPluginJarPathsSubscriptionKey = SubscriptionKey<UntrustedPluginJars>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -12,6 +12,9 @@
     <string name="check_for_updates_on_startup">起動時に更新を確認する</string>
     <string name="check_for_updates">更新を確認</string>
     <string name="installed_plugins">インストール済みプラグイン</string>
+    <string name="untrusted_plugins">未検証のプラグイン</string>
+    <string name="untrusted_jar_hint">これらの JAR はプラグインディレクトリにありますが、承認されていない（または承認後に内容が変更された）ため読み込まれていません。プラグインはこのアプリの全権限で動作します。信頼できる JAR のみ承認してください。</string>
+    <string name="approve_untrusted_plugin">承認</string>
     <string name="application_data_directory">アプリケーションデータディレクトリ</string>
     <string name="server_status_stopped">停止</string>
     <string name="server_status_running">ポート %1$d で実行中</string>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
@@ -14,6 +14,9 @@
     <string name="installed_plugins">Installed Plugins</string>
     <string name="failed_to_load_plugins">Failed to Load</string>
     <string name="failed_jar_path_hint">plugin-manifest.json was not found or the JAR is invalid.</string>
+    <string name="untrusted_plugins">Unverified Plugins</string>
+    <string name="untrusted_jar_hint">These JARs were found in the plugins directory but have not been approved (or their contents changed since approval), so they were not loaded. Only approve JARs you trust — a plugin runs with full access to this app.</string>
+    <string name="approve_untrusted_plugin">Approve</string>
     <string name="application_data_directory">Application Data Directory</string>
     <string name="server_status_stopped">Stopped</string>
     <string name="server_status_running">Running on port %1$d</string>

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenContext.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenContext.kt
@@ -16,6 +16,8 @@ import com.kitakkun.jetwhale.host.model.PluginInstallMutationKey
 import com.kitakkun.jetwhale.host.model.ServerPortMutationKey
 import com.kitakkun.jetwhale.host.model.ServerStatusSubscriptionKey
 import com.kitakkun.jetwhale.host.model.SettingsSubscriptionKey
+import com.kitakkun.jetwhale.host.model.TrustPluginMutationKey
+import com.kitakkun.jetwhale.host.model.UntrustedPluginJarPathsSubscriptionKey
 import dev.zacsweers.metro.Inject
 
 /**
@@ -31,6 +33,7 @@ class SettingsPresenterContext(
     val serverPortMutationKey: ServerPortMutationKey,
     val mcpServerPortMutationKey: McpServerPortMutationKey,
     val pluginInstallMutationKey: PluginInstallMutationKey,
+    val trustPluginMutationKey: TrustPluginMutationKey,
     val logCaptureService: LogCaptureService,
 ) : PresenterContext
 
@@ -45,6 +48,7 @@ class SettingsScreenContext(
     val diagnosticsQueryKey: DiagnosticsQueryKey,
     val loadedPluginsMetaDataSubscriptionKey: LoadedPluginsMetaDataSubscriptionKey,
     val failedPluginJarPathsSubscriptionKey: FailedPluginJarPathsSubscriptionKey,
+    val untrustedPluginJarPathsSubscriptionKey: UntrustedPluginJarPathsSubscriptionKey,
     val serverStatusSubscriptionKey: ServerStatusSubscriptionKey,
     val mcpServerStatusSubscriptionKey: McpServerStatusSubscriptionKey,
     val presenterContext: SettingsPresenterContext,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
@@ -30,16 +30,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.settings.Res
 import com.kitakkun.jetwhale.host.settings.SettingsScreenScaffoldPageContentPadding
+import com.kitakkun.jetwhale.host.settings.approve_untrusted_plugin
 import com.kitakkun.jetwhale.host.settings.dialog_ok
 import com.kitakkun.jetwhale.host.settings.failed_jar_path_hint
 import com.kitakkun.jetwhale.host.settings.failed_to_load_plugins
 import com.kitakkun.jetwhale.host.settings.installed_plugins
+import com.kitakkun.jetwhale.host.settings.untrusted_jar_hint
+import com.kitakkun.jetwhale.host.settings.untrusted_plugins
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun PluginSettingsScreen(
     uiState: PluginSettingsScreenUiState,
     onClickAddPlugin: () -> Unit,
+    onApproveUntrustedJar: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showFailedJarsDialog by remember { mutableStateOf(false) }
@@ -149,8 +153,69 @@ fun PluginSettingsScreen(
                 )
             }
         }
+        if (uiState.untrustedJarPaths.isNotEmpty()) {
+            UntrustedPluginsSection(
+                untrustedJarPaths = uiState.untrustedJarPaths,
+                onApprove = onApproveUntrustedJar,
+            )
+        }
         Button(onClickAddPlugin) {
             Text("Add Plugin")
+        }
+    }
+}
+
+@Composable
+private fun UntrustedPluginsSection(
+    untrustedJarPaths: List<String>,
+    onApprove: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.errorContainer,
+                shape = MaterialTheme.shapes.small,
+            )
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+            )
+            Text(
+                text = stringResource(Res.string.untrusted_plugins) + " (${untrustedJarPaths.size})",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+        }
+        Text(
+            text = stringResource(Res.string.untrusted_jar_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onErrorContainer,
+        )
+        untrustedJarPaths.forEach { path ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = path,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier.weight(1f),
+                )
+                Button(onClick = { onApprove(path) }) {
+                    Text(stringResource(Res.string.approve_untrusted_plugin))
+                }
+            }
         }
     }
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenAction.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenAction.kt
@@ -2,4 +2,7 @@ package com.kitakkun.jetwhale.host.settings.plugin
 
 sealed interface PluginSettingsScreenAction {
     data class PluginJarSelected(val path: String) : PluginSettingsScreenAction
+
+    /** The user approved a surfaced untrusted jar: pin its hash and load it. */
+    data class UntrustedJarApproved(val path: String) : PluginSettingsScreenAction
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenPresenter.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import com.kitakkun.jetwhale.host.architecture.ActionEffect
 import com.kitakkun.jetwhale.host.architecture.ScreenChannel
 import com.kitakkun.jetwhale.host.model.PluginMetaData
+import com.kitakkun.jetwhale.host.model.TrustPluginRequest
 import com.kitakkun.jetwhale.host.settings.SettingsPresenterContext
 import com.kitakkun.jetwhale.host.settings.component.PluginInfoUiState
 import kotlinx.collections.immutable.ImmutableList
@@ -16,13 +17,19 @@ fun pluginSettingsScreenPresenter(
     screenChannel: ScreenChannel<PluginSettingsScreenAction, Nothing>,
     loadedPlugins: ImmutableList<PluginMetaData>,
     failedJarPaths: ImmutableList<String>,
+    untrustedJarPaths: ImmutableList<String>,
 ): PluginSettingsScreenUiState {
     val pluginInstallMutation = rememberMutation(presenterContext.pluginInstallMutationKey)
+    val trustPluginMutation = rememberMutation(presenterContext.trustPluginMutationKey)
 
     ActionEffect(screenChannel) { action ->
         when (action) {
             is PluginSettingsScreenAction.PluginJarSelected -> {
                 pluginInstallMutation.mutateAsync(action.path)
+            }
+
+            is PluginSettingsScreenAction.UntrustedJarApproved -> {
+                trustPluginMutation.mutateAsync(TrustPluginRequest(action.path))
             }
         }
     }
@@ -36,5 +43,6 @@ fun pluginSettingsScreenPresenter(
             )
         }.toPersistentList(),
         failedJarPaths = failedJarPaths,
+        untrustedJarPaths = untrustedJarPaths,
     )
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenRoot.kt
@@ -15,13 +15,15 @@ fun PluginSettingsScreenRoot() {
     SoilDataBoundary(
         state1 = rememberSubscription(screenContext.loadedPluginsMetaDataSubscriptionKey),
         state2 = rememberSubscription(screenContext.failedPluginJarPathsSubscriptionKey),
-    ) { loadedPlugins, failedJarPaths ->
+        state3 = rememberSubscription(screenContext.untrustedPluginJarPathsSubscriptionKey),
+    ) { loadedPlugins, failedJarPaths, untrustedJars ->
         val screenChannel = rememberScreenChannel<PluginSettingsScreenAction, Nothing>()
         val uiState = context(screenContext.presenterContext) {
             pluginSettingsScreenPresenter(
                 screenChannel = screenChannel,
                 loadedPlugins = loadedPlugins,
                 failedJarPaths = failedJarPaths,
+                untrustedJarPaths = untrustedJars.paths,
             )
         }
 
@@ -30,6 +32,9 @@ fun PluginSettingsScreenRoot() {
             onClickAddPlugin = {
                 val selectedJar = selectJarFile() ?: return@PluginSettingsScreen
                 screenChannel.send(PluginSettingsScreenAction.PluginJarSelected(selectedJar.path))
+            },
+            onApproveUntrustedJar = { path ->
+                screenChannel.send(PluginSettingsScreenAction.UntrustedJarApproved(path))
             },
         )
     }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenUiState.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenUiState.kt
@@ -5,4 +5,5 @@ import kotlinx.collections.immutable.ImmutableList
 data class PluginSettingsScreenUiState(
     val plugins: ImmutableList<com.kitakkun.jetwhale.host.settings.component.PluginInfoUiState>,
     val failedJarPaths: ImmutableList<String>,
+    val untrustedJarPaths: ImmutableList<String>,
 )


### PR DESCRIPTION
> Targets `poc/symmetric-messaging` (#108) since it carries a large diff this branch is built on top of. Rebase onto `main` once #108 lands.

## Problem

The host loaded **every** jar in `~/.jetwhale/plugins` on startup (`ApplicationLifecycleOwner` → `getAllPluginJarFilePaths().forEach { loadPlugin(it) }`), and loading a jar executes attacker-controlled code (the factory's `newInstance()`, the plugin's Compose `Content()`). Any process running as the user could drop a jar into that directory and get **code execution inside the host process** on the next launch — running with whatever the trusted dev tool is granted, every time it starts.

There was no signature check, hash check, consent gate, or sandbox. (And once code is in the JVM it cannot be reliably sandboxed — `SecurityManager` is gone in modern JDKs — so the effective control has to be at the **load** boundary.)

## What changed

Loading is now gated on an explicit **trust registry**:

- `PluginTrustRepository` persists `~/.jetwhale/trusted-plugins.json` — each approved jar pinned to the content hash it had at approval time. Fails safe: a corrupt/unreadable registry treats everything as untrusted.
- `PluginTrustService` is the security boundary. On startup `loadTrustedPlugins()` loads **only** jars whose current SHA-256 still matches their pinned hash; everything else (never approved, or changed after approval) is collected into `untrustedJarPathsFlow` instead of being executed.
- Installing via the file picker is the consent point: `DefaultPluginInstallMutationKey` now `trustAndLoad`s (pin hash + load).
- Settings gains an **"Unverified Plugins"** section listing surfaced jars with an **Approve** action (`TrustPluginMutationKey` → `trustAndLoad`).

The dev hot-reload path is unaffected: it is gated on `jetwhale.devPluginsDir` (a developer-set system property) and watches only the dev directory, so it does not bypass the gate.

## Notes for review

- **Migration / breaking:** jars installed before this change become "unverified" on first launch and must be re-approved (re-installing also works). Correct TOFU behaviour, but a behaviour change worth a release note.
- **Why `JsonObject` tree API, not `@Serializable`:** `core:data` does not apply the kotlinx.serialization compiler plugin, so no serializer is generated for a local data class and `encodeToString` throws at runtime. (This was a real bug caught mid-development: `Approve` silently did nothing because the `SerializationException` was swallowed by the Soil mutation.) The registry is therefore built/parsed with `buildJsonObject` / `parseToJsonElement` / `JsonElement.serializer()`, all of which need no generated serializer.
- **Out of scope, surfaced:** the same missing plugin means existing `@Serializable` theme classes (`CustomThemes`, `DynamicThemes`, …) also have no runtime serializer — a latent pre-existing bug. Not fixed here to keep the diff focused.

## Validation

- `:jetwhale-host:app:compileKotlin`, `:jetwhale-host:core:data:test`, `spotlessCheck` pass.
- Added `DefaultPluginTrustRepositoryTest` (round-trips the registry through disk; regression guard for the serialization bug above).
- A live desktop run (drop an unapproved jar → confirm it is not loaded and is surfaced; Approve → confirm it loads) is recommended before merge.