### PR TITLE
feat(network): add OkHttp adapter for the Network Inspector plugin

### DIFF
--- a/demo/shared/build.gradle.kts
+++ b/demo/shared/build.gradle.kts
@@ -49,6 +49,12 @@ kotlin {
             implementation(projects.jetwhalePlugins.network.agentKtor)
             implementation(libs.ktorClientCio)
         }
+
+        androidMain.dependencies {
+            // OkHttp demo tab: OkHttp only targets JVM/Android, so this is androidMain-only.
+            implementation(projects.jetwhalePlugins.network.agentOkhttp)
+            implementation(libs.okhttp)
+        }
     }
 
     val xcFrameworkName = "shared"

--- a/demo/shared/src/androidMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.android.kt
+++ b/demo/shared/src/androidMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.android.kt
@@ -1,0 +1,150 @@
+package com.kitakkun.jetwhale.demo.shared
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.plugins.network.agent.okhttp.okHttpInterceptor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.cancellation.CancellationException
+
+actual val platformExtraTabLabel: String? = "Network (OkHttp)"
+
+/**
+ * OkHttp-based mirror of [NetworkTestScreen] — shares the same [DIModule.networkAgentPlugin], so
+ * both tabs' traffic shows up side by side in the same Network Inspector session. Android-only
+ * since OkHttp only targets JVM/Android.
+ */
+private val okHttpClient: OkHttpClient by lazy {
+    OkHttpClient.Builder()
+        .callTimeout(10, TimeUnit.SECONDS)
+        .addInterceptor(DIModule.networkAgentPlugin.okHttpInterceptor())
+        .build()
+}
+
+@Composable
+actual fun PlatformExtraTabScreen() {
+    val scope = rememberCoroutineScope()
+    var baseUrl by remember { mutableStateOf("https://jsonplaceholder.typicode.com") }
+    val log = remember { mutableStateListOf<String>() }
+
+    fun fire(label: String, block: (baseUrl: String) -> String) {
+        val target = baseUrl.trimEnd('/')
+        scope.launch {
+            val line = try {
+                "$label → ${withContext(Dispatchers.IO) { block(target) }}"
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                "$label → error: ${e.message}"
+            }
+            log.add(0, line)
+        }
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            OutlinedTextField(
+                value = baseUrl,
+                onValueChange = { baseUrl = it },
+                label = { Text("Server base URL") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        item {
+            Text("Requests go through the monitored OkHttp client; watch them in the Network Inspector.")
+        }
+        item {
+            Button(
+                onClick = {
+                    fire("GET /todos/1") { base ->
+                        val request = Request.Builder().url("$base/todos/1").build()
+                        okHttpClient.newCall(request).execute().use { response ->
+                            "${response.code} ${response.body?.string()}"
+                        }
+                    }
+                },
+            ) {
+                Text("GET /todos/1")
+            }
+        }
+        item {
+            Button(
+                onClick = {
+                    fire("POST /todos") { base ->
+                        val body = """{"title":"New todo"}""".toRequestBody("application/json".toMediaType())
+                        val request = Request.Builder().url("$base/todos").post(body).build()
+                        okHttpClient.newCall(request).execute().use { response ->
+                            "${response.code} ${response.body?.string()}"
+                        }
+                    }
+                },
+            ) {
+                Text("POST /todos")
+            }
+        }
+        item {
+            Button(
+                onClick = {
+                    fire("DELETE /todos/1") { base ->
+                        val request = Request.Builder().url("$base/todos/1").delete().build()
+                        okHttpClient.newCall(request).execute().use { response ->
+                            "${response.code} ${response.body?.string()}"
+                        }
+                    }
+                },
+            ) {
+                Text("DELETE /todos/1")
+            }
+        }
+        item {
+            Button(
+                onClick = {
+                    fire("GET /nonexistent-path") { base ->
+                        val request = Request.Builder().url("$base/nonexistent-path").build()
+                        okHttpClient.newCall(request).execute().use { response ->
+                            "${response.code} ${response.body?.string()}"
+                        }
+                    }
+                },
+            ) {
+                Text("GET /nonexistent-path (404)")
+            }
+        }
+        items(log) { line ->
+            Text(
+                text = line,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+    }
+}

--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/App.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/App.kt
@@ -43,10 +43,18 @@ fun App() {
                             onClick = { selectedTab = 1 },
                             text = { Text("Network plugin") },
                         )
+                        platformExtraTabLabel?.let { label ->
+                            Tab(
+                                selected = selectedTab == 2,
+                                onClick = { selectedTab = 2 },
+                                text = { Text(label) },
+                            )
+                        }
                     }
                     when (selectedTab) {
                         0 -> ExampleTestScreen()
-                        else -> NetworkTestScreen()
+                        1 -> NetworkTestScreen()
+                        else -> PlatformExtraTabScreen()
                     }
                 }
             }

--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/NetworkTestScreen.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/NetworkTestScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -32,14 +33,14 @@ import kotlin.coroutines.cancellation.CancellationException
 /**
  * Lets the user point the monitored Ktor client at any server and fire sample requests.
  *
- * On the JVM/desktop app a local demo server is started automatically, so the default URL works
- * out of the box; on other platforms (Android/iOS/web) there is no in-process server, so enter a
- * reachable server address (e.g. the desktop app's host, or your own backend).
+ * Defaults to the public JSONPlaceholder API (https://jsonplaceholder.typicode.com) — a free,
+ * real HTTPS test API — so this works out of the box on every platform with no local server or
+ * cleartext-traffic setup needed. Change the base URL to point at your own backend instead.
  */
 @Composable
 internal fun NetworkTestScreen() {
     val scope = rememberCoroutineScope()
-    var baseUrl by remember { mutableStateOf("http://127.0.0.1:8080") }
+    var baseUrl by remember { mutableStateOf("https://jsonplaceholder.typicode.com") }
     val log = remember { mutableStateListOf<String>() }
 
     fun fire(label: String, block: suspend (baseUrl: String) -> String) {
@@ -77,20 +78,20 @@ internal fun NetworkTestScreen() {
         item {
             Button(
                 onClick = {
-                    fire("GET /api/todos/1") { base ->
-                        val response = DIModule.httpClient.get("$base/api/todos/1")
+                    fire("GET /todos/1") { base ->
+                        val response = DIModule.httpClient.get("$base/todos/1")
                         "${response.status.value} ${response.bodyAsText()}"
                     }
                 },
             ) {
-                Text("GET /api/todos/1")
+                Text("GET /todos/1")
             }
         }
         item {
             Button(
                 onClick = {
-                    fire("POST /api/todos") { base ->
-                        val response = DIModule.httpClient.post("$base/api/todos") {
+                    fire("POST /todos") { base ->
+                        val response = DIModule.httpClient.post("$base/todos") {
                             contentType(ContentType.Application.Json)
                             setBody("""{"title":"New todo"}""")
                         }
@@ -98,19 +99,31 @@ internal fun NetworkTestScreen() {
                     }
                 },
             ) {
-                Text("POST /api/todos")
+                Text("POST /todos")
             }
         }
         item {
             Button(
                 onClick = {
-                    fire("GET /api/missing") { base ->
-                        val response = DIModule.httpClient.get("$base/api/missing")
+                    fire("DELETE /todos/1") { base ->
+                        val response = DIModule.httpClient.delete("$base/todos/1")
                         "${response.status.value} ${response.bodyAsText()}"
                     }
                 },
             ) {
-                Text("GET /api/missing (404)")
+                Text("DELETE /todos/1")
+            }
+        }
+        item {
+            Button(
+                onClick = {
+                    fire("GET /nonexistent-path") { base ->
+                        val response = DIModule.httpClient.get("$base/nonexistent-path")
+                        "${response.status.value} ${response.bodyAsText()}"
+                    }
+                },
+            ) {
+                Text("GET /nonexistent-path (404)")
             }
         }
         items(log) { line ->

--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.kt
@@ -1,0 +1,14 @@
+package com.kitakkun.jetwhale.demo.shared
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Label for an extra, platform-only demo tab shown alongside "Example plugin"/"Network plugin"
+ * (e.g. an OkHttp-based network screen on Android, since OkHttp only targets JVM/Android) — `null`
+ * on platforms with nothing extra to show.
+ */
+expect val platformExtraTabLabel: String?
+
+/** Content for the extra tab described by [platformExtraTabLabel]; a no-op where that's `null`. */
+@Composable
+expect fun PlatformExtraTabScreen()

--- a/demo/shared/src/iosMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.ios.kt
+++ b/demo/shared/src/iosMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.ios.kt
@@ -1,0 +1,8 @@
+package com.kitakkun.jetwhale.demo.shared
+
+import androidx.compose.runtime.Composable
+
+actual val platformExtraTabLabel: String? = null
+
+@Composable
+actual fun PlatformExtraTabScreen() {}

--- a/demo/shared/src/jsMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.js.kt
+++ b/demo/shared/src/jsMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.js.kt
@@ -1,0 +1,8 @@
+package com.kitakkun.jetwhale.demo.shared
+
+import androidx.compose.runtime.Composable
+
+actual val platformExtraTabLabel: String? = null
+
+@Composable
+actual fun PlatformExtraTabScreen() {}

--- a/demo/shared/src/jvmMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.jvm.kt
+++ b/demo/shared/src/jvmMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.jvm.kt
@@ -1,0 +1,8 @@
+package com.kitakkun.jetwhale.demo.shared
+
+import androidx.compose.runtime.Composable
+
+actual val platformExtraTabLabel: String? = null
+
+@Composable
+actual fun PlatformExtraTabScreen() {}

--- a/demo/shared/src/wasmJsMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.wasmJs.kt
+++ b/demo/shared/src/wasmJsMain/kotlin/com/kitakkun/jetwhale/demo/shared/PlatformExtraTab.wasmJs.kt
@@ -1,0 +1,8 @@
+package com.kitakkun.jetwhale.demo.shared
+
+import androidx.compose.runtime.Composable
+
+actual val platformExtraTabLabel: String? = null
+
+@Composable
+actual fun PlatformExtraTabScreen() {}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ androidxDatastore = "1.2.1"
 metro = "1.1.1"
 mokkery = "3.4.0"
 ktor = "3.5.0"
+okhttp = "4.12.0"
 mcpKotlinSdk = "0.13.0"
 
 logback = "1.5.32"
@@ -97,6 +98,10 @@ ktorClientLogging = { module = "io.ktor:ktor-client-logging", version.ref = "kto
 ktorSerializationKotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktorServerSse = { module = "io.ktor:ktor-server-sse", version.ref = "ktor" }
 ktorServerContentNegotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+
+# okhttp
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttpMockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 
 mcpKotlinSdk = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcpKotlinSdk" }
 

--- a/jetwhale-plugins/network/agent-okhttp/build.gradle.kts
+++ b/jetwhale-plugins/network/agent-okhttp/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    alias(libs.plugins.jvm)
+    alias(libs.plugins.publish)
+}
+
+// Distinct group so this module doesn't collide with other leaf-name-sharing modules.
+group = "com.kitakkun.jetwhale.plugins.network"
+
+dependencies {
+    api(projects.jetwhalePlugins.network.agent)
+    api(libs.okhttp) // Interceptor appears in the public API surface
+
+    testImplementation(libs.kotlinTest)
+    testImplementation(libs.okhttpMockwebserver)
+    testImplementation(libs.kotlinxCoroutinesCore)
+    testImplementation(libs.kotlinxSerializationJson)
+}
+
+jetwhalePublish {
+    artifactId = "jetwhale-network-inspector-agent-okhttp"
+    name = "JetWhale Network Inspector Agent (OkHttp)"
+    description = "OkHttp interceptor that wires the JetWhale Network Inspector into an OkHttpClient."
+}

--- a/jetwhale-plugins/network/agent-okhttp/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptor.kt
+++ b/jetwhale-plugins/network/agent-okhttp/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptor.kt
@@ -6,6 +6,7 @@ import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse
 import com.kitakkun.jetwhale.plugins.network.protocol.HttpRequestFailure
 import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Protocol
@@ -52,65 +53,66 @@ private class JetWhaleNetworkOkHttpInterceptor(
         val request = chain.request()
         val txId = agent.newTransactionId()
         val started = TimeSource.Monotonic.markNow()
-        val method = request.method
-        val url = request.url.toString()
 
-        val requestBody = captureRequestBody(request.body, maxBodyChars)
+        recordRequest(request, txId)
+        val mock = agent.findMock(request.method, request.url.toString())
+
+        val response = if (mock != null) {
+            serveMock(request, mock)
+        } else {
+            sendRequest(chain, request, txId, started)
+        }
+        recordResponse(response, fromMock = mock != null, txId = txId, started = started)
+        return response
+    }
+
+    private fun recordRequest(request: Request, txId: String) {
+        val body = captureRequestBodySafely(request.body, maxBodyChars)
         agent.recordRequest(
             CapturedHttpRequest(
                 txId = txId,
-                method = method,
-                url = url,
-                headers = request.capturedHeaders(),
-                body = requestBody.text,
-                bodyTruncated = requestBody.truncated,
+                method = request.method,
+                url = request.url.toString(),
+                headers = request.headersWithBodyDefaults(),
+                body = body.text,
+                bodyTruncated = body.truncated,
                 timestampMs = System.currentTimeMillis(),
             ),
         )
+    }
 
-        agent.findMock(method, url)?.let { mock ->
-            if (mock.delayMs > 0) Thread.sleep(mock.delayMs)
-            agent.recordResponse(
-                CapturedHttpResponse(
-                    txId = txId,
-                    statusCode = mock.statusCode,
-                    statusDescription = httpStatusDescription(mock.statusCode),
-                    headers = mock.headers.mapValues { listOf(it.value) },
-                    body = mock.body,
-                    durationMs = started.elapsedNow().inWholeMilliseconds,
-                    fromMock = true,
-                ),
-            )
-            return buildMockResponse(request, mock)
-        }
+    private fun serveMock(request: Request, mock: MockResponseSpec): Response {
+        if (mock.delayMs > 0) Thread.sleep(mock.delayMs)
+        return buildMockResponse(request, mock)
+    }
 
-        val response = try {
-            chain.proceed(request)
-        } catch (cause: Throwable) {
-            agent.recordFailure(
-                HttpRequestFailure(
-                    txId = txId,
-                    message = cause.message ?: cause.toString(),
-                    durationMs = started.elapsedNow().inWholeMilliseconds,
-                ),
-            )
-            throw cause
-        }
+    private fun sendRequest(chain: Interceptor.Chain, request: Request, txId: String, started: TimeSource.Monotonic.ValueTimeMark): Response = try {
+        chain.proceed(request)
+    } catch (e: Throwable) {
+        agent.recordFailure(
+            HttpRequestFailure(
+                txId = txId,
+                message = e.message ?: e.toString(),
+                durationMs = started.elapsedNow().inWholeMilliseconds,
+            ),
+        )
+        throw e
+    }
 
-        val responseBody = captureResponseBody(response, maxBodyChars)
+    private fun recordResponse(response: Response, fromMock: Boolean, txId: String, started: TimeSource.Monotonic.ValueTimeMark) {
+        val body = captureResponseBodySafely(response, maxBodyChars)
         agent.recordResponse(
             CapturedHttpResponse(
                 txId = txId,
                 statusCode = response.code,
                 statusDescription = response.message,
                 headers = response.headers.toCapturedMap(),
-                body = responseBody.text,
-                bodyTruncated = responseBody.truncated,
+                body = body.text,
+                bodyTruncated = body.truncated,
                 durationMs = started.elapsedNow().inWholeMilliseconds,
-                fromMock = false,
+                fromMock = fromMock,
             ),
         )
-        return response
     }
 }
 
@@ -118,7 +120,12 @@ private data class BodyCapture(val text: String?, val truncated: Boolean)
 
 private fun String.truncate(max: Int): BodyCapture = if (length <= max) BodyCapture(this, false) else BodyCapture(substring(0, max), true)
 
-private fun captureRequestBody(body: RequestBody?, maxChars: Int): BodyCapture {
+/**
+ * Reads the request body for capture without breaking the actual send: bodies that can't be
+ * materialized up front (one-shot, duplex) are replaced with a placeholder, and reads are
+ * byte-capped so large uploads aren't held in memory.
+ */
+private fun captureRequestBodySafely(body: RequestBody?, maxChars: Int): BodyCapture {
     if (body == null) return BodyCapture(null, false)
     // One-shot bodies can't be read twice; duplex bodies can't be materialized up front.
     if (body.isOneShot() || body.isDuplex()) return BodyCapture("<streaming request body>", false)
@@ -130,7 +137,7 @@ private fun captureRequestBody(body: RequestBody?, maxChars: Int): BodyCapture {
         val charset = body.contentType()?.charset(Charsets.UTF_8) ?: Charsets.UTF_8
         val capture = sink.captured.readString(charset).truncate(maxChars)
         if (sink.overflowed && !capture.truncated) capture.copy(truncated = true) else capture
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         BodyCapture(null, false)
     }
 }
@@ -155,7 +162,12 @@ private class TruncatingSink(private val maxBytes: Long) : Sink {
     override fun close() {}
 }
 
-private fun captureResponseBody(response: Response, maxChars: Int): BodyCapture {
+/**
+ * Reads the response body for capture without consuming or blocking the caller's response:
+ * bodies that can't be peeked safely (WebSocket upgrades, encoded bodies, endless streams)
+ * are replaced with a placeholder instead.
+ */
+private fun captureResponseBodySafely(response: Response, maxChars: Int): BodyCapture {
     if (response.isWebSocketUpgrade()) {
         // A WebSocket upgrade response (101) has no conventional body — the connection has
         // already switched to the raw frame stream by the time this interceptor sees it, so
@@ -180,24 +192,21 @@ private fun captureResponseBody(response: Response, maxChars: Int): BodyCapture 
         // The peek limit is in bytes but truncate() counts chars, so a multi-byte body can hit the
         // byte cap while still decoding to fewer than maxChars chars — flag it truncated anyway.
         if (peeked.contentLength() > maxChars && !capture.truncated) capture.copy(truncated = true) else capture
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         BodyCapture(null, false)
     }
 }
 
 private fun buildMockResponse(request: Request, mock: MockResponseSpec): Response {
-    val mediaType = mock.headers.entries
-        .firstOrNull { it.key.equals("Content-Type", ignoreCase = true) }
-        ?.value
-        ?.toMediaTypeOrNull()
-    val builder = Response.Builder()
+    val headers = mock.headers.toHeaders()
+    return Response.Builder()
         .request(request)
         .protocol(Protocol.HTTP_1_1)
         .code(mock.statusCode)
         .message(httpStatusDescription(mock.statusCode))
-        .body(mock.body.toResponseBody(mediaType))
-    mock.headers.forEach { (key, value) -> builder.addHeader(key, value) }
-    return builder.build()
+        .headers(headers)
+        .body(mock.body.toResponseBody(headers["Content-Type"]?.toMediaTypeOrNull()))
+        .build()
 }
 
 /** True for a successful WebSocket upgrade response (101 Switching Protocols + `Upgrade: websocket`). */
@@ -205,27 +214,22 @@ private fun Response.isWebSocketUpgrade(): Boolean =
     code == 101 && header("Upgrade")?.equals("websocket", ignoreCase = true) == true
 
 /** Preserves original header-name case, unlike [Headers.toMultimap] which lowercases keys. */
-private fun Headers.toCapturedMap(): Map<String, List<String>> {
-    val result = LinkedHashMap<String, MutableList<String>>()
-    forEach { (name, value) -> result.getOrPut(name) { mutableListOf() }.add(value) }
-    return result
-}
+private fun Headers.toCapturedMap(): Map<String, List<String>> = groupBy({ it.first }, { it.second })
 
 /**
  * [Request.headers] doesn't include Content-Type/Content-Length when they were derived from the
  * [RequestBody] rather than set explicitly, so backfill them from the body when absent.
  */
-private fun Request.capturedHeaders(): Map<String, List<String>> {
-    val result = headers.toCapturedMap().toMutableMap<String, List<String>>()
-    val body = body ?: return result
-    if (result.keys.none { it.equals("Content-Type", ignoreCase = true) }) {
-        body.contentType()?.let { result["Content-Type"] = listOf(it.toString()) }
+private fun Request.headersWithBodyDefaults(): Map<String, List<String>> = buildMap {
+    putAll(headers.toCapturedMap())
+    val body = body ?: return@buildMap
+    if (keys.none { it.equals("Content-Type", ignoreCase = true) }) {
+        body.contentType()?.let { put("Content-Type", listOf(it.toString())) }
     }
-    if (result.keys.none { it.equals("Content-Length", ignoreCase = true) }) {
+    if (keys.none { it.equals("Content-Length", ignoreCase = true) }) {
         val length = runCatching { body.contentLength() }.getOrDefault(-1L)
-        if (length >= 0) result["Content-Length"] = listOf(length.toString())
+        if (length >= 0) put("Content-Length", listOf(length.toString()))
     }
-    return result
 }
 
 private fun httpStatusDescription(code: Int): String = when (code) {

--- a/jetwhale-plugins/network/agent-okhttp/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptor.kt
+++ b/jetwhale-plugins/network/agent-okhttp/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptor.kt
@@ -175,7 +175,11 @@ private fun captureResponseBody(response: Response, maxChars: Int): BodyCapture 
         return BodyCapture("<streaming response body>", false)
     }
     return try {
-        response.peekBody(maxChars + 1L).string().truncate(maxChars)
+        val peeked = response.peekBody(maxChars + 1L)
+        val capture = peeked.string().truncate(maxChars)
+        // The peek limit is in bytes but truncate() counts chars, so a multi-byte body can hit the
+        // byte cap while still decoding to fewer than maxChars chars — flag it truncated anyway.
+        if (peeked.contentLength() > maxChars && !capture.truncated) capture.copy(truncated = true) else capture
     } catch (e: Exception) {
         BodyCapture(null, false)
     }

--- a/jetwhale-plugins/network/agent-okhttp/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptor.kt
+++ b/jetwhale-plugins/network/agent-okhttp/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptor.kt
@@ -210,8 +210,7 @@ private fun buildMockResponse(request: Request, mock: MockResponseSpec): Respons
 }
 
 /** True for a successful WebSocket upgrade response (101 Switching Protocols + `Upgrade: websocket`). */
-private fun Response.isWebSocketUpgrade(): Boolean =
-    code == 101 && header("Upgrade")?.equals("websocket", ignoreCase = true) == true
+private fun Response.isWebSocketUpgrade(): Boolean = code == 101 && header("Upgrade")?.equals("websocket", ignoreCase = true) == true
 
 /** Preserves original header-name case, unlike [Headers.toMultimap] which lowercases keys. */
 private fun Headers.toCapturedMap(): Map<String, List<String>> = groupBy({ it.first }, { it.second })

--- a/jetwhale-plugins/network/agent-okhttp/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptor.kt
+++ b/jetwhale-plugins/network/agent-okhttp/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptor.kt
@@ -1,0 +1,215 @@
+package com.kitakkun.jetwhale.plugins.network.agent.okhttp
+
+import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
+import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
+import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse
+import com.kitakkun.jetwhale.plugins.network.protocol.HttpRequestFailure
+import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
+import okhttp3.Headers
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+import kotlin.time.TimeSource
+
+/**
+ * OkHttp [Interceptor] that feeds request/response details to a [JetWhaleNetworkAgentPlugin] and
+ * serves mock responses configured from the host.
+ *
+ * Install it as an *application* interceptor (not a network interceptor) so mock responses can be
+ * served without ever touching the network, and add it after your other application interceptors
+ * (e.g. auth) so their added headers are captured too:
+ * ```
+ * val agent = JetWhaleNetworkAgentPlugin()
+ * val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
+ * startJetWhale { plugins { register(agent) } }
+ * ```
+ *
+ * Engine-added headers (`Accept-Encoding`, `Host`, `User-Agent`, ...) and intermediate redirect
+ * hops are not visible to an application interceptor and are omitted; only the final response is
+ * captured.
+ *
+ * @param maxBodyChars request/response bodies longer than this are truncated for transport.
+ */
+fun JetWhaleNetworkAgentPlugin.okHttpInterceptor(maxBodyChars: Int = 100_000): Interceptor = JetWhaleNetworkOkHttpInterceptor(agent = this, maxBodyChars = maxBodyChars)
+
+private class JetWhaleNetworkOkHttpInterceptor(
+    private val agent: JetWhaleNetworkAgentPlugin,
+    private val maxBodyChars: Int,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val txId = agent.newTransactionId()
+        val started = TimeSource.Monotonic.markNow()
+        val method = request.method
+        val url = request.url.toString()
+
+        val requestBody = captureRequestBody(request.body, maxBodyChars)
+        agent.recordRequest(
+            CapturedHttpRequest(
+                txId = txId,
+                method = method,
+                url = url,
+                headers = request.capturedHeaders(),
+                body = requestBody.text,
+                bodyTruncated = requestBody.truncated,
+                timestampMs = System.currentTimeMillis(),
+            ),
+        )
+
+        agent.findMock(method, url)?.let { mock ->
+            if (mock.delayMs > 0) Thread.sleep(mock.delayMs)
+            agent.recordResponse(
+                CapturedHttpResponse(
+                    txId = txId,
+                    statusCode = mock.statusCode,
+                    statusDescription = httpStatusDescription(mock.statusCode),
+                    headers = mock.headers.mapValues { listOf(it.value) },
+                    body = mock.body,
+                    durationMs = started.elapsedNow().inWholeMilliseconds,
+                    fromMock = true,
+                ),
+            )
+            return buildMockResponse(request, mock)
+        }
+
+        val response = try {
+            chain.proceed(request)
+        } catch (cause: Throwable) {
+            agent.recordFailure(
+                HttpRequestFailure(
+                    txId = txId,
+                    message = cause.message ?: cause.toString(),
+                    durationMs = started.elapsedNow().inWholeMilliseconds,
+                ),
+            )
+            throw cause
+        }
+
+        val responseBody = captureResponseBody(response, maxBodyChars)
+        agent.recordResponse(
+            CapturedHttpResponse(
+                txId = txId,
+                statusCode = response.code,
+                statusDescription = response.message,
+                headers = response.headers.toCapturedMap(),
+                body = responseBody.text,
+                bodyTruncated = responseBody.truncated,
+                durationMs = started.elapsedNow().inWholeMilliseconds,
+                fromMock = false,
+            ),
+        )
+        return response
+    }
+}
+
+private data class BodyCapture(val text: String?, val truncated: Boolean)
+
+private fun String.truncate(max: Int): BodyCapture = if (length <= max) BodyCapture(this, false) else BodyCapture(substring(0, max), true)
+
+private fun captureRequestBody(body: RequestBody?, maxChars: Int): BodyCapture {
+    if (body == null) return BodyCapture(null, false)
+    // One-shot bodies can't be read twice; duplex bodies can't be materialized up front.
+    if (body.isOneShot() || body.isDuplex()) return BodyCapture("<streaming request body>", false)
+    return try {
+        val buffer = Buffer()
+        body.writeTo(buffer)
+        val charset = body.contentType()?.charset(Charsets.UTF_8) ?: Charsets.UTF_8
+        buffer.readString(charset).truncate(maxChars)
+    } catch (e: Exception) {
+        BodyCapture(null, false)
+    }
+}
+
+private fun captureResponseBody(response: Response, maxChars: Int): BodyCapture {
+    if (response.isWebSocketUpgrade()) {
+        // A WebSocket upgrade response (101) has no conventional body — the connection has
+        // already switched to the raw frame stream by the time this interceptor sees it, so
+        // peekBody would read live WebSocket frames as if they were an HTTP body, corrupting the
+        // frame stream for the caller.
+        return BodyCapture("<websocket upgrade>", false)
+    }
+    val encoding = response.header("Content-Encoding")
+    if (encoding != null && !encoding.equals("identity", ignoreCase = true)) {
+        // Only present at this layer when the caller set Accept-Encoding itself, disabling
+        // OkHttp's transparent gzip handling — peekBody would return non-text bytes here.
+        return BodyCapture("<Content-Encoding: $encoding body>", false)
+    }
+    val contentType = response.header("Content-Type")
+    if (contentType?.startsWith("text/event-stream", ignoreCase = true) == true) {
+        // peekBody(n) blocks until n bytes are buffered or EOF — would hang on a never-ending stream.
+        return BodyCapture("<streaming response body>", false)
+    }
+    return try {
+        response.peekBody(maxChars + 1L).string().truncate(maxChars)
+    } catch (e: Exception) {
+        BodyCapture(null, false)
+    }
+}
+
+private fun buildMockResponse(request: Request, mock: MockResponseSpec): Response {
+    val mediaType = mock.headers.entries
+        .firstOrNull { it.key.equals("Content-Type", ignoreCase = true) }
+        ?.value
+        ?.toMediaTypeOrNull()
+    val builder = Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(mock.statusCode)
+        .message(httpStatusDescription(mock.statusCode))
+        .body(mock.body.toResponseBody(mediaType))
+    mock.headers.forEach { (key, value) -> builder.addHeader(key, value) }
+    return builder.build()
+}
+
+/** True for a successful WebSocket upgrade response (101 Switching Protocols + `Upgrade: websocket`). */
+private fun Response.isWebSocketUpgrade(): Boolean =
+    code == 101 && header("Upgrade")?.equals("websocket", ignoreCase = true) == true
+
+/** Preserves original header-name case, unlike [Headers.toMultimap] which lowercases keys. */
+private fun Headers.toCapturedMap(): Map<String, List<String>> {
+    val result = LinkedHashMap<String, MutableList<String>>()
+    forEach { (name, value) -> result.getOrPut(name) { mutableListOf() }.add(value) }
+    return result
+}
+
+/**
+ * [Request.headers] doesn't include Content-Type/Content-Length when they were derived from the
+ * [RequestBody] rather than set explicitly, so backfill them from the body when absent.
+ */
+private fun Request.capturedHeaders(): Map<String, List<String>> {
+    val result = headers.toCapturedMap().toMutableMap<String, List<String>>()
+    val body = body ?: return result
+    if (result.keys.none { it.equals("Content-Type", ignoreCase = true) }) {
+        body.contentType()?.let { result["Content-Type"] = listOf(it.toString()) }
+    }
+    if (result.keys.none { it.equals("Content-Length", ignoreCase = true) }) {
+        val length = runCatching { body.contentLength() }.getOrDefault(-1L)
+        if (length >= 0) result["Content-Length"] = listOf(length.toString())
+    }
+    return result
+}
+
+private fun httpStatusDescription(code: Int): String = when (code) {
+    200 -> "OK"
+    201 -> "Created"
+    204 -> "No Content"
+    301 -> "Moved Permanently"
+    302 -> "Found"
+    304 -> "Not Modified"
+    400 -> "Bad Request"
+    401 -> "Unauthorized"
+    403 -> "Forbidden"
+    404 -> "Not Found"
+    409 -> "Conflict"
+    429 -> "Too Many Requests"
+    500 -> "Internal Server Error"
+    502 -> "Bad Gateway"
+    503 -> "Service Unavailable"
+    504 -> "Gateway Timeout"
+    else -> ""
+}

--- a/jetwhale-plugins/network/agent-okhttp/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptor.kt
+++ b/jetwhale-plugins/network/agent-okhttp/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptor.kt
@@ -14,6 +14,9 @@ import okhttp3.RequestBody
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.Buffer
+import okio.Sink
+import okio.Timeout
+import okio.buffer
 import kotlin.time.TimeSource
 
 /**
@@ -32,6 +35,10 @@ import kotlin.time.TimeSource
  * Engine-added headers (`Accept-Encoding`, `Host`, `User-Agent`, ...) and intermediate redirect
  * hops are not visible to an application interceptor and are omitted; only the final response is
  * captured.
+ *
+ * Known limitation: response bodies are captured by peeking up to [maxBodyChars] before the
+ * response is returned, so a long-lived streaming response that isn't `text/event-stream` (which
+ * is skipped) delays the caller until that many bytes have arrived or the stream ends.
  *
  * @param maxBodyChars request/response bodies longer than this are truncated for transport.
  */
@@ -116,13 +123,36 @@ private fun captureRequestBody(body: RequestBody?, maxChars: Int): BodyCapture {
     // One-shot bodies can't be read twice; duplex bodies can't be materialized up front.
     if (body.isOneShot() || body.isDuplex()) return BodyCapture("<streaming request body>", false)
     return try {
-        val buffer = Buffer()
-        body.writeTo(buffer)
+        // Keep at most maxChars * 4 bytes (the widest UTF encoding of one char) so large uploads
+        // (files, multipart) are streamed through instead of fully materialized in memory.
+        val sink = TruncatingSink(maxBytes = maxChars * 4L)
+        sink.buffer().use { body.writeTo(it) }
         val charset = body.contentType()?.charset(Charsets.UTF_8) ?: Charsets.UTF_8
-        buffer.readString(charset).truncate(maxChars)
+        val capture = sink.captured.readString(charset).truncate(maxChars)
+        if (sink.overflowed && !capture.truncated) capture.copy(truncated = true) else capture
     } catch (e: Exception) {
         BodyCapture(null, false)
     }
+}
+
+/** Retains the first [maxBytes] written and discards the rest, flagging [overflowed]. */
+private class TruncatingSink(private val maxBytes: Long) : Sink {
+    val captured = Buffer()
+    var overflowed = false
+        private set
+
+    override fun write(source: Buffer, byteCount: Long) {
+        val keep = minOf(byteCount, maxBytes - captured.size)
+        if (keep > 0) captured.write(source, keep)
+        if (byteCount > keep) {
+            overflowed = true
+            source.skip(byteCount - keep)
+        }
+    }
+
+    override fun flush() {}
+    override fun timeout(): Timeout = Timeout.NONE
+    override fun close() {}
 }
 
 private fun captureResponseBody(response: Response, maxChars: Int): BodyCapture {

--- a/jetwhale-plugins/network/agent-okhttp/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorTest.kt
+++ b/jetwhale-plugins/network/agent-okhttp/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorTest.kt
@@ -1,0 +1,210 @@
+package com.kitakkun.jetwhale.plugins.network.agent.okhttp
+
+import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
+import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
+import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
+import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
+import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
+import com.kitakkun.jetwhale.plugins.network.protocol.NetworkEvent
+import com.kitakkun.jetwhale.plugins.network.protocol.NetworkMethod
+import com.kitakkun.jetwhale.protocol.serialization.JetWhaleJson
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class JetWhaleNetworkOkHttpInterceptorTest {
+
+    @OptIn(InternalJetWhaleApi::class)
+    private fun agentWithEvents(): Pair<JetWhaleNetworkAgentPlugin, MutableList<NetworkEvent>> {
+        val agent = JetWhaleNetworkAgentPlugin()
+        val events = mutableListOf<NetworkEvent>()
+        agent.activate { messages -> messages.forEach { events += JetWhaleJson.decodeFromString<NetworkEvent>(it) } }
+        return agent to events
+    }
+
+    private fun mockRule(pattern: String, spec: MockResponseSpec) = MockRule(id = pattern, matcher = MockMatcher(urlPattern = pattern), response = spec)
+
+    @Test
+    fun capturesRequestAndResponse_withMatchingTxId() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setResponseCode(200).setBody("hello"))
+        server.start()
+        try {
+            val (agent, events) = agentWithEvents()
+            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
+            val request = Request.Builder().url(server.url("/hello")).build()
+            val response = client.newCall(request).execute()
+
+            assertEquals("hello", response.body!!.string())
+
+            assertEquals(2, events.size)
+            val sent = events[0] as NetworkEvent.RequestSent
+            val received = events[1] as NetworkEvent.ResponseReceived
+            assertEquals(sent.request.txId, received.response.txId)
+            assertEquals("GET", sent.request.method)
+            assertEquals(200, received.response.statusCode)
+            assertEquals("hello", received.response.body)
+            assertEquals(false, received.response.fromMock)
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun capturesRequestBody() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setResponseCode(200))
+        server.start()
+        try {
+            val (agent, events) = agentWithEvents()
+            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
+            val body = "ping".toRequestBody("text/plain".toMediaType())
+            val request = Request.Builder().url(server.url("/echo")).post(body).build()
+            client.newCall(request).execute().close()
+
+            val sent = events[0] as NetworkEvent.RequestSent
+            assertEquals("ping", sent.request.body)
+            assertTrue(sent.request.headers.keys.any { it.equals("Content-Type", ignoreCase = true) })
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun recordsFailure_onConnectionError() {
+        val server = MockWebServer()
+        server.start()
+        val url = server.url("/gone")
+        server.shutdown()
+
+        val (agent, events) = agentWithEvents()
+        val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
+        val request = Request.Builder().url(url).build()
+
+        assertFailsWith<IOException> { client.newCall(request).execute() }
+
+        assertEquals(2, events.size)
+        val sent = events[0] as NetworkEvent.RequestSent
+        val failed = events[1] as NetworkEvent.RequestFailed
+        assertEquals(sent.request.txId, failed.failure.txId)
+    }
+
+    @Test
+    fun mockShortCircuits_serverNeverHit() {
+        val server = MockWebServer()
+        server.start()
+        try {
+            val (agent, events) = agentWithEvents()
+            runBlocking {
+                agent.onReceiveMethod(
+                    NetworkMethod.SetMockRules(
+                        listOf(
+                            mockRule(
+                                "/users",
+                                MockResponseSpec(
+                                    statusCode = 418,
+                                    headers = mapOf("Content-Type" to "application/json"),
+                                    body = "{\"mock\":true}",
+                                ),
+                            ),
+                        ),
+                    ),
+                )
+            }
+            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
+            val request = Request.Builder().url(server.url("/users")).build()
+            val response = client.newCall(request).execute()
+
+            assertEquals(418, response.code)
+            assertEquals("{\"mock\":true}", response.body!!.string())
+            assertEquals(0, server.requestCount)
+
+            val received = events.last() as NetworkEvent.ResponseReceived
+            assertEquals(true, received.response.fromMock)
+            assertEquals(listOf("application/json"), received.response.headers["Content-Type"])
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun truncatesLongBodies() {
+        val longBody = "x".repeat(500)
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setResponseCode(200).setBody(longBody))
+        server.start()
+        try {
+            val (agent, events) = agentWithEvents()
+            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor(maxBodyChars = 100)).build()
+            val request = Request.Builder().url(server.url("/big")).build()
+            val response = client.newCall(request).execute()
+
+            assertEquals(longBody, response.body!!.string())
+
+            val received = events.last() as NetworkEvent.ResponseReceived
+            assertEquals(true, received.response.bodyTruncated)
+            assertEquals(100, received.response.body?.length)
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun capturesWebSocketUpgrade_withoutCorruptingFrames() {
+        val server = MockWebServer()
+        val serverMessageSent = CountDownLatch(1)
+        server.enqueue(
+            MockResponse().withWebSocketUpgrade(
+                object : WebSocketListener() {
+                    override fun onOpen(webSocket: WebSocket, response: okhttp3.Response) {
+                        webSocket.send("hello from server")
+                        serverMessageSent.countDown()
+                    }
+                },
+            ),
+        )
+        server.start()
+        try {
+            val (agent, events) = agentWithEvents()
+            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
+            val clientReceived = CountDownLatch(1)
+            var receivedText: String? = null
+            val request = Request.Builder().url(server.url("/ws")).build()
+            client.newWebSocket(
+                request,
+                object : WebSocketListener() {
+                    override fun onMessage(webSocket: WebSocket, text: String) {
+                        receivedText = text
+                        clientReceived.countDown()
+                    }
+                },
+            )
+
+            assertTrue(serverMessageSent.await(5, TimeUnit.SECONDS), "server never opened the socket")
+            assertTrue(clientReceived.await(5, TimeUnit.SECONDS), "client never received the WebSocket message")
+            // The real regression check: the interceptor must not have stolen bytes from the frame stream.
+            assertEquals("hello from server", receivedText)
+
+            val received = events.last() as NetworkEvent.ResponseReceived
+            assertEquals(101, received.response.statusCode)
+            assertEquals("<websocket upgrade>", received.response.body)
+            assertEquals(false, received.response.bodyTruncated)
+        } finally {
+            server.shutdown()
+        }
+    }
+}

--- a/jetwhale-plugins/network/agent-okhttp/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorTest.kt
+++ b/jetwhale-plugins/network/agent-okhttp/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorTest.kt
@@ -19,6 +19,7 @@ import okhttp3.WebSocketListener
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import java.io.IOException
+import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
@@ -31,7 +32,8 @@ class JetWhaleNetworkOkHttpInterceptorTest {
     @OptIn(InternalJetWhaleApi::class)
     private fun agentWithEvents(): Pair<JetWhaleNetworkAgentPlugin, MutableList<NetworkEvent>> {
         val agent = JetWhaleNetworkAgentPlugin()
-        val events = mutableListOf<NetworkEvent>()
+        // The interceptor also runs on OkHttp's WebSocket threads, not just the test thread.
+        val events = Collections.synchronizedList(mutableListOf<NetworkEvent>())
         agent.activate { messages -> messages.forEach { events += JetWhaleJson.decodeFromString<NetworkEvent>(it) } }
         return agent to events
     }
@@ -178,13 +180,14 @@ class JetWhaleNetworkOkHttpInterceptorTest {
             ),
         )
         server.start()
+        var webSocket: WebSocket? = null
         try {
             val (agent, events) = agentWithEvents()
             val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
             val clientReceived = CountDownLatch(1)
             var receivedText: String? = null
             val request = Request.Builder().url(server.url("/ws")).build()
-            client.newWebSocket(
+            webSocket = client.newWebSocket(
                 request,
                 object : WebSocketListener() {
                     override fun onMessage(webSocket: WebSocket, text: String) {
@@ -203,6 +206,27 @@ class JetWhaleNetworkOkHttpInterceptorTest {
             assertEquals(101, received.response.statusCode)
             assertEquals("<websocket upgrade>", received.response.body)
             assertEquals(false, received.response.bodyTruncated)
+        } finally {
+            webSocket?.cancel()
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun truncatesLongRequestBodies() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setResponseCode(200))
+        server.start()
+        try {
+            val (agent, events) = agentWithEvents()
+            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor(maxBodyChars = 100)).build()
+            val longBody = "y".repeat(1_000_000)
+            val request = Request.Builder().url(server.url("/upload")).post(longBody.toRequestBody("text/plain".toMediaType())).build()
+            client.newCall(request).execute().close()
+
+            val sent = events[0] as NetworkEvent.RequestSent
+            assertEquals(true, sent.request.bodyTruncated)
+            assertEquals("y".repeat(100), sent.request.body)
         } finally {
             server.shutdown()
         }

--- a/jetwhale-plugins/network/agent-okhttp/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorTest.kt
+++ b/jetwhale-plugins/network/agent-okhttp/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorTest.kt
@@ -22,6 +22,8 @@ import java.io.IOException
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -29,75 +31,69 @@ import kotlin.test.assertTrue
 
 class JetWhaleNetworkOkHttpInterceptorTest {
 
+    private lateinit var server: MockWebServer
+    private lateinit var agent: JetWhaleNetworkAgentPlugin
+    private lateinit var events: MutableList<NetworkEvent>
+
     @OptIn(InternalJetWhaleApi::class)
-    private fun agentWithEvents(): Pair<JetWhaleNetworkAgentPlugin, MutableList<NetworkEvent>> {
-        val agent = JetWhaleNetworkAgentPlugin()
+    @BeforeTest
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        agent = JetWhaleNetworkAgentPlugin()
         // The interceptor also runs on OkHttp's WebSocket threads, not just the test thread.
-        val events = Collections.synchronizedList(mutableListOf<NetworkEvent>())
+        events = Collections.synchronizedList(mutableListOf())
         agent.activate { messages -> messages.forEach { events += JetWhaleJson.decodeFromString<NetworkEvent>(it) } }
-        return agent to events
     }
 
-    private fun mockRule(pattern: String, spec: MockResponseSpec) = MockRule(id = pattern, matcher = MockMatcher(urlPattern = pattern), response = spec)
+    @AfterTest
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun client() = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
+
+    /** Client whose interceptor captures at most [SMALL_BODY_CAP] chars, for truncation tests. */
+    private fun clientWithSmallBodyCap() = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor(maxBodyChars = SMALL_BODY_CAP)).build()
 
     @Test
-    fun capturesRequestAndResponse_withMatchingTxId() {
-        val server = MockWebServer()
+    fun `records request and response with a matching txId`() {
         server.enqueue(MockResponse().setResponseCode(200).setBody("hello"))
-        server.start()
-        try {
-            val (agent, events) = agentWithEvents()
-            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
-            val request = Request.Builder().url(server.url("/hello")).build()
-            val response = client.newCall(request).execute()
+        val request = Request.Builder().url(server.url("/hello")).build()
+        val response = client().newCall(request).execute()
 
-            assertEquals("hello", response.body!!.string())
+        assertEquals("hello", response.body!!.string())
 
-            assertEquals(2, events.size)
-            val sent = events[0] as NetworkEvent.RequestSent
-            val received = events[1] as NetworkEvent.ResponseReceived
-            assertEquals(sent.request.txId, received.response.txId)
-            assertEquals("GET", sent.request.method)
-            assertEquals(200, received.response.statusCode)
-            assertEquals("hello", received.response.body)
-            assertEquals(false, received.response.fromMock)
-        } finally {
-            server.shutdown()
-        }
+        assertEquals(2, events.size)
+        val sent = events[0] as NetworkEvent.RequestSent
+        val received = events[1] as NetworkEvent.ResponseReceived
+        assertEquals(sent.request.txId, received.response.txId)
+        assertEquals("GET", sent.request.method)
+        assertEquals(200, received.response.statusCode)
+        assertEquals("hello", received.response.body)
+        assertEquals(false, received.response.fromMock)
     }
 
     @Test
-    fun capturesRequestBody() {
-        val server = MockWebServer()
+    fun `captures the request body and its content type`() {
         server.enqueue(MockResponse().setResponseCode(200))
-        server.start()
-        try {
-            val (agent, events) = agentWithEvents()
-            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
-            val body = "ping".toRequestBody("text/plain".toMediaType())
-            val request = Request.Builder().url(server.url("/echo")).post(body).build()
-            client.newCall(request).execute().close()
+        val body = "ping".toRequestBody("text/plain".toMediaType())
+        val request = Request.Builder().url(server.url("/echo")).post(body).build()
+        client().newCall(request).execute().close()
 
-            val sent = events[0] as NetworkEvent.RequestSent
-            assertEquals("ping", sent.request.body)
-            assertTrue(sent.request.headers.keys.any { it.equals("Content-Type", ignoreCase = true) })
-        } finally {
-            server.shutdown()
-        }
+        val sent = events[0] as NetworkEvent.RequestSent
+        assertEquals("ping", sent.request.body)
+        assertTrue(sent.request.headers.keys.any { it.equals("Content-Type", ignoreCase = true) })
     }
 
     @Test
-    fun recordsFailure_onConnectionError() {
-        val server = MockWebServer()
-        server.start()
+    fun `records a failure when the connection fails`() {
         val url = server.url("/gone")
         server.shutdown()
 
-        val (agent, events) = agentWithEvents()
-        val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
         val request = Request.Builder().url(url).build()
 
-        assertFailsWith<IOException> { client.newCall(request).execute() }
+        assertFailsWith<IOException> { client().newCall(request).execute() }
 
         assertEquals(2, events.size)
         val sent = events[0] as NetworkEvent.RequestSent
@@ -106,68 +102,52 @@ class JetWhaleNetworkOkHttpInterceptorTest {
     }
 
     @Test
-    fun mockShortCircuits_serverNeverHit() {
-        val server = MockWebServer()
-        server.start()
-        try {
-            val (agent, events) = agentWithEvents()
-            runBlocking {
-                agent.onReceiveMethod(
-                    NetworkMethod.SetMockRules(
-                        listOf(
-                            mockRule(
-                                "/users",
-                                MockResponseSpec(
-                                    statusCode = 418,
-                                    headers = mapOf("Content-Type" to "application/json"),
-                                    body = "{\"mock\":true}",
-                                ),
+    fun `serves a mock response without hitting the server`() {
+        runBlocking {
+            agent.onReceiveMethod(
+                NetworkMethod.SetMockRules(
+                    listOf(
+                        MockRule(
+                            id = "/users",
+                            matcher = MockMatcher(urlPattern = "/users"),
+                            response = MockResponseSpec(
+                                statusCode = 418,
+                                headers = mapOf("Content-Type" to "application/json"),
+                                body = "{\"mock\":true}",
                             ),
                         ),
                     ),
-                )
-            }
-            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
-            val request = Request.Builder().url(server.url("/users")).build()
-            val response = client.newCall(request).execute()
-
-            assertEquals(418, response.code)
-            assertEquals("{\"mock\":true}", response.body!!.string())
-            assertEquals(0, server.requestCount)
-
-            val received = events.last() as NetworkEvent.ResponseReceived
-            assertEquals(true, received.response.fromMock)
-            assertEquals(listOf("application/json"), received.response.headers["Content-Type"])
-        } finally {
-            server.shutdown()
+                ),
+            )
         }
+        val request = Request.Builder().url(server.url("/users")).build()
+        val response = client().newCall(request).execute()
+
+        assertEquals(418, response.code)
+        assertEquals("{\"mock\":true}", response.body!!.string())
+        assertEquals(0, server.requestCount)
+
+        val received = events.last() as NetworkEvent.ResponseReceived
+        assertEquals(true, received.response.fromMock)
+        assertEquals(listOf("application/json"), received.response.headers["Content-Type"])
     }
 
     @Test
-    fun truncatesLongBodies() {
+    fun `truncates response bodies longer than maxBodyChars`() {
         val longBody = "x".repeat(500)
-        val server = MockWebServer()
         server.enqueue(MockResponse().setResponseCode(200).setBody(longBody))
-        server.start()
-        try {
-            val (agent, events) = agentWithEvents()
-            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor(maxBodyChars = 100)).build()
-            val request = Request.Builder().url(server.url("/big")).build()
-            val response = client.newCall(request).execute()
+        val request = Request.Builder().url(server.url("/big")).build()
+        val response = clientWithSmallBodyCap().newCall(request).execute()
 
-            assertEquals(longBody, response.body!!.string())
+        assertEquals(longBody, response.body!!.string())
 
-            val received = events.last() as NetworkEvent.ResponseReceived
-            assertEquals(true, received.response.bodyTruncated)
-            assertEquals(100, received.response.body?.length)
-        } finally {
-            server.shutdown()
-        }
+        val received = events.last() as NetworkEvent.ResponseReceived
+        assertEquals(true, received.response.bodyTruncated)
+        assertEquals(SMALL_BODY_CAP, received.response.body?.length)
     }
 
     @Test
-    fun capturesWebSocketUpgrade_withoutCorruptingFrames() {
-        val server = MockWebServer()
+    fun `records a WebSocket upgrade without corrupting the frame stream`() {
         val serverMessageSent = CountDownLatch(1)
         server.enqueue(
             MockResponse().withWebSocketUpgrade(
@@ -179,15 +159,12 @@ class JetWhaleNetworkOkHttpInterceptorTest {
                 },
             ),
         )
-        server.start()
         var webSocket: WebSocket? = null
         try {
-            val (agent, events) = agentWithEvents()
-            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor()).build()
             val clientReceived = CountDownLatch(1)
             var receivedText: String? = null
             val request = Request.Builder().url(server.url("/ws")).build()
-            webSocket = client.newWebSocket(
+            webSocket = client().newWebSocket(
                 request,
                 object : WebSocketListener() {
                     override fun onMessage(webSocket: WebSocket, text: String) {
@@ -208,48 +185,35 @@ class JetWhaleNetworkOkHttpInterceptorTest {
             assertEquals(false, received.response.bodyTruncated)
         } finally {
             webSocket?.cancel()
-            server.shutdown()
         }
     }
 
     @Test
-    fun flagsMultiByteResponseBodyHittingByteCapAsTruncated() {
+    fun `flags a multi-byte response body hitting the byte cap as truncated`() {
         // 200 chars × 3 bytes (UTF-8) = 600 bytes. The 100-byte peek cap yields ~33 decoded chars,
         // under the 100-char limit — a char-only check would report this cut body as not truncated.
         val longBody = "あ".repeat(200)
-        val server = MockWebServer()
         server.enqueue(MockResponse().setResponseCode(200).setBody(longBody))
-        server.start()
-        try {
-            val (agent, events) = agentWithEvents()
-            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor(maxBodyChars = 100)).build()
-            val request = Request.Builder().url(server.url("/jp")).build()
-            client.newCall(request).execute().close()
+        val request = Request.Builder().url(server.url("/jp")).build()
+        clientWithSmallBodyCap().newCall(request).execute().close()
 
-            val received = events.last() as NetworkEvent.ResponseReceived
-            assertEquals(true, received.response.bodyTruncated)
-        } finally {
-            server.shutdown()
-        }
+        val received = events.last() as NetworkEvent.ResponseReceived
+        assertEquals(true, received.response.bodyTruncated)
     }
 
     @Test
-    fun truncatesLongRequestBodies() {
-        val server = MockWebServer()
+    fun `truncates request bodies longer than maxBodyChars`() {
         server.enqueue(MockResponse().setResponseCode(200))
-        server.start()
-        try {
-            val (agent, events) = agentWithEvents()
-            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor(maxBodyChars = 100)).build()
-            val longBody = "y".repeat(1_000_000)
-            val request = Request.Builder().url(server.url("/upload")).post(longBody.toRequestBody("text/plain".toMediaType())).build()
-            client.newCall(request).execute().close()
+        val longBody = "y".repeat(1_000_000)
+        val request = Request.Builder().url(server.url("/upload")).post(longBody.toRequestBody("text/plain".toMediaType())).build()
+        clientWithSmallBodyCap().newCall(request).execute().close()
 
-            val sent = events[0] as NetworkEvent.RequestSent
-            assertEquals(true, sent.request.bodyTruncated)
-            assertEquals("y".repeat(100), sent.request.body)
-        } finally {
-            server.shutdown()
-        }
+        val sent = events[0] as NetworkEvent.RequestSent
+        assertEquals(true, sent.request.bodyTruncated)
+        assertEquals("y".repeat(SMALL_BODY_CAP), sent.request.body)
+    }
+
+    companion object {
+        private const val SMALL_BODY_CAP = 100
     }
 }

--- a/jetwhale-plugins/network/agent-okhttp/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorTest.kt
+++ b/jetwhale-plugins/network/agent-okhttp/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorTest.kt
@@ -213,6 +213,27 @@ class JetWhaleNetworkOkHttpInterceptorTest {
     }
 
     @Test
+    fun flagsMultiByteResponseBodyHittingByteCapAsTruncated() {
+        // 200 chars × 3 bytes (UTF-8) = 600 bytes. The 100-byte peek cap yields ~33 decoded chars,
+        // under the 100-char limit — a char-only check would report this cut body as not truncated.
+        val longBody = "あ".repeat(200)
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setResponseCode(200).setBody(longBody))
+        server.start()
+        try {
+            val (agent, events) = agentWithEvents()
+            val client = OkHttpClient.Builder().addInterceptor(agent.okHttpInterceptor(maxBodyChars = 100)).build()
+            val request = Request.Builder().url(server.url("/jp")).build()
+            client.newCall(request).execute().close()
+
+            val received = events.last() as NetworkEvent.ResponseReceived
+            assertEquals(true, received.response.bodyTruncated)
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
     fun truncatesLongRequestBodies() {
         val server = MockWebServer()
         server.enqueue(MockResponse().setResponseCode(200))

--- a/jetwhale-plugins/network/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin.kt
+++ b/jetwhale-plugins/network/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin.kt
@@ -20,8 +20,8 @@ import kotlin.uuid.Uuid
  *
  * It owns the mock configuration (pushed from the host) and exposes a small capture API
  * ([recordRequest]/[recordResponse]/[recordFailure]/[findMock]) that transport adapters call.
- * Today the only adapter is Ktor (`network:agent-ktor`); an OkHttp/Retrofit adapter could reuse
- * the exact same API without touching this class.
+ * Adapters exist for Ktor (`network:agent-ktor`) and OkHttp (`network:agent-okhttp`); a
+ * Retrofit adapter could reuse the exact same API without touching this class.
  */
 class JetWhaleNetworkAgentPlugin : JetWhaleAgentPlugin<NetworkEvent, NetworkMethod, NetworkMethodResult>() {
     override val pluginId: String get() = PLUGIN_ID

--- a/jetwhale-plugins/network/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/protocol/HttpModels.kt
+++ b/jetwhale-plugins/network/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/protocol/HttpModels.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Transport-agnostic representation of an outgoing HTTP request captured by an adapter
- * (Ktor today, OkHttp/Retrofit later).
+ * (Ktor, OkHttp).
  */
 @Serializable
 data class CapturedHttpRequest(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,6 +50,7 @@ include(":jetwhale-plugins:example:agent")
 include(":jetwhale-plugins:network:protocol")
 include(":jetwhale-plugins:network:agent")
 include(":jetwhale-plugins:network:agent-ktor")
+include(":jetwhale-plugins:network:agent-okhttp")
 include(":jetwhale-plugins:network:host")
 
 include(":test-annotations")


### PR DESCRIPTION
## Summary

Adds **`network:agent-okhttp`**, an OkHttp adapter for the Network Inspector plugin.
Apps built on OkHttp/Retrofit (instead of Ktor) can now capture and mock traffic
through the exact same `JetWhaleNetworkAgentPlugin` — the agent-side capture/mock
API is transport-agnostic and needed no changes.

Plain Kotlin/JVM module (OkHttp is JVM/Android-only), mirroring `network:agent-ktor`:

```kotlin
val agent = JetWhaleNetworkAgentPlugin()
val client = OkHttpClient.Builder()
    .addInterceptor(agent.okHttpInterceptor())
    .build()
startJetWhale { plugins { register(agent) } }
```

## Design

- Installed as an **application interceptor** (not a network interceptor) so mock
  responses short-circuit before ever touching the network. Consequence:
  engine-added headers (`Accept-Encoding`, `Host`, `User-Agent`, …) and
  intermediate redirect hops aren't visible and are omitted; only the final
  response is captured. Documented in the KDoc, which also recommends adding it
  *after* other application interceptors (e.g. auth) so their headers are
  captured too.
- **Request bodies** are streamed through a truncating sink that keeps only the
  first `maxBodyChars * 4` bytes (the widest UTF encoding of one char), so large
  uploads (files, multipart) are never fully materialized in memory. One-shot /
  duplex bodies can't be read twice and are recorded as `<streaming request body>`.
- **Response bodies** are captured with `peekBody(maxBodyChars + 1)`, with three
  guarded cases recorded as placeholders instead of being read:
  - WebSocket upgrade (`101` + `Upgrade: websocket`) — peeking would consume live
    frames (same class of bug as the Ktor-side fix, #111)
  - `text/event-stream` — `peekBody(n)` blocks until n bytes or EOF, which would
    hang on a never-ending stream
  - non-identity `Content-Encoding` — only present at this layer when the caller
    disabled OkHttp's transparent gzip, so the bytes aren't text
- The peek limit is in **bytes** while truncation counts **chars**, so a
  multi-byte body that hits the byte cap is flagged `bodyTruncated` even when it
  decodes to fewer than `maxBodyChars` chars.
- **Header fidelity:** original header-name case is preserved (OkHttp's
  `toMultimap()` lowercases), and `Content-Type`/`Content-Length` derived from
  the `RequestBody` are backfilled when not set explicitly.
- Known limitation (documented): a long-lived streaming response that isn't SSE
  delays the caller until `maxBodyChars` bytes arrive or the stream ends.

## Demo

The demo app gains a platform-conditional third tab via `expect`/`actual`
(`PlatformExtraTab`), so a transport-specific screen can live in `demo/shared`
without forcing JVM/Android-only code onto iOS/JS/wasm. Android's `actual` wires
the interceptor into an `OkHttpClient`; every other platform is a no-op stub.
The shared network demo now targets JSONPlaceholder over HTTPS and includes a
DELETE sample.

## Validation

- Unit tests (`:jetwhale-plugins:network:agent-okhttp:test`, green):
  request/response capture incl. truncation flags (including the byte-capped
  multi-byte case), mock short-circuiting, streaming/one-shot body placeholders,
  WebSocket upgrade passthrough.
- End-to-end on the Android demo: traffic from the OkHttp tab (GET/POST/DELETE,
  WebSocket) appears in the host's Network Inspector, and mocks configured on
  the host are served by the interceptor.
