### PR TITLE
fix(network): avoid buffering WebSocket upgrade and SSE response bodies in the Ktor adapter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,6 +88,7 @@ ktorServerNetty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktorServerTestHost = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 ktorClientCore = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktorClientCio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktorClientMock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktorClientJs = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktorClientDarwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktorClientWinHttp = { module = "io.ktor:ktor-client-winhttp", version.ref = "ktor" }

--- a/jetwhale-plugins/network/agent-ktor/build.gradle.kts
+++ b/jetwhale-plugins/network/agent-ktor/build.gradle.kts
@@ -17,6 +17,9 @@ dependencies {
     commonMainApi(projects.jetwhalePlugins.network.agent)
     commonMainApi(libs.ktorClientCore)
     commonMainImplementation(libs.kotlinxCoroutinesCore)
+    jvmTestImplementation(libs.kotlinTest)
+    jvmTestImplementation(libs.ktorClientMock)
+    jvmTestImplementation(libs.kotlinxSerializationJson)
 }
 
 jetwhalePublish {

--- a/jetwhale-plugins/network/agent-ktor/build.gradle.kts
+++ b/jetwhale-plugins/network/agent-ktor/build.gradle.kts
@@ -19,6 +19,10 @@ dependencies {
     commonMainImplementation(libs.kotlinxCoroutinesCore)
     jvmTestImplementation(libs.kotlinTest)
     jvmTestImplementation(libs.ktorClientMock)
+    jvmTestImplementation(libs.ktorClientCio)
+    jvmTestImplementation(libs.ktorClientWebSockets)
+    jvmTestImplementation(libs.ktorServerNetty)
+    jvmTestImplementation(libs.ktorServerWebSockets)
     jvmTestImplementation(libs.kotlinxSerializationJson)
 }
 

--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
@@ -11,8 +11,10 @@ import io.ktor.client.plugins.api.Send
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.HttpResponseData
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HeadersBuilder
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpProtocolVersion
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.OutgoingContent
@@ -87,9 +89,33 @@ fun JetWhaleNetworkAgentPlugin.ktorClientPlugin(maxBodyChars: Int = 100_000): Cl
             }
 
             try {
+                val rawCall = proceed(request)
+                val rawResponse = rawCall.response
+
+                // A WebSocket upgrade response (101) has no conventional body — by the time this
+                // plugin sees it, the connection has already switched to the raw frame stream, so
+                // save()/bodyAsText() would read live WebSocket frames as if they were an HTTP
+                // body, corrupting the frame stream for the caller. Record a placeholder instead
+                // of touching the body, and return the untouched call.
+                if (rawResponse.isWebSocketUpgrade()) {
+                    agent.recordResponse(
+                        CapturedHttpResponse(
+                            txId = txId,
+                            statusCode = rawResponse.status.value,
+                            statusDescription = rawResponse.status.description,
+                            headers = rawResponse.headers.toCapturedMap(),
+                            body = "<websocket upgrade>",
+                            bodyTruncated = false,
+                            durationMs = started.elapsedNow().inWholeMilliseconds,
+                            fromMock = false,
+                        ),
+                    )
+                    return@on rawCall
+                }
+
                 // save() buffers the body so we can read it for inspection and still hand a
                 // fresh, readable response to the caller.
-                val call = proceed(request).save()
+                val call = rawCall.save()
                 val response = call.response
                 val responseBody = response.bodyAsText().truncate(maxBodyChars)
                 agent.recordResponse(
@@ -133,6 +159,10 @@ private fun captureOutgoingBody(content: Any?, maxChars: Int): BodyCapture = whe
 }
 
 private fun StringValues.toCapturedMap(): Map<String, List<String>> = entries().associate { it.key to it.value }
+
+/** True for a successful WebSocket upgrade response (101 Switching Protocols + `Upgrade: websocket`). */
+private fun HttpResponse.isWebSocketUpgrade(): Boolean =
+    status == HttpStatusCode.SwitchingProtocols && headers[HttpHeaders.Upgrade]?.equals("websocket", ignoreCase = true) == true
 
 /**
  * Captures the request headers visible at the [Send] phase, enriched with the body's

--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
@@ -186,8 +186,7 @@ private fun captureOutgoingBody(content: Any?, maxChars: Int): BodyCapture = whe
 private fun StringValues.toCapturedMap(): Map<String, List<String>> = entries().associate { it.key to it.value }
 
 /** True for a successful WebSocket upgrade response (101 Switching Protocols + `Upgrade: websocket`). */
-private fun HttpResponse.isWebSocketUpgrade(): Boolean =
-    status == HttpStatusCode.SwitchingProtocols && headers[HttpHeaders.Upgrade]?.equals("websocket", ignoreCase = true) == true
+private fun HttpResponse.isWebSocketUpgrade(): Boolean = status == HttpStatusCode.SwitchingProtocols && headers[HttpHeaders.Upgrade]?.equals("websocket", ignoreCase = true) == true
 
 /**
  * Captures the request headers visible at the [Send] phase, enriched with the body's

--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
@@ -36,6 +36,10 @@ import kotlin.time.TimeSource
  * startJetWhale { plugins { register(agent) } }
  * ```
  *
+ * Known limitation: response bodies are buffered with `save()` before the caller sees them, so a
+ * long-lived streaming response that isn't `text/event-stream` (which is skipped) is fully
+ * buffered and delays the caller until the stream ends.
+ *
  * @param maxBodyChars request/response bodies longer than this are truncated for transport.
  */
 @OptIn(InternalAPI::class) // HttpClientCall's constructor is needed to synthesize mock responses.
@@ -105,6 +109,27 @@ fun JetWhaleNetworkAgentPlugin.ktorClientPlugin(maxBodyChars: Int = 100_000): Cl
                             statusDescription = rawResponse.status.description,
                             headers = rawResponse.headers.toCapturedMap(),
                             body = "<websocket upgrade>",
+                            bodyTruncated = false,
+                            durationMs = started.elapsedNow().inWholeMilliseconds,
+                            fromMock = false,
+                        ),
+                    )
+                    return@on rawCall
+                }
+
+                // save() buffers the entire body before returning, so on a never-ending stream
+                // (SSE) the caller would wait forever for a response that has already started
+                // arriving. Record a placeholder and hand back the untouched call, mirroring the
+                // OkHttp adapter.
+                val contentType = rawResponse.headers[HttpHeaders.ContentType]
+                if (contentType?.startsWith("text/event-stream", ignoreCase = true) == true) {
+                    agent.recordResponse(
+                        CapturedHttpResponse(
+                            txId = txId,
+                            statusCode = rawResponse.status.value,
+                            statusDescription = rawResponse.status.description,
+                            headers = rawResponse.headers.toCapturedMap(),
+                            body = "<streaming response body>",
                             bodyTruncated = false,
                             durationMs = started.elapsedNow().inWholeMilliseconds,
                             fromMock = false,

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
@@ -1,0 +1,86 @@
+package com.kitakkun.jetwhale.plugins.network.agent.ktor
+
+import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
+import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
+import com.kitakkun.jetwhale.plugins.network.protocol.NetworkEvent
+import com.kitakkun.jetwhale.protocol.serialization.JetWhaleJson
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.writeStringUtf8
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JetWhaleNetworkKtorPluginTest {
+
+    @OptIn(InternalJetWhaleApi::class)
+    private fun agentWithEvents(): Pair<JetWhaleNetworkAgentPlugin, MutableList<NetworkEvent>> {
+        val agent = JetWhaleNetworkAgentPlugin()
+        val events = mutableListOf<NetworkEvent>()
+        agent.activate { messages -> messages.forEach { events += JetWhaleJson.decodeFromString<NetworkEvent>(it) } }
+        return agent to events
+    }
+
+    @Test
+    fun sseResponse_returnsWithoutBufferingBody() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        // A channel that receives data but is never closed — save() would suspend on it forever.
+        val stream = ByteChannel(autoFlush = true)
+        stream.writeStringUtf8("data: hello\n\n")
+        val client = HttpClient(
+            MockEngine {
+                respond(
+                    content = stream,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "text/event-stream"),
+                )
+            },
+        ) {
+            install(agent.ktorClientPlugin())
+        }
+
+        // Streaming execution (as the SSE plugin does) skips Ktor's own SaveBody plugin; without
+        // the guard, the JetWhale plugin's save() would suspend on the endless channel forever.
+        val statusCode = withTimeout(5_000) {
+            client.prepareGet("http://example/sse").execute { response -> response.status.value }
+        }
+
+        assertEquals(200, statusCode)
+        val received = events.last() as NetworkEvent.ResponseReceived
+        assertEquals("<streaming response body>", received.response.body)
+        assertEquals(false, received.response.bodyTruncated)
+    }
+
+    @Test
+    fun regularResponse_isStillCaptured() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        val client = HttpClient(
+            MockEngine {
+                respond(
+                    content = "hello",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "text/plain"),
+                )
+            },
+        ) {
+            install(agent.ktorClientPlugin())
+        }
+
+        val response = client.get("http://example/plain")
+
+        assertEquals("hello", response.bodyAsText())
+        val received = events.last() as NetworkEvent.ResponseReceived
+        assertEquals("hello", received.response.body)
+        assertEquals(false, received.response.bodyTruncated)
+    }
+}

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
@@ -118,7 +118,7 @@ class JetWhaleNetworkKtorPluginTest {
         try {
             // Without the upgrade guard, save() would read live WebSocket frames as the HTTP
             // body, so the echo below would never arrive.
-            val echoed = withTimeout(5_000.milliseconds) {
+            val echoed = withTimeout(5_000) {
                 client.webSocketSession("ws://127.0.0.1:$port/ws").run {
                     send(Frame.Text("hello"))
                     val reply = (incoming.receive() as Frame.Text).readText()

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
@@ -5,16 +5,27 @@ import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
 import com.kitakkun.jetwhale.plugins.network.protocol.NetworkEvent
 import com.kitakkun.jetwhale.protocol.serialization.JetWhaleJson
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.client.request.get
 import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.server.application.install
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.webSocket
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.writeStringUtf8
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import io.ktor.websocket.readText
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.decodeFromString
@@ -82,5 +93,47 @@ class JetWhaleNetworkKtorPluginTest {
         val received = events.last() as NetworkEvent.ResponseReceived
         assertEquals("hello", received.response.body)
         assertEquals(false, received.response.bodyTruncated)
+    }
+
+    @Test
+    fun `records a WebSocket upgrade without corrupting the frame stream`() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        // A real server and engine are needed here: MockEngine can't perform a protocol upgrade.
+        val server = embeddedServer(Netty, port = 0) {
+            install(io.ktor.server.websocket.WebSockets)
+            routing {
+                webSocket("/ws") {
+                    for (frame in incoming) {
+                        if (frame is Frame.Text) send(Frame.Text("echo: ${frame.readText()}"))
+                    }
+                }
+            }
+        }.start(wait = false)
+        val port = server.engine.resolvedConnectors().first().port
+        val client = HttpClient(CIO) {
+            install(WebSockets)
+            install(agent.ktorClientPlugin())
+        }
+
+        try {
+            // Without the upgrade guard, save() would read live WebSocket frames as the HTTP
+            // body, so the echo below would never arrive.
+            val echoed = withTimeout(5_000.milliseconds) {
+                client.webSocketSession("ws://127.0.0.1:$port/ws").run {
+                    send(Frame.Text("hello"))
+                    val reply = (incoming.receive() as Frame.Text).readText()
+                    close()
+                    reply
+                }
+            }
+
+            assertEquals("echo: hello", echoed)
+            val received = events.last() as NetworkEvent.ResponseReceived
+            assertEquals(101, received.response.statusCode)
+            assertEquals("<websocket upgrade>", received.response.body)
+        } finally {
+            client.close()
+            server.stop()
+        }
     }
 }


### PR DESCRIPTION
## Summary

The Ktor adapter unconditionally buffered every response body for inspection
(`save()` + `bodyAsText()`). Two kinds of responses can't be treated that way:

**WebSocket upgrades.** A `101 Switching Protocols` response has no conventional
body — by the time the plugin sees it, the connection has already switched to
the raw frame stream, and the "body" is a `DelegatingClientWebSocketSession`
that Ktor cannot transform into a `Source`. The resulting
`NoTransformationFoundException` was recorded as a failure and then
**re-thrown to the caller**, so with the inspector installed, every
`client.webSocket { ... }` / `webSocketSession()` through the instrumented
`HttpClient` failed — the app's WebSocket feature was broken outright, not just
misreported:

> Failed: Expected response body of the type 'class kotlinx.io.Source' but was
> 'class io.ktor.client.plugins.websocket.DelegatingClientWebSocketSession'

Even where the body were readable, consuming it here would eat live WebSocket
frames and corrupt the stream for the caller.

**SSE.** `save()` buffers the entire body before returning, so a
`text/event-stream` response made the caller wait forever for a stream that had
already started arriving — the SSE plugin deliberately skips Ktor's own
`SaveBody` plugin, but this plugin's `save()` reintroduced the hang.

## Changes

- Detect a successful upgrade (`101` + `Upgrade: websocket`) after `proceed()`,
  record the transaction with its real status/headers and a
  `<websocket upgrade>` placeholder body, and return the call **untouched** —
  no `save()`, no body read.
- Detect `text/event-stream` responses the same way and record a
  `<streaming response body>` placeholder, mirroring the OkHttp adapter (#110).
- All other responses are captured exactly as before. The remaining limitation
  (a long-lived **non-SSE** streaming response is still fully buffered by
  `save()`) is now documented in the KDoc.

Same class of bug as the WebSocket/SSE handling in the new OkHttp adapter
(#110); this is the Ktor-side counterpart.

## Validation

- Reproduced against a real `wss://` endpoint: connection failed with
  `NoTransformationFoundException` before the fix, connects and exchanges frames
  normally after; the inspector shows the 101 transaction with the
  `<websocket upgrade>` placeholder.
- New unit tests (`agent-ktor` jvmTest, MockEngine): an SSE response backed by a
  never-closing channel returns immediately with the placeholder (it hangs
  without the guard), and plain responses are still captured.
- Plain HTTP request/response capture (incl. mocks) is unchanged.
