### PR TITLE
feat(host): add copy-as-cURL context menu to the traffic view

### DIFF
--- a/jetwhale-plugins/network/host/build.gradle.kts
+++ b/jetwhale-plugins/network/host/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     compileOnly(libs.material3)
     compileOnly(libs.kotlinxSerializationJson)
     api(projects.jetwhalePlugins.network.protocol)
+    testImplementation(libs.kotlinTest)
 }
 
 tasks.jar {

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/CopyTransaction.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/CopyTransaction.kt
@@ -1,0 +1,37 @@
+package com.kitakkun.jetwhale.plugins.network.host
+
+import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+
+internal fun copyToClipboard(text: String) {
+    Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(text), null)
+}
+
+/**
+ * Rebuilds the captured request as a shell-pasteable `curl` command.
+ *
+ * Content-Length is dropped (curl derives it from the body). A truncated capture can't be
+ * replayed faithfully, so it's flagged with a leading comment instead of silently emitting
+ * a partial body.
+ */
+internal fun buildCurlCommand(request: CapturedHttpRequest): String {
+    val lines = mutableListOf("curl")
+    if (!request.method.equals("GET", ignoreCase = true)) {
+        lines += "-X ${request.method.uppercase()}"
+    }
+    lines += "'${request.url.escapeSingleQuotes()}'"
+    request.headers.forEach { (name, values) ->
+        if (name.equals("Content-Length", ignoreCase = true)) return@forEach
+        values.forEach { value ->
+            lines += "-H '${"$name: $value".escapeSingleQuotes()}'"
+        }
+    }
+    request.body?.let { body ->
+        lines += "--data '${body.escapeSingleQuotes()}'"
+    }
+    val command = lines.joinToString(" \\\n  ")
+    return if (request.bodyTruncated) "# NOTE: request body was truncated at capture time\n$command" else command
+}
+
+private fun String.escapeSingleQuotes(): String = replace("'", "'\\''")

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/CopyTransaction.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/CopyTransaction.kt
@@ -16,8 +16,10 @@ internal fun copyToClipboard(text: String) {
  * a partial body.
  */
 internal fun buildCurlCommand(request: CapturedHttpRequest): String {
-    val lines = mutableListOf("curl")
-    if (!request.method.equals("GET", ignoreCase = true)) {
+    // --globoff: curl expands [] and {} in URLs itself, even inside shell quotes.
+    val lines = mutableListOf("curl --globoff")
+    // -X GET must be explicit when a body is present, or --data-raw switches the method to POST.
+    if (!request.method.equals("GET", ignoreCase = true) || request.body != null) {
         lines += "-X ${request.method.uppercase()}"
     }
     lines += "'${request.url.escapeSingleQuotes()}'"
@@ -28,7 +30,8 @@ internal fun buildCurlCommand(request: CapturedHttpRequest): String {
         }
     }
     request.body?.let { body ->
-        lines += "--data '${body.escapeSingleQuotes()}'"
+        // --data-raw, not --data: a body starting with @ must not be read as a file reference.
+        lines += "--data-raw '${body.escapeSingleQuotes()}'"
     }
     val command = lines.joinToString(" \\\n  ")
     return if (request.bodyTruncated) "# NOTE: request body was truncated at capture time\n$command" else command

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/CopyTransaction.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/CopyTransaction.kt
@@ -9,17 +9,25 @@ internal fun copyToClipboard(text: String) {
 }
 
 /**
+ * Adapters record bodies they can't read (streaming/binary) as a single `<...>` marker such as
+ * `<streaming request body>` or `<application/json>`. Real XML/HTML bodies contain nested tags
+ * with more than one `<`/`>`, so they don't match.
+ */
+private val PLACEHOLDER_BODY = Regex("^<[^<>]+>$")
+
+/**
  * Rebuilds the captured request as a shell-pasteable `curl` command.
  *
  * Content-Length is dropped (curl derives it from the body). A truncated capture can't be
  * replayed faithfully, so it's flagged with a leading comment instead of silently emitting
- * a partial body.
+ * a partial body; a placeholder body is omitted entirely and flagged the same way.
  */
 internal fun buildCurlCommand(request: CapturedHttpRequest): String {
+    val body = request.body?.takeUnless { it.matches(PLACEHOLDER_BODY) }
     // --globoff: curl expands [] and {} in URLs itself, even inside shell quotes.
     val lines = mutableListOf("curl --globoff")
     // -X GET must be explicit when a body is present, or --data-raw switches the method to POST.
-    if (!request.method.equals("GET", ignoreCase = true) || request.body != null) {
+    if (!request.method.equals("GET", ignoreCase = true) || body != null) {
         lines += "-X ${request.method.uppercase()}"
     }
     lines += "'${request.url.escapeSingleQuotes()}'"
@@ -29,12 +37,17 @@ internal fun buildCurlCommand(request: CapturedHttpRequest): String {
             lines += "-H '${"$name: $value".escapeSingleQuotes()}'"
         }
     }
-    request.body?.let { body ->
+    body?.let {
         // --data-raw, not --data: a body starting with @ must not be read as a file reference.
-        lines += "--data-raw '${body.escapeSingleQuotes()}'"
+        lines += "--data-raw '${it.escapeSingleQuotes()}'"
     }
     val command = lines.joinToString(" \\\n  ")
-    return if (request.bodyTruncated) "# NOTE: request body was truncated at capture time\n$command" else command
+    val note = when {
+        body == null && request.body != null -> "# NOTE: request body was not captured (${request.body}); the command omits it\n"
+        request.bodyTruncated -> "# NOTE: request body was truncated at capture time\n"
+        else -> ""
+    }
+    return note + command
 }
 
 private fun String.escapeSingleQuotes(): String = replace("'", "'\\''")

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
@@ -1,5 +1,7 @@
 package com.kitakkun.jetwhale.plugins.network.host
 
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
@@ -127,11 +129,13 @@ internal fun TrafficTab(
                     },
             ) {
                 items(visible, key = { it.txId }) { tx ->
-                    TransactionRow(
-                        tx = tx,
-                        selected = tx.txId == selectedTxId,
-                        onClick = { selectedTxId = tx.txId },
-                    )
+                    ContextMenuArea(items = { transactionContextMenuItems(tx) }) {
+                        TransactionRow(
+                            tx = tx,
+                            selected = tx.txId == selectedTxId,
+                            onClick = { selectedTxId = tx.txId },
+                        )
+                    }
                     HorizontalDivider()
                 }
             }
@@ -154,6 +158,17 @@ internal fun TrafficTab(
                 }
             }
         }
+    }
+}
+
+private fun transactionContextMenuItems(tx: HttpTransaction): List<ContextMenuItem> = buildList {
+    add(ContextMenuItem("Copy as cURL") { copyToClipboard(buildCurlCommand(tx.request)) })
+    add(ContextMenuItem("Copy URL") { copyToClipboard(tx.request.url) })
+    tx.request.body?.let { body ->
+        add(ContextMenuItem("Copy request body") { copyToClipboard(body) })
+    }
+    tx.response?.body?.let { body ->
+        add(ContextMenuItem("Copy response body") { copyToClipboard(body) })
     }
 }
 

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/CopyTransactionTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/CopyTransactionTest.kt
@@ -1,0 +1,91 @@
+package com.kitakkun.jetwhale.plugins.network.host
+
+import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CopyTransactionTest {
+
+    private fun request(
+        method: String = "GET",
+        url: String = "https://example.com/items",
+        headers: Map<String, List<String>> = emptyMap(),
+        body: String? = null,
+        bodyTruncated: Boolean = false,
+    ) = CapturedHttpRequest(
+        txId = "tx",
+        method = method,
+        url = url,
+        headers = headers,
+        body = body,
+        bodyTruncated = bodyTruncated,
+        timestampMs = 0L,
+    )
+
+    @Test
+    fun getWithoutBody_omitsExplicitMethod() {
+        val command = buildCurlCommand(request())
+        assertFalse("-X" in command)
+        assertTrue(command.startsWith("curl --globoff"))
+    }
+
+    @Test
+    fun getWithBody_keepsMethodExplicit() {
+        val command = buildCurlCommand(request(body = """{"q":1}"""))
+        assertTrue("-X GET" in command)
+    }
+
+    @Test
+    fun bodyUsesDataRaw() {
+        val command = buildCurlCommand(request(method = "POST", body = "@payload.json"))
+        assertTrue("--data-raw '@payload.json'" in command)
+        assertFalse("--data '" in command)
+    }
+
+    @Test
+    fun nonGetMethodIsUppercasedAndExplicit() {
+        val command = buildCurlCommand(request(method = "delete"))
+        assertTrue("-X DELETE" in command)
+    }
+
+    @Test
+    fun contentLengthHeaderIsDropped() {
+        val command = buildCurlCommand(
+            request(
+                method = "POST",
+                headers = mapOf("Content-Length" to listOf("42"), "Accept" to listOf("application/json")),
+                body = "{}",
+            ),
+        )
+        assertFalse("Content-Length" in command)
+        assertTrue("-H 'Accept: application/json'" in command)
+    }
+
+    @Test
+    fun singleQuotesAreEscaped() {
+        val command = buildCurlCommand(request(method = "POST", body = "it's"))
+        assertTrue("""--data-raw 'it'\''s'""" in command)
+    }
+
+    @Test
+    fun truncatedBodyIsFlaggedWithLeadingComment() {
+        val command = buildCurlCommand(request(method = "POST", body = "partial", bodyTruncated = true))
+        assertTrue(command.startsWith("# NOTE: request body was truncated at capture time\n"))
+    }
+
+    @Test
+    fun linesAreJoinedAsShellContinuations() {
+        val command = buildCurlCommand(request(method = "POST", body = "{}"))
+        assertEquals(
+            """
+            curl --globoff \
+              -X POST \
+              'https://example.com/items' \
+              --data-raw '{}'
+            """.trimIndent(),
+            command,
+        )
+    }
+}

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/CopyTransactionTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/CopyTransactionTest.kt
@@ -70,6 +70,29 @@ class CopyTransactionTest {
     }
 
     @Test
+    fun placeholderBodyIsOmittedAndFlagged() {
+        val command = buildCurlCommand(request(method = "POST", body = "<streaming request body>"))
+        assertFalse("--data-raw" in command)
+        assertTrue("-X POST" in command)
+        assertTrue(command.startsWith("# NOTE: request body was not captured (<streaming request body>); the command omits it\n"))
+    }
+
+    @Test
+    fun contentTypePlaceholderBodyIsOmitted() {
+        val command = buildCurlCommand(request(method = "GET", body = "<application/json>"))
+        assertFalse("--data-raw" in command)
+        assertFalse("-X" in command)
+        assertTrue(command.startsWith("# NOTE: request body was not captured"))
+    }
+
+    @Test
+    fun xmlBodyIsNotMistakenForPlaceholder() {
+        val command = buildCurlCommand(request(method = "POST", body = "<a><b/></a>"))
+        assertTrue("--data-raw '<a><b/></a>'" in command)
+        assertFalse("# NOTE" in command)
+    }
+
+    @Test
     fun truncatedBodyIsFlaggedWithLeadingComment() {
         val command = buildCurlCommand(request(method = "POST", body = "partial", bodyTruncated = true))
         assertTrue(command.startsWith("# NOTE: request body was truncated at capture time\n"))


### PR DESCRIPTION
## Summary

Adds a right-click context menu to the Network Inspector's traffic list. Menu
items on each transaction row:

- **Copy as cURL** — rebuilds the captured request as a shell-pasteable `curl`
  command
- **Copy URL**
- **Copy request body** / **Copy response body** (shown only when a body exists)

## cURL generation

The command is emitted multi-line (`\` continuations) with single quotes escaped
as `'\''`. Correctness details:

- `-X <METHOD>` is emitted for non-GET, and **also for GET with a body** —
  otherwise `--data-raw` would silently switch the replay to POST.
- `--data-raw` instead of `--data`, so a body starting with `@` is not
  interpreted as a file reference.
- `--globoff`, because curl expands `[]`/`{}` in URLs itself, even inside shell
  quotes.
- `Content-Length` is dropped (curl derives it from the body it actually sends).
- A body that was truncated at capture time can't be replayed faithfully, so the
  command is prefixed with a `# NOTE: request body was truncated at capture
  time` comment instead of silently emitting a partial body.
- Adapters record unreadable (streaming/binary) request bodies as a `<...>`
  placeholder marker; such bodies are **omitted** from the command and flagged
  with a leading `# NOTE:` comment, like the truncated case — never emitted
  verbatim as `--data-raw` payload.

## Validation

- `CopyTransactionTest` covers each generation rule above (method/body
  combinations, quoting, globbing, header filtering, truncation flag,
  placeholder-body omission).
- Manually verified: copied commands replay correctly against JSONPlaceholder
  from a shell.
