### PR TITLE
fix(agent): make the agent message queue and sender thread-safe

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotli
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinxCollectionsImmutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+kotlinxAtomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version = "0.29.0" }
 byteBuddyAgent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "byteBuddy" }
 kotlinxDatetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 

--- a/jetwhale-agent-sdk/build.gradle.kts
+++ b/jetwhale-agent-sdk/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
     commonMainApi(projects.jetwhaleProtocol.core)
     commonMainApi(projects.jetwhaleProtocol.agent)
     commonMainImplementation(libs.kotlinxCoroutinesCore)
+    commonMainImplementation(libs.kotlinxAtomicfu)
+    jvmTestImplementation(libs.kotlinTest)
+    jvmTestImplementation(libs.kotlinxCoroutinesCore)
 }
 
 jetwhalePublish {

--- a/jetwhale-agent-sdk/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/sdk/JetWhaleRawAgentPlugin.kt
+++ b/jetwhale-agent-sdk/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/sdk/JetWhaleRawAgentPlugin.kt
@@ -1,6 +1,8 @@
 package com.kitakkun.jetwhale.agent.sdk
 
 import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 
 /**
  * An abstract class representing a raw agent plugin for JetWhale.
@@ -35,6 +37,12 @@ public abstract class JetWhaleRawAgentPlugin {
     private val queue: JetWhaleAgentMessageQueue = JetWhaleAgentMessageQueue(bufferSize = queueBufferSize())
 
     /**
+     * Guards [sender] and [queue]: events can be enqueued from any thread (e.g. interceptors on
+     * OkHttp/Ktor worker threads) while the messaging service attaches or detaches the sender.
+     */
+    private val lock = SynchronizedObject()
+
+    /**
      * The size of the message queue buffer.
      * When the buffer is full, the oldest messages will be discarded.
      */
@@ -52,11 +60,10 @@ public abstract class JetWhaleRawAgentPlugin {
      */
     @InternalJetWhaleApi
     public fun enqueueRawEvent(message: String) {
-        if (sender != null) {
-            sender?.send(message)
-            return
+        synchronized(lock) {
+            val sender = sender
+            if (sender != null) sender.send(message) else queue.enqueue(message)
         }
-        queue.enqueue(message)
     }
 
     /**
@@ -65,10 +72,12 @@ public abstract class JetWhaleRawAgentPlugin {
      */
     @InternalJetWhaleApi
     public fun activate(sender: JetWhaleMessageSender) {
-        // Flush before setting sender to ensure queued messages are sent
-        // before any new messages from concurrent enqueueRawEvent calls.
-        flushQueue(sender)
-        this.sender = sender
+        synchronized(lock) {
+            // Flush before setting sender to ensure queued messages are sent
+            // before any new messages from concurrent enqueueRawEvent calls.
+            flushQueue(sender)
+            this.sender = sender
+        }
     }
 
     /**
@@ -76,7 +85,9 @@ public abstract class JetWhaleRawAgentPlugin {
      */
     @InternalJetWhaleApi
     public fun deactivate() {
-        this.sender = null
+        synchronized(lock) {
+            this.sender = null
+        }
     }
 
     /**

--- a/jetwhale-agent-sdk/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/sdk/JetWhaleRawAgentPluginTest.kt
+++ b/jetwhale-agent-sdk/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/sdk/JetWhaleRawAgentPluginTest.kt
@@ -1,0 +1,54 @@
+package com.kitakkun.jetwhale.agent.sdk
+
+import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(InternalJetWhaleApi::class)
+class JetWhaleRawAgentPluginTest {
+
+    private class TestPlugin : JetWhaleRawAgentPlugin() {
+        override val pluginId: String = "test"
+        override val pluginVersion: String = "1.0.0"
+        override suspend fun onRawMethod(message: String): String? = null
+        override fun queueBufferSize(): Int = 100_000
+    }
+
+    @Test
+    fun concurrentEnqueueAndActivate_losesNoMessages() {
+        val plugin = TestPlugin()
+        val received = Collections.synchronizedList(mutableListOf<String>())
+        val threadCount = 8
+        val messagesPerThread = 1_000
+        val start = CountDownLatch(1)
+        val workers = (0 until threadCount).map { t ->
+            Thread {
+                start.await()
+                repeat(messagesPerThread) { i -> plugin.enqueueRawEvent("$t-$i") }
+            }.apply { start() }
+        }
+
+        start.countDown()
+        // Attach the sender while producers are running, so the queue flush races the enqueues.
+        plugin.activate { messages -> received += messages }
+        workers.forEach { it.join() }
+
+        assertEquals(threadCount * messagesPerThread, received.size)
+        assertEquals(received.size, received.toSet().size)
+    }
+
+    @Test
+    fun eventsQueuedBeforeActivation_areFlushedInOrder() {
+        val plugin = TestPlugin()
+        plugin.enqueueRawEvent("first")
+        plugin.enqueueRawEvent("second")
+        val received = mutableListOf<String>()
+
+        plugin.activate { messages -> received += messages }
+        plugin.enqueueRawEvent("third")
+
+        assertEquals(listOf("first", "second", "third"), received)
+    }
+}


### PR DESCRIPTION
## Problem

`enqueueRawEvent` runs on arbitrary threads — network adapters record traffic
from whatever thread the request happens to run on (OkHttp dispatcher threads,
Ktor worker threads) — while the messaging service attaches or detaches the
sender concurrently. But the pending-message queue was a plain `ArrayDeque` and
the `sender` field non-volatile, so under concurrent traffic events could be
dropped or duplicated, or crash inside the deque. The flush-then-attach sequence
in `activate()` was also not atomic: an event enqueued between the flush and the
field assignment could be lost or reordered.

## Fix

Guard `sender` and the queue with a common lock (`kotlinx-atomicfu`'s
`SynchronizedObject`, so it stays multiplatform):

- `enqueueRawEvent` reads the sender and either sends or enqueues under the
  lock.
- `activate()` flushes the queue and installs the sender as one atomic step,
  preserving the "queued messages first, then live messages" ordering.
- `deactivate()` clears the sender under the same lock.

## Validation

- New `JetWhaleRawAgentPluginTest`:
  - 8 threads × 1,000 events racing against `activate()` — no message lost, no
    duplicates.
  - Events queued before activation are flushed in order, followed by live
    events.
