### PR TITLE
refactor(network): align the Ktor adapter's intercept flow with the OkHttp adapter

### DIFF
--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
@@ -4,6 +4,8 @@ import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
 import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
 import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse
 import com.kitakkun.jetwhale.plugins.network.protocol.HttpRequestFailure
+import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
+import io.ktor.client.HttpClient
 import io.ktor.client.call.HttpClientCall
 import io.ktor.client.call.save
 import io.ktor.client.plugins.api.ClientPlugin
@@ -22,7 +24,10 @@ import io.ktor.util.StringValues
 import io.ktor.util.date.GMTDate
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.InternalAPI
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 
 /**
@@ -42,7 +47,6 @@ import kotlin.time.TimeSource
  *
  * @param maxBodyChars request/response bodies longer than this are truncated for transport.
  */
-@OptIn(InternalAPI::class) // HttpClientCall's constructor is needed to synthesize mock responses.
 fun JetWhaleNetworkAgentPlugin.ktorClientPlugin(maxBodyChars: Int = 100_000): ClientPlugin<Unit> {
     val agent = this
     return createClientPlugin("JetWhaleNetworkMonitor") {
@@ -52,135 +56,117 @@ fun JetWhaleNetworkAgentPlugin.ktorClientPlugin(maxBodyChars: Int = 100_000): Cl
             val method = request.method.value
             val url = request.url.buildString()
 
-            val requestBody = captureOutgoingBody(request.body, maxBodyChars)
-            agent.recordRequest(
-                CapturedHttpRequest(
+            agent.recordRequest(request, txId, method, url, maxBodyChars)
+            val mock = agent.findMock(method, url)
+
+            val call = if (mock != null) {
+                serveMock(client, request, mock)
+            } else {
+                try {
+                    proceed(request)
+                } catch (cause: Throwable) {
+                    agent.recordFailure(
+                        HttpRequestFailure(
+                            txId = txId,
+                            message = cause.message ?: cause.toString(),
+                            durationMs = started.elapsedNow().inWholeMilliseconds,
+                        ),
+                    )
+                    throw cause
+                }
+            }
+
+            val (readableCall, body) = captureResponseBodySafely(call, maxBodyChars)
+            agent.recordResponse(
+                CapturedHttpResponse(
                     txId = txId,
-                    method = method,
-                    url = url,
-                    headers = request.capturedRequestHeaders(),
-                    body = requestBody.text,
-                    bodyTruncated = requestBody.truncated,
-                    timestampMs = GMTDate().timestamp,
+                    statusCode = readableCall.response.status.value,
+                    statusDescription = readableCall.response.status.description,
+                    headers = readableCall.response.headers.toCapturedMap(),
+                    body = body.text,
+                    bodyTruncated = body.truncated,
+                    durationMs = started.elapsedNow().inWholeMilliseconds,
+                    fromMock = mock != null,
                 ),
             )
-
-            agent.findMock(method, url)?.let { mock ->
-                if (mock.delayMs > 0) delay(mock.delayMs)
-                val status = HttpStatusCode.fromValue(mock.statusCode)
-                agent.recordResponse(
-                    CapturedHttpResponse(
-                        txId = txId,
-                        statusCode = mock.statusCode,
-                        statusDescription = status.description,
-                        headers = mock.headers.mapValues { listOf(it.value) },
-                        body = mock.body,
-                        durationMs = started.elapsedNow().inWholeMilliseconds,
-                        fromMock = true,
-                    ),
-                )
-                val responseData = HttpResponseData(
-                    statusCode = status,
-                    requestTime = GMTDate(),
-                    headers = HeadersBuilder().apply {
-                        mock.headers.forEach { (key, value) -> append(key, value) }
-                    }.build(),
-                    version = HttpProtocolVersion.HTTP_1_1,
-                    body = ByteReadChannel(mock.body.encodeToByteArray()),
-                    callContext = this.coroutineContext,
-                )
-                return@on HttpClientCall(client, request.build(), responseData)
-            }
-
-            try {
-                val rawCall = proceed(request)
-                val rawResponse = rawCall.response
-
-                // A WebSocket upgrade response (101) has no conventional body — by the time this
-                // plugin sees it, the connection has already switched to the raw frame stream, so
-                // save()/bodyAsText() would read live WebSocket frames as if they were an HTTP
-                // body, corrupting the frame stream for the caller. Record a placeholder instead
-                // of touching the body, and return the untouched call.
-                if (rawResponse.isWebSocketUpgrade()) {
-                    agent.recordResponse(
-                        CapturedHttpResponse(
-                            txId = txId,
-                            statusCode = rawResponse.status.value,
-                            statusDescription = rawResponse.status.description,
-                            headers = rawResponse.headers.toCapturedMap(),
-                            body = "<websocket upgrade>",
-                            bodyTruncated = false,
-                            durationMs = started.elapsedNow().inWholeMilliseconds,
-                            fromMock = false,
-                        ),
-                    )
-                    return@on rawCall
-                }
-
-                // save() buffers the entire body before returning, so on a never-ending stream
-                // (SSE) the caller would wait forever for a response that has already started
-                // arriving. Record a placeholder and hand back the untouched call, mirroring the
-                // OkHttp adapter.
-                val contentType = rawResponse.headers[HttpHeaders.ContentType]
-                if (contentType?.startsWith("text/event-stream", ignoreCase = true) == true) {
-                    agent.recordResponse(
-                        CapturedHttpResponse(
-                            txId = txId,
-                            statusCode = rawResponse.status.value,
-                            statusDescription = rawResponse.status.description,
-                            headers = rawResponse.headers.toCapturedMap(),
-                            body = "<streaming response body>",
-                            bodyTruncated = false,
-                            durationMs = started.elapsedNow().inWholeMilliseconds,
-                            fromMock = false,
-                        ),
-                    )
-                    return@on rawCall
-                }
-
-                // save() buffers the body so we can read it for inspection and still hand a
-                // fresh, readable response to the caller.
-                val call = rawCall.save()
-                val response = call.response
-                val responseBody = response.bodyAsText().truncate(maxBodyChars)
-                agent.recordResponse(
-                    CapturedHttpResponse(
-                        txId = txId,
-                        statusCode = response.status.value,
-                        statusDescription = response.status.description,
-                        headers = response.headers.toCapturedMap(),
-                        body = responseBody.text,
-                        bodyTruncated = responseBody.truncated,
-                        durationMs = started.elapsedNow().inWholeMilliseconds,
-                        fromMock = false,
-                    ),
-                )
-                call
-            } catch (cause: Throwable) {
-                agent.recordFailure(
-                    HttpRequestFailure(
-                        txId = txId,
-                        message = cause.message ?: cause.toString(),
-                        durationMs = started.elapsedNow().inWholeMilliseconds,
-                    ),
-                )
-                throw cause
-            }
+            readableCall
         }
     }
+}
+
+private fun JetWhaleNetworkAgentPlugin.recordRequest(request: HttpRequestBuilder, txId: String, method: String, url: String, maxBodyChars: Int) {
+    val body = captureRequestBodySafely(request.body, maxBodyChars)
+    recordRequest(
+        CapturedHttpRequest(
+            txId = txId,
+            method = method,
+            url = url,
+            headers = request.capturedRequestHeaders(),
+            body = body.text,
+            bodyTruncated = body.truncated,
+            timestampMs = GMTDate().timestamp,
+        ),
+    )
+}
+
+@OptIn(InternalAPI::class) // HttpClientCall's constructor is needed to synthesize mock responses.
+private suspend fun serveMock(client: HttpClient, request: HttpRequestBuilder, mock: MockResponseSpec): HttpClientCall {
+    if (mock.delayMs > 0) delay(mock.delayMs.milliseconds)
+    val responseData = HttpResponseData(
+        statusCode = HttpStatusCode.fromValue(mock.statusCode),
+        requestTime = GMTDate(),
+        headers = HeadersBuilder().apply {
+            mock.headers.forEach { (key, value) -> append(key, value) }
+        }.build(),
+        version = HttpProtocolVersion.HTTP_1_1,
+        body = ByteReadChannel(mock.body.encodeToByteArray()),
+        callContext = currentCoroutineContext(),
+    )
+    return HttpClientCall(client, request.build(), responseData)
 }
 
 private data class BodyCapture(val text: String?, val truncated: Boolean)
 
 private fun String.truncate(max: Int): BodyCapture = if (length <= max) BodyCapture(this, false) else BodyCapture(substring(0, max), true)
 
-private fun captureOutgoingBody(content: Any?, maxChars: Int): BodyCapture = when (content) {
+/**
+ * Reads the request body for capture without breaking the actual send: channel/stream bodies
+ * that can't be read without consuming them are replaced with a placeholder instead.
+ */
+private fun captureRequestBodySafely(content: Any?, maxChars: Int): BodyCapture = when (content) {
     is OutgoingContent.ByteArrayContent -> content.bytes().decodeToString().truncate(maxChars)
-
-    // Channel/stream bodies cannot be read here without consuming them; describe them instead.
     is OutgoingContent -> BodyCapture(content.contentType?.let { "<$it>" }, false)
-
     else -> BodyCapture(null, false)
+}
+
+/**
+ * Reads the response body for capture without consuming or blocking the caller's response:
+ * bodies that can't be buffered safely (WebSocket upgrades, endless streams) are replaced with a
+ * placeholder instead. Returns the call the caller should receive — the original one when the
+ * body was left untouched, or a saved copy whose body is still readable.
+ */
+private suspend fun captureResponseBodySafely(call: HttpClientCall, maxChars: Int): Pair<HttpClientCall, BodyCapture> {
+    val response = call.response
+
+    // A WebSocket upgrade response (101) has no conventional body — by the time this plugin sees
+    // it, the connection has already switched to the raw frame stream, so save()/bodyAsText()
+    // would read live WebSocket frames as if they were an HTTP body, corrupting the frame stream
+    // for the caller.
+    if (response.isWebSocketUpgrade()) {
+        return call to BodyCapture("<websocket upgrade>", false)
+    }
+
+    // save() buffers the entire body before returning, so on a never-ending stream (SSE) the
+    // caller would wait forever for a response that has already started arriving.
+    val contentType = response.headers[HttpHeaders.ContentType]
+    if (contentType?.startsWith("text/event-stream", ignoreCase = true) == true) {
+        return call to BodyCapture("<streaming response body>", false)
+    }
+
+    // save() buffers the body so we can read it for inspection and still hand a fresh, readable
+    // response to the caller.
+    val saved = call.save()
+    return saved to saved.response.bodyAsText().truncate(maxChars)
 }
 
 private fun StringValues.toCapturedMap(): Map<String, List<String>> = entries().associate { it.key to it.value }
@@ -193,20 +179,16 @@ private fun HttpResponse.isWebSocketUpgrade(): Boolean = status == HttpStatusCod
  * Content-Type / Content-Length and any body-level headers. Headers injected later by the engine
  * (e.g. User-Agent, Accept-Encoding, Host) are not visible to a client plugin and are omitted.
  */
-private fun HttpRequestBuilder.capturedRequestHeaders(): Map<String, List<String>> {
-    val result = LinkedHashMap<String, List<String>>()
-    headers.build().entries().forEach { (key, value) -> result[key] = value }
-    val content = body
-    if (content is OutgoingContent) {
-        content.contentType?.let { type ->
-            if ("Content-Type" !in result) result["Content-Type"] = listOf(type.toString())
-        }
-        content.contentLength?.let { length ->
-            if ("Content-Length" !in result) result["Content-Length"] = listOf(length.toString())
-        }
-        content.headers.entries().forEach { (key, value) ->
-            if (key !in result) result[key] = value
-        }
+private fun HttpRequestBuilder.capturedRequestHeaders(): Map<String, List<String>> = buildMap {
+    putAll(headers.build().toCapturedMap())
+    val content = body as? OutgoingContent ?: return@buildMap
+    content.contentType?.let { type ->
+        if (!containsKey("Content-Type")) put("Content-Type", listOf(type.toString()))
     }
-    return result
+    content.contentLength?.let { length ->
+        if (!containsKey("Content-Length")) put("Content-Length", listOf(length.toString()))
+    }
+    content.headers.entries().forEach { (key, value) ->
+        if (!containsKey(key)) put(key, value)
+    }
 }

--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
@@ -26,7 +26,6 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.InternalAPI
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
-import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 

--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
@@ -63,15 +63,15 @@ fun JetWhaleNetworkAgentPlugin.ktorClientPlugin(maxBodyChars: Int = 100_000): Cl
             } else {
                 try {
                     proceed(request)
-                } catch (cause: Throwable) {
+                } catch (e: Throwable) {
                     agent.recordFailure(
                         HttpRequestFailure(
                             txId = txId,
-                            message = cause.message ?: cause.toString(),
+                            message = e.message ?: e.toString(),
                             durationMs = started.elapsedNow().inWholeMilliseconds,
                         ),
                     )
-                    throw cause
+                    throw e
                 }
             }
 

--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
@@ -75,20 +75,20 @@ fun JetWhaleNetworkAgentPlugin.ktorClientPlugin(maxBodyChars: Int = 100_000): Cl
                 }
             }
 
-            val (readableCall, body) = captureResponseBodySafely(call, maxBodyChars)
+            val (callToReturn, body) = captureResponseBodySafely(call, maxBodyChars)
             agent.recordResponse(
                 CapturedHttpResponse(
                     txId = txId,
-                    statusCode = readableCall.response.status.value,
-                    statusDescription = readableCall.response.status.description,
-                    headers = readableCall.response.headers.toCapturedMap(),
+                    statusCode = callToReturn.response.status.value,
+                    statusDescription = callToReturn.response.status.description,
+                    headers = callToReturn.response.headers.toCapturedMap(),
                     body = body.text,
                     bodyTruncated = body.truncated,
                     durationMs = started.elapsedNow().inWholeMilliseconds,
                     fromMock = mock != null,
                 ),
             )
-            readableCall
+            callToReturn
         }
     }
 }

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.decodeFromString
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
 
 class JetWhaleNetworkKtorPluginTest {
 
@@ -43,7 +44,7 @@ class JetWhaleNetworkKtorPluginTest {
     }
 
     @Test
-    fun sseResponse_returnsWithoutBufferingBody() = runBlocking {
+    fun `returns an SSE response without buffering its body`() = runBlocking {
         val (agent, events) = agentWithEvents()
         // A channel that receives data but is never closed — save() would suspend on it forever.
         val stream = ByteChannel(autoFlush = true)
@@ -62,7 +63,7 @@ class JetWhaleNetworkKtorPluginTest {
 
         // Streaming execution (as the SSE plugin does) skips Ktor's own SaveBody plugin; without
         // the guard, the JetWhale plugin's save() would suspend on the endless channel forever.
-        val statusCode = withTimeout(5_000) {
+        val statusCode = withTimeout(5_000.milliseconds) {
             client.prepareGet("http://example/sse").execute { response -> response.status.value }
         }
 
@@ -73,7 +74,7 @@ class JetWhaleNetworkKtorPluginTest {
     }
 
     @Test
-    fun regularResponse_isStillCaptured() = runBlocking {
+    fun `captures a regular response body without breaking the caller's read`() = runBlocking {
         val (agent, events) = agentWithEvents()
         val client = HttpClient(
             MockEngine {


### PR DESCRIPTION
## Summary

Restructures the Ktor plugin to mirror the OkHttp interceptor introduced in #110:

- **Flat main flow** in `on(Send)`: record request → find mock → serve mock / proceed → capture → record response, instead of duplicating `recordResponse` at every early-return guard.
- **Per-concern helpers** with the same names as the OkHttp adapter: `serveMock`, `captureRequestBodySafely`, `captureResponseBodySafely`. The WebSocket-upgrade and SSE placeholder guards now live in `captureResponseBodySafely`, which returns the call the caller should receive (the untouched one, or a `save()`d readable copy) together with the capture.
- **Mock responses are recorded through the same path as real ones.** Small behavior change: a mock body longer than `maxBodyChars` is now flagged `bodyTruncated`, matching the OkHttp adapter.
- Tests renamed to sentence-style backtick names, matching the OkHttp adapter's tests.

No public API changes.

## Stacking

Stacked on #111 — the base includes its WebSocket/SSE guard fixes and the WebSocket upgrade test. Please merge #111 first; this PR's own diff is the last commit (`c380d99a`).