### PR TITLE
Apply the JetWhale host plugin conventions to network:host

### DIFF
--- a/jetwhale-plugins/network/host/build.gradle.kts
+++ b/jetwhale-plugins/network/host/build.gradle.kts
@@ -1,10 +1,16 @@
 plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.compose)
+    alias(libs.plugins.jetwhalePlugin)
+    alias(libs.plugins.jetwhaleHostLaunch)
 }
 
 // Distinct group so this module's coordinates don't collide with `example:host`.
 group = "com.kitakkun.jetwhale.plugins.network"
+
+jetwhalePlugin {
+    pluginArchiveName.set("jetwhale-network-inspector")
+}
 
 dependencies {
     compileOnly(projects.jetwhaleHostSdk)
@@ -12,16 +18,4 @@ dependencies {
     compileOnly(libs.kotlinxSerializationJson)
     api(projects.jetwhalePlugins.network.protocol)
     testImplementation(libs.kotlinTest)
-}
-
-tasks.jar {
-    // Unique name so the fat jar doesn't collide with `example:host` (also project name "host").
-    archiveBaseName = "jetwhale-network-inspector"
-
-    val dependencies = configurations
-        .runtimeClasspath
-        .get()
-        .map(::zipTree)
-    from(dependencies)
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }


### PR DESCRIPTION
## Summary
- Apply the published `com.kitakkun.jetwhale.host` plugin and the in-repo `jetwhale-host-launch` convention to `:jetwhale-plugins:network:host`, matching `example:host`.
- This provides `packagePlugin` / `installPlugin` / `stageDevPlugin` / `runJetWhale` / `runJetWhaleHot` / `runJetWhaleLocal` for developing and verifying the network plugin against a local host.
- Remove the hand-written fat-jar `tasks.jar` block, which `packagePlugin` replaces; the archive-name collision guard against `example:host` moves to `jetwhalePlugin.pluginArchiveName`.

## Verification
- `./gradlew :jetwhale-plugins:network:host:tasks --group jetwhale` lists all the jetwhale tasks.
- `./gradlew :jetwhale-plugins:network:host:stageDevPlugin` stages `jetwhale-network-inspector-1.0.0-alpha07-jetwhale-plugin.jar` into `build/jetwhale/devPlugins`.