### PR TITLE
chore: bump version to 1.0.0-alpha08

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jetwhale = "1.0.0-alpha07"
+jetwhale = "1.0.0-alpha08"
 mavenPublish = "0.36.0"
 
 # kotlin


### PR DESCRIPTION
Bump the `jetwhale` version to `1.0.0-alpha08` for the next development cycle, following the 1.0.0-alpha07 release.