### PR TITLE
fix: apply app name and icon when launched via Gradle run tasks

### DIFF
--- a/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
@@ -37,14 +37,18 @@ tasks.register<JavaExec>("runJetWhaleLocal") {
     // Point the host at the dev plugins directory; this enables dev-mode loading + hot reload.
     // Supplied lazily via a CommandLineArgumentProvider so the task stays configuration-cache safe.
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
+    val osName = providers.systemProperty("os.name")
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
-            listOf(
-                "-Djetwhale.devPluginsDir=${devDirProvider.get()}",
+            buildList {
+                add("-Djetwhale.devPluginsDir=${devDirProvider.get()}")
                 // Allow the dev hot-reload to self-attach a JVM agent (byte-buddy-agent) for in-place
                 // class redefinition; self-attach is disabled by default on JDK 9+.
-                "-Djdk.attach.allowAttachSelf=true",
-            )
+                add("-Djdk.attach.allowAttachSelf=true")
+                // The macOS Dock name (hover text) comes from the bundle name, which for a bare JVM
+                // can only be set via -Xdock:name at launch — it is not settable at runtime.
+                if (osName.getOrElse("").contains("mac", ignoreCase = true)) add("-Xdock:name=JetWhale")
+            }
         },
     )
 }

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -267,10 +267,14 @@ fun registerRunTask(name: String, taskDescription: String, hot: Boolean) = tasks
     }
 
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
+    val osName = providers.systemProperty("os.name")
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
             buildList {
                 add("-Djetwhale.devPluginsDir=${devDirProvider.get()}")
+                // The macOS Dock name (hover text) comes from the bundle name, which for a bare JVM
+                // can only be set via -Xdock:name at launch — it is not settable at runtime.
+                if (osName.getOrElse("").contains("mac", ignoreCase = true)) add("-Xdock:name=JetWhale")
                 // Self-attach for the dev hot-reload's in-place class redefinition (off by default
                 // on JDK 9+).
                 add("-Djdk.attach.allowAttachSelf=true")

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
@@ -19,8 +19,33 @@ import com.kitakkun.jetwhale.host.di.JetWhaleAppGraph
 import com.kitakkun.jetwhale.host.ui.isShortcutModifierPressed
 import dev.zacsweers.metro.createGraph
 import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.painterResource
+import java.awt.Taskbar
+import javax.imageio.ImageIO
+
+/**
+ * Applies the application name and icon at runtime so they are correct even when the host is
+ * launched as a plain JVM process (e.g. the `runJetWhale`/`runJetWhaleLocal` Gradle tasks or
+ * `java -jar` on the uber jar). Packaged distributions get them from the installer metadata,
+ * where these calls are harmless no-ops.
+ */
+private fun configureAppMetadata() {
+    // Read by macOS AWT during initialization, so this must run before any AWT class is touched.
+    System.setProperty("apple.awt.application.name", "JetWhale")
+
+    if (Taskbar.isTaskbarSupported()) {
+        val taskbar = Taskbar.getTaskbar()
+        if (taskbar.isSupported(Taskbar.Feature.ICON_IMAGE)) {
+            object {}.javaClass.getResource("/icon.png")?.let { iconUrl ->
+                taskbar.iconImage = ImageIO.read(iconUrl)
+            }
+        }
+    }
+}
 
 fun main(args: Array<String>) = runBlocking {
+    configureAppMetadata()
+
     CommandLineArgumentsParser().parse(args)
 
     val appGraph: JetWhaleAppGraph = createGraph()
@@ -49,6 +74,7 @@ fun main(args: Array<String>) = runBlocking {
 
         Window(
             title = "JetWhale",
+            icon = painterResource(Res.drawable.app_icon),
             state = WindowState(position = WindowPosition.Aligned(Alignment.Center)),
             onCloseRequest = appGraph.applicationLifecycleOwner::shutdown,
             onPreviewKeyEvent = { keyEvent ->

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/WindowSceneStrategy.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/WindowSceneStrategy.kt
@@ -18,7 +18,10 @@ import androidx.navigation3.scene.Scene
 import androidx.navigation3.scene.SceneStrategy
 import androidx.navigation3.scene.SceneStrategyScope
 import com.kitakkun.jetwhale.host.LocalComposeWindow
+import com.kitakkun.jetwhale.host.Res
+import com.kitakkun.jetwhale.host.app_icon
 import com.kitakkun.jetwhale.host.ui.isShortcutModifierPressed
+import org.jetbrains.compose.resources.painterResource
 
 data class WindowProperties(
     val windowPlacement: WindowPlacement = WindowPlacement.Floating,
@@ -50,6 +53,7 @@ internal class WindowOverlayScene<T : Any>(
 
                 Window(
                     state = windowState,
+                    icon = painterResource(Res.drawable.app_icon),
                     onCloseRequest = { onCloseRequest(windowEntry.entry) },
                     onPreviewKeyEvent = { keyEvent ->
                         if (keyEvent.type == KeyEventType.KeyDown && keyEvent.isShortcutModifierPressed && keyEvent.key == Key.W) {


### PR DESCRIPTION
## Summary
When the JetWhale host is launched as a bare JVM process (`runJetWhale`, `runJetWhaleHot`, `runJetWhaleLocal`), the OS showed the generic Java icon and "java" as the app name, because the `nativeDistributions` installer metadata only applies to packaged builds.

## Changes
- **Main.kt**: set `apple.awt.application.name` and the `java.awt.Taskbar` icon at startup (guarded by `isSupported`; harmless no-op on packaged builds), and set the main window icon
- **WindowSceneStrategy.kt**: set the same icon on plugin pop-out windows so Windows/Linux taskbars show it too
- **Run task conventions** (published `com.kitakkun.jetwhale.host` plugin and in-repo `jetwhale-host-launch`): pass `-Xdock:name=JetWhale` on macOS, since the Dock hover name comes from the bundle name and can only be set at JVM launch

## Verified
- `lsappinfo` reports `LSDisplayName="JetWhale"` for a host launched via `runJetWhaleLocal`, and the Dock shows the whale icon
- Known limitation: the process name in Activity Monitor / `ps` remains `java` — the executable name of a bare JVM cannot be changed; only packaged `.app` bundles get their own executable