### PR TITLE
docs: add icon, badges, and Kotlin version compatibility notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+<div align="center">
+  <img src="assets/icon.png" alt="JetWhale icon" width="128" />
+</div>
+
 # JetWhale
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.kitakkun.jetwhale/jetwhale-agent-runtime)](https://central.sonatype.com/search?namespace=com.kitakkun.jetwhale)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org)
+[![License](https://img.shields.io/github/license/kitakkun/JetWhale)](LICENSE)
 
 JetWhale is a next-generation, extensible debugging tool inspired
 by [Flipper](https://github.com/facebook/flipper).

--- a/compat-test/README.md
+++ b/compat-test/README.md
@@ -1,0 +1,48 @@
+# Kotlin version compatibility test
+
+A standalone Gradle build (not part of the root build) that compiles and runs a minimal consumer
+app against published JetWhale artifacts, to verify the **minimum consumer Kotlin version**
+documented in [Getting Started](../docs/guide/getting-started.md).
+
+## Run the matrix
+
+```sh
+./run-matrix.sh 1.0.0-alpha07                # default matrix: Kotlin 2.0 / 2.1 / 2.2 / 2.3
+./run-matrix.sh 1.0.0-alpha07 2.2.21 2.3.0   # explicit Kotlin versions
+```
+
+For each Kotlin version it compiles and runs `src/main/kotlin/Main.kt`. When a version fails
+(metadata-version error), it retries with `-Xskip-metadata-version-check` to confirm the
+documented workaround still works. The script exits non-zero only if the workaround also fails.
+
+## Test a pre-release version
+
+Publish to Maven Local from the repository root, then point the script at that version
+(`mavenLocal()` is resolved first):
+
+```sh
+(cd .. && ./gradlew publishToMavenLocal)
+./run-matrix.sh <version>
+```
+
+## Single invocation
+
+```sh
+../gradlew run -PkotlinVersion=2.3.0 -PjetwhaleVersion=1.0.0-alpha07
+../gradlew run -PkotlinVersion=2.2.21 -PjetwhaleVersion=1.0.0-alpha07 -PskipMetadataCheck=true
+```
+
+Success prints `RUNTIME_OK`. No running host is required — the agent simply retries the
+connection in the background.
+
+## Expected results (as of `1.0.0-alpha07`, built with Kotlin 2.4.0)
+
+| Consumer Kotlin | Plain | With `-Xskip-metadata-version-check` |
+|---|---|---|
+| 2.0.21 | ❌ | ✅ |
+| 2.1.21 | ❌ | ✅ |
+| 2.2.21 | ❌ | ✅ |
+| 2.3.0 | ✅ | — |
+
+The Kotlin compiler reads metadata up to one minor version ahead of itself, so the minimum
+consumer Kotlin is one minor version below the Kotlin used to build the artifacts.

--- a/compat-test/build.gradle.kts
+++ b/compat-test/build.gradle.kts
@@ -3,7 +3,14 @@ plugins {
     application
 }
 
-val jetwhaleVersion = providers.gradleProperty("jetwhaleVersion").get()
+val jetwhaleVersion = providers.gradleProperty("jetwhaleVersion").orNull
+    ?: error("Missing -PjetwhaleVersion=<version>, e.g. -PjetwhaleVersion=1.0.0-alpha07")
+
+kotlin {
+    // Pin the toolchain to the repo's convention (gradle-conventions/src/main/kotlin/jvm.gradle.kts)
+    // so matrix failures can only come from Kotlin compatibility, not local JDK differences.
+    jvmToolchain(17)
+}
 
 if (providers.gradleProperty("skipMetadataCheck").isPresent) {
     kotlin.compilerOptions.freeCompilerArgs.add("-Xskip-metadata-version-check")

--- a/compat-test/build.gradle.kts
+++ b/compat-test/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    kotlin("jvm")
+    application
+}
+
+val jetwhaleVersion = providers.gradleProperty("jetwhaleVersion").get()
+
+if (providers.gradleProperty("skipMetadataCheck").isPresent) {
+    kotlin.compilerOptions.freeCompilerArgs.add("-Xskip-metadata-version-check")
+}
+
+dependencies {
+    implementation("com.kitakkun.jetwhale:jetwhale-agent-runtime:$jetwhaleVersion")
+}
+
+application {
+    mainClass.set("MainKt")
+}

--- a/compat-test/run-matrix.sh
+++ b/compat-test/run-matrix.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Verifies which consumer Kotlin versions can compile & run against JetWhale artifacts.
+#
+# Usage:
+#   ./run-matrix.sh <jetwhaleVersion> [kotlinVersion...]
+#
+# Examples:
+#   ./run-matrix.sh 1.0.0-alpha07                       # default Kotlin matrix
+#   ./run-matrix.sh 1.0.0-alpha07 2.2.21 2.3.0          # explicit versions
+#   (cd .. && ./gradlew publishToMavenLocal) && ./run-matrix.sh <version>   # pre-release check
+set -u
+cd "$(dirname "$0")"
+
+JETWHALE_VERSION="${1:?usage: ./run-matrix.sh <jetwhaleVersion> [kotlinVersion...]}"
+shift
+KOTLIN_VERSIONS=("${@:-}")
+if [ -z "${KOTLIN_VERSIONS[0]:-}" ]; then
+    KOTLIN_VERSIONS=(2.0.21 2.1.21 2.2.21 2.3.0)
+fi
+
+GRADLEW=../gradlew
+FAILED=0
+
+run_case() {
+    local kotlin="$1" extra="${2:-}" label="$3"
+    if "$GRADLEW" run --console=plain -q \
+        -PkotlinVersion="$kotlin" -PjetwhaleVersion="$JETWHALE_VERSION" $extra \
+        2>/dev/null | grep -q RUNTIME_OK; then
+        echo "✅ $label"
+    else
+        echo "❌ $label"
+        return 1
+    fi
+}
+
+echo "JetWhale $JETWHALE_VERSION vs Kotlin: ${KOTLIN_VERSIONS[*]}"
+for kotlin in "${KOTLIN_VERSIONS[@]}"; do
+    if ! run_case "$kotlin" "" "Kotlin $kotlin"; then
+        # Expected to fail below the minimum version; check the documented workaround still works.
+        run_case "$kotlin" "-PskipMetadataCheck=true" "Kotlin $kotlin + -Xskip-metadata-version-check" \
+            || FAILED=1
+    fi
+done
+
+exit "$FAILED"

--- a/compat-test/settings.gradle.kts
+++ b/compat-test/settings.gradle.kts
@@ -1,0 +1,27 @@
+// Standalone build (NOT included in the root build): it compiles a consumer app against
+// published JetWhale artifacts with an arbitrary Kotlin version to verify the minimum
+// supported Kotlin version. See README.md in this directory.
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    val kotlinVersion = providers.gradleProperty("kotlinVersion").get()
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id.startsWith("org.jetbrains.kotlin")) {
+                useVersion(kotlinVersion)
+            }
+        }
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        // mavenLocal first so a locally published (pre-release) JetWhale can be tested
+        // via ./gradlew publishToMavenLocal in the root build.
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+}
+rootProject.name = "jetwhale-compat-test"

--- a/compat-test/settings.gradle.kts
+++ b/compat-test/settings.gradle.kts
@@ -6,7 +6,8 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
-    val kotlinVersion = providers.gradleProperty("kotlinVersion").get()
+    val kotlinVersion = providers.gradleProperty("kotlinVersion").orNull
+        ?: error("Missing -PkotlinVersion=<version>, e.g. -PkotlinVersion=2.3.0")
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id.startsWith("org.jetbrains.kotlin")) {

--- a/compat-test/src/main/kotlin/Main.kt
+++ b/compat-test/src/main/kotlin/Main.kt
@@ -1,0 +1,15 @@
+import com.kitakkun.jetwhale.agent.runtime.startJetWhale
+
+// A minimal consumer of the public agent API. Compiling this file proves the artifacts'
+// Kotlin metadata is readable; running it smoke-tests the runtime (no host needs to be up —
+// the agent just fails to connect and keeps retrying in the background).
+fun main() {
+    startJetWhale {
+        connection {
+            host = "localhost"
+            port = 5080
+        }
+    }
+    Thread.sleep(3000)
+    println("RUNTIME_OK")
+}

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -60,6 +60,16 @@ jetwhalePlugin {
 }
 ```
 
+::: warning Kotlin version compatibility
+The host loads your plugin jar into its own runtime, which ships a fixed Kotlin stdlib and Compose
+runtime. Kotlin is **not forward-compatible**: a plugin compiled with a newer Kotlin than the host's
+may fail to load or crash at runtime. Build your plugin with the **same Kotlin (and Compose) version
+as the host release you target** — check the host's release notes for the versions it was built
+with. When in doubt, match the versions used by
+[`jetwhale-plugins`](https://github.com/kitakkun/JetWhale/tree/main/jetwhale-plugins) at the
+corresponding release tag.
+:::
+
 The agent SDK goes in the **app being debugged** (a normal runtime dependency, not in the plugin
 module):
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -32,6 +32,27 @@ dependencies {
 }
 ```
 
+::: warning Kotlin version compatibility
+JetWhale artifacts are built with a recent Kotlin release (currently **2.4.0**), and your app needs
+**Kotlin 2.3 or newer** to use them. With an older Kotlin, the build fails with metadata-version
+errors — upgrade your app's Kotlin plugin, or pick an older JetWhale release built with a matching
+Kotlin.
+
+If you cannot upgrade, `-Xskip-metadata-version-check` is an unofficial escape hatch:
+
+```kotlin
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xskip-metadata-version-check")
+    }
+}
+```
+
+This only silences the metadata check — it does not guarantee compatibility. It is verified to
+compile and run against the current release with Kotlin 2.0–2.2, but it is unsupported by JetBrains
+and may break (especially around `inline` functions) with future releases. Prefer upgrading Kotlin.
+:::
+
 ::: tip
 Only add JetWhale to debug builds (e.g. `debugImplementation` on Android, or your own build-flavor
 wiring) — it is a debugging tool and should not ship in release builds.


### PR DESCRIPTION
## Summary
- Show the app icon and Maven Central / Kotlin / License badges at the top of the README
- Document Kotlin version compatibility in the docs:
  - **Getting Started**: apps consuming JetWhale artifacts need **Kotlin 2.3+** (artifacts are built with 2.4.0); documents `-Xskip-metadata-version-check` as an unofficial escape hatch with caveats
  - **Developing Plugins**: plugin authors must build with the same Kotlin/Compose versions as the target host release
- Add `compat-test/`, a standalone Gradle build (not part of the root build) that verifies the minimum consumer Kotlin version against published or `mavenLocal` artifacts

## Verification
Ran `compat-test/run-matrix.sh 1.0.0-alpha07` against Maven Central artifacts:

| Consumer Kotlin | Plain | With `-Xskip-metadata-version-check` |
|---|---|---|
| 2.0.21 | ❌ | ✅ (compiles & runs) |
| 2.1.21 | ❌ | ✅ |
| 2.2.21 | ❌ | ✅ |
| 2.3.0 | ✅ | — |

Failures are `Module was compiled with an incompatible version of Kotlin` metadata errors, confirming the documented 2.3 minimum.