### PR TITLE
fix(messaging)!: isolate plugin lifecycle failures and harden transport error paths

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -166,7 +166,9 @@ class MyHostPlugin : JetWhaleMessagingHostPlugin(), JetWhaleHostPluginUi {
 ```
 
 Requests work in **both directions** — the agent can `request` the host just as the host can `request`
-the agent. A failed/timed-out request throws `JetWhaleRequestException`; pass `timeout` to `request`
+the agent. A failed/timed-out request throws `JetWhaleRequestException` (and `sendOrFail`/`request`
+throw `JetWhaleConnectionClosedException` while disconnected — both are `JetWhaleMessagingException`);
+pass `timeout` to `request`
 to override the default per call (e.g. `request(SlowOp, timeout = 30.seconds)`). Implement `JetWhaleHostPluginUi`
 (`@Composable Content()`) to render a UI; plugins that don't are **headless** (e.g. MCP-only).
 

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -32,10 +32,15 @@ The negotiation phase consists of the following steps:
 
 ## Debugging Session
 
-During the debugging session, both sides can send or receive the following types of messages:
+During the debugging session, plugin messages travel as **plugin frames**, carried symmetrically in
+both directions (there is no directional difference between the debugger and the debuggee). A frame
+is one of:
 
-- **Debuggee Event**: This message is sent from the debuggee to the debugger. The debuggee can
-  send various types of information to support plugin debugging features. This is a unidirectional
-  message, so the debuggee does not expect any response from the debugger.
-- **Method**: This message is sent from the debugger to the debuggee to request specific actions or
-  information. The debuggee processes the method and sends back a corresponding response message.
+- **Notification**: a fire-and-forget event. The sender expects no response.
+- **Request**: expects a reply; the sender assigns a correlation id and applies a timeout.
+- **Reply**: completes a request (as a success payload or a failure message), matched to it by the
+  correlation id.
+
+Frames are addressed by plugin id and routed to that plugin's messaging peer on the receiving side.
+Notifications and requests are dispatched in arrival order; replies bypass the queue so a handler
+awaiting a reply is never blocked behind other traffic.

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleAgentPluginService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleAgentPluginService.kt
@@ -10,8 +10,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Owns the messaging peers for the agent plugins, and tracks two independent lifecycles:
@@ -90,7 +92,13 @@ internal class JetWhaleAgentPluginService(
         val runtime = runtimes[id] ?: return
         if (!runtime.active) {
             runtime.active = true
-            runtime.plugin.dispatchActivate()
+            // A plugin whose onActivate throws must not take down the connection (and with it every
+            // other plugin): isolate the failure and keep the plugin activated so its peer still works.
+            try {
+                runtime.plugin.dispatchActivate()
+            } catch (e: Throwable) {
+                JetWhaleLogger.w("JetWhale: onActivate for plugin '${runtime.plugin.pluginId}' failed.", e)
+            }
         }
         establishPeer(runtime)
     }
@@ -101,7 +109,13 @@ internal class JetWhaleAgentPluginService(
         // Not a transient disconnect, so no onDisconnected; the plugin gets onDeactivate to stop its work.
         dropPeer(runtime, notifyDisconnected = false)
         runtime.active = false
-        runtime.plugin.dispatchDeactivate()
+        try {
+            runtime.plugin.dispatchDeactivate()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            JetWhaleLogger.w("JetWhale: onDeactivate for plugin '${runtime.plugin.pluginId}' failed.", e)
+        }
     }
 
     private fun establishPeer(runtime: PluginRuntime) {
@@ -109,7 +123,15 @@ internal class JetWhaleAgentPluginService(
         val sendFrame = sendFrame ?: return
         if (runtime.peer != null) return
         val peer = JetWhalePluginPeer(pluginId = runtime.plugin.pluginId, parentScope = scope, sendFrame = sendFrame, awaitReady = true)
-        peer.configure { runtime.plugin.registerHandlers(this) }
+        // A broken configure (e.g. duplicate handler registration) must not leak the half-built peer
+        // or abort the connection for other plugins.
+        try {
+            peer.configure { runtime.plugin.registerHandlers(this) }
+        } catch (e: Throwable) {
+            JetWhaleLogger.w("JetWhale: handler registration for plugin '${runtime.plugin.pluginId}' failed; plugin stays offline this connection.", e)
+            scope.launch { peer.close() }
+            return
+        }
         runtime.peer = peer
         // markReady() and the buffered-event flush also run on prepare timeout: degraded beats frozen.
         runtime.messenger.bind(peer.messenger)
@@ -120,6 +142,12 @@ internal class JetWhaleAgentPluginService(
                 }
             } catch (e: TimeoutCancellationException) {
                 JetWhaleLogger.w("JetWhale: onPrepare for plugin '${runtime.plugin.pluginId}' did not complete in time; proceeding.", e)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // A failed request (JetWhaleRequestException etc.) is the common degraded path here;
+                // it must never escape as an uncaught exception in the debuggee process.
+                JetWhaleLogger.w("JetWhale: onPrepare for plugin '${runtime.plugin.pluginId}' failed; proceeding.", e)
             } finally {
                 peer.markReady()
                 runtime.messenger.startFlush()
@@ -129,13 +157,22 @@ internal class JetWhaleAgentPluginService(
 
     private suspend fun dropPeer(runtime: PluginRuntime, notifyDisconnected: Boolean) {
         val peer = runtime.peer ?: return
-        runtime.connectJob?.cancel()
+        // Join, don't just cancel: the job's finally opens the flush gate (markReady/startFlush), and
+        // if it ran after the next connection's bind() it would open that connection's gate before its
+        // prepare completed.
+        runtime.connectJob?.cancelAndJoin()
         runtime.connectJob = null
         // Detach the transport (closing the flush gate) but keep the messenger alive so it keeps buffering.
         runtime.messenger.unbind()
         runtime.peer = null
         try {
             if (notifyDisconnected) runtime.plugin.dispatchDisconnected()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // Isolate per plugin: one throwing onDisconnected must not skip dropPeer for the others,
+            // or they would stay bound to the dead peer across the reconnect.
+            JetWhaleLogger.w("JetWhale: onDisconnected for plugin '${runtime.plugin.pluginId}' failed.", e)
         } finally {
             peer.close()
         }
@@ -155,13 +192,21 @@ internal class JetWhaleAgentPluginService(
         if (frame is PluginFrame.Request) {
             val sendFrame = sendFrame ?: return
             serviceScope.launch {
-                sendFrame(
-                    PluginFrame.Reply.Failure(
-                        pluginId = frame.pluginId,
-                        inReplyTo = frame.correlationId,
-                        errorMessage = "Plugin '${frame.pluginId}' is not active in the agent.",
-                    ),
-                )
+                // Best effort: the socket may already be dead (e.g. a request racing a disconnect);
+                // a failed failure-reply must not surface as an uncaught exception in the debuggee.
+                try {
+                    sendFrame(
+                        PluginFrame.Reply.Failure(
+                            pluginId = frame.pluginId,
+                            inReplyTo = frame.correlationId,
+                            errorMessage = "Plugin '${frame.pluginId}' is not active in the agent.",
+                        ),
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    JetWhaleLogger.w("JetWhale: failed to send fast-fail reply for plugin '${frame.pluginId}'.", e)
+                }
             }
         }
     }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/PluginPrepareTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/PluginPrepareTest.kt
@@ -29,7 +29,6 @@ private class FakeMessenger(
     private val scope: CoroutineScope,
     private val cannedReply: String,
 ) : JetWhaleMessenger {
-    override val coroutineScope: CoroutineScope get() = scope
     override val payloadFormat: StringFormat = Json
 
     val requested: MutableList<String> = mutableListOf()

--- a/jetwhale-agent-sdk/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/sdk/JetWhaleAgentPlugin.kt
+++ b/jetwhale-agent-sdk/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/sdk/JetWhaleAgentPlugin.kt
@@ -50,7 +50,7 @@ public abstract class JetWhaleAgentPlugin {
      */
     protected val messenger: JetWhaleMessenger
         get() = checkNotNull(boundMessenger) {
-            "messenger is only available after the plugin has been registered (in or after onActivate())."
+            "messenger is not bound: the plugin has not been registered with the JetWhale agent runtime."
         }
 
     /** Registers handlers for messages from the host (`onEvent { e: E -> }` / `onRequest { req -> reply(...) }`). */

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMessagingHostPlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMessagingHostPlugin.kt
@@ -22,7 +22,8 @@ public abstract class JetWhaleMessagingHostPlugin : JetWhaleHostPlugin() {
     /**
      * Sends messages to the agent counterpart: `trySend` / `sendOrQueue` / `sendOrFail` for events,
      * `request(req): R` for request-reply. Valid for the whole life of this instance ([onCreate]
-     * onwards) — the instance only exists while its session is connected.
+     * onwards) — the instance only exists while its session is connected. For that same reason there
+     * is no offline buffer here: `sendOrQueue` behaves like `trySend` on the host side.
      */
     protected val messenger: JetWhaleMessenger
         get() = checkNotNull(boundMessenger) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstanceService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstanceService.kt
@@ -75,7 +75,7 @@ class DefaultPluginInstanceService(
             val key = PluginInstanceKey(pluginId, sessionId)
             loadedPlugins.computeIfAbsent(key) {
                 newlyInitializedSessions += sessionId
-                createInstance(pluginId, sessionId, loaded.factory.createPlugin())
+                createInstance(pluginId, sessionId, loaded.factory.createPlugin(), loaded.manifest.requiresAgent)
             }
         }
 
@@ -85,10 +85,22 @@ class DefaultPluginInstanceService(
         return newlyInitializedSessions
     }
 
-    private fun createInstance(pluginId: String, sessionId: String, plugin: JetWhaleHostPlugin): LoadedInstance {
+    private fun createInstance(pluginId: String, sessionId: String, plugin: JetWhaleHostPlugin, requiresAgent: Boolean): LoadedInstance {
+        if (!requiresAgent && plugin is JetWhaleMessagingHostPlugin) {
+            // A messaging plugin without an agent counterpart waits out its prepare timeout on every
+            // session and gets "not active" failures for every request — surface the misconfiguration
+            // instead of degrading silently.
+            logger.warning(
+                "Plugin '$pluginId' declares requiresAgent=false but its factory returns a JetWhaleMessagingHostPlugin; " +
+                    "its messenger will never reach an agent.",
+            )
+        }
         val instanceScope = CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext[Job]))
         plugin.bindPluginScope(instanceScope)
 
+        // User code below (registerHandlers, onCreate) is guarded: this runs inside the map's
+        // computeIfAbsent, and a throwing plugin must neither leak the just-created peer/scope nor
+        // abort loading for the caller.
         // Only messaging plugins get a peer; a pure plugin pays none of the messaging cost.
         val peer = if (plugin is JetWhaleMessagingHostPlugin) {
             JetWhalePluginPeer(
@@ -97,13 +109,21 @@ class DefaultPluginInstanceService(
                 sendFrame = { frame -> frameSender.sendFrame(sessionId, frame) },
                 awaitReady = true,
             ).also { peer ->
-                peer.configure { plugin.registerHandlers(this) }
+                try {
+                    peer.configure { plugin.registerHandlers(this) }
+                } catch (e: Throwable) {
+                    logger.warning("Handler registration for plugin '$pluginId' in session '$sessionId' failed: ${e.message}")
+                }
                 plugin.bindMessenger(peer.messenger)
             }
         } else {
             null
         }
-        plugin.dispatchCreate()
+        try {
+            plugin.dispatchCreate()
+        } catch (e: Throwable) {
+            logger.warning("onCreate for plugin '$pluginId' in session '$sessionId' failed: ${e.message}")
+        }
         if (peer != null && plugin is JetWhaleMessagingHostPlugin) {
             // markReady() also runs on prepare timeout/failure: a degraded plugin beats a frozen one.
             instanceScope.launch {
@@ -138,14 +158,22 @@ class DefaultPluginInstanceService(
         // session while this one failure reply is in flight.
         if (frame is PluginFrame.Request) {
             scope.launch {
-                frameSender.sendFrame(
-                    sessionId = sessionId,
-                    frame = PluginFrame.Reply.Failure(
-                        pluginId = frame.pluginId,
-                        inReplyTo = frame.correlationId,
-                        errorMessage = "Plugin '${frame.pluginId}' is not loaded in session '$sessionId'.",
-                    ),
-                )
+                // Best effort: the session may already be half-closed; a failed failure-reply must
+                // not escalate through the supervisor.
+                try {
+                    frameSender.sendFrame(
+                        sessionId = sessionId,
+                        frame = PluginFrame.Reply.Failure(
+                            pluginId = frame.pluginId,
+                            inReplyTo = frame.correlationId,
+                            errorMessage = "Plugin '${frame.pluginId}' is not loaded in session '$sessionId'.",
+                        ),
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    logger.warning("Failed to send fast-fail reply for plugin '${frame.pluginId}' in session '$sessionId': ${e.message}")
+                }
             }
         }
     }
@@ -164,10 +192,17 @@ class DefaultPluginInstanceService(
 
     private fun disposeInstance(key: PluginInstanceKey, emitEvent: Boolean = true) {
         val removed = loadedPlugins.remove(key) ?: return
-        removed.plugin.dispatchDispose()
-        removed.instanceScope.cancel()
-        // close() suspends (it fails pending requests under a mutex), so run it off the caller.
-        removed.peer?.let { peer -> scope.launch { peer.close() } }
+        try {
+            removed.plugin.dispatchDispose()
+        } catch (e: Throwable) {
+            // A throwing onDispose must not leak the scope/peer, nor abort disposing the session's
+            // other plugins from the callers' forEach loops.
+            logger.warning("onDispose for plugin '${key.pluginId}' in session '${key.sessionId}' failed: ${e.message}")
+        } finally {
+            removed.instanceScope.cancel()
+            // close() suspends (it fails pending requests under a mutex), so run it off the caller.
+            removed.peer?.let { peer -> scope.launch { peer.close() } }
+        }
         if (emitEvent) emitEvent(PluginInstanceEvent.Disposed(key.pluginId, key.sessionId))
     }
 

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
@@ -148,7 +148,6 @@ class JetWhaleNetworkKtorPluginTest {
 
 /** Records every event the plugin sends, decoded back to its typed form. */
 private class RecordingMessenger(val events: MutableList<Any>) : JetWhaleMessenger {
-    override val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob())
     override val payloadFormat: StringFormat = DefaultJetWhaleMessagingFormat
 
     override fun sendRaw(messageType: String, payload: String, policy: OfflineSendPolicy): Boolean {

--- a/jetwhale-plugins/network/agent-okhttp/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorTest.kt
+++ b/jetwhale-plugins/network/agent-okhttp/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorTest.kt
@@ -238,7 +238,6 @@ class JetWhaleNetworkOkHttpInterceptorTest {
 
 /** Records every event the plugin sends, decoded back to its typed form. */
 private class RecordingMessenger(val events: MutableList<Any>) : JetWhaleMessenger {
-    override val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob())
     override val payloadFormat: StringFormat = DefaultJetWhaleMessagingFormat
 
     override fun sendRaw(messageType: String, payload: String, policy: OfflineSendPolicy): Boolean {

--- a/jetwhale-protocol/core/api/core.klib.api
+++ b/jetwhale-protocol/core/api/core.klib.api
@@ -23,8 +23,6 @@ abstract interface <#A: kotlin/Any> com.kitakkun.jetwhale.protocol.messaging/Jet
 abstract interface com.kitakkun.jetwhale.protocol.messaging/JetWhaleEvent // com.kitakkun.jetwhale.protocol.messaging/JetWhaleEvent|null[0]
 
 abstract interface com.kitakkun.jetwhale.protocol.messaging/JetWhaleMessenger { // com.kitakkun.jetwhale.protocol.messaging/JetWhaleMessenger|null[0]
-    abstract val coroutineScope // com.kitakkun.jetwhale.protocol.messaging/JetWhaleMessenger.coroutineScope|{}coroutineScope[0]
-        abstract fun <get-coroutineScope>(): kotlinx.coroutines/CoroutineScope // com.kitakkun.jetwhale.protocol.messaging/JetWhaleMessenger.coroutineScope.<get-coroutineScope>|<get-coroutineScope>(){}[0]
     abstract val payloadFormat // com.kitakkun.jetwhale.protocol.messaging/JetWhaleMessenger.payloadFormat|{}payloadFormat[0]
         abstract fun <get-payloadFormat>(): kotlinx.serialization/StringFormat // com.kitakkun.jetwhale.protocol.messaging/JetWhaleMessenger.payloadFormat.<get-payloadFormat>|<get-payloadFormat>(){}[0]
 
@@ -584,8 +582,6 @@ final class <#A: kotlin/Any> com.kitakkun.jetwhale.protocol.messaging/Reply // c
 final class com.kitakkun.jetwhale.protocol.messaging/BufferedMessenger : com.kitakkun.jetwhale.protocol.messaging/JetWhaleMessenger { // com.kitakkun.jetwhale.protocol.messaging/BufferedMessenger|null[0]
     constructor <init>(kotlinx.coroutines/CoroutineScope, kotlinx.serialization/StringFormat, kotlin/Int, kotlin/Function1<kotlin/String, kotlin/Unit> = ...) // com.kitakkun.jetwhale.protocol.messaging/BufferedMessenger.<init>|<init>(kotlinx.coroutines.CoroutineScope;kotlinx.serialization.StringFormat;kotlin.Int;kotlin.Function1<kotlin.String,kotlin.Unit>){}[0]
 
-    final val coroutineScope // com.kitakkun.jetwhale.protocol.messaging/BufferedMessenger.coroutineScope|{}coroutineScope[0]
-        final fun <get-coroutineScope>(): kotlinx.coroutines/CoroutineScope // com.kitakkun.jetwhale.protocol.messaging/BufferedMessenger.coroutineScope.<get-coroutineScope>|<get-coroutineScope>(){}[0]
     final val payloadFormat // com.kitakkun.jetwhale.protocol.messaging/BufferedMessenger.payloadFormat|{}payloadFormat[0]
         final fun <get-payloadFormat>(): kotlinx.serialization/StringFormat // com.kitakkun.jetwhale.protocol.messaging/BufferedMessenger.payloadFormat.<get-payloadFormat>|<get-payloadFormat>(){}[0]
 

--- a/jetwhale-protocol/core/api/jvm/core.api
+++ b/jetwhale-protocol/core/api/jvm/core.api
@@ -127,7 +127,6 @@ public final class com/kitakkun/jetwhale/protocol/messaging/BufferedMessenger : 
 	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/StringFormat;ILkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun bind (Lcom/kitakkun/jetwhale/protocol/messaging/JetWhaleMessenger;)V
 	public final fun close ()V
-	public fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getPayloadFormat ()Lkotlinx/serialization/StringFormat;
 	public fun requestRaw-5_5nbZA (Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun sendRaw (Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/protocol/messaging/OfflineSendPolicy;)Z
@@ -159,7 +158,6 @@ public class com/kitakkun/jetwhale/protocol/messaging/JetWhaleMessagingException
 }
 
 public abstract interface class com/kitakkun/jetwhale/protocol/messaging/JetWhaleMessenger {
-	public abstract fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public abstract fun getPayloadFormat ()Lkotlinx/serialization/StringFormat;
 	public abstract fun requestRaw-5_5nbZA (Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun sendRaw (Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/protocol/messaging/OfflineSendPolicy;)Z

--- a/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/messaging/BufferedMessenger.kt
+++ b/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/messaging/BufferedMessenger.kt
@@ -47,8 +47,6 @@ public class BufferedMessenger(
     private val scope: CoroutineScope =
         CoroutineScope(parentScope.coroutineContext + SupervisorJob(parentScope.coroutineContext[Job]))
 
-    override val coroutineScope: CoroutineScope get() = scope
-
     /** The live transport, or null while disconnected. Sole writer is [bind]/[unbind]. */
     private val live = MutableStateFlow<JetWhaleMessenger?>(null)
 

--- a/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/messaging/JetWhaleMessenger.kt
+++ b/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/messaging/JetWhaleMessenger.kt
@@ -32,9 +32,6 @@ public enum class OfflineSendPolicy {
  * capture the message serializer at the call site via reified type parameters.
  */
 public interface JetWhaleMessenger {
-    /** Scope tied to this connection; cancelled when the connection closes. */
-    public val coroutineScope: CoroutineScope
-
     /** Format used to (de)serialize message payloads. */
     public val payloadFormat: StringFormat
 
@@ -77,7 +74,9 @@ public inline fun <reified E : JetWhaleEvent> JetWhaleMessenger.trySend(event: E
  * Sends a fire-and-forget event, **buffering it** while the connection is unavailable and flushing
  * it (in order) on reconnect. Use this for streams you must not lose across a disconnect (e.g.
  * captured traffic). The buffer is bounded and opt-in — without capacity this behaves like
- * [trySend]. Only [JetWhaleEvent] types are accepted.
+ * [trySend]. Buffering exists only on the agent's connection-independent messenger; a host plugin's
+ * messenger lives exactly as long as its connection, so there is nothing to buffer across and this
+ * degrades to [trySend] there. Only [JetWhaleEvent] types are accepted.
  */
 public inline fun <reified E : JetWhaleEvent> JetWhaleMessenger.sendOrQueue(event: E) {
     val eventSerializer = serializer<E>()

--- a/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/messaging/JetWhalePluginPeer.kt
+++ b/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/messaging/JetWhalePluginPeer.kt
@@ -95,7 +95,19 @@ public class JetWhalePluginPeer(
         // Single writer: every outbound frame goes through one queue so send order is preserved.
         scope.launch {
             for (frame in outgoingQueue) {
-                sendFrame(frame)
+                try {
+                    sendFrame(frame)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    // The transport is broken (e.g. a half-closed socket). Without this the pump would
+                    // die silently and every later request would wait out its full timeout: close the
+                    // outbound side and fail pending requests fast instead.
+                    logger("JetWhale: transport send failed for plugin '$pluginId'; closing outbound. (${e.message})")
+                    outgoingQueue.close()
+                    failAllPending()
+                    break
+                }
             }
         }
         // Single consumer: notifications and requests are dispatched in arrival order. A notification
@@ -124,7 +136,6 @@ public class JetWhalePluginPeer(
 
     /** The sending face handed to plugin code. Valid for the lifetime of this peer. */
     public val messenger: JetWhaleMessenger = object : JetWhaleMessenger {
-        override val coroutineScope: CoroutineScope get() = scope
         override val payloadFormat: StringFormat get() = this@JetWhalePluginPeer.payloadFormat
 
         // The peer is the live transport: while it is bound it simply sends. There is no per-peer
@@ -193,11 +204,15 @@ public class JetWhalePluginPeer(
         // Close the queues first so further sends fail fast instead of enqueueing with no consumer.
         outgoingQueue.close()
         inboundQueue.close()
+        failAllPending()
+        scope.cancel()
+    }
+
+    private suspend fun failAllPending() {
         pendingMutex.withLock {
             pendingReplies.values.forEach { it.completeExceptionally(JetWhaleConnectionClosedException()) }
             pendingReplies.clear()
         }
-        scope.cancel()
     }
 
     private suspend fun requestRaw(messageType: String, payload: String, timeout: Duration?): String {

--- a/jetwhale-protocol/core/src/jvmTest/kotlin/com/kitakkun/jetwhale/protocol/messaging/BufferedMessengerTest.kt
+++ b/jetwhale-protocol/core/src/jvmTest/kotlin/com/kitakkun/jetwhale/protocol/messaging/BufferedMessengerTest.kt
@@ -27,7 +27,6 @@ class BufferedMessengerTest {
 
     /** A live transport that records the payloads forwarded to it, in order. */
     private class Recorder : JetWhaleMessenger {
-        override val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob())
         override val payloadFormat: StringFormat = Json
         val received: CopyOnWriteArrayList<String> = CopyOnWriteArrayList()
 


### PR DESCRIPTION
Follow-up to #108, addressing the post-merge review findings (3 High + the actionable Medium/Low items).

## High — one broken plugin could crash or degrade everything

- **Agent `onPrepare` no longer crashes the debuggee.** The prepare job caught only `TimeoutCancellationException`; a failed `request` inside `onPrepare` (`JetWhaleRequestException` — the *common* degraded path, since the request timeout is shorter than the prepare timeout) escaped as an uncaught exception in a handler-less scope and could kill the app on Android. Now every non-cancellation failure is warn-and-proceed, matching the host side and the documented contract.
- **`disconnectAll` is exception-isolated per plugin.** A throwing `onDisconnected` used to abort the loop, leaving the remaining plugins bound to the dead peer forever (reconnect saw `peer != null` and returned early).
- **`onActivate` / `onDeactivate` / `registerHandlers` are guarded.** A deterministically-throwing plugin used to tear down the whole connection and trigger an infinite reconnect storm that repeatedly disconnected every other plugin.

## Medium

- **`dropPeer` uses `cancelAndJoin`.** The cancelled prepare job's `finally { markReady(); startFlush() }` could run after the next connection's `bind()`, opening the flush gate mid-prepare and letting buffered events bypass the prepare barrier.
- **The peer's outbound pump survives transport failures.** A throwing `sendFrame` (half-closed socket) used to kill the pump silently; every later request then waited out its full timeout. Now the pump closes the outbound queue and fails pending requests fast.
- **Host `disposeInstance`/`createInstance` no longer leak on user exceptions**, and one plugin's failure no longer skips disposing/loading the session's remaining plugins.
- **Fast-fail failure replies are best-effort** on both runtimes — a dead socket no longer surfaces as an uncaught exception.
- **`requiresAgent=false` + messaging plugin misconfiguration is now logged** instead of degrading silently (prepare timeout on every session).

## Breaking

- **Removed `JetWhaleMessenger.coroutineScope`.** It had zero consumers, and its documented lifetime ("cancelled when the connection closes") was wrong for the agent's connection-independent messenger — a leaked-background-work trap. Plugin authors already have `pluginScope`. ABI dumps regenerated.

## Docs

- `docs/reference/protocol.md` now describes the symmetric `PluginFrame` model (the pre-migration Debuggee Event / Method text was stale).
- The plugin guide mentions `JetWhaleConnectionClosedException`; host-side `sendOrQueue` degrading to `trySend` is documented; the agent messenger's `checkNotNull` message now states the actual contract.

Not included here: the network host plugin's optimistic UI updates — fixed in #122.

## Validation

`checkLegacyAbi`, `spotlessCheck`, and the JVM test suites of `jetwhale-protocol:core`, `jetwhale-agent-runtime`, `jetwhale-host:core:data`, and the network plugin modules all pass. The reconnect / mid-session-enable manual E2E recommended on #108 remains worthwhile — these are exactly the paths it exercises.