### PR TITLE
chore: bump dependencies to latest versions

### DIFF
--- a/demo/android/build.gradle.kts
+++ b/demo/android/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
 android {
     namespace = "com.kitakkun.jetwhale.demo"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 23

--- a/demo/shared/build.gradle.kts
+++ b/demo/shared/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 
     android {
         namespace = "com.kitakkun.jetwhale.demo.shared"
-        compileSdk = 36
+        compileSdk = 37
     }
 
     sourceSets {

--- a/gradle-conventions/src/main/kotlin/multiplatform.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/multiplatform.gradle.kts
@@ -28,6 +28,6 @@ configure<KotlinMultiplatformExtension> {
     linuxArm64()
 
     configure<KotlinMultiplatformAndroidLibraryExtension> {
-        compileSdk = 36
+        compileSdk = 37
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,41 +1,41 @@
 [versions]
 jetwhale = "1.0.0-alpha08"
-mavenPublish = "0.36.0"
+mavenPublish = "0.37.0"
 
 # kotlin
-kotlin = "2.4.0"
-ksp = "2.3.9"
+kotlin = "2.4.10"
+ksp = "2.3.10"
 kotlinDsl = "6.5.7"
 kotlinxSerializationJson = "1.11.0"
-kotlinxCollectionsImmutable = "0.4.0"
+kotlinxCollectionsImmutable = "0.5.1"
 kotlinxCoroutines = "1.11.0"
-byteBuddy = "1.15.11"
+byteBuddy = "1.18.11"
 kotlinxDatetime = "0.8.0"
 
 # android
-androidGradlePlugin = "9.2.0"
-androidxCoreKtx = "1.18.0"
+androidGradlePlugin = "9.3.0"
+androidxCoreKtx = "1.19.0"
 androidxActivity = "1.13.0"
 
 jetbrainsCompose = "1.11.1"
 material3 = "1.11.0-alpha07"
-material3Adaptive = "1.3.0-alpha07"
+material3Adaptive = "1.3.0-beta02"
 navigation3 = "1.1.1"
-lifecycle = "2.11.0-beta01"
+lifecycle = "2.11.0"
 soil = "1.0.0-alpha15"
 
 androidxDatastore = "1.2.1"
-metro = "1.1.1"
-mokkery = "3.4.0"
-ktor = "3.5.0"
-okhttp = "4.12.0"
-mcpKotlinSdk = "0.13.0"
+metro = "1.3.2"
+mokkery = "3.4.2"
+ktor = "3.5.1"
+okhttp = "5.4.0"
+mcpKotlinSdk = "0.14.0"
 
-logback = "1.5.32"
+logback = "1.5.38"
 kermit = "2.1.0"
 
-aboutLibraries = "14.2.1"
-spotless = "8.6.0"
+aboutLibraries = "15.0.4"
+spotless = "8.8.0"
 
 [libraries]
 # Gradle Plugins

--- a/jetwhale-agent-runtime/build.gradle.kts
+++ b/jetwhale-agent-runtime/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
 
     android {
         namespace = "com.kitakkun.jetwhale.agent.runtime"
-        compileSdk = 36
+        compileSdk = 37
     }
 
     sourceSets {

--- a/jetwhale-plugins/example/agent/build.gradle.kts
+++ b/jetwhale-plugins/example/agent/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 kotlin {
     android {
         namespace = "com.kitakkun.jetwhale.plugins.example"
-        compileSdk = 36
+        compileSdk = 37
     }
 }
 

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
 
-ws@8.18.3:
-  version "8.18.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+ws@8.20.1:
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -3320,15 +3320,20 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@8.18.3, ws@~8.18.3:
-  version "8.18.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+ws@8.20.1:
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
 ws@^8.18.0:
   version "8.19.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.19.0.tgz#ddc2bdfa5b9ad860204f5a72a4863a8895fd8c8b"
   integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
+
+ws@~8.18.3:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 wsl-utils@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary
Bumps all dependencies in `gradle/libs.versions.toml` to their latest versions. Policy: latest stable, or latest of the same pre-release line for entries already on one.

| Dependency | Old → New |
|---|---|
| Kotlin / KSP | 2.4.0 → 2.4.10 / 2.3.9 → 2.3.10 |
| kotlinx-collections-immutable | 0.4.0 → 0.5.1 |
| Byte Buddy | 1.15.11 → 1.18.11 |
| AGP | 9.2.0 → 9.3.0 |
| androidx.core | 1.18.0 → 1.19.0 |
| material3-adaptive | 1.3.0-alpha07 → 1.3.0-beta02 |
| lifecycle | 2.11.0-beta01 → 2.11.0 |
| Metro | 1.1.1 → 1.3.2 |
| Mokkery / Ktor | 3.4.0 → 3.4.2 / 3.5.0 → 3.5.1 |
| OkHttp | 4.12.0 → 5.4.0 (major) |
| MCP Kotlin SDK | 0.13.0 → 0.14.0 |
| Logback | 1.5.32 → 1.5.38 |
| AboutLibraries | 14.2.1 → 15.0.4 (major) |
| maven-publish / Spotless | 0.36.0 → 0.37.0 / 8.6.0 → 8.8.0 |

Accompanying changes:
- `compileSdk` 36 → 37 (required by androidx.core 1.19.0)
- Regenerated js/wasm yarn lock files

Left untouched: `kotlinDsl` (matches Gradle wrapper 9.5.1), `jetbrainsCompose` / `material3` / `navigation3` (1.12 line is still alpha/beta), and entries already at their latest (kotlinx-serialization, coroutines, datetime, soil, kermit, etc.).

## Test plan
- `./gradlew build` ✅
- `./gradlew check` ✅ (all tests pass, incl. major bumps of OkHttp 5 and AboutLibraries 15)