### PR TITLE
docs: update built-with Kotlin version to 2.4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # JetWhale
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.kitakkun.jetwhale/jetwhale-agent-runtime)](https://central.sonatype.com/search?namespace=com.kitakkun.jetwhale)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.4.10-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org)
 [![License](https://img.shields.io/github/license/kitakkun/JetWhale)](LICENSE)
 
 JetWhale is a next-generation, extensible debugging tool inspired

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,7 +33,7 @@ dependencies {
 ```
 
 ::: warning Kotlin version compatibility
-JetWhale artifacts are built with a recent Kotlin release (currently **2.4.0**), and your app needs
+JetWhale artifacts are built with a recent Kotlin release (currently **2.4.10**), and your app needs
 **Kotlin 2.3 or newer** to use them. With an older Kotlin, the build fails with metadata-version
 errors — upgrade your app's Kotlin plugin, or pick an older JetWhale release built with a matching
 Kotlin.


### PR DESCRIPTION
## Summary
Follow-up to #124 (Kotlin 2.4.0 → 2.4.10): updates the hardcoded "built with" Kotlin version in `docs/guide/getting-started.md` and the README badge. The minimum consumer Kotlin (2.3+) is unchanged since 2.4.10 is a patch release with the same metadata version.

This commit was originally pushed to the #124 branch after it was merged, so it is re-landed here.