### PR TITLE
ci: add paths filters and tune caching

### DIFF
--- a/.github/actions/setup-java/action.yaml
+++ b/.github/actions/setup-java/action.yaml
@@ -22,6 +22,9 @@ runs:
       uses: gradle/actions/setup-gradle@v5.0.0
       with:
         gradle-version: wrapper
+        # Only main-branch builds write to the Gradle cache; PR builds read it.
+        # Keeps short-lived PR entries from evicting the shared cache (10 GB repo limit).
+        cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
     - name: Set konan cache key
       id: konan-cache-key
@@ -34,3 +37,7 @@ runs:
         path: |
           ~/.konan
         key: v1-konan-${{ runner.os }}-${{ hashFiles('.xcode-version') }}-${{ steps.konan-cache-key.outputs.KOTLIN_VERSION }}
+        # Warm start after a Kotlin/Xcode bump instead of re-downloading everything.
+        restore-keys: |
+          v1-konan-${{ runner.os }}-${{ hashFiles('.xcode-version') }}-
+          v1-konan-${{ runner.os }}-

--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -11,6 +11,9 @@ on:
       - 'jetwhale-protocol/agent/**'
       - 'jetwhale-protocol/host/**'
       - '**/build.gradle.kts'
+      - 'gradle/libs.versions.toml'
+      - '.github/workflows/abi-check.yml'
+      - '.github/actions/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,16 @@
 name: Lint
 
+# Paths mirror the spotless targets in build.gradle.kts (**/*.kt, **/*.gradle.kts),
+# plus files that change how the check itself runs.
 on:
   pull_request:
+    paths:
+      - '**/*.kt'
+      - '**/*.kts'
+      - 'gradle/libs.versions.toml'
+      - 'gradle/wrapper/**'
+      - '.github/workflows/lint.yml'
+      - '.github/actions/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,18 @@
 name: Run Test
 
 on:
+  # Unfiltered on main so every merge seeds the Gradle cache for PR builds.
   push:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'docs-site/**'
+      - '**/*.md'
+      - 'assets/**'
+      - '.claude/**'
+      - 'LICENSE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Cuts unnecessary CI runs and improves cache behavior.

### Paths filters
- **Lint**: runs only when `**/*.kt` / `**/*.kts`, the version catalog, wrapper, or the workflow/composite action change — mirroring the spotless targets in `build.gradle.kts`.
- **Test**: skips PRs that only touch `docs/`, `docs-site/`, markdown, `assets/`, `.claude/`, or `LICENSE`. Pushes to `main` stay unfiltered so every merge seeds the shared Gradle cache.
- **ABI check**: now also triggers on `gradle/libs.versions.toml` (dependency bumps can shift the ABI) and on changes to the workflow/composite action.

### Cache tuning (`.github/actions/setup-java`)
- `setup-gradle` gets `cache-read-only` outside `main`: PR builds read the cache but no longer write, so short-lived PR entries stop evicting shared entries under the 10 GB repo cache limit.
- Konan cache gets `restore-keys` fallbacks, so a Kotlin or Xcode bump starts from the previous cache instead of cold.

## Caveat
If **Lint** / **Test** are (or become) required status checks in branch protection, a paths-skipped run leaves them in "Expected" state and blocks merging. If you enable required checks or a merge queue later, either drop these filters or add a no-op counterpart workflow with the same job names for the ignored paths.

## Test plan
- YAML validated locally.
- Filter behavior is verifiable on this PR itself: it touches only `.github/**`, so **Lint** should run (workflow/action changed) while **Test** runs because `.github` is not in its ignore list.