### PR TITLE
feat: add plugin installation from Maven repository

### DIFF
--- a/jetwhale-host/core/data/build.gradle.kts
+++ b/jetwhale-host/core/data/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     // redefinition. Dormant in production: only touched when the dev plugins directory is configured.
     implementation(libs.byteBuddyAgent)
     implementation(libs.bundles.ktorServer)
+    implementation(libs.ktorClientCore)
+    implementation(libs.ktorClientCio)
     implementation(libs.logbackClassic)
     implementation(libs.kotlinTest)
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
@@ -44,6 +44,8 @@ class AppDataDirectoryProvider {
         return pluginDirectory.listFiles { file -> file.extension == "jar" }?.map { it.absolutePath } ?: emptyList()
     }
 
+    fun getPluginDirectory(): File = File(pluginDir)
+
     /**
      * The development-only "dev plugins directory" supplied by a plugin developer via the
      * `jetwhale.devPluginsDir` JVM system property (set by the `runJetWhale` Gradle task).

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallFromMavenMutationKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallFromMavenMutationKey.kt
@@ -1,0 +1,41 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
+import com.kitakkun.jetwhale.host.model.MavenCoordinates
+import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.PluginInstallFromMavenMutationKey
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import soil.query.MutationId
+import soil.query.buildMutationKey
+import java.io.File
+
+@Inject
+@ContributesBinding(AppScope::class)
+class DefaultPluginInstallFromMavenMutationKey(
+    private val pluginFactoryRepository: PluginFactoryRepository,
+    private val appDataDirectoryProvider: AppDataDirectoryProvider,
+    private val mavenArtifactResolver: MavenArtifactResolver,
+) : PluginInstallFromMavenMutationKey by buildMutationKey(
+    id = MutationId("pluginInstallFromMaven"),
+    mutate = { coordinates: MavenCoordinates ->
+        appDataDirectoryProvider.createAppDataDirectoriesIfNeeded()
+        val pluginDir = appDataDirectoryProvider.getPluginDirectory()
+        val downloadedJarPath = mavenArtifactResolver.downloadJar(coordinates, pluginDir)
+        try {
+            pluginFactoryRepository.loadPlugin(downloadedJarPath)
+        } catch (e: Exception) {
+            File(downloadedJarPath).delete()
+            throw PluginInstallationException(
+                "Failed to load plugin from $coordinates: ${e.message}",
+                e,
+            )
+        }
+    },
+)
+
+class PluginInstallationException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolver.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolver.kt
@@ -1,0 +1,63 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.model.MavenCoordinates
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import java.io.File
+
+@SingleIn(AppScope::class)
+@Inject
+class MavenArtifactResolver {
+    private val httpClient = HttpClient(CIO)
+
+    /**
+     * Downloads a JAR file from Maven repository to the specified destination directory.
+     * @param coordinates Maven coordinates of the artifact to download
+     * @param destinationDir Directory where the JAR file will be saved
+     * @return Path to the downloaded JAR file
+     * @throws MavenArtifactDownloadException if download fails
+     */
+    suspend fun downloadJar(coordinates: MavenCoordinates, destinationDir: File): String {
+        val jarUrl = coordinates.toJarUrl()
+        val jarFileName = "${coordinates.artifactId}-${coordinates.version}.jar"
+        val destinationFile = File(destinationDir, jarFileName)
+
+        try {
+            val response = httpClient.get(jarUrl)
+            if (!response.status.isSuccess()) {
+                throw MavenArtifactDownloadException(
+                    "Failed to download artifact from $jarUrl. HTTP status: ${response.status}",
+                )
+            }
+
+            destinationFile.outputStream().use { output ->
+                response.bodyAsChannel().toInputStream().use { input ->
+                    input.copyTo(output)
+                }
+            }
+
+            return destinationFile.absolutePath
+        } catch (e: MavenArtifactDownloadException) {
+            destinationFile.delete()
+            throw e
+        } catch (e: Exception) {
+            destinationFile.delete()
+            throw MavenArtifactDownloadException(
+                "Failed to download artifact $coordinates: ${e.message}",
+                e,
+            )
+        }
+    }
+}
+
+class MavenArtifactDownloadException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolver.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolver.kt
@@ -6,6 +6,7 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.isSuccess
@@ -15,7 +16,12 @@ import java.io.File
 @SingleIn(AppScope::class)
 @Inject
 class MavenArtifactResolver {
-    private val httpClient = HttpClient(CIO)
+    private val httpClient = HttpClient(CIO) {
+        install(HttpTimeout) {
+            connectTimeoutMillis = 30_000
+            socketTimeoutMillis = 30_000
+        }
+    }
 
     /**
      * Downloads a JAR file from Maven repository to the specified destination directory.
@@ -26,7 +32,7 @@ class MavenArtifactResolver {
      */
     suspend fun downloadJar(coordinates: MavenCoordinates, destinationDir: File): String {
         val jarUrl = coordinates.toJarUrl()
-        val jarFileName = "${coordinates.artifactId}-${coordinates.version}.jar"
+        val jarFileName = "${coordinates.groupId}-${coordinates.artifactId}-${coordinates.version}.jar"
         val destinationFile = File(destinationDir, jarFileName)
 
         try {

--- a/jetwhale-host/core/model/build.gradle.kts
+++ b/jetwhale-host/core/model/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
     implementation(libs.jetbrainsComposeRuntime)
     implementation(compose.desktop.currentOs)
     implementation(libs.aboutLibrariesCore)
+    testImplementation(libs.kotlinTest)
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinates.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinates.kt
@@ -1,0 +1,49 @@
+package com.kitakkun.jetwhale.host.model
+
+/**
+ * Represents Maven artifact coordinates (groupId:artifactId:version)
+ */
+data class MavenCoordinates(
+    val groupId: String,
+    val artifactId: String,
+    val version: String,
+    val repositoryUrl: String = MAVEN_CENTRAL_URL,
+) {
+    companion object {
+        const val MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2"
+
+        /**
+         * Parse Maven coordinates from a string in the format "groupId:artifactId:version"
+         * Optionally with repository URL: "groupId:artifactId:version@repositoryUrl"
+         */
+        fun parse(coordinates: String): MavenCoordinates {
+            val (coordPart, repoUrl) = if (coordinates.contains("@")) {
+                val parts = coordinates.split("@", limit = 2)
+                parts[0] to parts[1]
+            } else {
+                coordinates to MAVEN_CENTRAL_URL
+            }
+
+            val parts = coordPart.split(":")
+            require(parts.size == 3) {
+                "Invalid Maven coordinates format. Expected 'groupId:artifactId:version', got: $coordinates"
+            }
+            return MavenCoordinates(
+                groupId = parts[0],
+                artifactId = parts[1],
+                version = parts[2],
+                repositoryUrl = repoUrl,
+            )
+        }
+    }
+
+    /**
+     * Builds the URL to download the JAR file from the Maven repository
+     */
+    fun toJarUrl(): String {
+        val groupPath = groupId.replace('.', '/')
+        return "$repositoryUrl/$groupPath/$artifactId/$version/$artifactId-$version.jar"
+    }
+
+    override fun toString(): String = "$groupId:$artifactId:$version"
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinates.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinates.kt
@@ -35,6 +35,44 @@ data class MavenCoordinates(
                 repositoryUrl = repoUrl,
             )
         }
+
+        private val GAV_REGEX = Regex("""([\w.\-]+):([\w.\-]+):([\w.\-+]+)""")
+
+        /**
+         * Leniently extracts coordinates from text pasted from a build script.
+         * Supported formats:
+         * - Plain coordinates: `com.example:my-plugin:1.0.0` (optionally with `@repositoryUrl`)
+         * - Gradle Kotlin DSL: `implementation("com.example:my-plugin:1.0.0")`
+         * - Gradle Groovy DSL: `implementation 'com.example:my-plugin:1.0.0'`
+         * - Maven XML: a `<dependency>` block containing groupId/artifactId/version tags
+         *
+         * Returns null when no coordinates can be extracted.
+         */
+        fun parseLenient(input: String): MavenCoordinates? {
+            val text = input.trim()
+            if (text.isEmpty()) return null
+
+            if (text.contains("<groupId>")) {
+                return MavenCoordinates(
+                    groupId = extractXmlTagValue(text, "groupId") ?: return null,
+                    artifactId = extractXmlTagValue(text, "artifactId") ?: return null,
+                    version = extractXmlTagValue(text, "version") ?: return null,
+                )
+            }
+
+            val match = GAV_REGEX.find(text) ?: return null
+            val (groupId, artifactId, version) = match.destructured
+            val repositoryUrl = text.substringAfter('@', "").trim()
+                .takeIf { it.startsWith("http") }
+            return MavenCoordinates(
+                groupId = groupId,
+                artifactId = artifactId,
+                version = version,
+                repositoryUrl = repositoryUrl ?: MAVEN_CENTRAL_URL,
+            )
+        }
+
+        private fun extractXmlTagValue(text: String, tag: String): String? = Regex("<$tag>\\s*([^<]+?)\\s*</$tag>").find(text)?.groupValues?.get(1)
     }
 
     /**

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinates.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinates.kt
@@ -17,15 +17,16 @@ data class MavenCoordinates(
          * Optionally with repository URL: "groupId:artifactId:version@repositoryUrl"
          */
         fun parse(coordinates: String): MavenCoordinates {
-            val (coordPart, repoUrl) = if (coordinates.contains("@")) {
-                val parts = coordinates.split("@", limit = 2)
-                parts[0] to parts[1]
+            val trimmed = coordinates.trim()
+            val (coordPart, repoUrl) = if (trimmed.contains("@")) {
+                val parts = trimmed.split("@", limit = 2)
+                parts[0].trim() to parts[1].trim()
             } else {
-                coordinates to MAVEN_CENTRAL_URL
+                trimmed to MAVEN_CENTRAL_URL
             }
 
-            val parts = coordPart.split(":")
-            require(parts.size == 3) {
+            val parts = coordPart.split(":").map { it.trim() }
+            require(parts.size == 3 && parts.none { it.isEmpty() }) {
                 "Invalid Maven coordinates format. Expected 'groupId:artifactId:version', got: $coordinates"
             }
             return MavenCoordinates(
@@ -80,7 +81,7 @@ data class MavenCoordinates(
      */
     fun toJarUrl(): String {
         val groupPath = groupId.replace('.', '/')
-        return "$repositoryUrl/$groupPath/$artifactId/$version/$artifactId-$version.jar"
+        return "${repositoryUrl.trimEnd('/')}/$groupPath/$artifactId/$version/$artifactId-$version.jar"
     }
 
     override fun toString(): String = "$groupId:$artifactId:$version"

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstallFromMavenMutationKey.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstallFromMavenMutationKey.kt
@@ -1,0 +1,5 @@
+package com.kitakkun.jetwhale.host.model
+
+import soil.query.MutationKey
+
+typealias PluginInstallFromMavenMutationKey = MutationKey<Unit, MavenCoordinates>

--- a/jetwhale-host/core/model/src/test/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinatesTest.kt
+++ b/jetwhale-host/core/model/src/test/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinatesTest.kt
@@ -1,0 +1,78 @@
+package com.kitakkun.jetwhale.host.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MavenCoordinatesTest {
+    @Test
+    fun parseLenient_plainCoordinates() {
+        val coordinates = MavenCoordinates.parseLenient("com.example:my-plugin:1.0.0")
+        assertEquals("com.example", coordinates?.groupId)
+        assertEquals("my-plugin", coordinates?.artifactId)
+        assertEquals("1.0.0", coordinates?.version)
+        assertEquals(MavenCoordinates.MAVEN_CENTRAL_URL, coordinates?.repositoryUrl)
+    }
+
+    @Test
+    fun parseLenient_plainCoordinatesWithRepositoryUrl() {
+        val coordinates = MavenCoordinates.parseLenient("com.example:my-plugin:1.0.0@https://example.com/maven2")
+        assertEquals("com.example", coordinates?.groupId)
+        assertEquals("my-plugin", coordinates?.artifactId)
+        assertEquals("1.0.0", coordinates?.version)
+        assertEquals("https://example.com/maven2", coordinates?.repositoryUrl)
+    }
+
+    @Test
+    fun parseLenient_gradleKotlinDsl() {
+        val coordinates = MavenCoordinates.parseLenient("""implementation("com.example:my-plugin:1.0.0-alpha01")""")
+        assertEquals("com.example", coordinates?.groupId)
+        assertEquals("my-plugin", coordinates?.artifactId)
+        assertEquals("1.0.0-alpha01", coordinates?.version)
+    }
+
+    @Test
+    fun parseLenient_gradleGroovyDsl() {
+        val coordinates = MavenCoordinates.parseLenient("implementation 'com.example:my-plugin:1.0.0'")
+        assertEquals("com.example", coordinates?.groupId)
+        assertEquals("my-plugin", coordinates?.artifactId)
+        assertEquals("1.0.0", coordinates?.version)
+    }
+
+    @Test
+    fun parseLenient_mavenXml() {
+        val coordinates = MavenCoordinates.parseLenient(
+            """
+            <dependency>
+                <groupId>com.example</groupId>
+                <artifactId>my-plugin</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+            """.trimIndent(),
+        )
+        assertEquals("com.example", coordinates?.groupId)
+        assertEquals("my-plugin", coordinates?.artifactId)
+        assertEquals("1.0.0", coordinates?.version)
+    }
+
+    @Test
+    fun parseLenient_mavenXmlMissingVersion() {
+        val coordinates = MavenCoordinates.parseLenient(
+            """
+            <dependency>
+                <groupId>com.example</groupId>
+                <artifactId>my-plugin</artifactId>
+            </dependency>
+            """.trimIndent(),
+        )
+        assertNull(coordinates)
+    }
+
+    @Test
+    fun parseLenient_unparseableInput() {
+        assertNull(MavenCoordinates.parseLenient(""))
+        assertNull(MavenCoordinates.parseLenient("   "))
+        assertNull(MavenCoordinates.parseLenient("not coordinates"))
+        assertNull(MavenCoordinates.parseLenient("group:artifact"))
+    }
+}

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -42,4 +42,16 @@
     <string name="log_viewer_auto_scroll">自動スクロール</string>
     <string name="log_viewer_clear_logs">ログをクリア</string>
     <string name="log_viewer_no_logs">まだログがキャプチャされていません</string>
+    <string name="add_plugin_from_file">ファイルからプラグインを追加</string>
+    <string name="install_from_maven">Mavenからインストール</string>
+    <string name="maven_install_dialog_title">Mavenリポジトリからプラグインをインストール</string>
+    <string name="maven_install_dialog_description">Maven座標を入力してプラグインをダウンロード・インストールします。</string>
+    <string name="maven_install_paste_label">座標を貼り付け</string>
+    <string name="maven_install_paste_supporting_text">group:artifact:version、Gradleの依存関係の行、Mavenの&lt;dependency&gt;ブロックに対応しています。下のフィールドは自動的に入力されます。</string>
+    <string name="maven_install_group_id_label">Group ID</string>
+    <string name="maven_install_artifact_id_label">Artifact ID</string>
+    <string name="maven_install_version_label">バージョン</string>
+    <string name="maven_install_repository_url_label">リポジトリURL</string>
+    <string name="maven_install_error_fill_required">必須フィールドをすべて入力してください。</string>
+    <string name="maven_install_install">インストール</string>
 </resources>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -45,8 +45,8 @@
     <string name="add_plugin_from_file">ファイルからプラグインを追加</string>
     <string name="install_from_maven">Mavenからインストール</string>
     <string name="maven_install_dialog_title">Mavenリポジトリからプラグインをインストール</string>
-    <string name="maven_install_dialog_description">Maven座標を入力してプラグインをダウンロード・インストールします。</string>
-    <string name="maven_install_paste_label">座標を貼り付け</string>
+    <string name="maven_install_dialog_description">Mavenアーティファクトの情報（group:artifact:version）を入力してプラグインをダウンロード・インストールします。</string>
+    <string name="maven_install_paste_label">依存関係表記を貼り付け</string>
     <string name="maven_install_paste_supporting_text">group:artifact:version、Gradleの依存関係の行、Mavenの&lt;dependency&gt;ブロックに対応しています。下のフィールドは自動的に入力されます。</string>
     <string name="maven_install_group_id_label">Group ID</string>
     <string name="maven_install_artifact_id_label">Artifact ID</string>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -45,8 +45,8 @@
     <string name="add_plugin_from_file">ファイルからプラグインを追加</string>
     <string name="install_from_maven">Mavenからインストール</string>
     <string name="maven_install_dialog_title">Mavenリポジトリからプラグインをインストール</string>
-    <string name="maven_install_dialog_description">Mavenアーティファクトの情報（group:artifact:version）を入力してプラグインをダウンロード・インストールします。</string>
-    <string name="maven_install_paste_label">依存関係表記を貼り付け</string>
+    <string name="maven_install_dialog_description">Maven coordinatesを入力してプラグインをダウンロード・インストールします。</string>
+    <string name="maven_install_paste_label">Maven coordinatesを貼り付け</string>
     <string name="maven_install_paste_supporting_text">group:artifact:version、Gradleの依存関係の行、Mavenの&lt;dependency&gt;ブロックに対応しています。下のフィールドは自動的に入力されます。</string>
     <string name="maven_install_group_id_label">Group ID</string>
     <string name="maven_install_artifact_id_label">Artifact ID</string>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
@@ -44,4 +44,16 @@
     <string name="log_viewer_auto_scroll">Auto-scroll</string>
     <string name="log_viewer_clear_logs">Clear Logs</string>
     <string name="log_viewer_no_logs">No logs captured yet</string>
+    <string name="add_plugin_from_file">Add Plugin from File</string>
+    <string name="install_from_maven">Install from Maven</string>
+    <string name="maven_install_dialog_title">Install Plugin from Maven Repository</string>
+    <string name="maven_install_dialog_description">Enter Maven coordinates to download and install a plugin.</string>
+    <string name="maven_install_paste_label">Paste coordinates</string>
+    <string name="maven_install_paste_supporting_text">Accepts group:artifact:version, Gradle dependency lines, or a Maven &lt;dependency&gt; block. Fields below are filled automatically.</string>
+    <string name="maven_install_group_id_label">Group ID</string>
+    <string name="maven_install_artifact_id_label">Artifact ID</string>
+    <string name="maven_install_version_label">Version</string>
+    <string name="maven_install_repository_url_label">Repository URL</string>
+    <string name="maven_install_error_fill_required">Please fill in all required fields.</string>
+    <string name="maven_install_install">Install</string>
 </resources>

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenContext.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenContext.kt
@@ -12,6 +12,7 @@ import com.kitakkun.jetwhale.host.model.LoadedPluginsMetaDataSubscriptionKey
 import com.kitakkun.jetwhale.host.model.LogCaptureService
 import com.kitakkun.jetwhale.host.model.McpServerPortMutationKey
 import com.kitakkun.jetwhale.host.model.McpServerStatusSubscriptionKey
+import com.kitakkun.jetwhale.host.model.PluginInstallFromMavenMutationKey
 import com.kitakkun.jetwhale.host.model.PluginInstallMutationKey
 import com.kitakkun.jetwhale.host.model.ServerPortMutationKey
 import com.kitakkun.jetwhale.host.model.ServerStatusSubscriptionKey
@@ -31,6 +32,7 @@ class SettingsPresenterContext(
     val serverPortMutationKey: ServerPortMutationKey,
     val mcpServerPortMutationKey: McpServerPortMutationKey,
     val pluginInstallMutationKey: PluginInstallMutationKey,
+    val pluginInstallFromMavenMutationKey: PluginInstallFromMavenMutationKey,
     val logCaptureService: LogCaptureService,
 ) : PresenterContext
 

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/MavenPluginInstallDialog.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/MavenPluginInstallDialog.kt
@@ -1,0 +1,141 @@
+package com.kitakkun.jetwhale.host.settings.plugin
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.host.model.MavenCoordinates
+
+@Composable
+fun MavenPluginInstallDialog(
+    onDismissRequest: () -> Unit,
+    onInstall: (MavenCoordinates) -> Unit,
+) {
+    var groupId by remember { mutableStateOf("") }
+    var artifactId by remember { mutableStateOf("") }
+    var version by remember { mutableStateOf("") }
+    var repositoryUrl by remember { mutableStateOf(MavenCoordinates.MAVEN_CENTRAL_URL) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = {
+            Text("Install Plugin from Maven Repository")
+        },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = "Enter Maven coordinates to download and install a plugin.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                OutlinedTextField(
+                    value = groupId,
+                    onValueChange = {
+                        groupId = it
+                        errorMessage = null
+                    },
+                    label = { Text("Group ID") },
+                    placeholder = { Text("com.example") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                OutlinedTextField(
+                    value = artifactId,
+                    onValueChange = {
+                        artifactId = it
+                        errorMessage = null
+                    },
+                    label = { Text("Artifact ID") },
+                    placeholder = { Text("my-plugin") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                OutlinedTextField(
+                    value = version,
+                    onValueChange = {
+                        version = it
+                        errorMessage = null
+                    },
+                    label = { Text("Version") },
+                    placeholder = { Text("1.0.0") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                OutlinedTextField(
+                    value = repositoryUrl,
+                    onValueChange = {
+                        repositoryUrl = it
+                        errorMessage = null
+                    },
+                    label = { Text("Repository URL") },
+                    placeholder = { Text(MavenCoordinates.MAVEN_CENTRAL_URL) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                errorMessage?.let { error ->
+                    Text(
+                        text = error,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                TextButton(onClick = onDismissRequest) {
+                    Text("Cancel")
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(
+                    onClick = {
+                        if (groupId.isBlank() || artifactId.isBlank() || version.isBlank()) {
+                            errorMessage = "Please fill in all required fields."
+                            return@Button
+                        }
+                        val coordinates = MavenCoordinates(
+                            groupId = groupId.trim(),
+                            artifactId = artifactId.trim(),
+                            version = version.trim(),
+                            repositoryUrl = repositoryUrl.trim().ifBlank { MavenCoordinates.MAVEN_CENTRAL_URL },
+                        )
+                        onInstall(coordinates)
+                        onDismissRequest()
+                    },
+                ) {
+                    Text("Install")
+                }
+            }
+        },
+    )
+}

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/MavenPluginInstallDialog.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/MavenPluginInstallDialog.kt
@@ -2,12 +2,10 @@ package com.kitakkun.jetwhale.host.settings.plugin
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -132,31 +130,28 @@ fun MavenPluginInstallDialog(
             }
         },
         confirmButton = {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            Button(
+                onClick = {
+                    if (groupId.isBlank() || artifactId.isBlank() || version.isBlank()) {
+                        errorMessage = "Please fill in all required fields."
+                        return@Button
+                    }
+                    val coordinates = MavenCoordinates(
+                        groupId = groupId.trim(),
+                        artifactId = artifactId.trim(),
+                        version = version.trim(),
+                        repositoryUrl = repositoryUrl.trim().ifBlank { MavenCoordinates.MAVEN_CENTRAL_URL },
+                    )
+                    onInstall(coordinates)
+                    onDismissRequest()
+                },
             ) {
-                TextButton(onClick = onDismissRequest) {
-                    Text("Cancel")
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Button(
-                    onClick = {
-                        if (groupId.isBlank() || artifactId.isBlank() || version.isBlank()) {
-                            errorMessage = "Please fill in all required fields."
-                            return@Button
-                        }
-                        val coordinates = MavenCoordinates(
-                            groupId = groupId.trim(),
-                            artifactId = artifactId.trim(),
-                            version = version.trim(),
-                            repositoryUrl = repositoryUrl.trim().ifBlank { MavenCoordinates.MAVEN_CENTRAL_URL },
-                        )
-                        onInstall(coordinates)
-                        onDismissRequest()
-                    },
-                ) {
-                    Text("Install")
-                }
+                Text("Install")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Cancel")
             }
         },
     )

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/MavenPluginInstallDialog.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/MavenPluginInstallDialog.kt
@@ -20,6 +20,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.model.MavenCoordinates
+import com.kitakkun.jetwhale.host.settings.Res
+import com.kitakkun.jetwhale.host.settings.dialog_cancel
+import com.kitakkun.jetwhale.host.settings.maven_install_artifact_id_label
+import com.kitakkun.jetwhale.host.settings.maven_install_dialog_description
+import com.kitakkun.jetwhale.host.settings.maven_install_dialog_title
+import com.kitakkun.jetwhale.host.settings.maven_install_error_fill_required
+import com.kitakkun.jetwhale.host.settings.maven_install_group_id_label
+import com.kitakkun.jetwhale.host.settings.maven_install_install
+import com.kitakkun.jetwhale.host.settings.maven_install_paste_label
+import com.kitakkun.jetwhale.host.settings.maven_install_paste_supporting_text
+import com.kitakkun.jetwhale.host.settings.maven_install_repository_url_label
+import com.kitakkun.jetwhale.host.settings.maven_install_version_label
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun MavenPluginInstallDialog(
@@ -32,11 +45,12 @@ fun MavenPluginInstallDialog(
     var version by remember { mutableStateOf("") }
     var repositoryUrl by remember { mutableStateOf(MavenCoordinates.MAVEN_CENTRAL_URL) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
+    val fillRequiredFieldsError = stringResource(Res.string.maven_install_error_fill_required)
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
         title = {
-            Text("Install Plugin from Maven Repository")
+            Text(stringResource(Res.string.maven_install_dialog_title))
         },
         text = {
             Column(
@@ -44,7 +58,7 @@ fun MavenPluginInstallDialog(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Text(
-                    text = "Enter Maven coordinates to download and install a plugin.",
+                    text = stringResource(Res.string.maven_install_dialog_description),
                     style = MaterialTheme.typography.bodyMedium,
                 )
 
@@ -62,10 +76,10 @@ fun MavenPluginInstallDialog(
                         }
                         errorMessage = null
                     },
-                    label = { Text("Paste coordinates") },
+                    label = { Text(stringResource(Res.string.maven_install_paste_label)) },
                     placeholder = { Text("com.example:my-plugin:1.0.0") },
                     supportingText = {
-                        Text("Accepts group:artifact:version, Gradle dependency lines, or a Maven <dependency> block. Fields below are filled automatically.")
+                        Text(stringResource(Res.string.maven_install_paste_supporting_text))
                     },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
@@ -77,7 +91,7 @@ fun MavenPluginInstallDialog(
                         groupId = it
                         errorMessage = null
                     },
-                    label = { Text("Group ID") },
+                    label = { Text(stringResource(Res.string.maven_install_group_id_label)) },
                     placeholder = { Text("com.example") },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
@@ -89,7 +103,7 @@ fun MavenPluginInstallDialog(
                         artifactId = it
                         errorMessage = null
                     },
-                    label = { Text("Artifact ID") },
+                    label = { Text(stringResource(Res.string.maven_install_artifact_id_label)) },
                     placeholder = { Text("my-plugin") },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
@@ -101,7 +115,7 @@ fun MavenPluginInstallDialog(
                         version = it
                         errorMessage = null
                     },
-                    label = { Text("Version") },
+                    label = { Text(stringResource(Res.string.maven_install_version_label)) },
                     placeholder = { Text("1.0.0") },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
@@ -113,7 +127,7 @@ fun MavenPluginInstallDialog(
                         repositoryUrl = it
                         errorMessage = null
                     },
-                    label = { Text("Repository URL") },
+                    label = { Text(stringResource(Res.string.maven_install_repository_url_label)) },
                     placeholder = { Text(MavenCoordinates.MAVEN_CENTRAL_URL) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
@@ -133,7 +147,7 @@ fun MavenPluginInstallDialog(
             Button(
                 onClick = {
                     if (groupId.isBlank() || artifactId.isBlank() || version.isBlank()) {
-                        errorMessage = "Please fill in all required fields."
+                        errorMessage = fillRequiredFieldsError
                         return@Button
                     }
                     val coordinates = MavenCoordinates(
@@ -146,12 +160,12 @@ fun MavenPluginInstallDialog(
                     onDismissRequest()
                 },
             ) {
-                Text("Install")
+                Text(stringResource(Res.string.maven_install_install))
             }
         },
         dismissButton = {
             TextButton(onClick = onDismissRequest) {
-                Text("Cancel")
+                Text(stringResource(Res.string.dialog_cancel))
             }
         },
     )

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/MavenPluginInstallDialog.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/MavenPluginInstallDialog.kt
@@ -28,6 +28,7 @@ fun MavenPluginInstallDialog(
     onDismissRequest: () -> Unit,
     onInstall: (MavenCoordinates) -> Unit,
 ) {
+    var pastedNotation by remember { mutableStateOf("") }
     var groupId by remember { mutableStateOf("") }
     var artifactId by remember { mutableStateOf("") }
     var version by remember { mutableStateOf("") }
@@ -50,6 +51,27 @@ fun MavenPluginInstallDialog(
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
+
+                OutlinedTextField(
+                    value = pastedNotation,
+                    onValueChange = { input ->
+                        pastedNotation = input
+                        MavenCoordinates.parseLenient(input)?.let { parsed ->
+                            groupId = parsed.groupId
+                            artifactId = parsed.artifactId
+                            version = parsed.version
+                            repositoryUrl = parsed.repositoryUrl
+                        }
+                        errorMessage = null
+                    },
+                    label = { Text("Paste coordinates") },
+                    placeholder = { Text("com.example:my-plugin:1.0.0") },
+                    supportingText = {
+                        Text("Accepts group:artifact:version, Gradle dependency lines, or a Maven <dependency> block. Fields below are filled automatically.")
+                    },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
 
                 OutlinedTextField(
                     value = groupId,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
@@ -32,9 +32,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.settings.Res
 import com.kitakkun.jetwhale.host.settings.SettingsScreenScaffoldPageContentPadding
+import com.kitakkun.jetwhale.host.settings.add_plugin_from_file
 import com.kitakkun.jetwhale.host.settings.dialog_ok
 import com.kitakkun.jetwhale.host.settings.failed_jar_path_hint
 import com.kitakkun.jetwhale.host.settings.failed_to_load_plugins
+import com.kitakkun.jetwhale.host.settings.install_from_maven
 import com.kitakkun.jetwhale.host.settings.installed_plugins
 import org.jetbrains.compose.resources.stringResource
 
@@ -174,13 +176,13 @@ fun PluginSettingsScreen(
                 onClick = onClickAddPlugin,
                 enabled = !uiState.isInstalling,
             ) {
-                Text("Add Plugin from File")
+                Text(stringResource(Res.string.add_plugin_from_file))
             }
             Button(
                 onClick = onClickInstallFromMaven,
                 enabled = !uiState.isInstalling,
             ) {
-                Text("Install from Maven")
+                Text(stringResource(Res.string.install_from_maven))
             }
             if (uiState.isInstalling) {
                 CircularProgressIndicator(

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -15,6 +16,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -40,6 +42,7 @@ import org.jetbrains.compose.resources.stringResource
 fun PluginSettingsScreen(
     uiState: PluginSettingsScreenUiState,
     onClickAddPlugin: () -> Unit,
+    onClickInstallFromMaven: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showFailedJarsDialog by remember { mutableStateOf(false) }
@@ -149,8 +152,42 @@ fun PluginSettingsScreen(
                 )
             }
         }
-        Button(onClickAddPlugin) {
-            Text("Add Plugin")
+        uiState.installError?.let { error ->
+            Text(
+                text = error,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = MaterialTheme.colorScheme.errorContainer,
+                        shape = MaterialTheme.shapes.small,
+                    )
+                    .padding(8.dp),
+            )
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(
+                onClick = onClickAddPlugin,
+                enabled = !uiState.isInstalling,
+            ) {
+                Text("Add Plugin from File")
+            }
+            Button(
+                onClick = onClickInstallFromMaven,
+                enabled = !uiState.isInstalling,
+            ) {
+                Text("Install from Maven")
+            }
+            if (uiState.isInstalling) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
+                )
+            }
         }
     }
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenAction.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenAction.kt
@@ -1,5 +1,8 @@
 package com.kitakkun.jetwhale.host.settings.plugin
 
+import com.kitakkun.jetwhale.host.model.MavenCoordinates
+
 sealed interface PluginSettingsScreenAction {
     data class PluginJarSelected(val path: String) : PluginSettingsScreenAction
+    data class InstallFromMaven(val coordinates: MavenCoordinates) : PluginSettingsScreenAction
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenPresenter.kt
@@ -27,7 +27,7 @@ fun pluginSettingsScreenPresenter(
             }
 
             is PluginSettingsScreenAction.InstallFromMaven -> {
-                pluginInstallFromMavenMutation.mutate(action.coordinates)
+                pluginInstallFromMavenMutation.mutateAsync(action.coordinates)
             }
         }
     }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenPresenter.kt
@@ -18,14 +18,23 @@ fun pluginSettingsScreenPresenter(
     failedJarPaths: ImmutableList<String>,
 ): PluginSettingsScreenUiState {
     val pluginInstallMutation = rememberMutation(presenterContext.pluginInstallMutationKey)
+    val pluginInstallFromMavenMutation = rememberMutation(presenterContext.pluginInstallFromMavenMutationKey)
 
     ActionEffect(screenChannel) { action ->
         when (action) {
             is PluginSettingsScreenAction.PluginJarSelected -> {
                 pluginInstallMutation.mutateAsync(action.path)
             }
+
+            is PluginSettingsScreenAction.InstallFromMaven -> {
+                pluginInstallFromMavenMutation.mutate(action.coordinates)
+            }
         }
     }
+
+    val isInstalling = pluginInstallMutation.isPending || pluginInstallFromMavenMutation.isPending
+    val installError = pluginInstallFromMavenMutation.error?.message
+        ?: pluginInstallMutation.error?.message
 
     return PluginSettingsScreenUiState(
         plugins = loadedPlugins.map {
@@ -36,5 +45,7 @@ fun pluginSettingsScreenPresenter(
             )
         }.toPersistentList(),
         failedJarPaths = failedJarPaths,
+        isInstalling = isInstalling,
+        installError = installError,
     )
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenRoot.kt
@@ -1,6 +1,10 @@
 package com.kitakkun.jetwhale.host.settings.plugin
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.settings.SettingsScreenContext
@@ -12,6 +16,8 @@ import java.io.File
 @Composable
 context(screenContext: SettingsScreenContext)
 fun PluginSettingsScreenRoot() {
+    var showMavenDialog by remember { mutableStateOf(false) }
+
     SoilDataBoundary(
         state1 = rememberSubscription(screenContext.loadedPluginsMetaDataSubscriptionKey),
         state2 = rememberSubscription(screenContext.failedPluginJarPathsSubscriptionKey),
@@ -31,7 +37,19 @@ fun PluginSettingsScreenRoot() {
                 val selectedJar = selectJarFile() ?: return@PluginSettingsScreen
                 screenChannel.send(PluginSettingsScreenAction.PluginJarSelected(selectedJar.path))
             },
+            onClickInstallFromMaven = {
+                showMavenDialog = true
+            },
         )
+
+        if (showMavenDialog) {
+            MavenPluginInstallDialog(
+                onDismissRequest = { showMavenDialog = false },
+                onInstall = { coordinates ->
+                    screenChannel.send(PluginSettingsScreenAction.InstallFromMaven(coordinates))
+                },
+            )
+        }
     }
 }
 

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenUiState.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenUiState.kt
@@ -5,4 +5,6 @@ import kotlinx.collections.immutable.ImmutableList
 data class PluginSettingsScreenUiState(
     val plugins: ImmutableList<com.kitakkun.jetwhale.host.settings.component.PluginInfoUiState>,
     val failedJarPaths: ImmutableList<String>,
+    val isInstalling: Boolean = false,
+    val installError: String? = null,
 )


### PR DESCRIPTION
Add ability to install plugins by downloading JAR files from Maven Central
or other Maven repositories using artifact coordinates (groupId:artifactId:version).

- Add MavenCoordinates model class for parsing Maven coordinates
- Add MavenArtifactResolver service using Ktor client for downloading JARs
- Add PluginInstallFromMavenMutationKey for the installation mutation
- Add MavenPluginInstallDialog UI component for entering coordinates
- Update PluginSettingsScreen with "Install from Maven" button

## Error handling

- Delete the downloaded JAR when plugin loading fails, and the incomplete JAR when the download fails
- Show an error message in the UI when installation fails
- Show a loading indicator and disable the install buttons while installation is in progress

## Paste dependency notation

The install dialog has a "Paste coordinates" field that auto-fills the
groupId/artifactId/version/repository fields from common dependency notations
(`MavenCoordinates.parseLenient`, covered by unit tests):

- Plain coordinates: `com.example:my-plugin:1.0.0` (optionally with `@repositoryUrl`)
- Gradle Kotlin DSL: `implementation("com.example:my-plugin:1.0.0")`
- Gradle Groovy DSL: `implementation 'com.example:my-plugin:1.0.0'`
- Maven XML `<dependency>` blocks
