### PR TITLE
feat: publish Network Inspector host plugin jar to Maven Central

### DIFF
--- a/jetwhale-plugins/network/host/build.gradle.kts
+++ b/jetwhale-plugins/network/host/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.jetwhalePlugin)
     // In-repo only: adds runJetWhaleLocal, which launches the local :jetwhale-host:app project.
     alias(libs.plugins.jetwhaleHostLaunch)
+    alias(libs.plugins.publish)
 }
 
 // Distinct group so this module's coordinates don't collide with `example:host`.
@@ -28,4 +29,13 @@ dependencies {
     testImplementation(libs.kotlinTest)
     testImplementation(compose.desktop.currentOs)
     testImplementation(libs.material3)
+}
+
+// The jetwhalePlugin convention publishes the `packageMavenPlugin` jar (the module's classes plus a
+// manifest of its runtime dependencies) as the main artifact; the host's "Install from Maven"
+// feature downloads it and fetches the listed dependencies itself.
+jetwhalePublish {
+    artifactId = "jetwhale-network-inspector"
+    name = "JetWhale Network Inspector"
+    description = "JetWhale host plugin for the Network Inspector (HTTP capture and mocking)."
 }


### PR DESCRIPTION
Stacked on #132 (thin-jar + dependency-manifest Maven publishing support) — merge that first.

Publish the network host plugin module as `com.kitakkun.jetwhale:jetwhale-network-inspector`, so the host's Install-from-Maven feature (#128) can be tested against a real published artifact.

- Applies the existing `publish` convention (vanniktech maven-publish + Central + signing); the `jetwhalePlugin` convention from #132 makes the published main artifact the `packageMavenPlugin` jar — the module's own classes plus `META-INF/jetwhale/dependencies.txt`. The protocol modules are listed in the manifest by their own publication coordinates (`jetwhale-network-inspector-protocol-jvm` etc.) — nothing is bundled
- The tag-triggered `publish.yaml` workflow (`publishToMavenCentral`) picks this module up automatically; `publish-snapshot.yaml` likewise covers SNAPSHOT publishing, so a snapshot run can be used to test installation before a release