### PR TITLE
feat: Maven publishing support for JetWhale plugins via thin jars + dependency manifest

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -12,6 +12,7 @@ The `com.kitakkun.jetwhale.host` plugin gives your plugin's module these tasks:
 | `packagePlugin`          | Builds the distributable plugin fat-jar (the artifact you drop into `~/.jetwhale/plugins/`).          |
 | `installPlugin`          | Copies the packaged fat-jar into `~/.jetwhale/plugins/`.                                              |
 | `stageDevPlugin`         | Stages the packaged fat-jar into a private dev directory the host watches for hot reload.             |
+| `packageMavenPlugin`     | Builds the publishable plugin jar (see [Publishing your plugin to Maven](#publishing-your-plugin-to-maven)). |
 | `runJetWhale`            | Downloads a released JetWhale host for your OS and launches it with your plugin loaded.|
 | `runJetWhaleHot`         | Like `runJetWhale`, but runs the host on the JetBrains Runtime so structural changes hot-reload in place (see [Limitations](#limitations)), and auto re-stages your plugin in the background — the whole hot-reload loop in one command. |
 
@@ -317,6 +318,36 @@ plugins { id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 
 So: a change that can't be redefined in place costs you the plugin's in-memory state — never a host
 restart.
+
+## Publishing your plugin to Maven
+
+Users can install a plugin straight from a Maven repository: **Settings → Plugins → Install from
+Maven**, entering `group:artifact:version` (append `@https://your.repo/url` for a repository other
+than Maven Central — pasting a Gradle dependency line or a Maven `<dependency>` block also works).
+
+To make your plugin installable that way, apply a Maven publishing plugin (e.g.
+[`com.vanniktech.maven.publish`](https://github.com/vanniktech/gradle-maven-publish-plugin) or plain
+`maven-publish`) to the plugin module alongside `com.kitakkun.jetwhale.host`, and publish to any
+Maven repository you like. The JetWhale plugin automatically makes the published main artifact the
+`packageMavenPlugin` jar, which contains:
+
+- your module's classes and resources, and
+- `META-INF/jetwhale/dependencies.txt` — the flat `group:artifact:version` list of your runtime
+  dependencies, exactly as Gradle resolved them at build time.
+
+Dependencies are deliberately **not** bundled: the host downloads each jar listed in the manifest
+when the plugin is installed (from your plugin's repository, falling back to Maven Central) and
+puts them on the plugin's classpath. This keeps the published artifact small and
+platform-independent, and means you never redistribute third-party code.
+
+In-build project dependencies (e.g. a sibling `protocol` module) are listed in the manifest by
+their own publication coordinates when the module has a Maven publication configured — publish
+them alongside the plugin. A project dependency without a publication is bundled into the plugin
+jar as a fallback.
+
+Remember that host-provided dependencies (`jetwhale-host-sdk`, Compose, `material3`) must stay
+`compileOnly` — they are provided by the host at runtime and must appear neither in the jar nor in
+the dependency manifest.
 
 ## Trying an unreleased (SNAPSHOT) build
 

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -18,9 +18,16 @@ The JetWhale host's behavior is configured from its **Settings** screen.
 
 ## Plugins
 
-Installed plugins live in `~/.jetwhale/plugins/` as fat-jars. Drop a plugin jar there (or run
-`./gradlew installPlugin` from a plugin project) and the host picks it up. See
-[Developing Plugins](/guide/developing-plugins) for building your own.
+Installed plugins live in `~/.jetwhale/plugins/`. There are two ways to install one:
+
+- **Install from Maven** — enter the plugin's `group:artifact:version` (append
+  `@https://your.repo/url` for a repository other than Maven Central; pasting a Gradle dependency
+  line or a Maven `<dependency>` block also works). The host downloads the plugin jar and the
+  external dependencies it declares (stored in `~/.jetwhale/plugins/libs/`).
+- **Add Plugin from File** — pick a locally built fat-jar, or drop one into `~/.jetwhale/plugins/`
+  yourself (or run `./gradlew installPlugin` from a plugin project).
+
+See [Developing Plugins](/guide/developing-plugins) for building your own.
 
 ### Plugin trust
 

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -371,3 +371,146 @@ registerRunTask(
 tasks.named("assemble") {
     dependsOn(packagePlugin)
 }
+
+// ---------------------------------------------------------------------------
+// Maven publishing: publish a thin plugin jar plus a dependency manifest.
+// ---------------------------------------------------------------------------
+
+// The published plugin artifact deliberately does NOT bundle third-party dependencies (publishing a
+// fat-jar would redistribute them, with the license obligations that entails, and would bake the
+// build machine's platform-specific artifacts into a supposedly universal jar). Instead the
+// published jar carries:
+//
+// - the module's own classes and resources (plus, as a fallback, the classes of any in-build
+//   project dependency that is NOT itself published — a published project dependency has Maven
+//   coordinates of its own, taken from its `publishing` configuration exactly as the generated POM
+//   does, and is listed in the manifest like any external dependency), and
+// - `META-INF/jetwhale/dependencies.txt` — the flat list of runtime dependencies as
+//   `group:artifact:version` lines, exactly as Gradle resolved them at build time.
+//
+// The host downloads the listed jars itself when installing the plugin from Maven, so no full
+// dependency-resolution logic (parent POMs, BOMs, Gradle module metadata…) is ever needed at
+// runtime, and nothing third-party is redistributed by the plugin author.
+
+val runtimeElementsIncoming = configurations.getByName("runtimeClasspath").incoming
+
+// External module dependencies -> lockfile lines. Resolved lazily and configuration-cache safe.
+val externalDependencyCoordinates: Provider<List<String>> = runtimeElementsIncoming.artifacts.resolvedArtifacts.map { artifacts ->
+    artifacts
+        .mapNotNull { it.id.componentIdentifier as? org.gradle.api.artifacts.component.ModuleComponentIdentifier }
+        .map { "${it.group}:${it.module}:${it.version}" }
+        .distinct()
+        .sorted()
+}
+
+// In-build project dependencies: published ones are trusted to be fetchable by their publication
+// coordinates (the same source the generated POM uses — for KMP modules that is the `jvm`
+// publication, e.g. `protocol-jvm`); unpublished ones are bundled into the jar as a fallback.
+// Both sets are filled once every project is evaluated (publication coordinates are configured in
+// the dependency projects' own afterEvaluate blocks, so they cannot be read earlier).
+val publishedProjectDependencyCoordinates = mutableSetOf<String>()
+val bundledProjectPaths = mutableSetOf<String>()
+
+// Declared-dependency configurations that can carry project dependencies, for plain-JVM and KMP
+// modules alike. Walking declarations (instead of resolving the classpath, which is not allowed at
+// configuration time) is safe here: we only need to identify the project modules in the graph.
+val projectDependencyConfigurationNames = listOf(
+    "api",
+    "implementation",
+    "runtimeOnly",
+    "commonMainApi",
+    "commonMainImplementation",
+    "jvmMainApi",
+    "jvmMainImplementation",
+)
+
+fun collectProjectDependencies(from: Project, seenPaths: MutableSet<String>) {
+    projectDependencyConfigurationNames.forEach { configurationName ->
+        from.configurations.findByName(configurationName)
+            ?.dependencies
+            ?.withType(org.gradle.api.artifacts.ProjectDependency::class.java)
+            ?.forEach { dependency ->
+                val depProject = runCatching { from.project(dependency.path) }.getOrNull() ?: return@forEach
+                if (seenPaths.add(depProject.path)) collectProjectDependencies(depProject, seenPaths)
+            }
+    }
+}
+
+gradle.projectsEvaluated {
+    val seenPaths = mutableSetOf<String>()
+    collectProjectDependencies(project, seenPaths)
+    seenPaths.forEach { path ->
+        val depProject = project.project(path)
+        val publications = depProject.extensions
+            .findByType(org.gradle.api.publish.PublishingExtension::class.java)
+            ?.publications
+            ?.withType(org.gradle.api.publish.maven.MavenPublication::class.java)
+        // KMP modules publish the JVM variant under the `jvm` publication; plain JVM modules
+        // publish a single publication (commonly `maven`).
+        val publication = publications?.findByName("jvm") ?: publications?.singleOrNull()
+        if (publication != null) {
+            publishedProjectDependencyCoordinates +=
+                "${publication.groupId}:${publication.artifactId}:${publication.version}"
+        } else {
+            logger.info(
+                "packageMavenPlugin: project dependency $path has no Maven publication; " +
+                    "bundling its classes into the plugin jar.",
+            )
+            bundledProjectPaths += path
+        }
+    }
+}
+
+val projectDependencyFiles = runtimeElementsIncoming.artifactView {
+    componentFilter {
+        it is org.gradle.api.artifacts.component.ProjectComponentIdentifier && it.projectPath in bundledProjectPaths
+    }
+}.files
+
+val generatePluginDependencyManifest = tasks.register("generatePluginDependencyManifest") {
+    group = "jetwhale"
+    description = "Writes the plugin's external runtime dependencies as a Maven-coordinates manifest."
+
+    val projectCoordinates = publishedProjectDependencyCoordinates
+    val coordinates = externalDependencyCoordinates.map { external ->
+        (external + projectCoordinates).distinct().sorted()
+    }
+    val outputFile = layout.buildDirectory.file("jetwhale/dependencies.txt")
+    inputs.property("coordinates", coordinates)
+    outputs.file(outputFile)
+
+    doLast {
+        outputFile.get().asFile.writeText(coordinates.get().joinToString("\n", postfix = "\n"))
+    }
+}
+
+val packageMavenPlugin = tasks.register<Jar>("packageMavenPlugin") {
+    group = "jetwhale"
+    description = "Builds the publishable plugin jar (own + project-dependency classes, external deps as a manifest)."
+
+    archiveBaseName.set(pluginExtension.pluginArchiveName)
+    archiveClassifier.set("jetwhale-maven-plugin")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    val thinJar = tasks.named<Jar>("jar")
+    from(thinJar.map { zipTree(it.archiveFile) })
+    from({ projectDependencyFiles.map { zipTree(it) } })
+    from(generatePluginDependencyManifest) {
+        into("META-INF/jetwhale")
+    }
+}
+
+// When the plugin author also applies a Maven publishing plugin, replace the outgoing jar of the
+// java component with the `packageMavenPlugin` jar (classifier cleared, so it publishes as the
+// plain `<artifactId>-<version>.jar`): the JetWhale host's Install-from-Maven feature downloads
+// exactly that main artifact.
+pluginManager.withPlugin("maven-publish") {
+    listOf("apiElements", "runtimeElements").forEach { configurationName ->
+        configurations.named(configurationName) {
+            outgoing.artifacts.clear()
+            outgoing.artifact(packageMavenPlugin) {
+                classifier = null
+            }
+        }
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
@@ -13,6 +13,7 @@ class AppDataDirectoryProvider {
     private val homeDir = System.getProperty("user.home")
     private val appDataDir = "$homeDir/.jetwhale"
     private val pluginDir = "$appDataDir/plugins"
+    private val pluginLibsDir = "$pluginDir/libs"
     private val dataStoreFilesDir = "$appDataDir/dataStorePreferences"
 
     fun resolveDataStoreFilePath(fileName: String): Path = "$dataStoreFilesDir/$fileName".toPath()
@@ -51,6 +52,10 @@ class AppDataDirectoryProvider {
         if (!pluginDirectory.exists()) {
             pluginDirectory.mkdirs()
         }
+        val pluginLibsDirectory = File(pluginLibsDir)
+        if (!pluginLibsDirectory.exists()) {
+            pluginLibsDirectory.mkdirs()
+        }
     }
 
     fun copyJarFileToAppDataDirectory(jarFilePath: String): String {
@@ -68,6 +73,13 @@ class AppDataDirectoryProvider {
     }
 
     fun getPluginDirectory(): File = File(pluginDir)
+
+    /**
+     * Directory holding the external dependency jars that Maven-installed plugins declare in their
+     * `META-INF/jetwhale/dependencies.txt` manifest. Kept in a subdirectory of the plugins
+     * directory so the jars are not themselves picked up as plugins by [getAllPluginJarFilePaths].
+     */
+    fun getPluginLibsDirectory(): File = File(pluginLibsDir)
 
     /**
      * The development-only "dev plugins directory" supplied by a plugin developer via the

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -79,7 +79,21 @@ class DefaultPluginFactoryRepository @Inject constructor(
         // which otherwise throws ZipException on later resource/class reads. Every plugin declared by
         // the jar shares this single classloader.
         val runtimeJar = createRuntimeCopyIfDevJar(pluginJarPath)
-        val classLoader = URLClassLoader(arrayOf((runtimeJar ?: File(pluginJarPath)).toURI().toURL()))
+        val openedJar = runtimeJar ?: File(pluginJarPath)
+
+        // Maven-installed plugins declare their external dependencies in a manifest instead of
+        // bundling them; those jars were downloaded into the plugin libs directory at install time
+        // and join the plugin's classpath here. A missing jar (or an unreadable manifest) fails the
+        // load and surfaces the jar in the failed list. Fat-jars have no manifest → empty list.
+        val dependencyJarUrls = try {
+            resolveDeclaredDependencyJars(openedJar).map { it.toURI().toURL() }
+        } catch (e: Exception) {
+            println("Failed to load plugin from $pluginJarPath: ${e.message}")
+            mutableFailedJarPathsFlow.update { if (pluginJarPath in it) it else it + pluginJarPath }
+            runtimeJar?.delete()
+            return
+        }
+        val classLoader = URLClassLoader((listOf(openedJar.toURI().toURL()) + dependencyJarUrls).toTypedArray())
 
         // Once the classloader is handed to `classLoaders`, the map owns it and the `finally` below
         // must not close it; until then it (and its temp copy) is ours to discard on any failure.
@@ -123,6 +137,23 @@ class DefaultPluginFactoryRepository @Inject constructor(
                 classLoader.close()
                 runtimeJar?.delete()
             }
+        }
+    }
+
+    /**
+     * Maps the plugin jar's dependency manifest to the downloaded jar files in the plugin libs
+     * directory, failing with a clear message when one is missing (e.g. the jar was copied from
+     * another machine without its libs, or the libs directory was cleaned).
+     */
+    private fun resolveDeclaredDependencyJars(pluginJar: File): List<File> {
+        val libsDir = appDataDirectoryProvider.getPluginLibsDirectory()
+        return PluginDependencyManifest.readFrom(pluginJar).map { dependency ->
+            val libFile = File(libsDir, dependency.jarFileName())
+            check(libFile.exists()) {
+                "Declared dependency $dependency is missing (expected at ${libFile.path}). " +
+                    "Reinstall the plugin to download it."
+            }
+            libFile
         }
     }
 

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallFromMavenMutationKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallFromMavenMutationKey.kt
@@ -2,8 +2,8 @@ package com.kitakkun.jetwhale.host.data.plugin
 
 import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
 import com.kitakkun.jetwhale.host.model.MavenCoordinates
-import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
 import com.kitakkun.jetwhale.host.model.PluginInstallFromMavenMutationKey
+import com.kitakkun.jetwhale.host.model.PluginTrustService
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -14,7 +14,7 @@ import java.io.File
 @Inject
 @ContributesBinding(AppScope::class)
 class DefaultPluginInstallFromMavenMutationKey(
-    private val pluginFactoryRepository: PluginFactoryRepository,
+    private val pluginTrustService: PluginTrustService,
     private val appDataDirectoryProvider: AppDataDirectoryProvider,
     private val mavenArtifactResolver: MavenArtifactResolver,
 ) : PluginInstallFromMavenMutationKey by buildMutationKey(
@@ -24,7 +24,15 @@ class DefaultPluginInstallFromMavenMutationKey(
         val pluginDir = appDataDirectoryProvider.getPluginDirectory()
         val downloadedJarPath = mavenArtifactResolver.downloadJar(coordinates, pluginDir)
         try {
-            pluginFactoryRepository.loadPlugin(downloadedJarPath)
+            downloadDeclaredDependencies(
+                pluginJar = File(downloadedJarPath),
+                pluginCoordinates = coordinates,
+                libsDir = appDataDirectoryProvider.getPluginLibsDirectory(),
+                resolver = mavenArtifactResolver,
+            )
+            // Requesting an install by coordinates is the user's explicit consent, exactly like the
+            // file picker: approve (pin the content hash) and load.
+            pluginTrustService.trustAndLoad(downloadedJarPath)
         } catch (e: Exception) {
             File(downloadedJarPath).delete()
             throw PluginInstallationException(
@@ -34,6 +42,32 @@ class DefaultPluginInstallFromMavenMutationKey(
         }
     },
 )
+
+/**
+ * Downloads every external dependency the plugin jar declares in its dependency manifest into
+ * [libsDir], skipping jars that are already present (dependencies are shared across plugins by
+ * coordinates, and released artifacts are immutable).
+ *
+ * Each dependency is fetched from the repository the plugin itself came from first, falling back to
+ * Maven Central: a plugin in a custom repository may keep its own modules there while depending on
+ * public libraries.
+ */
+private suspend fun downloadDeclaredDependencies(
+    pluginJar: File,
+    pluginCoordinates: MavenCoordinates,
+    libsDir: File,
+    resolver: MavenArtifactResolver,
+) {
+    PluginDependencyManifest.readFrom(pluginJar).forEach { dependency ->
+        if (File(libsDir, dependency.jarFileName()).exists()) return@forEach
+        try {
+            resolver.downloadJar(dependency.copy(repositoryUrl = pluginCoordinates.repositoryUrl), libsDir)
+        } catch (e: MavenArtifactDownloadException) {
+            if (pluginCoordinates.repositoryUrl == MavenCoordinates.MAVEN_CENTRAL_URL) throw e
+            resolver.downloadJar(dependency.copy(repositoryUrl = MavenCoordinates.MAVEN_CENTRAL_URL), libsDir)
+        }
+    }
+}
 
 class PluginInstallationException(
     message: String,

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolver.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolver.kt
@@ -32,8 +32,7 @@ class MavenArtifactResolver {
      */
     suspend fun downloadJar(coordinates: MavenCoordinates, destinationDir: File): String {
         val jarUrl = coordinates.toJarUrl()
-        val jarFileName = "${coordinates.groupId}-${coordinates.artifactId}-${coordinates.version}.jar"
-        val destinationFile = File(destinationDir, jarFileName)
+        val destinationFile = File(destinationDir, coordinates.jarFileName())
 
         try {
             val response = httpClient.get(jarUrl)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/PluginDependencyManifest.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/PluginDependencyManifest.kt
@@ -1,0 +1,26 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.model.MavenCoordinates
+import java.io.File
+import java.util.jar.JarFile
+
+/**
+ * Reads the external-dependency manifest that Maven-published plugin jars carry at
+ * [JAR_ENTRY]: one `group:artifact:version` line per external runtime dependency, written by the
+ * JetWhale Gradle plugin from the dependency set Gradle resolved at build time.
+ *
+ * The host downloads each listed jar next to the plugin (see `AppDataDirectoryProvider`'s plugin
+ * libs directory) and puts them on the plugin's classpath. Locally packaged fat-jars carry no
+ * manifest and resolve to an empty list, keeping the pre-existing flow unchanged.
+ */
+object PluginDependencyManifest {
+    const val JAR_ENTRY = "META-INF/jetwhale/dependencies.txt"
+
+    fun readFrom(pluginJar: File): List<MavenCoordinates> = JarFile(pluginJar).use { jar ->
+        val entry = jar.getJarEntry(JAR_ENTRY) ?: return emptyList()
+        jar.getInputStream(entry).bufferedReader().readLines()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("#") }
+            .map { MavenCoordinates.parse(it) }
+    }
+}

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/PluginDependencyManifestTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/PluginDependencyManifestTest.kt
@@ -1,0 +1,54 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.model.MavenCoordinates
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PluginDependencyManifestTest {
+    private fun jarWith(manifestContent: String?): File {
+        val jar = File.createTempFile("plugin", ".jar").apply { deleteOnExit() }
+        JarOutputStream(jar.outputStream()).use { out ->
+            out.putNextEntry(JarEntry("META-INF/jetwhale/plugin-manifest.json"))
+            out.write("{}".toByteArray())
+            out.closeEntry()
+            if (manifestContent != null) {
+                out.putNextEntry(JarEntry(PluginDependencyManifest.JAR_ENTRY))
+                out.write(manifestContent.toByteArray())
+                out.closeEntry()
+            }
+        }
+        return jar
+    }
+
+    @Test
+    fun `reads coordinates one per line skipping blanks and comments`() {
+        val jar = jarWith(
+            """
+            # external runtime dependencies
+            org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.11.0
+
+            org.jetbrains.kotlin:kotlin-stdlib:2.4.10
+            """.trimIndent(),
+        )
+        assertEquals(
+            listOf(
+                MavenCoordinates("org.jetbrains.kotlinx", "kotlinx-serialization-json-jvm", "1.11.0"),
+                MavenCoordinates("org.jetbrains.kotlin", "kotlin-stdlib", "2.4.10"),
+            ),
+            PluginDependencyManifest.readFrom(jar),
+        )
+    }
+
+    @Test
+    fun `jar without manifest resolves to no dependencies`() {
+        assertEquals(emptyList(), PluginDependencyManifest.readFrom(jarWith(null)))
+    }
+
+    @Test
+    fun `empty manifest resolves to no dependencies`() {
+        assertEquals(emptyList(), PluginDependencyManifest.readFrom(jarWith("\n")))
+    }
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinates.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinates.kt
@@ -77,6 +77,12 @@ data class MavenCoordinates(
     }
 
     /**
+     * File name used for this artifact's jar on disk. Includes the groupId so artifacts that share
+     * an artifactId/version cannot collide.
+     */
+    fun jarFileName(): String = "$groupId-$artifactId-$version.jar"
+
+    /**
      * Builds the URL to download the JAR file from the Maven repository
      */
     fun toJarUrl(): String {

--- a/jetwhale-plugins/example/host/build.gradle.kts
+++ b/jetwhale-plugins/example/host/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.jvm)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.jetbrainsCompose)
     // Provides packagePlugin / installPlugin / stageDevPlugin / runJetWhale / runJetWhaleHot (published).
     alias(libs.plugins.jetwhalePlugin)
     // In-repo only: adds runJetWhaleLocal, which launches the local :jetwhale-host:app project.
@@ -8,7 +9,10 @@ plugins {
 }
 
 dependencies {
+    // Provided by the host at runtime, so compileOnly: these must be neither bundled into the
+    // plugin jar nor listed in its dependency manifest.
     compileOnly(projects.jetwhaleHostSdk)
+    compileOnly(compose.desktop.currentOs)
     compileOnly(libs.material3)
     compileOnly(libs.kotlinxSerializationJson)
     api(projects.jetwhalePlugins.example.protocol)

--- a/jetwhale-plugins/network/host/build.gradle.kts
+++ b/jetwhale-plugins/network/host/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.jvm)
-    alias(libs.plugins.compose)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.jetbrainsCompose)
     // Provides packagePlugin / installPlugin / stageDevPlugin / runJetWhale / runJetWhaleHot (published).
     alias(libs.plugins.jetwhalePlugin)
     // In-repo only: adds runJetWhaleLocal, which launches the local :jetwhale-host:app project.
@@ -17,9 +18,14 @@ jetwhalePlugin {
 }
 
 dependencies {
+    // Provided by the host at runtime, so compileOnly: these must be neither bundled into the
+    // plugin jar nor listed in its dependency manifest.
     compileOnly(projects.jetwhaleHostSdk)
+    compileOnly(compose.desktop.currentOs)
     compileOnly(libs.material3)
     compileOnly(libs.kotlinxSerializationJson)
     api(projects.jetwhalePlugins.network.protocol)
     testImplementation(libs.kotlinTest)
+    testImplementation(compose.desktop.currentOs)
+    testImplementation(libs.material3)
 }


### PR DESCRIPTION
Infrastructure so plugin authors can publish their plugin to a Maven repository, for the host's Install-from-Maven feature (#128) — **without bundling third-party code** (no license/redistribution concerns, no platform-specific artifacts) and without hand-rolling any packaging.

## Design

Dependency resolution happens once, at build time, where Gradle already did it; the host only ever downloads pinned jars.

- **`com.kitakkun.jetwhale.host` convention**: when the module also applies `maven-publish`, the published main artifact becomes `packageMavenPlugin`: the module's own classes plus `META-INF/jetwhale/dependencies.txt` — the flat `group:artifact:version` list of runtime dependencies exactly as Gradle resolved them (KMP variants like `-jvm` already picked). In-build project dependencies are trusted at their own publication coordinates (the same source the generated POM uses — `jvm` publication for KMP modules); a project dependency without a Maven publication is bundled into the jar as a fallback. The `packagePlugin` fat-jar is untouched and remains the local-install/dev format
- **Host**: installing from Maven downloads each listed dependency into `~/.jetwhale/plugins/libs/` (shared by coordinates, skipped if present; plugin's repository first, Maven Central fallback), then approves and loads the plugin via `PluginTrustService.trustAndLoad` — entering coordinates is explicit user consent, same as the file picker. Missing dependency jars or an unreadable manifest fail the load into the existing failed-jar list. Fat-jars carry no manifest → unchanged flow
- **Plugin modules declare Compose as `compileOnly` directly** (no extra convention; matches the documented external-author setup) — the host provides Compose through the plugin classloader's parent, so bundling it (including build-machine-specific skiko natives, previously via `implementation(compose.desktop.currentOs)`) was dead weight

## Verified

- `packageMavenPlugin` for the Network Inspector: 51-entry jar of own classes only; manifest lists `jetwhale-network-inspector-protocol-jvm`, `jetwhale-protocol-core-jvm`, `jetwhale-annotations-jvm` (publication coordinates of the in-build project deps) plus `kotlin-stdlib`, `kotlinx-coroutines-core-jvm`, `kotlinx-serialization-{core,json}-jvm`, `annotations`
- Host app compile, core:data tests (incl. new `PluginDependencyManifest` tests), both plugin modules' builds/tests, spotless

Stacked children: #131 (Network Inspector publication), #133 (install progress UI).