### PR TITLE
feat: show plugin installation progress in the plugin settings screen

### DIFF
--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallFromMavenMutationKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallFromMavenMutationKey.kt
@@ -3,6 +3,8 @@ package com.kitakkun.jetwhale.host.data.plugin
 import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
 import com.kitakkun.jetwhale.host.model.MavenCoordinates
 import com.kitakkun.jetwhale.host.model.PluginInstallFromMavenMutationKey
+import com.kitakkun.jetwhale.host.model.PluginInstallProgress
+import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
 import com.kitakkun.jetwhale.host.model.PluginTrustService
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -17,28 +19,36 @@ class DefaultPluginInstallFromMavenMutationKey(
     private val pluginTrustService: PluginTrustService,
     private val appDataDirectoryProvider: AppDataDirectoryProvider,
     private val mavenArtifactResolver: MavenArtifactResolver,
+    private val pluginInstallProgressRepository: PluginInstallProgressRepository,
 ) : PluginInstallFromMavenMutationKey by buildMutationKey(
     id = MutationId("pluginInstallFromMaven"),
     mutate = { coordinates: MavenCoordinates ->
         appDataDirectoryProvider.createAppDataDirectoriesIfNeeded()
         val pluginDir = appDataDirectoryProvider.getPluginDirectory()
-        val downloadedJarPath = mavenArtifactResolver.downloadJar(coordinates, pluginDir)
         try {
-            downloadDeclaredDependencies(
-                pluginJar = File(downloadedJarPath),
-                pluginCoordinates = coordinates,
-                libsDir = appDataDirectoryProvider.getPluginLibsDirectory(),
-                resolver = mavenArtifactResolver,
-            )
-            // Requesting an install by coordinates is the user's explicit consent, exactly like the
-            // file picker: approve (pin the content hash) and load.
-            pluginTrustService.trustAndLoad(downloadedJarPath)
-        } catch (e: Exception) {
-            File(downloadedJarPath).delete()
-            throw PluginInstallationException(
-                "Failed to load plugin from $coordinates: ${e.message}",
-                e,
-            )
+            pluginInstallProgressRepository.update(PluginInstallProgress.DownloadingPlugin)
+            val downloadedJarPath = mavenArtifactResolver.downloadJar(coordinates, pluginDir)
+            try {
+                downloadDeclaredDependencies(
+                    pluginJar = File(downloadedJarPath),
+                    pluginCoordinates = coordinates,
+                    libsDir = appDataDirectoryProvider.getPluginLibsDirectory(),
+                    resolver = mavenArtifactResolver,
+                    onProgress = pluginInstallProgressRepository::update,
+                )
+                pluginInstallProgressRepository.update(PluginInstallProgress.LoadingPlugin)
+                // Requesting an install by coordinates is the user's explicit consent, exactly like
+                // the file picker: approve (pin the content hash) and load.
+                pluginTrustService.trustAndLoad(downloadedJarPath)
+            } catch (e: Exception) {
+                File(downloadedJarPath).delete()
+                throw PluginInstallationException(
+                    "Failed to load plugin from $coordinates: ${e.message}",
+                    e,
+                )
+            }
+        } finally {
+            pluginInstallProgressRepository.update(null)
         }
     },
 )
@@ -57,9 +67,12 @@ private suspend fun downloadDeclaredDependencies(
     pluginCoordinates: MavenCoordinates,
     libsDir: File,
     resolver: MavenArtifactResolver,
+    onProgress: (PluginInstallProgress) -> Unit,
 ) {
-    PluginDependencyManifest.readFrom(pluginJar).forEach { dependency ->
-        if (File(libsDir, dependency.jarFileName()).exists()) return@forEach
+    val dependencies = PluginDependencyManifest.readFrom(pluginJar)
+    dependencies.forEachIndexed { index, dependency ->
+        onProgress(PluginInstallProgress.DownloadingDependencies(completed = index, total = dependencies.size))
+        if (File(libsDir, dependency.jarFileName()).exists()) return@forEachIndexed
         try {
             resolver.downloadJar(dependency.copy(repositoryUrl = pluginCoordinates.repositoryUrl), libsDir)
         } catch (e: MavenArtifactDownloadException) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallProgressRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallProgressRepository.kt
@@ -1,0 +1,22 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.model.PluginInstallProgress
+import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+@SingleIn(AppScope::class)
+@Inject
+@ContributesBinding(AppScope::class)
+class DefaultPluginInstallProgressRepository : PluginInstallProgressRepository {
+    private val mutableProgressFlow = MutableStateFlow<PluginInstallProgress?>(null)
+    override val progressFlow: Flow<PluginInstallProgress?> = mutableProgressFlow
+
+    override fun update(progress: PluginInstallProgress?) {
+        mutableProgressFlow.value = progress
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallProgressSubscriptionKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallProgressSubscriptionKey.kt
@@ -1,0 +1,18 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
+import com.kitakkun.jetwhale.host.model.PluginInstallProgressSubscriptionKey
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import soil.query.SubscriptionId
+import soil.query.buildSubscriptionKey
+
+@Inject
+@ContributesBinding(AppScope::class)
+class DefaultPluginInstallProgressSubscriptionKey(
+    private val pluginInstallProgressRepository: PluginInstallProgressRepository,
+) : PluginInstallProgressSubscriptionKey by buildSubscriptionKey(
+    id = SubscriptionId("default_plugin_install_progress_subscription_key"),
+    subscribe = { pluginInstallProgressRepository.progressFlow },
+)

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstallProgress.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstallProgress.kt
@@ -1,0 +1,14 @@
+package com.kitakkun.jetwhale.host.model
+
+/**
+ * Progress of an in-flight plugin installation from a Maven repository. Installation downloads the
+ * plugin jar, then each external dependency the plugin declares, then loads the plugin — each step
+ * involves the network, so the UI surfaces which one is running.
+ */
+sealed interface PluginInstallProgress {
+    data object DownloadingPlugin : PluginInstallProgress
+
+    data class DownloadingDependencies(val completed: Int, val total: Int) : PluginInstallProgress
+
+    data object LoadingPlugin : PluginInstallProgress
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstallProgressRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstallProgressRepository.kt
@@ -1,0 +1,13 @@
+package com.kitakkun.jetwhale.host.model
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * In-memory holder for the progress of the currently running plugin installation.
+ * `null` means no installation is in flight.
+ */
+interface PluginInstallProgressRepository {
+    val progressFlow: Flow<PluginInstallProgress?>
+
+    fun update(progress: PluginInstallProgress?)
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstallProgressSubscriptionKey.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstallProgressSubscriptionKey.kt
@@ -1,0 +1,5 @@
+package com.kitakkun.jetwhale.host.model
+
+import soil.query.SubscriptionKey
+
+typealias PluginInstallProgressSubscriptionKey = SubscriptionKey<PluginInstallProgress?>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -57,4 +57,7 @@
     <string name="maven_install_repository_url_label">リポジトリURL</string>
     <string name="maven_install_error_fill_required">必須フィールドをすべて入力してください。</string>
     <string name="maven_install_install">インストール</string>
+    <string name="install_progress_downloading_plugin">プラグインをダウンロード中…</string>
+    <string name="install_progress_downloading_dependencies">依存関係をダウンロード中 (%1$d/%2$d)…</string>
+    <string name="install_progress_loading_plugin">プラグインを読み込み中…</string>
 </resources>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
@@ -59,4 +59,7 @@
     <string name="maven_install_repository_url_label">Repository URL</string>
     <string name="maven_install_error_fill_required">Please fill in all required fields.</string>
     <string name="maven_install_install">Install</string>
+    <string name="install_progress_downloading_plugin">Downloading plugin…</string>
+    <string name="install_progress_downloading_dependencies">Downloading dependencies (%1$d/%2$d)…</string>
+    <string name="install_progress_loading_plugin">Loading plugin…</string>
 </resources>

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenContext.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenContext.kt
@@ -14,6 +14,7 @@ import com.kitakkun.jetwhale.host.model.McpServerPortMutationKey
 import com.kitakkun.jetwhale.host.model.McpServerStatusSubscriptionKey
 import com.kitakkun.jetwhale.host.model.PluginInstallFromMavenMutationKey
 import com.kitakkun.jetwhale.host.model.PluginInstallMutationKey
+import com.kitakkun.jetwhale.host.model.PluginInstallProgressSubscriptionKey
 import com.kitakkun.jetwhale.host.model.ServerPortMutationKey
 import com.kitakkun.jetwhale.host.model.ServerStatusSubscriptionKey
 import com.kitakkun.jetwhale.host.model.SettingsSubscriptionKey
@@ -51,6 +52,7 @@ class SettingsScreenContext(
     val loadedPluginsMetaDataSubscriptionKey: LoadedPluginsMetaDataSubscriptionKey,
     val failedPluginJarPathsSubscriptionKey: FailedPluginJarPathsSubscriptionKey,
     val untrustedPluginJarPathsSubscriptionKey: UntrustedPluginJarPathsSubscriptionKey,
+    val pluginInstallProgressSubscriptionKey: PluginInstallProgressSubscriptionKey,
     val serverStatusSubscriptionKey: ServerStatusSubscriptionKey,
     val mcpServerStatusSubscriptionKey: McpServerStatusSubscriptionKey,
     val presenterContext: SettingsPresenterContext,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.host.model.PluginInstallProgress
 import com.kitakkun.jetwhale.host.settings.Res
 import com.kitakkun.jetwhale.host.settings.SettingsScreenScaffoldPageContentPadding
 import com.kitakkun.jetwhale.host.settings.add_plugin_from_file
@@ -38,6 +39,9 @@ import com.kitakkun.jetwhale.host.settings.dialog_ok
 import com.kitakkun.jetwhale.host.settings.failed_jar_path_hint
 import com.kitakkun.jetwhale.host.settings.failed_to_load_plugins
 import com.kitakkun.jetwhale.host.settings.install_from_maven
+import com.kitakkun.jetwhale.host.settings.install_progress_downloading_dependencies
+import com.kitakkun.jetwhale.host.settings.install_progress_downloading_plugin
+import com.kitakkun.jetwhale.host.settings.install_progress_loading_plugin
 import com.kitakkun.jetwhale.host.settings.installed_plugins
 import com.kitakkun.jetwhale.host.settings.untrusted_jar_hint
 import com.kitakkun.jetwhale.host.settings.untrusted_plugins
@@ -195,6 +199,26 @@ fun PluginSettingsScreen(
                 Text(stringResource(Res.string.install_from_maven))
             }
             if (uiState.isInstalling) {
+                uiState.installProgress?.let { progress ->
+                    Text(
+                        text = when (progress) {
+                            is PluginInstallProgress.DownloadingPlugin ->
+                                stringResource(Res.string.install_progress_downloading_plugin)
+
+                            is PluginInstallProgress.DownloadingDependencies ->
+                                stringResource(
+                                    Res.string.install_progress_downloading_dependencies,
+                                    progress.completed + 1,
+                                    progress.total,
+                                )
+
+                            is PluginInstallProgress.LoadingPlugin ->
+                                stringResource(Res.string.install_progress_loading_plugin)
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 CircularProgressIndicator(
                     modifier = Modifier.size(24.dp),
                     strokeWidth = 2.dp,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenPresenter.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.host.settings.plugin
 import androidx.compose.runtime.Composable
 import com.kitakkun.jetwhale.host.architecture.ActionEffect
 import com.kitakkun.jetwhale.host.architecture.ScreenChannel
+import com.kitakkun.jetwhale.host.model.PluginInstallProgress
 import com.kitakkun.jetwhale.host.model.PluginMetaData
 import com.kitakkun.jetwhale.host.model.TrustPluginRequest
 import com.kitakkun.jetwhale.host.settings.SettingsPresenterContext
@@ -18,6 +19,7 @@ fun pluginSettingsScreenPresenter(
     loadedPlugins: ImmutableList<PluginMetaData>,
     failedJarPaths: ImmutableList<String>,
     untrustedJarPaths: ImmutableList<String>,
+    installProgress: PluginInstallProgress?,
 ): PluginSettingsScreenUiState {
     val pluginInstallMutation = rememberMutation(presenterContext.pluginInstallMutationKey)
     val pluginInstallFromMavenMutation = rememberMutation(presenterContext.pluginInstallFromMavenMutationKey)
@@ -54,6 +56,7 @@ fun pluginSettingsScreenPresenter(
         failedJarPaths = failedJarPaths,
         untrustedJarPaths = untrustedJarPaths,
         isInstalling = isInstalling,
+        installProgress = installProgress,
         installError = installError,
     )
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenRoot.kt
@@ -22,7 +22,8 @@ fun PluginSettingsScreenRoot() {
         state1 = rememberSubscription(screenContext.loadedPluginsMetaDataSubscriptionKey),
         state2 = rememberSubscription(screenContext.failedPluginJarPathsSubscriptionKey),
         state3 = rememberSubscription(screenContext.untrustedPluginJarPathsSubscriptionKey),
-    ) { loadedPlugins, failedJarPaths, untrustedJars ->
+        state4 = rememberSubscription(screenContext.pluginInstallProgressSubscriptionKey),
+    ) { loadedPlugins, failedJarPaths, untrustedJars, installProgress ->
         val screenChannel = rememberScreenChannel<PluginSettingsScreenAction, Nothing>()
         val uiState = context(screenContext.presenterContext) {
             pluginSettingsScreenPresenter(
@@ -30,6 +31,7 @@ fun PluginSettingsScreenRoot() {
                 loadedPlugins = loadedPlugins,
                 failedJarPaths = failedJarPaths,
                 untrustedJarPaths = untrustedJars.paths,
+                installProgress = installProgress,
             )
         }
 

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenUiState.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenUiState.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.settings.plugin
 
+import com.kitakkun.jetwhale.host.model.PluginInstallProgress
 import kotlinx.collections.immutable.ImmutableList
 
 data class PluginSettingsScreenUiState(
@@ -7,5 +8,6 @@ data class PluginSettingsScreenUiState(
     val failedJarPaths: ImmutableList<String>,
     val untrustedJarPaths: ImmutableList<String>,
     val isInstalling: Boolean = false,
+    val installProgress: PluginInstallProgress? = null,
     val installError: String? = null,
 )


### PR DESCRIPTION
Stacked on #132.

Install-from-Maven now downloads the plugin jar, then its declared dependencies (#132), then loads the plugin — noticeably longer than before, with no indication of what is happening.

- `PluginInstallProgress` model (`DownloadingPlugin` / `DownloadingDependencies(completed, total)` / `LoadingPlugin`) and an in-memory `PluginInstallProgressRepository` updated by the install mutation (cleared in `finally`)
- Exposed as a subscription key and rendered next to the progress indicator in the plugin settings screen, with en/ja strings

Verified: host app compile, core:data tests, spotless.