### PR TITLE
fix: resolve snapshot artifacts through maven-metadata.xml

### DIFF
--- a/jetwhale-host/core/data/build.gradle.kts
+++ b/jetwhale-host/core/data/build.gradle.kts
@@ -36,4 +36,5 @@ dependencies {
     implementation(libs.ktorClientCio)
     implementation(libs.logbackClassic)
     implementation(libs.kotlinTest)
+    testImplementation(libs.ktorClientMock)
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallFromMavenMutationKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstallFromMavenMutationKey.kt
@@ -72,7 +72,9 @@ private suspend fun downloadDeclaredDependencies(
     val dependencies = PluginDependencyManifest.readFrom(pluginJar)
     dependencies.forEachIndexed { index, dependency ->
         onProgress(PluginInstallProgress.DownloadingDependencies(completed = index, total = dependencies.size))
-        if (File(libsDir, dependency.jarFileName()).exists()) return@forEachIndexed
+        // Released artifacts are immutable, so an already-downloaded jar can be reused; snapshots
+        // are overwritable and must be re-downloaded to pick up the current build.
+        if (!dependency.isSnapshot && File(libsDir, dependency.jarFileName()).exists()) return@forEachIndexed
         try {
             resolver.downloadJar(dependency.copy(repositoryUrl = pluginCoordinates.repositoryUrl), libsDir)
         } catch (e: MavenArtifactDownloadException) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolver.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolver.kt
@@ -9,6 +9,7 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.jvm.javaio.toInputStream
 import java.io.File
@@ -31,7 +32,7 @@ class MavenArtifactResolver {
      * @throws MavenArtifactDownloadException if download fails
      */
     suspend fun downloadJar(coordinates: MavenCoordinates, destinationDir: File): String {
-        val jarUrl = coordinates.toJarUrl()
+        val jarUrl = resolveJarUrl(coordinates)
         val destinationFile = File(destinationDir, coordinates.jarFileName())
 
         try {
@@ -60,6 +61,27 @@ class MavenArtifactResolver {
             )
         }
     }
+
+    /**
+     * Maven repositories store snapshot jars under timestamped file names (e.g.
+     * `foo-1.0.0-20260718.103017-1.jar`), so for `-SNAPSHOT` versions the current build is resolved
+     * through the version directory's `maven-metadata.xml`. Falls back to the literal `-SNAPSHOT`
+     * file name when the metadata is missing or incomplete (some repositories serve it directly).
+     */
+    private suspend fun resolveJarUrl(coordinates: MavenCoordinates): String {
+        if (!coordinates.isSnapshot) return coordinates.toJarUrl()
+
+        val metadataResponse = httpClient.get("${coordinates.toVersionDirectoryUrl()}/maven-metadata.xml")
+        if (!metadataResponse.status.isSuccess()) return coordinates.toJarUrl()
+
+        val metadata = metadataResponse.bodyAsText()
+        val timestamp = extractXmlTagValue(metadata, "timestamp") ?: return coordinates.toJarUrl()
+        val buildNumber = extractXmlTagValue(metadata, "buildNumber") ?: return coordinates.toJarUrl()
+        val timestampedVersion = coordinates.version.removeSuffix("SNAPSHOT") + "$timestamp-$buildNumber"
+        return coordinates.toSnapshotJarUrl(timestampedVersion)
+    }
+
+    private fun extractXmlTagValue(text: String, tag: String): String? = Regex("<$tag>\\s*([^<]+?)\\s*</$tag>").find(text)?.groupValues?.get(1)
 }
 
 class MavenArtifactDownloadException(

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolver.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolver.kt
@@ -5,6 +5,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.get
@@ -15,9 +16,13 @@ import io.ktor.utils.io.jvm.javaio.toInputStream
 import java.io.File
 
 @SingleIn(AppScope::class)
-@Inject
-class MavenArtifactResolver {
-    private val httpClient = HttpClient(CIO) {
+class MavenArtifactResolver internal constructor(
+    engine: HttpClientEngine,
+) {
+    @Inject
+    constructor() : this(CIO.create())
+
+    private val httpClient = HttpClient(engine) {
         install(HttpTimeout) {
             connectTimeoutMillis = 30_000
             socketTimeoutMillis = 30_000
@@ -32,10 +37,10 @@ class MavenArtifactResolver {
      * @throws MavenArtifactDownloadException if download fails
      */
     suspend fun downloadJar(coordinates: MavenCoordinates, destinationDir: File): String {
-        val jarUrl = resolveJarUrl(coordinates)
         val destinationFile = File(destinationDir, coordinates.jarFileName())
 
         try {
+            val jarUrl = resolveJarUrl(coordinates)
             val response = httpClient.get(jarUrl)
             if (!response.status.isSuccess()) {
                 throw MavenArtifactDownloadException(
@@ -68,7 +73,7 @@ class MavenArtifactResolver {
      * through the version directory's `maven-metadata.xml`. Falls back to the literal `-SNAPSHOT`
      * file name when the metadata is missing or incomplete (some repositories serve it directly).
      */
-    private suspend fun resolveJarUrl(coordinates: MavenCoordinates): String {
+    internal suspend fun resolveJarUrl(coordinates: MavenCoordinates): String {
         if (!coordinates.isSnapshot) return coordinates.toJarUrl()
 
         val metadataResponse = httpClient.get("${coordinates.toVersionDirectoryUrl()}/maven-metadata.xml")
@@ -77,7 +82,7 @@ class MavenArtifactResolver {
         val metadata = metadataResponse.bodyAsText()
         val timestamp = extractXmlTagValue(metadata, "timestamp") ?: return coordinates.toJarUrl()
         val buildNumber = extractXmlTagValue(metadata, "buildNumber") ?: return coordinates.toJarUrl()
-        val timestampedVersion = coordinates.version.removeSuffix("SNAPSHOT") + "$timestamp-$buildNumber"
+        val timestampedVersion = coordinates.version.removeSuffix("-SNAPSHOT") + "-$timestamp-$buildNumber"
         return coordinates.toSnapshotJarUrl(timestampedVersion)
     }
 

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolverTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/MavenArtifactResolverTest.kt
@@ -1,0 +1,78 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.model.MavenCoordinates
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MavenArtifactResolverTest {
+    private val snapshotCoordinates = MavenCoordinates(
+        groupId = "com.example",
+        artifactId = "my-plugin",
+        version = "1.0.0-SNAPSHOT",
+        repositoryUrl = "https://example.com/snapshots",
+    )
+
+    private fun resolverRespondingMetadata(metadata: String?): MavenArtifactResolver = MavenArtifactResolver(
+        MockEngine { request ->
+            if (request.url.toString().endsWith("/maven-metadata.xml") && metadata != null) {
+                respond(metadata)
+            } else {
+                respondError(HttpStatusCode.NotFound)
+            }
+        },
+    )
+
+    @Test
+    fun `snapshot metadata produces a timestamped jar url`() = runBlocking {
+        val resolver = resolverRespondingMetadata(
+            """
+            <metadata>
+              <versioning>
+                <snapshot>
+                  <timestamp>20260718.103017</timestamp>
+                  <buildNumber>1</buildNumber>
+                </snapshot>
+              </versioning>
+            </metadata>
+            """.trimIndent(),
+        )
+        assertEquals(
+            "https://example.com/snapshots/com/example/my-plugin/1.0.0-SNAPSHOT/my-plugin-1.0.0-20260718.103017-1.jar",
+            resolver.resolveJarUrl(snapshotCoordinates),
+        )
+    }
+
+    @Test
+    fun `missing metadata falls back to the literal snapshot jar url`() = runBlocking {
+        val resolver = resolverRespondingMetadata(null)
+        assertEquals(
+            "https://example.com/snapshots/com/example/my-plugin/1.0.0-SNAPSHOT/my-plugin-1.0.0-SNAPSHOT.jar",
+            resolver.resolveJarUrl(snapshotCoordinates),
+        )
+    }
+
+    @Test
+    fun `incomplete metadata falls back to the literal snapshot jar url`() = runBlocking {
+        val resolver = resolverRespondingMetadata("<metadata><versioning/></metadata>")
+        assertEquals(
+            "https://example.com/snapshots/com/example/my-plugin/1.0.0-SNAPSHOT/my-plugin-1.0.0-SNAPSHOT.jar",
+            resolver.resolveJarUrl(snapshotCoordinates),
+        )
+    }
+
+    @Test
+    fun `release versions use the literal jar url without fetching metadata`() = runBlocking {
+        val resolver = MavenArtifactResolver(
+            MockEngine { error("no request expected for release versions") },
+        )
+        assertEquals(
+            "https://repo1.maven.org/maven2/com/example/my-plugin/1.0.0/my-plugin-1.0.0.jar",
+            resolver.resolveJarUrl(MavenCoordinates("com.example", "my-plugin", "1.0.0")),
+        )
+    }
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinates.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinates.kt
@@ -82,13 +82,26 @@ data class MavenCoordinates(
      */
     fun jarFileName(): String = "$groupId-$artifactId-$version.jar"
 
+    val isSnapshot: Boolean get() = version.endsWith("-SNAPSHOT")
+
     /**
-     * Builds the URL to download the JAR file from the Maven repository
+     * URL of the directory holding this version's artifacts (and, for snapshots, the
+     * `maven-metadata.xml` naming the current timestamped build).
      */
-    fun toJarUrl(): String {
+    fun toVersionDirectoryUrl(): String {
         val groupPath = groupId.replace('.', '/')
-        return "${repositoryUrl.trimEnd('/')}/$groupPath/$artifactId/$version/$artifactId-$version.jar"
+        return "${repositoryUrl.trimEnd('/')}/$groupPath/$artifactId/$version"
     }
+
+    /**
+     * URL of this version's jar under its literal version name. For snapshots most repositories
+     * only store timestamped file names — resolve those through [toVersionDirectoryUrl]'s
+     * `maven-metadata.xml` and [toSnapshotJarUrl] instead.
+     */
+    fun toJarUrl(): String = "${toVersionDirectoryUrl()}/$artifactId-$version.jar"
+
+    /** URL of the snapshot jar for a concrete timestamped build (e.g. `1.0.0-20260718.103017-1`). */
+    fun toSnapshotJarUrl(timestampedVersion: String): String = "${toVersionDirectoryUrl()}/$artifactId-$timestampedVersion.jar"
 
     override fun toString(): String = "$groupId:$artifactId:$version"
 }

--- a/jetwhale-host/core/model/src/test/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinatesTest.kt
+++ b/jetwhale-host/core/model/src/test/kotlin/com/kitakkun/jetwhale/host/model/MavenCoordinatesTest.kt
@@ -75,4 +75,23 @@ class MavenCoordinatesTest {
         assertNull(MavenCoordinates.parseLenient("not coordinates"))
         assertNull(MavenCoordinates.parseLenient("group:artifact"))
     }
+
+    @Test
+    fun snapshotUrls() {
+        val coordinates = MavenCoordinates("com.example", "my-plugin", "1.0.0-SNAPSHOT", "https://example.com/snapshots/")
+        assertEquals(true, coordinates.isSnapshot)
+        assertEquals(
+            "https://example.com/snapshots/com/example/my-plugin/1.0.0-SNAPSHOT",
+            coordinates.toVersionDirectoryUrl(),
+        )
+        assertEquals(
+            "https://example.com/snapshots/com/example/my-plugin/1.0.0-SNAPSHOT/my-plugin-1.0.0-20260718.103017-1.jar",
+            coordinates.toSnapshotJarUrl("1.0.0-20260718.103017-1"),
+        )
+    }
+
+    @Test
+    fun releaseIsNotSnapshot() {
+        assertEquals(false, MavenCoordinates("com.example", "my-plugin", "1.0.0").isSnapshot)
+    }
 }


### PR DESCRIPTION
Installing a `-SNAPSHOT` plugin from the Central snapshots repository failed with a 404: Maven repositories store snapshot jars under **timestamped** file names (`jetwhale-network-inspector-1.0.0-alpha08-20260718.103017-1.jar`), not the literal `-SNAPSHOT` name the resolver requested.

- For `-SNAPSHOT` versions, fetch the version directory's `maven-metadata.xml`, read `<timestamp>`/`<buildNumber>`, and download the timestamped jar; fall back to the literal name when metadata is missing (some repositories serve it directly)
- Snapshot dependencies listed in the plugin's dependency manifest are always re-downloaded instead of reusing the cached jar in `~/.jetwhale/plugins/libs/` — snapshots are overwritable
- Unit tests for the new `MavenCoordinates` snapshot URL helpers

Verified against the published snapshot: `com.kitakkun.jetwhale:jetwhale-network-inspector:1.0.0-alpha08-SNAPSHOT@https://central.sonatype.com/repository/maven-snapshots` resolves to the timestamped jar URL.