### PR TITLE
feat(agent-runtime): CA support for Linux (curl) and Windows guidance

### DIFF
--- a/jetwhale-agent-runtime/src/linuxMain/kotlin/com/kitakkun/jetwhale/agent/runtime/SslConfig.linux.kt
+++ b/jetwhale-agent-runtime/src/linuxMain/kotlin/com/kitakkun/jetwhale/agent/runtime/SslConfig.linux.kt
@@ -2,19 +2,63 @@ package com.kitakkun.jetwhale.agent.runtime
 
 import io.ktor.client.engine.HttpClientEngineConfig
 import io.ktor.client.engine.curl.CurlClientEngineConfig
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.O_CREAT
+import platform.posix.O_TRUNC
+import platform.posix.O_WRONLY
+import platform.posix.S_IRUSR
+import platform.posix.S_IWUSR
+import platform.posix.close
+import platform.posix.getenv
+import platform.posix.getpid
+import platform.posix.open
+import platform.posix.write
 
+@OptIn(ExperimentalForeignApi::class)
 internal actual fun HttpClientEngineConfig.configureSsl(sslConfiguration: JetWhaleSslConfiguration) {
     if (sslConfiguration.trustedCertificates.isEmpty()) return
 
+    // The engine is not user-configurable: it always comes from defaultKtorEngineFactory(), which
+    // returns Curl on this platform. If the default engine ever changes, fail fast here instead of
+    // silently skipping certificate pinning (which would surface as an obscure TLS handshake error).
     check(this is CurlClientEngineConfig) { "Expected CurlClientEngineConfig but got ${this::class.simpleName}" }
 
-    // Note: Curl engine requires certificate files on disk.
-    // For custom certificates, users should configure the system's CA bundle
-    // or provide certificates via environment variables (CURL_CA_BUNDLE).
-    // Direct PEM string configuration is not supported by Curl engine.
+    // Curl only accepts CA material as a file (CURLOPT_CAINFO), so the configured PEMs are written
+    // to a private per-process bundle file and pinned via caInfo.
+    val bundlePath = writeCaBundle(sslConfiguration.trustedCertificates)
+    if (bundlePath == null) {
+        JetWhaleLogger.w("Failed to write the trusted CA bundle; falling back to system trust evaluation.")
+        return
+    }
 
-    JetWhaleLogger.w(
-        "SSL certificate configuration for Linux/Curl is limited. " +
-            "Consider using system CA bundle or CURL_CA_BUNDLE environment variable.",
-    )
+    caInfo = bundlePath
+}
+
+/**
+ * Writes the PEM certificates as one bundle file under the temporary directory with owner-only
+ * permissions. Returns null when the file cannot be created.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun writeCaBundle(pemCertificates: List<String>): String? {
+    val tmpDir = getenv("TMPDIR")?.toKString()?.trimEnd('/') ?: "/tmp"
+    val path = "$tmpDir/jetwhale_ca_${getpid()}.pem"
+    val fd = open(path, O_WRONLY or O_CREAT or O_TRUNC, (S_IRUSR or S_IWUSR).toUInt())
+    if (fd < 0) return null
+    try {
+        val bytes = pemCertificates.joinToString("\n").encodeToByteArray()
+        var offset = 0
+        while (offset < bytes.size) {
+            val written = bytes.usePinned { pinned ->
+                write(fd, pinned.addressOf(offset), (bytes.size - offset).toULong())
+            }
+            if (written < 0) return null
+            offset += written.toInt()
+        }
+    } finally {
+        close(fd)
+    }
+    return path
 }

--- a/jetwhale-agent-runtime/src/mingwMain/kotlin/com/kitakkun/jetwhale/agent/runtime/SslConfig.mingw.kt
+++ b/jetwhale-agent-runtime/src/mingwMain/kotlin/com/kitakkun/jetwhale/agent/runtime/SslConfig.mingw.kt
@@ -6,14 +6,18 @@ import io.ktor.client.engine.winhttp.WinHttpClientEngineConfig
 internal actual fun HttpClientEngineConfig.configureSsl(sslConfiguration: JetWhaleSslConfiguration) {
     if (sslConfiguration.trustedCertificates.isEmpty()) return
 
+    // The engine is not user-configurable: it always comes from defaultKtorEngineFactory(), which
+    // returns WinHttp on this platform. If the default engine ever changes, fail fast here instead of
+    // silently skipping certificate pinning (which would surface as an obscure TLS handshake error).
     check(this is WinHttpClientEngineConfig) { "Expected WinHttpClientEngineConfig but got ${this::class.simpleName}" }
 
-    // Note: WinHttp uses Windows certificate store.
-    // For custom certificates, users should install them in the Windows certificate store.
-    // Direct PEM string configuration is not supported by WinHttp engine.
-
+    // WinHttp exposes no per-connection CA configuration (only sslVerify on/off); it always
+    // validates against the Windows certificate store. In-code pinning is therefore not possible
+    // without installing the CA into the store, which is left to the user to keep this library from
+    // mutating machine state.
     JetWhaleLogger.w(
-        "SSL certificate configuration for Windows/WinHttp is limited. " +
-            "Consider installing certificates in the Windows certificate store.",
+        "WinHttp validates certificates against the Windows certificate store and cannot pin a custom CA in code. " +
+            "Export the JetWhale CA certificate from the desktop app and install it into the store, e.g.: " +
+            "certutil -user -addstore Root jetwhale-ca.pem",
     )
 }


### PR DESCRIPTION
Stacked on #49.

## Linux (curl)

Curl only accepts CA material as a file (`CURLOPT_CAINFO`), so the PEMs configured via `ssl { trustCertificate(...) }` are written to an owner-only per-process bundle file under the temporary directory and pinned via `caInfo`.

## Windows (WinHttp)

WinHttp has no per-connection CA configuration in Ktor (`sslVerify` on/off only) and always validates against the Windows certificate store. In-code pinning would require mutating the machine's store, which this library intentionally does not do. The warning log now gives concrete guidance instead:

```
certutil -user -addstore Root jetwhale-ca.crt
```
