### PR TITLE
Collapse disconnected sessions into an expandable dropdown group

### DIFF
--- a/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
@@ -10,6 +10,8 @@
     <string name="no_session_available">利用可能なセッションがありません</string>
     <string name="select_session">セッションを選択</string>
     <string name="disconnected_sessions">切断されたセッション (%1$d)</string>
+    <string name="group_expanded">展開済み</string>
+    <string name="group_collapsed">折りたたみ済み</string>
     <string name="initializing">初期化中...</string>
     <string name="shutting_down">シャットダウン中...</string>
     <string name="plugin_popped_out_message">このプラグインはポップアウトされています。別のウィンドウを確認してください。</string>

--- a/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
@@ -9,6 +9,7 @@
     <string name="no_plugin_selected">プラグインが選択されていません</string>
     <string name="no_session_available">利用可能なセッションがありません</string>
     <string name="select_session">セッションを選択</string>
+    <string name="disconnected_sessions">切断されたセッション (%1$d)</string>
     <string name="initializing">初期化中...</string>
     <string name="shutting_down">シャットダウン中...</string>
     <string name="plugin_popped_out_message">このプラグインはポップアウトされています。別のウィンドウを確認してください。</string>

--- a/jetwhale-host/app/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="no_plugin_selected">No plugin selected</string>
     <string name="no_session_available">No session available</string>
     <string name="select_session">Select Session</string>
+    <string name="disconnected_sessions">Disconnected Sessions (%1$d)</string>
     <string name="initializing">Initializing...</string>
     <string name="shutting_down">Shutting down...</string>
     <string name="plugin_popped_out_message">This plugin is popped out. Please check the separate window.</string>

--- a/jetwhale-host/app/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="no_session_available">No session available</string>
     <string name="select_session">Select Session</string>
     <string name="disconnected_sessions">Disconnected Sessions (%1$d)</string>
+    <string name="group_expanded">Expanded</string>
+    <string name="group_collapsed">Collapsed</string>
     <string name="initializing">Initializing...</string>
     <string name="shutting_down">Shutting down...</string>
     <string name="plugin_popped_out_message">This plugin is popped out. Please check the separate window.</string>

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
@@ -8,7 +8,10 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Devices
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -25,6 +28,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.Res
 import com.kitakkun.jetwhale.host.model.DebugSession
+import com.kitakkun.jetwhale.host.disconnected_sessions
 import com.kitakkun.jetwhale.host.no_session_available
 import com.kitakkun.jetwhale.host.select_session
 import kotlinx.collections.immutable.ImmutableList
@@ -74,7 +78,8 @@ fun SessionSelectorView(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
-            sessions.forEach {
+            val (activeSessions, disconnectedSessions) = sessions.partition { it.isActive }
+            activeSessions.forEach {
                 SessionDropdownMenuItem(
                     selected = it.id == selectedSession?.id,
                     isActive = it.isActive,
@@ -84,6 +89,34 @@ fun SessionSelectorView(
                         expanded = false
                     },
                 )
+            }
+            if (disconnectedSessions.isNotEmpty()) {
+                var disconnectedExpanded by remember { mutableStateOf(false) }
+                DropdownMenuItem(
+                    text = {
+                        Text(stringResource(Res.string.disconnected_sessions, disconnectedSessions.size))
+                    },
+                    trailingIcon = {
+                        Icon(
+                            imageVector = if (disconnectedExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                            contentDescription = null,
+                        )
+                    },
+                    onClick = { disconnectedExpanded = !disconnectedExpanded },
+                )
+                if (disconnectedExpanded) {
+                    disconnectedSessions.forEach {
+                        SessionDropdownMenuItem(
+                            selected = it.id == selectedSession?.id,
+                            isActive = it.isActive,
+                            displayName = it.displayName,
+                            onClick = {
+                                onSelectSession(it)
+                                expanded = false
+                            },
+                        )
+                    }
+                }
             }
         }
     }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
@@ -24,11 +24,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.Res
-import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.disconnected_sessions
+import com.kitakkun.jetwhale.host.group_collapsed
+import com.kitakkun.jetwhale.host.group_expanded
+import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.no_session_available
 import com.kitakkun.jetwhale.host.select_session
 import kotlinx.collections.immutable.ImmutableList
@@ -78,7 +82,7 @@ fun SessionSelectorView(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
-            val (activeSessions, disconnectedSessions) = sessions.partition { it.isActive }
+            val (activeSessions, disconnectedSessions) = remember(sessions) { sessions.partition { it.isActive } }
             activeSessions.forEach {
                 SessionDropdownMenuItem(
                     selected = it.id == selectedSession?.id,
@@ -92,6 +96,9 @@ fun SessionSelectorView(
             }
             if (disconnectedSessions.isNotEmpty()) {
                 var disconnectedExpanded by remember { mutableStateOf(false) }
+                val groupStateDescription = stringResource(
+                    if (disconnectedExpanded) Res.string.group_expanded else Res.string.group_collapsed,
+                )
                 DropdownMenuItem(
                     text = {
                         Text(stringResource(Res.string.disconnected_sessions, disconnectedSessions.size))
@@ -103,6 +110,7 @@ fun SessionSelectorView(
                         )
                     },
                     onClick = { disconnectedExpanded = !disconnectedExpanded },
+                    modifier = Modifier.semantics { stateDescription = groupStateDescription },
                 )
                 if (disconnectedExpanded) {
                     disconnectedSessions.forEach {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
@@ -1,6 +1,10 @@
 package com.kitakkun.jetwhale.host.drawer
 
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -95,34 +99,41 @@ fun SessionSelectorView(
                 )
             }
             if (disconnectedSessions.isNotEmpty()) {
-                var disconnectedExpanded by remember { mutableStateOf(false) }
+                val groupInteractionSource = remember { MutableInteractionSource() }
+                val hovered by groupInteractionSource.collectIsHoveredAsState()
+                var pinnedExpanded by remember { mutableStateOf(false) }
+                val disconnectedExpanded = hovered || pinnedExpanded
                 val groupStateDescription = stringResource(
                     if (disconnectedExpanded) Res.string.group_expanded else Res.string.group_collapsed,
                 )
-                DropdownMenuItem(
-                    text = {
-                        Text(stringResource(Res.string.disconnected_sessions, disconnectedSessions.size))
-                    },
-                    trailingIcon = {
-                        Icon(
-                            imageVector = if (disconnectedExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                            contentDescription = null,
-                        )
-                    },
-                    onClick = { disconnectedExpanded = !disconnectedExpanded },
-                    modifier = Modifier.semantics { stateDescription = groupStateDescription },
-                )
-                if (disconnectedExpanded) {
-                    disconnectedSessions.forEach {
-                        SessionDropdownMenuItem(
-                            selected = it.id == selectedSession?.id,
-                            isActive = it.isActive,
-                            displayName = it.displayName,
-                            onClick = {
-                                onSelectSession(it)
-                                expanded = false
-                            },
-                        )
+                Column(
+                    modifier = Modifier.hoverable(interactionSource = groupInteractionSource),
+                ) {
+                    DropdownMenuItem(
+                        text = {
+                            Text(stringResource(Res.string.disconnected_sessions, disconnectedSessions.size))
+                        },
+                        trailingIcon = {
+                            Icon(
+                                imageVector = if (disconnectedExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                                contentDescription = null,
+                            )
+                        },
+                        onClick = { pinnedExpanded = !pinnedExpanded },
+                        modifier = Modifier.semantics { stateDescription = groupStateDescription },
+                    )
+                    if (disconnectedExpanded) {
+                        disconnectedSessions.forEach {
+                            SessionDropdownMenuItem(
+                                selected = it.id == selectedSession?.id,
+                                isActive = it.isActive,
+                                displayName = it.displayName,
+                                onClick = {
+                                    onSelectSession(it)
+                                    expanded = false
+                                },
+                            )
+                        }
                     }
                 }
             }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
@@ -14,12 +14,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Devices
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -109,14 +111,26 @@ fun SessionSelectorView(
                 Column(
                     modifier = Modifier.hoverable(interactionSource = groupInteractionSource),
                 ) {
+                    val groupContentColor = MaterialTheme.colorScheme.onSurfaceVariant
                     DropdownMenuItem(
                         text = {
-                            Text(stringResource(Res.string.disconnected_sessions, disconnectedSessions.size))
+                            Text(
+                                text = stringResource(Res.string.disconnected_sessions, disconnectedSessions.size),
+                                color = groupContentColor,
+                            )
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.LinkOff,
+                                contentDescription = null,
+                                tint = groupContentColor,
+                            )
                         },
                         trailingIcon = {
                             Icon(
                                 imageVector = if (disconnectedExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
                                 contentDescription = null,
+                                tint = groupContentColor,
                             )
                         },
                         onClick = { pinnedExpanded = !pinnedExpanded },


### PR DESCRIPTION
## Summary
- Disconnected sessions no longer pile up as a flat list in the session selector dropdown.
- Active sessions are shown directly; inactive ones are aggregated under a collapsed "Disconnected Sessions (N)" item that expands on click.
- Added `disconnected_sessions` string resource (en/ja) with a count placeholder.

## Notes
- Disconnected session rows keep their existing disabled/grey appearance; only their grouping changed.