### PR TITLE
Make read-only detail text selectable in viewers

### DIFF
--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/logviewer/components/LogEntryRow.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/logviewer/components/LogEntryRow.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,29 +24,34 @@ fun LogEntryRow(
     val backgroundColor = logEntry.level.backgroundColor
     val textColor = logEntry.level.textColor
 
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(backgroundColor)
-            .padding(horizontal = 12.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        LogTimestamp(
-            timestamp = logEntry.timestamp.toString()
-                .substringAfter("T")
-                .substringBefore("."),
-        )
+    // Per-item SelectionContainer: the log list is a LazyColumn, so selection is scoped to a
+    // single line. Wrapping the whole LazyColumn in one SelectionContainer is avoided because it
+    // forces composition of off-screen items and has known perf/UX issues.
+    SelectionContainer {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(backgroundColor)
+                .padding(horizontal = 12.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            LogTimestamp(
+                timestamp = logEntry.timestamp.toString()
+                    .substringAfter("T")
+                    .substringBefore("."),
+            )
 
-        LogLevelBadge(
-            level = logEntry.level,
-            color = textColor,
-        )
+            LogLevelBadge(
+                level = logEntry.level,
+                color = textColor,
+            )
 
-        LogMessage(
-            message = logEntry.message,
-            color = textColor,
-            modifier = Modifier.weight(1f),
-        )
+            LogMessage(
+                message = logEntry.message,
+                color = textColor,
+                modifier = Modifier.weight(1f),
+            )
+        }
     }
 }
 

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -154,7 +155,11 @@ internal fun TrafficTab(
                         color = MaterialTheme.colorScheme.outline,
                     )
                 } else {
-                    TransactionDetail(tx = tx, onCreateMock = { onCreateMock(tx) })
+                    // Detail pane values (URL, headers, bodies) are read-only reference data
+                    // developers frequently copy, so make the whole pane text-selectable.
+                    SelectionContainer {
+                        TransactionDetail(tx = tx, onCreateMock = { onCreateMock(tx) })
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Scope

Enable mouse text selection + copy where developers frequently need to copy values.

### Network Inspector plugin (`jetwhale-plugins/network/host`)
Wrapped the transaction **detail pane** in `SelectionContainer` (`TrafficView.kt`). URLs, query params, request/response headers, and bodies (both Raw and Tree JSON views) are now selectable and copyable. The left transaction **list** is deliberately left outside the container so row clicks, keyboard up/down navigation, and the existing right-click context menu (Copy as cURL / Copy URL / Copy body) keep working unchanged. Expand/collapse of JSON tree nodes still works inside the selection container.

### Host log viewer (`jetwhale-host/feature/settings/.../LogEntryRow.kt`)
Made log lines selectable via a **per-item** `SelectionContainer` inside `LogEntryRow`.

**LazyColumn tradeoff:** the log list is a `LazyColumn`, so selection is scoped to a single log line — you cannot drag-select across multiple lines. This is the pragmatic choice: wrapping the entire `LazyColumn` in one `SelectionContainer` would force composition of all off-screen items (defeating lazy virtualization) and has known perf/UX issues, so per-item selection was chosen.

### Sweep
- Checked the host app for other copy-worthy read-only text (about/diagnostics/certificate PEM dialogs). No about/diagnostics or certificate/PEM dialogs exist on `main`, so nothing else was in scope.
- `PluginInfoView` (plugin id/version row) was left as-is — low value and it lives inside an interactive settings list row.

## Verification
`./gradlew :jetwhale-host:app:compileKotlin :jetwhale-plugins:network:host:compileKotlin spotlessApply` passes.