### PR TITLE
feat(host): run dev-plugin host in an isolated app-data sandbox

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -328,7 +328,8 @@ state; for changes it can't apply that way it recreates the plugin from a fresh 
 
 ### Isolated sandbox environment
 
-`runJetWhale` and `runJetWhaleHot` run the host against an **isolated, per-project sandbox** at
+`runJetWhale`, `runJetWhaleHot` and the in-repo `runJetWhaleLocal` run the host against an
+**isolated, per-project sandbox** at
 `build/jetwhale-sandbox/` instead of your real `~/.jetwhale/`. Everything the host persists — installed
 plugins, settings, per-plugin data, TLS material and the plugin trust registry — lives there, so trying
 a plugin never reads or mutates your actual JetWhale installation. The sandbox starts empty: only your

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -320,11 +320,27 @@ Rules of thumb:
 ## Hot reload (the live dev loop)
 
 `runJetWhale` starts the host with `-Djetwhale.devPluginsDir=<dir>` pointing at a dev
-directory under your module's `build` folder. The host loads plugins from that directory **in addition
-to** `~/.jetwhale/plugins/` and watches it: whenever the plugin jar is re-staged, the host reloads it
-and refreshes the open plugin screen — **no host restart needed**. For simple edits it redefines your
-classes in place and keeps the plugin's state; for changes it can't apply that way it recreates the
-plugin from a fresh classloader (see [Limitations](#limitations) below).
+directory under your module's `build` folder. The host loads plugins from that directory and watches
+it: whenever the plugin jar is re-staged, the host reloads it and refreshes the open plugin screen —
+**no host restart needed**. For simple edits it redefines your classes in place and keeps the plugin's
+state; for changes it can't apply that way it recreates the plugin from a fresh classloader (see
+[Limitations](#limitations) below).
+
+### Isolated sandbox environment
+
+`runJetWhale` and `runJetWhaleHot` run the host against an **isolated, per-project sandbox** at
+`build/jetwhale-sandbox/` instead of your real `~/.jetwhale/`. Everything the host persists — installed
+plugins, settings, per-plugin data, TLS material and the plugin trust registry — lives there, so trying
+a plugin never reads or mutates your actual JetWhale installation. The sandbox starts empty: only your
+dev plugin is loaded (dev-directory plugins are trusted implicitly, so there is no trust prompt to
+click through), and there are no leftover plugins or settings from previous work.
+
+The sandbox lives under `build/`, so it **persists across re-launches** of the same project — test data
+you set up survives the next `runJetWhale`. Running `./gradlew :myPlugin:clean` wipes it for a
+completely fresh environment.
+
+Non-dev launches (the installed JetWhale app) are unaffected: without the override they use
+`~/.jetwhale/` exactly as before.
 
 The simplest loop is a single command — `runJetWhaleHot` launches the host **and** keeps re-staging
 your plugin for you:

--- a/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
@@ -37,11 +37,15 @@ tasks.register<JavaExec>("runJetWhaleLocal") {
     // Point the host at the dev plugins directory; this enables dev-mode loading + hot reload.
     // Supplied lazily via a CommandLineArgumentProvider so the task stays configuration-cache safe.
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
+    // Isolated, disposable app-data root for this plugin project so the host does not run against the
+    // developer's real `~/.jetwhale`. Lives under `build/`, so it survives re-launches but `clean` wipes it.
+    val sandboxDirProvider = layout.buildDirectory.dir("jetwhale-sandbox").map { it.asFile.absolutePath }
     val osName = providers.systemProperty("os.name")
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
             buildList {
                 add("-Djetwhale.devPluginsDir=${devDirProvider.get()}")
+                add("-Djetwhale.appDataDir=${sandboxDirProvider.get()}")
                 // Allow the dev hot-reload to self-attach a JVM agent (byte-buddy-agent) for in-place
                 // class redefinition; self-attach is disabled by default on JDK 9+.
                 add("-Djdk.attach.allowAttachSelf=true")

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -267,11 +267,17 @@ fun registerRunTask(name: String, taskDescription: String, hot: Boolean) = tasks
     }
 
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
+    // An isolated, disposable app-data root for this plugin project. The host runs against it instead
+    // of the developer's real `~/.jetwhale`, so trying the plugin never reads or mutates their installed
+    // plugins, settings, plugin-data or trust registry. It lives under `build/`, so it persists across
+    // re-launches of the same project (test data survives) but `clean` wipes it for a fresh start.
+    val sandboxDirProvider = layout.buildDirectory.dir("jetwhale-sandbox").map { it.asFile.absolutePath }
     val osName = providers.systemProperty("os.name")
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
             buildList {
                 add("-Djetwhale.devPluginsDir=${devDirProvider.get()}")
+                add("-Djetwhale.appDataDir=${sandboxDirProvider.get()}")
                 // The macOS Dock name (hover text) comes from the bundle name, which for a bare JVM
                 // can only be set via -Xdock:name at launch — it is not settable at runtime.
                 if (osName.getOrElse("").contains("mac", ignoreCase = true)) add("-Xdock:name=JetWhale")

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
@@ -11,7 +11,15 @@ import java.io.File
 @Inject
 class AppDataDirectoryProvider {
     private val homeDir = System.getProperty("user.home")
-    private val appDataDir = "$homeDir/.jetwhale"
+
+    // The app data root. Normally `~/.jetwhale`, but a launch may point it elsewhere via the
+    // `jetwhale.appDataDir` system property. The plugin-developer Gradle tasks (`runJetWhale`,
+    // `runJetWhaleHot`) set it to a disposable per-project sandbox under the plugin module's `build/`
+    // directory, so trying a plugin never reads or mutates the developer's real installed plugins,
+    // settings, plugin-data or trust registry. Every path below is derived from this single root.
+    private val appDataDir = System.getProperty(APP_DATA_DIR_PROPERTY)?.takeIf { it.isNotBlank() }
+        ?: "$homeDir/.jetwhale"
+    private val isAppDataDirOverridden = System.getProperty(APP_DATA_DIR_PROPERTY)?.isNotBlank() == true
     private val pluginDir = "$appDataDir/plugins"
     private val pluginLibsDir = "$pluginDir/libs"
     private val dataStoreFilesDir = "$appDataDir/dataStorePreferences"
@@ -43,7 +51,10 @@ class AppDataDirectoryProvider {
         }
     }
 
-    fun getAppDataPath(): String = "~/.jetwhale"
+    // For display (diagnostics/settings). Shows the literal sandbox path when overridden so a developer
+    // can see they are running against the isolated directory, and the tilde-abbreviated `~/.jetwhale`
+    // otherwise.
+    fun getAppDataPath(): String = if (isAppDataDirOverridden) appDataDir else "~/.jetwhale"
 
     /**
      * The file backing the plugin trust registry (the list of jars the user has explicitly approved,
@@ -125,5 +136,11 @@ class AppDataDirectoryProvider {
 
     companion object {
         const val DEV_PLUGINS_DIR_PROPERTY = "jetwhale.devPluginsDir"
+
+        /**
+         * JVM system property overriding the app data root (normally `~/.jetwhale`). Set by the
+         * plugin-developer Gradle tasks to an isolated per-project sandbox directory.
+         */
+        const val APP_DATA_DIR_PROPERTY = "jetwhale.appDataDir"
     }
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
@@ -14,7 +14,7 @@ class AppDataDirectoryProvider {
 
     // The app data root. Normally `~/.jetwhale`, but a launch may point it elsewhere via the
     // `jetwhale.appDataDir` system property. The plugin-developer Gradle tasks (`runJetWhale`,
-    // `runJetWhaleHot`) set it to a disposable per-project sandbox under the plugin module's `build/`
+    // `runJetWhaleHot`, `runJetWhaleLocal`) set it to a disposable per-project sandbox under the plugin module's `build/`
     // directory, so trying a plugin never reads or mutates the developer's real installed plugins,
     // settings, plugin-data or trust registry. Every path below is derived from this single root.
     private val appDataDir = System.getProperty(APP_DATA_DIR_PROPERTY)?.takeIf { it.isNotBlank() }
@@ -122,8 +122,9 @@ class AppDataDirectoryProvider {
      * `jetwhale.devPluginsDir` JVM system property (set by the `runJetWhale` Gradle task).
      *
      * Returns `null` in normal usage so production behaviour is unchanged. When present, the host
-     * additionally loads and hot-reloads plugins from this directory, on top of the regular
-     * `~/.jetwhale/plugins` directory.
+     * additionally loads and hot-reloads plugins from this directory, on top of the regular managed
+     * plugins directory ([getPluginDirectory], which is `~/.jetwhale/plugins` — or, under the dev
+     * sandbox, the sandbox root's `plugins` subdirectory).
      */
     fun getDevPluginsDir(): String? = System.getProperty(DEV_PLUGINS_DIR_PROPERTY)?.takeIf { it.isNotBlank() }
 

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProviderTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProviderTest.kt
@@ -1,0 +1,71 @@
+package com.kitakkun.jetwhale.host.data
+
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AppDataDirectoryProviderTest {
+    private val originalUserHome: String? = System.getProperty("user.home")
+    private val originalAppDataDir: String? = System.getProperty(AppDataDirectoryProvider.APP_DATA_DIR_PROPERTY)
+
+    @AfterTest
+    fun restoreProperties() {
+        originalUserHome?.let { System.setProperty("user.home", it) }
+        if (originalAppDataDir != null) {
+            System.setProperty(AppDataDirectoryProvider.APP_DATA_DIR_PROPERTY, originalAppDataDir)
+        } else {
+            System.clearProperty(AppDataDirectoryProvider.APP_DATA_DIR_PROPERTY)
+        }
+    }
+
+    @Test
+    fun `defaults every path under the user home when no override is set`() {
+        val home = Files.createTempDirectory("jetwhale-home").toString()
+        System.setProperty("user.home", home)
+        System.clearProperty(AppDataDirectoryProvider.APP_DATA_DIR_PROPERTY)
+
+        val provider = AppDataDirectoryProvider()
+
+        assertEquals("~/.jetwhale", provider.getAppDataPath())
+        assertTrue(provider.getPluginDirectory().path.startsWith("$home/.jetwhale"))
+        assertTrue(provider.getTrustRegistryFile().path.startsWith("$home/.jetwhale"))
+        assertTrue(
+            provider.resolveDataStoreFilePath("prefs.preferences_pb").toString().startsWith("$home/.jetwhale"),
+        )
+    }
+
+    @Test
+    fun `routes every path through the sandbox root when the override is set`() {
+        val home = Files.createTempDirectory("jetwhale-home").toString()
+        val sandbox = Files.createTempDirectory("jetwhale-sandbox").toString()
+        System.setProperty("user.home", home)
+        System.setProperty(AppDataDirectoryProvider.APP_DATA_DIR_PROPERTY, sandbox)
+
+        val provider = AppDataDirectoryProvider()
+
+        // Nothing resolves under the real home; everything flows from the sandbox root.
+        assertEquals(sandbox, provider.getAppDataPath())
+        assertTrue(provider.getPluginDirectory().path.startsWith(sandbox))
+        assertTrue(provider.getPluginLibsDirectory().path.startsWith(sandbox))
+        assertTrue(provider.getTrustRegistryFile().path.startsWith(sandbox))
+        assertTrue(provider.resolveDataStoreFilePath("prefs.preferences_pb").toString().startsWith(sandbox))
+        assertTrue(provider.resolvePluginDataFilePath("plugin.a").toString().startsWith(sandbox))
+
+        provider.createAppDataDirectoriesIfNeeded()
+        assertTrue(provider.getPluginDirectory().exists())
+    }
+
+    @Test
+    fun `treats a blank override as no override`() {
+        val home = Files.createTempDirectory("jetwhale-home").toString()
+        System.setProperty("user.home", home)
+        System.setProperty(AppDataDirectoryProvider.APP_DATA_DIR_PROPERTY, "   ")
+
+        val provider = AppDataDirectoryProvider()
+
+        assertEquals("~/.jetwhale", provider.getAppDataPath())
+        assertTrue(provider.getPluginDirectory().path.startsWith("$home/.jetwhale"))
+    }
+}


### PR DESCRIPTION
## Problem

The plugin-developer workflow (`runJetWhale`, `runJetWhaleHot`, and the in-repo `runJetWhaleLocal`) launched the host against the developer's **real** `~/.jetwhale` directory. Trying a plugin in the "sandbox" therefore read and mutated the developer's actual installed plugins, settings, per-plugin data and trust registry — the sandbox was not a sandbox at all.

## Design

Introduce a `jetwhale.appDataDir` JVM system property that overrides the app-data root in `AppDataDirectoryProvider`. Every derived path — `plugins/`, `dataStorePreferences/`, `plugin-data/`, `trusted-plugins.json`, plugin libs — flows from that single root, so overriding it relocates everything at once. A blank value is treated as no override.

- Audited the host modules for other `user.home` path builders: `AdbUtil` (Android SDK lookup — unrelated to app data, left as-is) and the settings display path (now shows the literal sandbox path when overridden). Trust and dev-plugin loading already derive entirely from `AppDataDirectoryProvider`, so no other class needed touching.
- The dev Gradle tasks set the property to a disposable per-project `build/jetwhale-sandbox/` directory. Because it lives under `build/`, it **persists across re-launches** of the same project (test data survives) but `clean` wipes it for a fresh start.
- No trust weakening: dev-directory plugins are already loaded outside the managed-plugins trust flow (they bypass the trust registry by design), so an empty sandbox means the dev plugin loads with no trust prompt while production trust rules are untouched.

## Behaviour: dev vs normal launch

| | App-data root | Installed plugins / settings / trust | Lifetime |
|---|---|---|---|
| **Dev launch** (`runJetWhale`, `runJetWhaleHot`, `runJetWhaleLocal`) | `build/jetwhale-sandbox/` | Isolated, starts empty | Persists across re-launches; wiped by `clean` |
| **Normal launch** (installed app) | `~/.jetwhale/` | The developer's real data | Unchanged |

## Verification

- `./gradlew :jetwhale-host:app:compileKotlin :jetwhale-host:core:data:test spotlessApply` — pass (includes new `AppDataDirectoryProviderTest`)
- `./gradlew -p gradle-conventions build -x test` and `-p jetwhale-gradle-plugin compileKotlin` — pass

## Docs

Updated `docs/guide/developing-plugins.md` with an "Isolated sandbox environment" section describing the sandbox, its empty starting state, persistence across runs, and the `clean` reset.
