### PR TITLE
feat: carry app and device metadata through session negotiation

### DIFF
--- a/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
+++ b/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
@@ -34,7 +34,23 @@ final enum class com.kitakkun.jetwhale.agent.runtime/LogLevel : kotlin/Enum<com.
     final fun values(): kotlin/Array<com.kitakkun.jetwhale.agent.runtime/LogLevel> // com.kitakkun.jetwhale.agent.runtime/LogLevel.values|values#static(){}[0]
 }
 
+abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope|null[0]
+    abstract var appIconPng // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.appIconPng|{}appIconPng[0]
+        abstract fun <get-appIconPng>(): kotlin/ByteArray? // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.appIconPng.<get-appIconPng>|<get-appIconPng>(){}[0]
+        abstract fun <set-appIconPng>(kotlin/ByteArray?) // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.appIconPng.<set-appIconPng>|<set-appIconPng>(kotlin.ByteArray?){}[0]
+    abstract var appName // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.appName|{}appName[0]
+        abstract fun <get-appName>(): kotlin/String? // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.appName.<get-appName>|<get-appName>(){}[0]
+        abstract fun <set-appName>(kotlin/String?) // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.appName.<set-appName>|<set-appName>(kotlin.String?){}[0]
+    abstract var deviceId // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.deviceId|{}deviceId[0]
+        abstract fun <get-deviceId>(): kotlin/String? // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.deviceId.<get-deviceId>|<get-deviceId>(){}[0]
+        abstract fun <set-deviceId>(kotlin/String?) // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.deviceId.<set-deviceId>|<set-deviceId>(kotlin.String?){}[0]
+    abstract var deviceName // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.deviceName|{}deviceName[0]
+        abstract fun <get-deviceName>(): kotlin/String? // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.deviceName.<get-deviceName>|<get-deviceName>(){}[0]
+        abstract fun <set-deviceName>(kotlin/String?) // com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope.deviceName.<set-deviceName>|<set-deviceName>(kotlin.String?){}[0]
+}
+
 abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope|null[0]
+    abstract fun app(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleAppConfigurationScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope.app|app(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleAppConfigurationScope,kotlin.Unit>){}[0]
     abstract fun connection(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope.connection|connection(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleConnectionConfigurationScope,kotlin.Unit>){}[0]
     abstract fun logging(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleLoggingConfigurationScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope.logging|logging(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleLoggingConfigurationScope,kotlin.Unit>){}[0]
     abstract fun plugins(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhalePluginConfigurationScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope.plugins|plugins(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhalePluginConfigurationScope,kotlin.Unit>){}[0]

--- a/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
+++ b/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
@@ -1,4 +1,16 @@
+public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleAppConfigurationScope {
+	public abstract fun getAppIconPng ()[B
+	public abstract fun getAppName ()Ljava/lang/String;
+	public abstract fun getDeviceId ()Ljava/lang/String;
+	public abstract fun getDeviceName ()Ljava/lang/String;
+	public abstract fun setAppIconPng ([B)V
+	public abstract fun setAppName (Ljava/lang/String;)V
+	public abstract fun setDeviceId (Ljava/lang/String;)V
+	public abstract fun setDeviceName (Ljava/lang/String;)V
+}
+
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleConfigurationScope {
+	public abstract fun app (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun connection (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun logging (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun plugins (Lkotlin/jvm/functions/Function1;)V

--- a/jetwhale-agent-runtime/src/androidMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.android.kt
+++ b/jetwhale-agent-runtime/src/androidMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.android.kt
@@ -1,0 +1,35 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.content.Context
+import android.provider.Settings
+
+/**
+ * Retrieves the current [Application] context without requiring the host app to pass one in.
+ * Uses the hidden `ActivityThread.currentApplication()` entry point reflectively so metadata
+ * resolution stays best-effort and never crashes the debuggee.
+ */
+private fun currentApplicationOrNull(): Context? = try {
+    val activityThread = Class.forName("android.app.ActivityThread")
+    val method = activityThread.getMethod("currentApplication")
+    method.invoke(null) as? Application
+} catch (_: Throwable) {
+    null
+}
+
+@SuppressLint("HardwareIds")
+internal actual fun getDeviceId(): String? = try {
+    val context = currentApplicationOrNull() ?: return null
+    Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+} catch (_: Throwable) {
+    null
+}
+
+internal actual fun resolveDefaultAppName(): String? = try {
+    val context = currentApplicationOrNull() ?: return null
+    val applicationInfo = context.applicationInfo
+    context.packageManager.getApplicationLabel(applicationInfo).toString()
+} catch (_: Throwable) {
+    null
+}

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataResolver.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataResolver.kt
@@ -1,0 +1,71 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * Maximum size of an app icon PNG (in bytes) that is allowed on the wire.
+ * Icons larger than this are dropped so the negotiation payload stays small.
+ * Senders are expected to downscale icons to at most 64x64 pixels before providing them.
+ */
+internal const val MAX_APP_ICON_BYTES: Int = 32 * 1024
+
+/**
+ * Best-effort resolver for [JetWhaleAppMetadata].
+ * Explicit values provided through the DSL always win; anything left unset is filled in
+ * with a platform-specific auto-resolved value when one is available.
+ */
+internal fun resolveAppMetadata(config: ResolvedAppConfiguration): JetWhaleAppMetadata = JetWhaleAppMetadata(
+    appName = config.appName ?: resolveDefaultAppName(),
+    deviceId = config.deviceId ?: getDeviceId(),
+    deviceName = config.deviceName ?: getDeviceModelName(),
+    appIconPngBase64 = encodeAppIconOrNull(config.appIconPng),
+)
+
+@OptIn(ExperimentalEncodingApi::class)
+internal fun encodeAppIconOrNull(png: ByteArray?): String? {
+    if (png == null) return null
+    if (png.size > MAX_APP_ICON_BYTES) {
+        JetWhaleLogger.w("App icon dropped: ${png.size} bytes exceeds the ${MAX_APP_ICON_BYTES} byte cap")
+        return null
+    }
+    return Base64.encode(png)
+}
+
+/**
+ * Snapshot of the app-related DSL configuration used to resolve [JetWhaleAppMetadata].
+ */
+internal data class ResolvedAppConfiguration(
+    val appName: String?,
+    val deviceId: String?,
+    val deviceName: String?,
+    val appIconPng: ByteArray?,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ResolvedAppConfiguration) return false
+        return appName == other.appName &&
+            deviceId == other.deviceId &&
+            deviceName == other.deviceName &&
+            appIconPng.contentEquals(other.appIconPng)
+    }
+
+    override fun hashCode(): Int {
+        var result = appName?.hashCode() ?: 0
+        result = 31 * result + (deviceId?.hashCode() ?: 0)
+        result = 31 * result + (deviceName?.hashCode() ?: 0)
+        result = 31 * result + (appIconPng?.contentHashCode() ?: 0)
+        return result
+    }
+}
+
+/**
+ * Resolves a stable per-device identifier for the current platform, or null when unavailable.
+ */
+internal expect fun getDeviceId(): String?
+
+/**
+ * Resolves the human-readable application name for the current platform, or null when unavailable.
+ */
+internal expect fun resolveDefaultAppName(): String?

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataResolver.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataResolver.kt
@@ -5,11 +5,13 @@ import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 /**
- * Maximum size of an app icon PNG (in bytes) that is allowed on the wire.
- * Icons larger than this are dropped so the negotiation payload stays small.
- * Senders are expected to downscale icons to at most 64x64 pixels before providing them.
+ * Maximum length (in characters) of the base64-encoded app icon that is allowed on the wire.
+ * The bound is applied to the encoded string that actually travels in the negotiation payload,
+ * so the wire cost stays capped regardless of base64's ~4/3 expansion of the raw PNG bytes.
+ * Icons whose encoded form exceeds this are dropped. Senders are expected to downscale icons to
+ * at most 64x64 pixels before providing them.
  */
-internal const val MAX_APP_ICON_BYTES: Int = 32 * 1024
+internal const val MAX_APP_ICON_BASE64_LENGTH: Int = 32 * 1024
 
 /**
  * Best-effort resolver for [JetWhaleAppMetadata].
@@ -26,11 +28,12 @@ internal fun resolveAppMetadata(config: ResolvedAppConfiguration): JetWhaleAppMe
 @OptIn(ExperimentalEncodingApi::class)
 internal fun encodeAppIconOrNull(png: ByteArray?): String? {
     if (png == null) return null
-    if (png.size > MAX_APP_ICON_BYTES) {
-        JetWhaleLogger.w("App icon dropped: ${png.size} bytes exceeds the ${MAX_APP_ICON_BYTES} byte cap")
+    val encoded = Base64.encode(png)
+    if (encoded.length > MAX_APP_ICON_BASE64_LENGTH) {
+        JetWhaleLogger.w("App icon dropped: base64 length ${encoded.length} exceeds the $MAX_APP_ICON_BASE64_LENGTH character cap")
         return null
     }
-    return Base64.encode(png)
+    return encoded
 }
 
 /**

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultClientSessionNegotiationStrategy.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultClientSessionNegotiationStrategy.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.agent.runtime
 
 import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAgentNegotiationRequest
+import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata
 import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleHostNegotiationResponse
 import com.kitakkun.jetwhale.protocol.negotiation.JetWhalePluginInfo
 import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleProtocolVersion
@@ -9,7 +10,10 @@ import io.ktor.client.plugins.websocket.receiveDeserialized
 import io.ktor.client.plugins.websocket.sendSerialized
 import kotlin.coroutines.cancellation.CancellationException
 
-internal class DefaultClientSessionNegotiationStrategy(private val plugins: List<AgentPlugin>) : ClientSessionNegotiationStrategy {
+internal class DefaultClientSessionNegotiationStrategy(
+    private val plugins: List<AgentPlugin>,
+    private val appMetadata: JetWhaleAppMetadata,
+) : ClientSessionNegotiationStrategy {
     private var sessionId: String? = null
 
     override suspend fun DefaultClientWebSocketSession.negotiate(): ClientSessionNegotiationResult = try {
@@ -58,7 +62,8 @@ internal class DefaultClientSessionNegotiationStrategy(private val plugins: List
         sendSerialized(
             JetWhaleAgentNegotiationRequest.Session(
                 sessionId = resumingSessionId,
-                sessionName = getDeviceModelName(),
+                sessionName = appMetadata.deviceName ?: getDeviceModelName(),
+                appMetadata = appMetadata,
             ),
         )
         JetWhaleLogger.v("Sent session negotiation request" + " with sessionId: $resumingSessionId".takeIf { resumingSessionId != null })

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -17,11 +17,15 @@ public fun startJetWhale(configure: JetWhaleConfigurationScope.() -> Unit) {
     JetWhaleLogger.setKtorLogLevel(configuration.logging.ktorLogLevel)
 
     val json = JetWhaleJson
+    val appMetadata = resolveAppMetadata(configuration.app.toResolvedConfiguration())
     val service: JetWhaleMessagingService =
         DefaultJetWhaleMessagingService(
             socketClient = KtorWebSocketClient(
                 json = json,
-                negotiationStrategy = DefaultClientSessionNegotiationStrategy(configuration.plugins.plugins),
+                negotiationStrategy = DefaultClientSessionNegotiationStrategy(
+                    plugins = configuration.plugins.plugins,
+                    appMetadata = appMetadata,
+                ),
                 sslConfiguration = configuration.connection.sslConfiguration,
             ),
             pluginService = JetWhaleAgentPluginService(
@@ -42,6 +46,34 @@ public interface JetWhaleConfigurationScope {
     public fun connection(configure: JetWhaleConnectionConfigurationScope.() -> Unit)
     public fun logging(configure: JetWhaleLoggingConfigurationScope.() -> Unit)
     public fun plugins(configure: JetWhalePluginConfigurationScope.() -> Unit)
+
+    /**
+     * Configures the application/device metadata reported to the host during session negotiation.
+     * All values are optional: unset values are auto-resolved per platform on a best-effort basis.
+     */
+    public fun app(configure: JetWhaleAppConfigurationScope.() -> Unit)
+}
+
+/**
+ * DSL scope for the application/device metadata reported to the host.
+ * Explicit values set here always take precedence over auto-resolved defaults.
+ */
+@JetWhaleDsl
+public interface JetWhaleAppConfigurationScope {
+    /** Human-readable application name. Auto-resolved on Android/iOS/macOS when left null. */
+    public var appName: String?
+
+    /** Stable per-device identifier used by the host to group sessions. Auto-resolved on Android/iOS when left null. */
+    public var deviceId: String?
+
+    /** Human-readable device name. Defaults to the platform device/host name when left null. */
+    public var deviceName: String?
+
+    /**
+     * Application icon as PNG bytes. Provide an image already downscaled to at most 64x64 pixels;
+     * icons whose encoded PNG exceeds 32KB are dropped so the negotiation payload stays small.
+     */
+    public var appIconPng: ByteArray?
 }
 
 @JetWhaleDsl
@@ -106,6 +138,7 @@ private class JetWhaleConfiguration : JetWhaleConfigurationScope {
     val connection: JetWhaleConnectionConfiguration = JetWhaleConnectionConfiguration()
     val logging: JetWhaleLoggingConfiguration = JetWhaleLoggingConfiguration()
     val plugins: JetWhalePluginConfiguration = JetWhalePluginConfiguration()
+    val app: JetWhaleAppConfiguration = JetWhaleAppConfiguration()
 
     override fun connection(configure: JetWhaleConnectionConfigurationScope.() -> Unit) {
         connection.configure()
@@ -118,6 +151,24 @@ private class JetWhaleConfiguration : JetWhaleConfigurationScope {
     override fun plugins(configure: JetWhalePluginConfigurationScope.() -> Unit) {
         plugins.configure()
     }
+
+    override fun app(configure: JetWhaleAppConfigurationScope.() -> Unit) {
+        app.configure()
+    }
+}
+
+private class JetWhaleAppConfiguration : JetWhaleAppConfigurationScope {
+    override var appName: String? = null
+    override var deviceId: String? = null
+    override var deviceName: String? = null
+    override var appIconPng: ByteArray? = null
+
+    fun toResolvedConfiguration(): ResolvedAppConfiguration = ResolvedAppConfiguration(
+        appName = appName,
+        deviceId = deviceId,
+        deviceName = deviceName,
+        appIconPng = appIconPng,
+    )
 }
 
 private class JetWhaleConnectionConfiguration : JetWhaleConnectionConfigurationScope {

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -71,7 +71,7 @@ public interface JetWhaleAppConfigurationScope {
 
     /**
      * Application icon as PNG bytes. Provide an image already downscaled to at most 64x64 pixels;
-     * icons whose encoded PNG exceeds 32KB are dropped so the negotiation payload stays small.
+     * icons whose base64-encoded form exceeds 32KB are dropped so the negotiation payload stays small.
      */
     public var appIconPng: ByteArray?
 }

--- a/jetwhale-agent-runtime/src/iosMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.ios.kt
+++ b/jetwhale-agent-runtime/src/iosMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.ios.kt
@@ -1,0 +1,11 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import platform.Foundation.NSBundle
+import platform.UIKit.UIDevice
+
+internal actual fun getDeviceId(): String? = UIDevice.currentDevice.identifierForVendor?.UUIDString
+
+internal actual fun resolveDefaultAppName(): String? {
+    val info = NSBundle.mainBundle.infoDictionary ?: return null
+    return (info["CFBundleDisplayName"] ?: info["CFBundleName"]) as? String
+}

--- a/jetwhale-agent-runtime/src/jvmMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.jvm.kt
+++ b/jetwhale-agent-runtime/src/jvmMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.jvm.kt
@@ -1,0 +1,7 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+// On the JVM there is no reliable stable device id or application name available, so both are
+// left unresolved. Provide them explicitly through the `app { }` DSL when needed.
+internal actual fun getDeviceId(): String? = null
+
+internal actual fun resolveDefaultAppName(): String? = null

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataResolverTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataResolverTest.kt
@@ -1,0 +1,71 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class AppMetadataResolverTest {
+
+    @Test
+    fun `encodeAppIconOrNull returns null for a null icon`() {
+        assertNull(encodeAppIconOrNull(null))
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @Test
+    fun `encodeAppIconOrNull encodes a small icon as base64`() {
+        val png = byteArrayOf(1, 2, 3, 4)
+        assertEquals(Base64.encode(png), encodeAppIconOrNull(png))
+    }
+
+    @Test
+    fun `encodeAppIconOrNull drops an icon whose encoded form exceeds the cap`() {
+        // 3 raw bytes encode to 4 base64 chars, so this comfortably exceeds the encoded-length cap.
+        val oversized = ByteArray(MAX_APP_ICON_BASE64_LENGTH) { 0 }
+        assertNull(encodeAppIconOrNull(oversized))
+    }
+
+    @Test
+    fun `encodeAppIconOrNull keeps an icon right at the encoded-length cap`() {
+        // Raw byte count that encodes to exactly the cap length (base64 encodes 3 bytes to 4 chars).
+        val rawSize = MAX_APP_ICON_BASE64_LENGTH / 4 * 3
+        val encoded = encodeAppIconOrNull(ByteArray(rawSize) { 0 })
+        assertNotNull(encoded)
+        assertEquals(MAX_APP_ICON_BASE64_LENGTH, encoded.length)
+    }
+
+    @Test
+    fun `resolveAppMetadata prefers explicit values over auto-resolved ones`() {
+        val config = ResolvedAppConfiguration(
+            appName = "Explicit App",
+            deviceId = "explicit-device-id",
+            deviceName = "Explicit Device",
+            appIconPng = byteArrayOf(9, 8, 7),
+        )
+
+        val metadata = resolveAppMetadata(config)
+
+        assertEquals("Explicit App", metadata.appName)
+        assertEquals("explicit-device-id", metadata.deviceId)
+        assertEquals("Explicit Device", metadata.deviceName)
+        assertEquals(encodeAppIconOrNull(byteArrayOf(9, 8, 7)), metadata.appIconPngBase64)
+    }
+
+    @Test
+    fun `resolveAppMetadata falls back to the platform device name when unset`() {
+        val config = ResolvedAppConfiguration(
+            appName = null,
+            deviceId = null,
+            deviceName = null,
+            appIconPng = null,
+        )
+
+        val metadata = resolveAppMetadata(config)
+
+        // On the JVM the device name falls back to the OS name and is never blank.
+        assertEquals(getDeviceModelName(), metadata.deviceName)
+    }
+}

--- a/jetwhale-agent-runtime/src/linuxMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.linux.kt
+++ b/jetwhale-agent-runtime/src/linuxMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.linux.kt
@@ -1,0 +1,6 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+// No reliable stable device id or application name on Linux native; provide them explicitly if needed.
+internal actual fun getDeviceId(): String? = null
+
+internal actual fun resolveDefaultAppName(): String? = null

--- a/jetwhale-agent-runtime/src/macosMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.macos.kt
+++ b/jetwhale-agent-runtime/src/macosMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.macos.kt
@@ -1,0 +1,12 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import platform.Foundation.NSBundle
+
+// macOS does not expose a stable per-device id without extra entitlements, so device id is left
+// unresolved; the bundle name is used as the application name when available.
+internal actual fun getDeviceId(): String? = null
+
+internal actual fun resolveDefaultAppName(): String? {
+    val info = NSBundle.mainBundle.infoDictionary ?: return null
+    return (info["CFBundleDisplayName"] ?: info["CFBundleName"]) as? String
+}

--- a/jetwhale-agent-runtime/src/mingwMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.mingw.kt
+++ b/jetwhale-agent-runtime/src/mingwMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.mingw.kt
@@ -1,0 +1,6 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+// No reliable stable device id or application name on Windows native; provide them explicitly if needed.
+internal actual fun getDeviceId(): String? = null
+
+internal actual fun resolveDefaultAppName(): String? = null

--- a/jetwhale-agent-runtime/src/webMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.web.kt
+++ b/jetwhale-agent-runtime/src/webMain/kotlin/com/kitakkun/jetwhale/agent/runtime/AppMetadataPlatform.web.kt
@@ -1,0 +1,7 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+// Browser environments do not expose a stable per-device id or a meaningful app name without
+// extra dependencies; provide them explicitly through the `app { }` DSL when needed.
+internal actual fun getDeviceId(): String? = null
+
+internal actual fun resolveDefaultAppName(): String? = null

--- a/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
@@ -8,12 +8,10 @@
     <string name="oss_licenses">OSSライセンス</string>
     <string name="no_plugin_selected">プラグインが選択されていません</string>
     <string name="no_session_available">利用可能なセッションがありません</string>
-    <string name="select_session">セッションを選択</string>
+    <string name="select_device">デバイスを選択</string>
+    <string name="select_app">アプリを選択</string>
     <string name="session_secure_connection">暗号化された接続 (wss)</string>
     <string name="session_local_connection">ローカル接続 (ADB)</string>
-    <string name="disconnected_sessions">切断されたセッション (%1$d)</string>
-    <string name="group_expanded">展開済み</string>
-    <string name="group_collapsed">折りたたみ済み</string>
     <string name="initializing">初期化中...</string>
     <string name="shutting_down">シャットダウン中...</string>
     <string name="plugin_popped_out_message">このプラグインはポップアウトされています。別のウィンドウを確認してください。</string>

--- a/jetwhale-host/app/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values/strings.xml
@@ -8,12 +8,10 @@
     <string name="oss_licenses">OSS Licenses</string>
     <string name="no_plugin_selected">No plugin selected</string>
     <string name="no_session_available">No session available</string>
-    <string name="select_session">Select Session</string>
+    <string name="select_device">Select Device</string>
+    <string name="select_app">Select App</string>
     <string name="session_secure_connection">Secure connection (wss)</string>
     <string name="session_local_connection">Local connection (ADB)</string>
-    <string name="disconnected_sessions">Disconnected Sessions (%1$d)</string>
-    <string name="group_expanded">Expanded</string>
-    <string name="group_collapsed">Collapsed</string>
     <string name="initializing">Initializing...</string>
     <string name="shutting_down">Shutting down...</string>
     <string name="plugin_popped_out_message">This plugin is popped out. Please check the separate window.</string>

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/AppIconDecoder.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/AppIconDecoder.kt
@@ -1,0 +1,17 @@
+package com.kitakkun.jetwhale.host.drawer
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import org.jetbrains.skia.Image
+import java.util.Base64
+
+/**
+ * Decodes a base64-encoded PNG app icon into an [ImageBitmap].
+ * Returns null when the payload is missing or cannot be decoded.
+ */
+internal fun decodeIconOrNull(base64Png: String): ImageBitmap? = try {
+    val bytes = Base64.getDecoder().decode(base64Png)
+    Image.makeFromEncoded(bytes).toComposeImageBitmap()
+} catch (_: Throwable) {
+    null
+}

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/AppIconDecoder.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/AppIconDecoder.kt
@@ -6,12 +6,21 @@ import org.jetbrains.skia.Image
 import java.util.Base64
 
 /**
- * Decodes a base64-encoded PNG app icon into an [ImageBitmap].
- * Returns null when the payload is missing or cannot be decoded.
+ * Maximum accepted length of a base64-encoded app icon. Matches the cap agents enforce before
+ * sending, so a buggy or malicious agent cannot make the host decode an unbounded payload.
  */
-internal fun decodeIconOrNull(base64Png: String): ImageBitmap? = try {
-    val bytes = Base64.getDecoder().decode(base64Png)
-    Image.makeFromEncoded(bytes).toComposeImageBitmap()
-} catch (_: Throwable) {
-    null
+private const val MAX_APP_ICON_BASE64_LENGTH: Int = 32 * 1024
+
+/**
+ * Decodes a base64-encoded PNG app icon into an [ImageBitmap].
+ * Returns null when the payload is missing, exceeds the size cap, or cannot be decoded.
+ */
+internal fun decodeIconOrNull(base64Png: String): ImageBitmap? {
+    if (base64Png.length > MAX_APP_ICON_BASE64_LENGTH) return null
+    return try {
+        val bytes = Base64.getDecoder().decode(base64Png)
+        Image.makeFromEncoded(bytes).toComposeImageBitmap()
+    } catch (_: Throwable) {
+        null
+    }
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
@@ -1,8 +1,6 @@
 package com.kitakkun.jetwhale.host.drawer
 
-import androidx.compose.foundation.hoverable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,18 +8,17 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Android
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Devices
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,31 +27,70 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.Res
-import com.kitakkun.jetwhale.host.disconnected_sessions
-import com.kitakkun.jetwhale.host.group_collapsed
-import com.kitakkun.jetwhale.host.group_expanded
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.no_session_available
-import com.kitakkun.jetwhale.host.select_session
+import com.kitakkun.jetwhale.host.select_app
+import com.kitakkun.jetwhale.host.select_device
 import kotlinx.collections.immutable.ImmutableList
 import org.jetbrains.compose.resources.stringResource
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * Two-level session selector. Only active sessions are shown; disconnected sessions are hidden
+ * entirely while remaining in the repository. Sessions are grouped by device, and within the
+ * selected device the concrete app (session) can be picked. Each entry keeps the transport-security
+ * lock indicator so the connection type stays visible per session.
+ */
 @Composable
 fun SessionSelectorView(
     selectedSession: DebugSession?,
     sessions: ImmutableList<DebugSession>,
     onSelectSession: (DebugSession) -> Unit,
 ) {
+    val activeSessions = remember(sessions) { sessions.filter { it.isActive } }
+    val devices = remember(activeSessions) {
+        activeSessions.groupBy { it.groupingDeviceId }.entries.toList()
+    }
+    val selectedDeviceId = selectedSession?.groupingDeviceId
+    val appsForSelectedDevice = remember(devices, selectedDeviceId) {
+        devices.firstOrNull { it.key == selectedDeviceId }?.value.orEmpty()
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        DeviceSelector(
+            devices = devices,
+            selectedDeviceId = selectedDeviceId,
+            onSelectDevice = { deviceSessions ->
+                // Selecting a device selects its first app so a session is always active.
+                deviceSessions.firstOrNull()?.let(onSelectSession)
+            },
+        )
+        if (appsForSelectedDevice.size > 1 || selectedSession != null) {
+            AppSelector(
+                apps = appsForSelectedDevice,
+                selectedSession = selectedSession,
+                onSelectSession = onSelectSession,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DeviceSelector(
+    devices: List<Map.Entry<String, List<DebugSession>>>,
+    selectedDeviceId: String?,
+    onSelectDevice: (List<DebugSession>) -> Unit,
+) {
     var expanded by remember { mutableStateOf(false) }
+    val selectedDevice = devices.firstOrNull { it.key == selectedDeviceId }?.value?.firstOrNull()
+
     ExposedDropdownMenuBox(
         expanded = expanded,
-        onExpandedChange = { expanded = it && sessions.isNotEmpty() },
+        onExpandedChange = { expanded = it && devices.isNotEmpty() },
     ) {
         Card(
             modifier = Modifier
@@ -69,16 +105,77 @@ fun SessionSelectorView(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                Icon(
-                    imageVector = Icons.Default.Devices,
-                    contentDescription = null,
-                )
+                Icon(imageVector = Icons.Default.Devices, contentDescription = null)
                 Text(
                     text = when {
-                        selectedSession != null -> selectedSession.displayName
-                        sessions.isNotEmpty() -> stringResource(Res.string.select_session)
+                        selectedDevice != null -> selectedDevice.deviceDisplayName
+                        devices.isNotEmpty() -> stringResource(Res.string.select_device)
                         else -> stringResource(Res.string.no_session_available)
                     },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                if (selectedDevice != null) {
+                    SessionSecurityIcon(selectedDevice.transportSecurity)
+                }
+            }
+        }
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            devices.forEach { entry ->
+                val representative = entry.value.first()
+                DropdownMenuItem(
+                    leadingIcon = {
+                        if (entry.key == selectedDeviceId) {
+                            Icon(imageVector = Icons.Default.Check, contentDescription = null)
+                        } else {
+                            Icon(imageVector = Icons.Default.Devices, contentDescription = null)
+                        }
+                    },
+                    trailingIcon = { SessionSecurityIcon(representative.transportSecurity) },
+                    text = { Text(representative.deviceDisplayName) },
+                    onClick = {
+                        onSelectDevice(entry.value)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AppSelector(
+    apps: List<DebugSession>,
+    selectedSession: DebugSession?,
+    onSelectSession: (DebugSession) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it && apps.isNotEmpty() },
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 56.dp)
+                .menuAnchor(type = ExposedDropdownMenuAnchorType.PrimaryEditable),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                AppIcon(selectedSession)
+                Text(
+                    text = selectedSession?.appDisplayName ?: stringResource(Res.string.select_app),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f, fill = false),
@@ -92,71 +189,39 @@ fun SessionSelectorView(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
-            val (activeSessions, disconnectedSessions) = remember(sessions) { sessions.partition { it.isActive } }
-            activeSessions.forEach {
-                SessionDropdownMenuItem(
-                    selected = it.id == selectedSession?.id,
-                    isActive = it.isActive,
-                    transportSecurity = it.transportSecurity,
-                    displayName = it.displayName,
+            apps.forEach { app ->
+                DropdownMenuItem(
+                    leadingIcon = {
+                        if (app.id == selectedSession?.id) {
+                            Icon(imageVector = Icons.Default.Check, contentDescription = null)
+                        } else {
+                            AppIcon(app)
+                        }
+                    },
+                    trailingIcon = { SessionSecurityIcon(app.transportSecurity) },
+                    text = { Text(app.appDisplayName) },
                     onClick = {
-                        onSelectSession(it)
+                        onSelectSession(app)
                         expanded = false
                     },
                 )
             }
-            if (disconnectedSessions.isNotEmpty()) {
-                val groupInteractionSource = remember { MutableInteractionSource() }
-                val hovered by groupInteractionSource.collectIsHoveredAsState()
-                var pinnedExpanded by remember { mutableStateOf(false) }
-                val disconnectedExpanded = hovered || pinnedExpanded
-                val groupStateDescription = stringResource(
-                    if (disconnectedExpanded) Res.string.group_expanded else Res.string.group_collapsed,
-                )
-                Column(
-                    modifier = Modifier.hoverable(interactionSource = groupInteractionSource),
-                ) {
-                    val groupContentColor = MaterialTheme.colorScheme.onSurfaceVariant
-                    DropdownMenuItem(
-                        text = {
-                            Text(
-                                text = stringResource(Res.string.disconnected_sessions, disconnectedSessions.size),
-                                color = groupContentColor,
-                            )
-                        },
-                        leadingIcon = {
-                            Icon(
-                                imageVector = Icons.Default.LinkOff,
-                                contentDescription = null,
-                                tint = groupContentColor,
-                            )
-                        },
-                        trailingIcon = {
-                            Icon(
-                                imageVector = if (disconnectedExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                                contentDescription = null,
-                                tint = groupContentColor,
-                            )
-                        },
-                        onClick = { pinnedExpanded = !pinnedExpanded },
-                        modifier = Modifier.semantics { stateDescription = groupStateDescription },
-                    )
-                    if (disconnectedExpanded) {
-                        disconnectedSessions.forEach {
-                            SessionDropdownMenuItem(
-                                selected = it.id == selectedSession?.id,
-                                isActive = it.isActive,
-                                transportSecurity = it.transportSecurity,
-                                displayName = it.displayName,
-                                onClick = {
-                                    onSelectSession(it)
-                                    expanded = false
-                                },
-                            )
-                        }
-                    }
-                }
-            }
         }
+    }
+}
+
+@Composable
+private fun AppIcon(session: DebugSession?) {
+    val bitmap: ImageBitmap? = remember(session?.appIconPngBase64) {
+        session?.appIconPngBase64?.let { decodeIconOrNull(it) }
+    }
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap,
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+        )
+    } else {
+        Icon(imageVector = Icons.Default.Android, contentDescription = null)
     }
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ShrunkToolingDrawerView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ShrunkToolingDrawerView.kt
@@ -97,12 +97,12 @@ fun ShrunkToolingDrawerView(
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
             ) {
-                sessions.forEach { session ->
+                sessions.filter { it.isActive }.forEach { session ->
                     SessionDropdownMenuItem(
                         selected = session.id == selectedSessionId,
                         isActive = session.isActive,
                         transportSecurity = session.transportSecurity,
-                        displayName = session.displayName,
+                        displayName = "${session.deviceDisplayName} · ${session.appDisplayName}",
                         onClick = {
                             onSelectSession(session)
                             expanded = false

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultDebugWebSocketServer.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultDebugWebSocketServer.kt
@@ -103,6 +103,7 @@ class DefaultDebugWebSocketServer(
                 sessionName = opened.result.session.sessionName,
                 transportSecurity = opened.transportSecurity,
                 installedPlugins = opened.result.plugin.requestedPlugins,
+                appMetadata = opened.result.session.appMetadata,
             )
         }
     }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/negotiation/SessionNegotiationResult.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/negotiation/SessionNegotiationResult.kt
@@ -1,6 +1,9 @@
 package com.kitakkun.jetwhale.host.data.server.negotiation
 
+import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata
+
 data class SessionNegotiationResult(
     val sessionId: String,
     val sessionName: String,
+    val appMetadata: JetWhaleAppMetadata,
 )

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/negotiation/SessionNegotiationStrategy.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/negotiation/SessionNegotiationStrategy.kt
@@ -20,6 +20,7 @@ class SessionNegotiationStrategy : NegotiationStrategy<SessionNegotiationResult>
         return SessionNegotiationResult(
             sessionId = sessionId,
             sessionName = sessionNegotiationRequest.sessionName,
+            appMetadata = sessionNegotiationRequest.appMetadata,
         )
     }
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/session/DefaultDebugSessionRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/session/DefaultDebugSessionRepository.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.host.data.session
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.DebugSessionRepository
 import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
+import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata
 import com.kitakkun.jetwhale.protocol.negotiation.JetWhalePluginInfo
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -30,6 +31,7 @@ class DefaultDebugSessionRepository : DebugSessionRepository {
         sessionName: String?,
         transportSecurity: SessionTransportSecurity,
         installedPlugins: List<JetWhalePluginInfo>,
+        appMetadata: JetWhaleAppMetadata,
     ) {
         mutableDebugSessions.update { sessions ->
             sessions.toMutableMap().apply {
@@ -41,6 +43,10 @@ class DefaultDebugSessionRepository : DebugSessionRepository {
                         isActive = true,
                         transportSecurity = transportSecurity,
                         installedPlugins = installedPlugins.toImmutableList(),
+                        appName = appMetadata.appName,
+                        deviceId = appMetadata.deviceId,
+                        deviceName = appMetadata.deviceName,
+                        appIconPngBase64 = appMetadata.appIconPngBase64,
                     ),
                 )
             }.toPersistentMap()

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/SessionTools.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/SessionTools.kt
@@ -66,6 +66,9 @@ private fun DebugSession.toSessionInfo() = SessionInfo(
     sessionName = name,
     isActive = isActive,
     installedPlugins = installedPlugins.map { it.pluginId },
+    appName = appName,
+    deviceId = deviceId,
+    deviceName = deviceName,
 )
 
 @Inject
@@ -120,6 +123,9 @@ data class SessionInfo(
     val sessionName: String?,
     val isActive: Boolean,
     val installedPlugins: List<String>,
+    val appName: String? = null,
+    val deviceId: String? = null,
+    val deviceName: String? = null,
 )
 
 @Serializable

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugSession.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugSession.kt
@@ -10,10 +10,33 @@ data class DebugSession(
     /** Security of the transport carrying this session. */
     val transportSecurity: SessionTransportSecurity,
     val installedPlugins: ImmutableList<JetWhalePluginInfo>,
+    val appName: String? = null,
+    val deviceId: String? = null,
+    val deviceName: String? = null,
+    val appIconPngBase64: String? = null,
 ) {
     private val shortId: String
         get() = id.take(6)
 
     val displayName: String
         get() = name?.let { "$it ($shortId)" } ?: shortId
+
+    /**
+     * Identifier used to group sessions by device. Falls back to the session id when no
+     * stable device id was negotiated, so ungrouped sessions still appear as their own device.
+     */
+    val groupingDeviceId: String
+        get() = deviceId ?: id
+
+    /**
+     * Human-readable device label. Prefers the negotiated device name, then the session name.
+     */
+    val deviceDisplayName: String
+        get() = deviceName ?: name ?: shortId
+
+    /**
+     * Human-readable application label. Prefers the negotiated app name, then the session display name.
+     */
+    val appDisplayName: String
+        get() = appName ?: displayName
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugSessionRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugSessionRepository.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.model
 
+import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata
 import com.kitakkun.jetwhale.protocol.negotiation.JetWhalePluginInfo
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.Flow
@@ -12,6 +13,7 @@ interface DebugSessionRepository {
         sessionName: String?,
         transportSecurity: SessionTransportSecurity,
         installedPlugins: List<JetWhalePluginInfo>,
+        appMetadata: JetWhaleAppMetadata,
     )
 
     fun unregisterDebugSession(sessionId: String)

--- a/jetwhale-protocol/core/api/core.klib.api
+++ b/jetwhale-protocol/core/api/core.klib.api
@@ -387,8 +387,10 @@ sealed interface com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotia
     }
 
     final class Session : com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest { // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session|null[0]
-        constructor <init>(kotlin/String?, kotlin/String) // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.<init>|<init>(kotlin.String?;kotlin.String){}[0]
+        constructor <init>(kotlin/String?, kotlin/String, com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata = ...) // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.<init>|<init>(kotlin.String?;kotlin.String;com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata){}[0]
 
+        final val appMetadata // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.appMetadata|{}appMetadata[0]
+            final fun <get-appMetadata>(): com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.appMetadata.<get-appMetadata>|<get-appMetadata>(){}[0]
         final val sessionId // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.sessionId|{}sessionId[0]
             final fun <get-sessionId>(): kotlin/String? // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.sessionId.<get-sessionId>|<get-sessionId>(){}[0]
         final val sessionName // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.sessionName|{}sessionName[0]
@@ -396,7 +398,8 @@ sealed interface com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotia
 
         final fun component1(): kotlin/String? // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.component1|component1(){}[0]
         final fun component2(): kotlin/String // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.component2|component2(){}[0]
-        final fun copy(kotlin/String? = ..., kotlin/String = ...): com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.copy|copy(kotlin.String?;kotlin.String){}[0]
+        final fun component3(): com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.component3|component3(){}[0]
+        final fun copy(kotlin/String? = ..., kotlin/String = ..., com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata = ...): com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.copy|copy(kotlin.String?;kotlin.String;com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAgentNegotiationRequest.Session.toString|toString(){}[0]
@@ -627,6 +630,41 @@ final class com.kitakkun.jetwhale.protocol.messaging/JetWhalePluginPeer { // com
 
 final class com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequestException : com.kitakkun.jetwhale.protocol.messaging/JetWhaleMessagingException { // com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequestException|null[0]
     constructor <init>(kotlin/String, kotlin/Throwable? = ...) // com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequestException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+}
+
+final class com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata { // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ...) // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.<init>|<init>(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
+
+    final val appIconPngBase64 // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.appIconPngBase64|{}appIconPngBase64[0]
+        final fun <get-appIconPngBase64>(): kotlin/String? // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.appIconPngBase64.<get-appIconPngBase64>|<get-appIconPngBase64>(){}[0]
+    final val appName // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.appName|{}appName[0]
+        final fun <get-appName>(): kotlin/String? // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.appName.<get-appName>|<get-appName>(){}[0]
+    final val deviceId // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.deviceId|{}deviceId[0]
+        final fun <get-deviceId>(): kotlin/String? // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.deviceId.<get-deviceId>|<get-deviceId>(){}[0]
+    final val deviceName // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.deviceName|{}deviceName[0]
+        final fun <get-deviceName>(): kotlin/String? // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.deviceName.<get-deviceName>|<get-deviceName>(){}[0]
+
+    final fun component1(): kotlin/String? // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.component2|component2(){}[0]
+    final fun component3(): kotlin/String? // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.component3|component3(){}[0]
+    final fun component4(): kotlin/String? // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.component4|component4(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ...): com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.copy|copy(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata> { // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata) // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata> // com.kitakkun.jetwhale.protocol.negotiation/JetWhaleAppMetadata.Companion.serializer|serializer(){}[0]
+    }
 }
 
 final class com.kitakkun.jetwhale.protocol.negotiation/JetWhalePluginInfo { // com.kitakkun.jetwhale.protocol.negotiation/JetWhalePluginInfo|null[0]

--- a/jetwhale-protocol/core/api/jvm/core.api
+++ b/jetwhale-protocol/core/api/jvm/core.api
@@ -439,12 +439,15 @@ public final class com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegot
 
 public final class com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest$Session : com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest {
 	public static final field Companion Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest$Session$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest$Session;
-	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest$Session;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest$Session;
+	public final fun component3 ()Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;)Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest$Session;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest$Session;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest$Session;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppMetadata ()Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;
 	public final fun getSessionId ()Ljava/lang/String;
 	public final fun getSessionName ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -463,6 +466,41 @@ public final synthetic class com/kitakkun/jetwhale/protocol/negotiation/JetWhale
 }
 
 public final class com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest$Session$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata {
+	public static final field Companion Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppIconPngBase64 ()Ljava/lang/String;
+	public final fun getAppName ()Ljava/lang/String;
+	public final fun getDeviceId ()Ljava/lang/String;
+	public final fun getDeviceName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/JetWhaleSerialNames.kt
+++ b/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/JetWhaleSerialNames.kt
@@ -38,4 +38,5 @@ internal object JetWhaleSerialNames {
     // model/*
     const val MODEL_PLUGIN_INFO = "model/plugin_info"
     const val MODEL_PROTOCOL_VERSION = "model/protocol_version"
+    const val MODEL_APP_METADATA = "model/app_metadata"
 }

--- a/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest.kt
+++ b/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequest.kt
@@ -33,6 +33,8 @@ public sealed interface JetWhaleAgentNegotiationRequest {
      *
      * @param sessionId the session ID to join. If null, a new session is requested.
      * @param sessionName the name of the session which is displayed in the host UI.
+     * @param appMetadata optional application/device metadata used by the host to group sessions.
+     *   Added additively with a default so older hosts and agents keep interoperating.
      * @see [JetWhaleHostNegotiationResponse.AcceptSession] for response
      */
     @SerialName(JetWhaleSerialNames.NEGOTIATION_AGENT_SESSION)
@@ -40,6 +42,7 @@ public sealed interface JetWhaleAgentNegotiationRequest {
     public data class Session(
         val sessionId: String?,
         val sessionName: String,
+        val appMetadata: JetWhaleAppMetadata = JetWhaleAppMetadata(),
     ) : JetWhaleAgentNegotiationRequest
 
     /**

--- a/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata.kt
+++ b/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata.kt
@@ -1,0 +1,29 @@
+package com.kitakkun.jetwhale.protocol.negotiation
+
+import com.kitakkun.jetwhale.protocol.JetWhaleSerialNames
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Metadata that identifies the debuggee application and the device it runs on.
+ *
+ * This is exchanged additively during session negotiation so the host can group
+ * sessions by device and by application. Every field is optional: agents that
+ * cannot resolve a value (or predate this metadata) simply omit it, and the host
+ * falls back to other identifiers such as [JetWhaleAgentNegotiationRequest.Session.sessionName].
+ *
+ * @param appName Human-readable application name (e.g. the Android launcher label or the iOS bundle name).
+ * @param deviceId Stable per-device identifier used to group sessions coming from the same device.
+ * @param deviceName Human-readable device name (e.g. `Build.MODEL`, `UIDevice.name`, or the machine hostname).
+ * @param appIconPngBase64 Base64-encoded PNG of the application icon. Senders MUST downscale to at most
+ *   64x64 pixels and skip the icon entirely when the encoded PNG would exceed 32KB, so hosts can rely on
+ *   the payload staying small.
+ */
+@SerialName(JetWhaleSerialNames.MODEL_APP_METADATA)
+@Serializable
+public data class JetWhaleAppMetadata(
+    val appName: String? = null,
+    val deviceId: String? = null,
+    val deviceName: String? = null,
+    val appIconPngBase64: String? = null,
+)

--- a/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata.kt
+++ b/jetwhale-protocol/core/src/commonMain/kotlin/com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAppMetadata.kt
@@ -16,8 +16,8 @@ import kotlinx.serialization.Serializable
  * @param deviceId Stable per-device identifier used to group sessions coming from the same device.
  * @param deviceName Human-readable device name (e.g. `Build.MODEL`, `UIDevice.name`, or the machine hostname).
  * @param appIconPngBase64 Base64-encoded PNG of the application icon. Senders MUST downscale to at most
- *   64x64 pixels and skip the icon entirely when the encoded PNG would exceed 32KB, so hosts can rely on
- *   the payload staying small.
+ *   64x64 pixels and skip the icon entirely when the base64-encoded string would exceed 32KB (the cap is
+ *   applied to the encoded payload, not the raw PNG bytes), so hosts can rely on the payload staying small.
  */
 @SerialName(JetWhaleSerialNames.MODEL_APP_METADATA)
 @Serializable

--- a/jetwhale-protocol/core/src/commonTest/kotlin/com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequestSerializationTest.kt
+++ b/jetwhale-protocol/core/src/commonTest/kotlin/com/kitakkun/jetwhale/protocol/negotiation/JetWhaleAgentNegotiationRequestSerializationTest.kt
@@ -29,14 +29,45 @@ class JetWhaleAgentNegotiationRequestSerializationTest : JetWhaleSerializationTe
         val request = JetWhaleAgentNegotiationRequest.Session(
             sessionId = null,
             sessionName = "SessionName",
+            appMetadata = JetWhaleAppMetadata(
+                appName = "Sample App",
+                deviceId = "device-1",
+                deviceName = "Pixel 8",
+                appIconPngBase64 = "aWNvbg==",
+            ),
         )
 
         val encoded = json.encodeToString(request)
 
         assertEquals(
-            expected = """{"type":"negotiation/agent/session","sessionId":null,"sessionName":"SessionName"}""",
+            expected = """{"type":"negotiation/agent/session","sessionId":null,"sessionName":"SessionName","appMetadata":{"type":"model/app_metadata","appName":"Sample App","deviceId":"device-1","deviceName":"Pixel 8","appIconPngBase64":"aWNvbg=="}}""",
             actual = encoded,
         )
+    }
+
+    @Test
+    fun `session negotiation request without app metadata should serialize the default metadata`() {
+        val request = JetWhaleAgentNegotiationRequest.Session(
+            sessionId = null,
+            sessionName = "SessionName",
+        )
+
+        val encoded = json.encodeToString(request)
+
+        assertEquals(
+            expected = """{"type":"negotiation/agent/session","sessionId":null,"sessionName":"SessionName","appMetadata":{"type":"model/app_metadata","appName":null,"deviceId":null,"deviceName":null,"appIconPngBase64":null}}""",
+            actual = encoded,
+        )
+    }
+
+    @Test
+    fun `legacy session negotiation request without app metadata should be deserializable`() {
+        val jsonString = """{"type":"negotiation/agent/session","sessionId":"session-1","sessionName":"My Session"}"""
+
+        val decoded = json.decodeFromString<JetWhaleAgentNegotiationRequest>(jsonString)
+
+        val session = assertIs<JetWhaleAgentNegotiationRequest.Session>(decoded)
+        assertEquals(JetWhaleAppMetadata(), session.appMetadata)
     }
 
     @Test


### PR DESCRIPTION
## Motivation

Debug sessions previously carried only a device model name, so the debugger could not
group sessions by device or distinguish multiple apps on the same device. This PR adds
richer, optional identification (app name + icon, stable device id + name) that flows
from the agent through the wire protocol into the host model and a new two-level selector.

## Wire-format additions (compatibility)

The capabilities exchange remains an intentional forward-compat surface; every existing
negotiation step is preserved and additions are purely additive.

- New `` `JetWhaleAppMetadata` `` model (`SerialName` `model/app_metadata`) with all-optional
  fields: `appName`, `deviceId`, `deviceName`, `appIconPngBase64`.
- `` `JetWhaleAgentNegotiationRequest.Session` `` gains `appMetadata: JetWhaleAppMetadata = JetWhaleAppMetadata()`.
  The default means old agents (no field) decode fine on the new host, and the new host
  handles both. `` `JetWhaleJson` `` already sets `ignoreUnknownKeys = true`, so a new agent
  talking to an old host degrades gracefully.
- App icons travel as base64-encoded PNG. Senders MUST downscale to at most 64x64 px and
  drop the icon when the encoded PNG exceeds a 32KB cap (`MAX_APP_ICON_BYTES`), keeping the
  negotiation payload small.

## Agent DSL

New optional `app { }` block on `startJetWhale`:

```kotlin
startJetWhale {
    app {
        appName = "My App"
        deviceId = "stable-id"
        deviceName = "Pixel 8"
        appIconPng = iconBytes // <=64x64 PNG, dropped if >32KB
    }
}
```

Explicit values always win; anything unset is auto-resolved best-effort per platform.

| Platform | appName | deviceId | deviceName |
|----------|---------|----------|------------|
| Android  | launcher label (reflected app context) | `ANDROID_ID` | `Build.MODEL` |
| iOS      | bundle display/name | `identifierForVendor` | `UIDevice.name` |
| macOS    | bundle display/name | — (explicit) | host localized name |
| JVM      | — (explicit) | — (explicit) | `os.name` |
| JS/Wasm  | — (explicit) | — (explicit) | "Web Browser" |
| linux/mingw | — (explicit) | — (explicit) | hostname |

Android context is obtained reflectively via `ActivityThread.currentApplication()`, so no
context needs to be passed in; all resolution is wrapped in try/catch and never crashes the
debuggee.

## Host model / UI

- `` `DebugSession` `` stores `appName`/`deviceId`/`deviceName`/`appIconPngBase64` and exposes
  `groupingDeviceId`, `deviceDisplayName`, `appDisplayName` helpers.
- Metadata is threaded through `` `DefaultDebugSessionRepository` ``,
  `` `SessionNegotiationStrategy` ``/`` `SessionNegotiationResult` ``, and
  `` `DefaultDebugWebSocketServer` ``.
- `SessionSelectorView` is now a two-level device -> app selector (app icons decoded from the
  base64 PNG). **Disconnected sessions are hidden from the selectors entirely**; the previous
  "disconnected sessions" group UI and its strings were removed. Repository data is untouched,
  so nothing else breaks. The compact drawer likewise lists only active sessions.
- MCP `listSessions` output includes the new app/device fields.

## Verification

`:jetwhale-host:app:compileKotlin`, `:jetwhale-host:core:data:test`,
`:jetwhale-host:core:mcp:test`, `:jetwhale-agent-runtime` JVM/iosArm64/JS (+macos/linux/wasm)
compiles, `:jetwhale-protocol:core:jvmTest`, `checkLegacyAbi`, `spotlessApply` all pass.
ABI dumps regenerated via `updateLegacyAbi` and committed.

## Deferred

- Automatic icon downscaling is not performed; callers provide an already-sized PNG and
  oversized icons are dropped. Cross-platform image resampling can be added later.