### PR TITLE
feat(discovery): zero-config host discovery over mDNS/Bonjour

### DIFF
--- a/demo/ios-cmp/ios-cmp/Info.plist
+++ b/demo/ios-cmp/ios-cmp/Info.plist
@@ -8,5 +8,11 @@
 	     trust-on-first-use CA fetch). iOS prompts the user for this on first connection. -->
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>JetWhale connects to the debugger host running on your local network.</string>
+	<!-- Required so the agent can browse for the host over mDNS/Bonjour (discoverHost()). Without
+	     this the OS silently blocks discovery of the _jetwhale._tcp service. -->
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_jetwhale._tcp</string>
+	</array>
 </dict>
 </plist>

--- a/demo/ios-cmp/ios-cmp/Info.plist
+++ b/demo/ios-cmp/ios-cmp/Info.plist
@@ -8,8 +8,8 @@
 	     trust-on-first-use CA fetch). iOS prompts the user for this on first connection. -->
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>JetWhale connects to the debugger host running on your local network.</string>
-	<!-- Required so the agent can browse for the host over mDNS/Bonjour (discoverHost()). Without
-	     this the OS silently blocks discovery of the _jetwhale._tcp service. -->
+	<!-- Required so the agent can browse for the host over mDNS/Bonjour (endpoint = discovered(...)).
+	     Without this the OS silently blocks discovery of the _jetwhale._tcp service. -->
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_jetwhale._tcp</string>

--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
@@ -7,6 +7,10 @@ import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 fun initializeJetWhale() {
     startJetWhale {
         connection {
+            // Zero-config discovery of the host over mDNS for physical LAN devices. When no host is
+            // advertised (or the platform lacks mDNS), the connection falls back to host/port below,
+            // keeping "localhost" working for emulators/simulators and ADB-forwarded devices.
+            discoverHost()
             host = "localhost"
             port = 5443
             ssl {

--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
@@ -8,11 +8,9 @@ fun initializeJetWhale() {
     startJetWhale {
         connection {
             // Zero-config discovery of the host over mDNS for physical LAN devices. When no host is
-            // advertised (or the platform lacks mDNS), the connection falls back to host/port below,
+            // advertised (or the platform lacks mDNS), the connection falls back to the fixed endpoint,
             // keeping "localhost" working for emulators/simulators and ADB-forwarded devices.
-            discoverHost()
-            host = "localhost"
-            port = 5443
+            endpoint = discovered(fallback = fixed("localhost", 5443))
             ssl {
                 // Fetches the host's active CA over the plain channel (via ADB forwarding) and pins
                 // the wss connection to it, so the app never has to hardcode a CA certificate.

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -119,7 +119,7 @@ import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 import com.kitakkun.jetwhale.plugins.semantics.agent.JetWhaleSemanticsAgentPlugin
 
 startJetWhale {
-    connection { host = "localhost"; port = 5080 }
+    connection { endpoint = fixed("localhost", 5080) }
     plugins { register(JetWhaleSemanticsAgentPlugin()) }
 }
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -236,25 +236,27 @@ warning listing all discovered hosts). Narrow the selection with a filter block:
 ```kotlin
 connection {
     endpoint = discovered(fallback = fixed("localhost", 5443)) {
-        // Accept only the host whose machine hostname equals this (exact, case-insensitive).
-        matchHostName("my-macbook")
+        // Accept only a host advertising this machine hostname (exact, case-insensitive).
+        allowHostName("my-macbook")
 
-        // ...and/or only hosts resolving to specific IPs (repeatable allowlist), e.g. to pin
-        // discovery to your build machine.
+        // ...and/or only hosts resolving to specific IPs, e.g. to pin discovery to your build
+        // machine — which may answer on both Wi-Fi and Ethernet.
         allowAddress("192.168.3.26")
+        allowAddress("192.168.3.27")
     }
     ssl { trustServerCertificate() }
 }
 ```
 
-- **`matchHostName(name)`** — matches the advertised hostname exactly, compared case-insensitively.
+- **`allowHostName(name)`** — matches the advertised hostname exactly, compared case-insensitively.
   The compared value is the host machine's hostname (from the `hostName` TXT record, falling back to
   the mDNS instance name).
-- **`allowAddress(ip)`** — an allowlist of resolved IPs; repeatable. A host is accepted only when it
-  resolves to one of them. (On iOS/macOS the agent connects by the resolved `.local.` hostname, so
-  prefer `matchHostName` there.)
+- **`allowAddress(ip)`** — matches a resolved IP. (On iOS/macOS the agent connects by the resolved
+  `.local.` hostname, so prefer `allowHostName` there.)
 
-Everything inside the block is a filter, and when both are set a host must satisfy both.
+Both are **repeatable allowlists**: calling one twice widens it rather than replacing the earlier
+value. An empty allowlist means "no restriction on this", so a host must match every allowlist that
+has entries — name **and** address when both are set, either entry within each.
 
 Discovery is best-effort: if no matching host is found within a few seconds — or on a platform
 without mDNS support (**JS/Wasm, Linux, Windows**) — the agent logs a warning and falls back to the

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -189,6 +189,78 @@ desktop and web in particular, setting `appName` is what makes a session readabl
 An `appIconPng` whose base64 form exceeds the 32KB cap is dropped with a warning — which is visible,
 since `WARN` is the default log level.
 
+## Zero-config host discovery (recommended for physical devices)
+
+A physical iPhone or Android device on the same Wi-Fi cannot reach the host over `localhost`. Rather
+than hardcoding the host machine's LAN IP (which changes between machines and networks), call
+`discoverHost()` and let the agent find the host over mDNS/Bonjour:
+
+```kotlin
+startJetWhale {
+    connection {
+        // Browse the LAN for the host advertised as `_jetwhale._tcp` and connect to it.
+        discoverHost()
+
+        // Fallback used when nothing is discovered in time (or the platform lacks mDNS):
+        // keeps emulators/simulators and ADB-forwarded devices working over localhost.
+        host = "localhost"
+        port = 5443
+
+        ssl { trustServerCertificate() }
+    }
+    plugins { /* ... */ }
+}
+```
+
+While its debug server runs, the host advertises a `_jetwhale._tcp.local.` service whose TXT records
+carry the `wsPort` and `wssPort` (the latter only when wss is enabled), the host machine's `hostName`,
+and a protocol marker `v=1`. The agent picks the **wss** port when an `ssl { }` block is configured,
+otherwise the **ws** port.
+
+### Constraining discovery
+
+When several JetWhale hosts run on the same network, first-match is ambiguous (the agent logs a
+warning listing all discovered hosts). Constrain the selection with a `discoverHost { }` block:
+
+```kotlin
+connection {
+    discoverHost {
+        // Match only the host whose machine hostname equals this (exact, case-insensitive).
+        hostName("my-macbook")
+
+        // ...or only accept hosts resolving to specific IPs (repeatable allowlist), e.g. to pin
+        // discovery to your build machine.
+        address("192.168.3.26")
+    }
+    host = "localhost"
+    port = 5443
+    ssl { trustServerCertificate() }
+}
+```
+
+- **`hostName(name)`** — matches the advertised hostname exactly, compared case-insensitively. The
+  compared value is the host machine's hostname (from the `hostName` TXT record, falling back to the
+  mDNS instance name).
+- **`address(ip)`** — an allowlist of resolved IPs; repeatable. A host is accepted only when it
+  resolves to one of them. (On iOS/macOS the agent connects by the resolved `.local.` hostname, so
+  prefer `hostName` there.)
+
+When both are set, a host must satisfy both.
+
+Discovery is best-effort: if no matching host is found within a few seconds — or on a platform
+without mDNS support (**JS/Wasm, Linux, Windows**) — the agent logs a warning and falls back to the
+configured `host`/`port`. So keep an explicit `host`/`port` as the fallback.
+
+| Platform | Discovery backend |
+|----------|-------------------|
+| **JVM (Desktop)** | jmDNS |
+| **Android** | `NsdManager` (`android.net.nsd`) |
+| **iOS / macOS** | `NSNetServiceBrowser` (Network.framework / Bonjour) |
+| **JS / Wasm / Linux / Windows** | Not supported — falls back to the configured host |
+
+On **iOS**, browsing for the service also requires listing it under `NSBonjourServices` in
+`Info.plist` (see [iOS Local Network permission](#ios-local-network-permission)).
+
 ## Secure connections (wss)
 
 By default the agent connects over plain **ws** (port **5080**). The host can additionally serve
@@ -260,10 +332,17 @@ behind a user permission, so add a usage-description string to the app's `Info.p
 ```xml
 <key>NSLocalNetworkUsageDescription</key>
 <string>JetWhale connects to the debugger host running on your local network.</string>
+<!-- Required when using discoverHost(): iOS blocks the Bonjour browse without it. -->
+<key>NSBonjourServices</key>
+<array>
+    <string>_jetwhale._tcp</string>
+</array>
 ```
 
 iOS prompts the user to allow local-network access on the first connection. `NSBonjourServices` is
-not required — the agent dials the host by address, not via Bonjour discovery. Because the CA fetch
+required whenever you use [`discoverHost()`](#zero-config-host-discovery-recommended-for-physical-devices):
+iOS silently blocks browsing for a service type that is not declared. If you dial the host by an
+explicit address instead of discovering it, `NSBonjourServices` can be omitted. Because the CA fetch
 falls back to `https` over the wss port, no App Transport Security exception for plain HTTP is needed.
 
 ## 4. Connect a device

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -251,8 +251,8 @@ connection {
 - **`allowHostName(name)`** — matches the advertised hostname exactly, compared case-insensitively.
   The compared value is the host machine's hostname (from the `hostName` TXT record, falling back to
   the mDNS instance name).
-- **`allowAddress(ip)`** — matches a resolved IP. (On iOS/macOS the agent connects by the resolved
-  `.local.` hostname, so prefer `allowHostName` there.)
+- **`allowAddress(ip)`** — matches a resolved IP. Every platform connects by the resolved IP, so this
+  matches what the connection actually uses.
 
 Both are **repeatable allowlists**: calling one twice widens it rather than replacing the earlier
 value. An empty allowlist means "no restriction on this", so a host must match every allowlist that

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -219,9 +219,14 @@ never be left without one.
 
 While its debug server runs, the host advertises a `_jetwhale._tcp.local.` service whose TXT records
 carry the `wsPort` and `wssPort` (the latter only when wss is enabled), the host machine's `hostName`,
-and a protocol marker `v=1`. Discovery therefore resolves the **port** as well as the address — the
-agent picks the **wss** port when an `ssl { }` block is configured, otherwise the **ws** port, and the
+and a protocol marker `v=1`. Discovery therefore resolves the **port** as well as the address, and the
 fallback's port applies only when discovery finds nothing.
+
+The scheme is not negotiable: the agent uses wss exactly when an `ssl { }` block is configured. So a
+host counts as a candidate only if it advertises the port for that scheme — an ssl-configured agent
+**skips** a host whose wss is disabled, rather than dialling `wss://` at its plain-ws port. If every
+matching host is skipped that way, the log says so by name, since the host being there but serving
+the wrong scheme looks nothing like the host being absent.
 
 ### Narrowing discovery
 
@@ -254,6 +259,12 @@ Everything inside the block is a filter, and when both are set a host must satis
 Discovery is best-effort: if no matching host is found within a few seconds — or on a platform
 without mDNS support (**JS/Wasm, Linux, Windows**) — the agent logs a warning and falls back to the
 endpoint passed as `fallback`.
+
+Falling back is **per attempt, not permanent**. The agent browses again before every connection
+attempt, so [the usual reconnect promise](#reconnecting) still holds with discovery enabled: start the
+app first and the host later, and the next browse picks it up. The same applies when a host restarts
+on a different port. Warnings are not repeated while the outcome stays the same, so an unreachable
+host does not flood the log.
 
 | Platform | Discovery backend |
 |----------|-------------------|

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -68,8 +68,7 @@ import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 fun initializeJetWhale() {
     startJetWhale {
         connection {
-            host = "localhost"
-            port = 5080 // the host's WebSocket server port
+            endpoint = fixed("localhost", 5080) // the host's WebSocket server port
         }
         plugins {
             // register agent plugins here, e.g. the Network Inspector:
@@ -79,11 +78,17 @@ fun initializeJetWhale() {
 }
 ```
 
-::: warning Always set `port`
-The agent's `connection { }` defaults are `host = "localhost"` and **`port = 8080`**, while the
-host's debug server listens on **5080**. The defaults deliberately do not match, so set `port`
-explicitly to whichever port the host reports in
+::: warning Always set `endpoint`
+The agent's `connection { }` defaults to `fixed("localhost", 8080)`, while the host's debug server
+listens on **5080**. The defaults deliberately do not match, so set `endpoint` explicitly to
+whichever port the host reports in
 [Settings → Connection → Debug Server](/guide/host-settings#debug-server).
+:::
+
+::: info `host` / `port` are deprecated
+Earlier releases configured the address with separate `host` and `port` properties. They still work
+and mean exactly `endpoint = fixed(host, port)`, but new code should assign `endpoint` — it is what
+[host discovery](#zero-config-host-discovery-recommended-for-physical-devices) extends.
 :::
 
 Where to call it, per platform:
@@ -192,19 +197,16 @@ since `WARN` is the default log level.
 ## Zero-config host discovery (recommended for physical devices)
 
 A physical iPhone or Android device on the same Wi-Fi cannot reach the host over `localhost`. Rather
-than hardcoding the host machine's LAN IP (which changes between machines and networks), call
-`discoverHost()` and let the agent find the host over mDNS/Bonjour:
+than hardcoding the host machine's LAN IP (which changes between machines and networks), assign a
+`discovered(...)` endpoint and let the agent find the host over mDNS/Bonjour:
 
 ```kotlin
 startJetWhale {
     connection {
-        // Browse the LAN for the host advertised as `_jetwhale._tcp` and connect to it.
-        discoverHost()
-
-        // Fallback used when nothing is discovered in time (or the platform lacks mDNS):
-        // keeps emulators/simulators and ADB-forwarded devices working over localhost.
-        host = "localhost"
-        port = 5443
+        // Browse the LAN for the host advertised as `_jetwhale._tcp` and connect to it. The fallback
+        // applies when nothing is discovered in time (or the platform lacks mDNS), which keeps
+        // emulators/simulators and ADB-forwarded devices working over localhost.
+        endpoint = discovered(fallback = fixed("localhost", 5443))
 
         ssl { trustServerCertificate() }
     }
@@ -212,44 +214,46 @@ startJetWhale {
 }
 ```
 
+The fallback is a required argument rather than a separate property, so a discovered endpoint can
+never be left without one.
+
 While its debug server runs, the host advertises a `_jetwhale._tcp.local.` service whose TXT records
 carry the `wsPort` and `wssPort` (the latter only when wss is enabled), the host machine's `hostName`,
-and a protocol marker `v=1`. The agent picks the **wss** port when an `ssl { }` block is configured,
-otherwise the **ws** port.
+and a protocol marker `v=1`. Discovery therefore resolves the **port** as well as the address — the
+agent picks the **wss** port when an `ssl { }` block is configured, otherwise the **ws** port, and the
+fallback's port applies only when discovery finds nothing.
 
-### Constraining discovery
+### Narrowing discovery
 
 When several JetWhale hosts run on the same network, first-match is ambiguous (the agent logs a
-warning listing all discovered hosts). Constrain the selection with a `discoverHost { }` block:
+warning listing all discovered hosts). Narrow the selection with a filter block:
 
 ```kotlin
 connection {
-    discoverHost {
-        // Match only the host whose machine hostname equals this (exact, case-insensitive).
-        hostName("my-macbook")
+    endpoint = discovered(fallback = fixed("localhost", 5443)) {
+        // Accept only the host whose machine hostname equals this (exact, case-insensitive).
+        matchHostName("my-macbook")
 
-        // ...or only accept hosts resolving to specific IPs (repeatable allowlist), e.g. to pin
+        // ...and/or only hosts resolving to specific IPs (repeatable allowlist), e.g. to pin
         // discovery to your build machine.
-        address("192.168.3.26")
+        allowAddress("192.168.3.26")
     }
-    host = "localhost"
-    port = 5443
     ssl { trustServerCertificate() }
 }
 ```
 
-- **`hostName(name)`** — matches the advertised hostname exactly, compared case-insensitively. The
-  compared value is the host machine's hostname (from the `hostName` TXT record, falling back to the
-  mDNS instance name).
-- **`address(ip)`** — an allowlist of resolved IPs; repeatable. A host is accepted only when it
+- **`matchHostName(name)`** — matches the advertised hostname exactly, compared case-insensitively.
+  The compared value is the host machine's hostname (from the `hostName` TXT record, falling back to
+  the mDNS instance name).
+- **`allowAddress(ip)`** — an allowlist of resolved IPs; repeatable. A host is accepted only when it
   resolves to one of them. (On iOS/macOS the agent connects by the resolved `.local.` hostname, so
-  prefer `hostName` there.)
+  prefer `matchHostName` there.)
 
-When both are set, a host must satisfy both.
+Everything inside the block is a filter, and when both are set a host must satisfy both.
 
 Discovery is best-effort: if no matching host is found within a few seconds — or on a platform
 without mDNS support (**JS/Wasm, Linux, Windows**) — the agent logs a warning and falls back to the
-configured `host`/`port`. So keep an explicit `host`/`port` as the fallback.
+endpoint passed as `fallback`.
 
 | Platform | Discovery backend |
 |----------|-------------------|
@@ -274,8 +278,7 @@ one trusted certificate is configured, the connection switches from ws to wss:
 ```kotlin
 startJetWhale {
     connection {
-        host = "localhost"
-        port = 5443 // the host's wss port
+        endpoint = fixed("localhost", 5443) // the host's wss port
 
         ssl {
             // Option A: fetch and pin the host's active CA automatically (trust-on-first-use).
@@ -332,7 +335,7 @@ behind a user permission, so add a usage-description string to the app's `Info.p
 ```xml
 <key>NSLocalNetworkUsageDescription</key>
 <string>JetWhale connects to the debugger host running on your local network.</string>
-<!-- Required when using discoverHost(): iOS blocks the Bonjour browse without it. -->
+<!-- Required when using discovered(): iOS blocks the Bonjour browse without it. -->
 <key>NSBonjourServices</key>
 <array>
     <string>_jetwhale._tcp</string>
@@ -340,7 +343,7 @@ behind a user permission, so add a usage-description string to the app's `Info.p
 ```
 
 iOS prompts the user to allow local-network access on the first connection. `NSBonjourServices` is
-required whenever you use [`discoverHost()`](#zero-config-host-discovery-recommended-for-physical-devices):
+required whenever you use [`discovered()`](#zero-config-host-discovery-recommended-for-physical-devices):
 iOS silently blocks browsing for a service type that is not declared. If you dial the host by an
 explicit address instead of discovering it, `NSBonjourServices` can be omitted. Because the CA fetch
 falls back to `https` over the wss port, no App Transport Security exception for plain HTTP is needed.

--- a/docs/guide/network-inspector.md
+++ b/docs/guide/network-inspector.md
@@ -52,7 +52,7 @@ val client = HttpClient {
 }
 
 startJetWhale {
-    connection { host = "localhost"; port = 5080 }
+    connection { endpoint = fixed("localhost", 5080) }
     plugins { register(networkAgent) }
 }
 ```
@@ -90,7 +90,7 @@ val client = OkHttpClient.Builder()
     .build()
 
 startJetWhale {
-    connection { host = "localhost"; port = 5080 }
+    connection { endpoint = fixed("localhost", 5080) }
     plugins { register(networkAgent) }
 }
 ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ conveyor = "2.0"
 conveyorControl = "1.1"
 
 bouncyCastle = "1.83"
+jmdns = "3.6.1"
 
 [libraries]
 # Gradle Plugins
@@ -133,6 +134,9 @@ aboutLibrariesCore = { module = "com.mikepenz:aboutlibraries-core", version.ref 
 # certs
 bouncyCastleBcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle" }
 bouncyCastleBcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle" }
+
+# mDNS / DNS-SD service discovery (host advertising, JVM agent discovery)
+jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
 
 [bundles]
 gradlePlugins = [

--- a/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
+++ b/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
@@ -64,7 +64,13 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigu
         abstract fun <get-port>(): kotlin/Int // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.port.<get-port>|<get-port>(){}[0]
         abstract fun <set-port>(kotlin/Int) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.port.<set-port>|<set-port>(kotlin.Int){}[0]
 
+    abstract fun discoverHost(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleHostDiscoveryScope, kotlin/Unit> = ...) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.discoverHost|discoverHost(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleHostDiscoveryScope,kotlin.Unit>){}[0]
     abstract fun ssl(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.ssl|ssl(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleSslConfigurationScope,kotlin.Unit>){}[0]
+}
+
+abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleHostDiscoveryScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleHostDiscoveryScope|null[0]
+    abstract fun address(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleHostDiscoveryScope.address|address(kotlin.String){}[0]
+    abstract fun hostName(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleHostDiscoveryScope.hostName|hostName(kotlin.String){}[0]
 }
 
 abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleLoggingConfigurationScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleLoggingConfigurationScope|null[0]

--- a/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
+++ b/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
@@ -57,6 +57,9 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScop
 }
 
 abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope|null[0]
+    abstract var endpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.endpoint|{}endpoint[0]
+        abstract fun <get-endpoint>(): com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.endpoint.<get-endpoint>|<get-endpoint>(){}[0]
+        abstract fun <set-endpoint>(com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.endpoint.<set-endpoint>|<set-endpoint>(com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpoint){}[0]
     abstract var host // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.host|{}host[0]
         abstract fun <get-host>(): kotlin/String // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.host.<get-host>|<get-host>(){}[0]
         abstract fun <set-host>(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.host.<set-host>|<set-host>(kotlin.String){}[0]
@@ -64,13 +67,14 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigu
         abstract fun <get-port>(): kotlin/Int // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.port.<get-port>|<get-port>(){}[0]
         abstract fun <set-port>(kotlin/Int) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.port.<set-port>|<set-port>(kotlin.Int){}[0]
 
-    abstract fun discoverHost(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleHostDiscoveryScope, kotlin/Unit> = ...) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.discoverHost|discoverHost(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleHostDiscoveryScope,kotlin.Unit>){}[0]
+    abstract fun discovered(com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint, kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope, kotlin/Unit> = ...): com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.discovered|discovered(com.kitakkun.jetwhale.agent.runtime.JetWhaleFixedEndpoint;kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleDiscoveredEndpointScope,kotlin.Unit>){}[0]
+    abstract fun fixed(kotlin/String, kotlin/Int): com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.fixed|fixed(kotlin.String;kotlin.Int){}[0]
     abstract fun ssl(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.ssl|ssl(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleSslConfigurationScope,kotlin.Unit>){}[0]
 }
 
-abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleHostDiscoveryScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleHostDiscoveryScope|null[0]
-    abstract fun address(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleHostDiscoveryScope.address|address(kotlin.String){}[0]
-    abstract fun hostName(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleHostDiscoveryScope.hostName|hostName(kotlin.String){}[0]
+abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope|null[0]
+    abstract fun allowAddress(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope.allowAddress|allowAddress(kotlin.String){}[0]
+    abstract fun matchHostName(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope.matchHostName|matchHostName(kotlin.String){}[0]
 }
 
 abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleLoggingConfigurationScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleLoggingConfigurationScope|null[0]
@@ -97,5 +101,9 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationS
     abstract fun trustCertificate(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope.trustCertificate|trustCertificate(kotlin.String){}[0]
     abstract fun trustServerCertificate() // com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope.trustServerCertificate|trustServerCertificate(){}[0]
 }
+
+sealed interface com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint|null[0]
+
+final class com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint : com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint|null[0]
 
 final fun com.kitakkun.jetwhale.agent.runtime/startJetWhale(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope, kotlin/Unit>): com.kitakkun.jetwhale.agent.runtime/JetWhaleSession // com.kitakkun.jetwhale.agent.runtime/startJetWhale|startJetWhale(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleConfigurationScope,kotlin.Unit>){}[0]

--- a/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
+++ b/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
@@ -74,7 +74,7 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigu
 
 abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope|null[0]
     abstract fun allowAddress(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope.allowAddress|allowAddress(kotlin.String){}[0]
-    abstract fun matchHostName(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope.matchHostName|matchHostName(kotlin.String){}[0]
+    abstract fun allowHostName(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope.allowHostName|allowHostName(kotlin.String){}[0]
 }
 
 abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleLoggingConfigurationScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleLoggingConfigurationScope|null[0]

--- a/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
+++ b/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
@@ -17,11 +17,22 @@ public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleConf
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope {
+	public abstract fun discoverHost (Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun discoverHost$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public abstract fun getHost ()Ljava/lang/String;
 	public abstract fun getPort ()I
 	public abstract fun setHost (Ljava/lang/String;)V
 	public abstract fun setPort (I)V
 	public abstract fun ssl (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope$DefaultImpls {
+	public static synthetic fun discoverHost$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleHostDiscoveryScope {
+	public abstract fun address (Ljava/lang/String;)V
+	public abstract fun hostName (Ljava/lang/String;)V
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleLoggingConfigurationScope {

--- a/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
+++ b/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
@@ -17,22 +17,31 @@ public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleConf
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope {
-	public abstract fun discoverHost (Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun discoverHost$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public abstract fun discovered (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint;Lkotlin/jvm/functions/Function1;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
+	public static synthetic fun discovered$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
+	public abstract fun fixed (Ljava/lang/String;I)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint;
+	public abstract fun getEndpoint ()Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
 	public abstract fun getHost ()Ljava/lang/String;
 	public abstract fun getPort ()I
+	public abstract fun setEndpoint (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;)V
 	public abstract fun setHost (Ljava/lang/String;)V
 	public abstract fun setPort (I)V
 	public abstract fun ssl (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope$DefaultImpls {
-	public static synthetic fun discoverHost$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun discovered$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
 }
 
-public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleHostDiscoveryScope {
-	public abstract fun address (Ljava/lang/String;)V
-	public abstract fun hostName (Ljava/lang/String;)V
+public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleDiscoveredEndpointScope {
+	public abstract fun allowAddress (Ljava/lang/String;)V
+	public abstract fun matchHostName (Ljava/lang/String;)V
+}
+
+public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint {
+}
+
+public final class com/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint : com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint {
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleLoggingConfigurationScope {

--- a/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
+++ b/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
@@ -35,7 +35,7 @@ public final class com/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigu
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleDiscoveredEndpointScope {
 	public abstract fun allowAddress (Ljava/lang/String;)V
-	public abstract fun matchHostName (Ljava/lang/String;)V
+	public abstract fun allowHostName (Ljava/lang/String;)V
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint {

--- a/jetwhale-agent-runtime/build.gradle.kts
+++ b/jetwhale-agent-runtime/build.gradle.kts
@@ -33,6 +33,11 @@ kotlin {
         // The websocket client test spins up a real Ktor server (ktor-server-test-host), which
         // is JVM-only and pulls ktor-network; keeping it here avoids leaking node:net into the
         // JS browser test bundle.
+        jvmMain.dependencies {
+            // JVM mDNS/DNS-SD browsing for zero-config host discovery.
+            implementation(libs.jmdns)
+        }
+
         jvmTest.dependencies {
             implementation(projects.testAnnotations)
             implementation(libs.kotlinTest)

--- a/jetwhale-agent-runtime/src/androidMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.android.kt
+++ b/jetwhale-agent-runtime/src/androidMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.android.kt
@@ -8,6 +8,10 @@ import kotlinx.coroutines.withTimeoutOrNull
 import java.util.Collections
 import kotlin.coroutines.resume
 
+// NsdManager requires the DNS-SD service type terminated with a dot; the bare "_jetwhale._tcp" makes
+// discovery silently find nothing.
+private const val NSD_SERVICE_TYPE = "$JETWHALE_SERVICE_TYPE."
+
 /**
  * Android mDNS host discovery via [NsdManager]. The application [Context] is obtained reflectively
  * (`ActivityThread.currentApplication()`) so the discovery DSL needs no Context wiring from the app.
@@ -73,7 +77,10 @@ internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<Di
                 }
             }
 
-            nsdManager.discoverServices(JETWHALE_SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+            // NsdManager requires the DNS-SD service type WITH a trailing dot ("_jetwhale._tcp.");
+            // without it discovery finds nothing. (Per-platform format differs: jmDNS/JVM wants the
+            // fully-qualified "_jetwhale._tcp.local.", Apple's NSNetServiceBrowser wants "_jetwhale._tcp.".)
+            nsdManager.discoverServices(NSD_SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
 
             continuation.invokeOnCancellation {
                 try {

--- a/jetwhale-agent-runtime/src/androidMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.android.kt
+++ b/jetwhale-agent-runtime/src/androidMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.android.kt
@@ -1,0 +1,110 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.Collections
+import kotlin.coroutines.resume
+
+/**
+ * Android mDNS host discovery via [NsdManager]. The application [Context] is obtained reflectively
+ * (`ActivityThread.currentApplication()`) so the discovery DSL needs no Context wiring from the app.
+ *
+ * Every instance found and resolved within the timeout window is returned; resolves are serialized
+ * because older API levels reject a resolve while another is in flight.
+ */
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> {
+    val context = currentApplicationContext()
+    if (context == null) {
+        JetWhaleLogger.w("mDNS host discovery unavailable: could not obtain the application Context; using the configured host")
+        return emptyList()
+    }
+    val nsdManager = context.getSystemService(Context.NSD_SERVICE) as? NsdManager
+    if (nsdManager == null) {
+        JetWhaleLogger.w("mDNS host discovery unavailable: NsdManager not present; using the configured host")
+        return emptyList()
+    }
+
+    val results = Collections.synchronizedList(mutableListOf<DiscoveredService>())
+    // A single-slot serialized resolve queue: NsdManager rejects concurrent resolveService calls on
+    // older API levels.
+    val pending = ArrayDeque<NsdServiceInfo>()
+    var resolving = false
+
+    withTimeoutOrNull(timeoutMillis) {
+        suspendCancellableCoroutine<Unit> { continuation ->
+            fun resolveNext(nsdManager: NsdManager, listener: NsdManager.ResolveListener) {
+                synchronized(pending) {
+                    if (resolving) return
+                    val next = pending.removeFirstOrNull() ?: return
+                    resolving = true
+                    @Suppress("DEPRECATION")
+                    nsdManager.resolveService(next, listener)
+                }
+            }
+
+            lateinit var resolveListener: NsdManager.ResolveListener
+            resolveListener = object : NsdManager.ResolveListener {
+                override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                    JetWhaleLogger.d("mDNS resolve failed for ${serviceInfo.serviceName} (error=$errorCode)")
+                    synchronized(pending) { resolving = false }
+                    resolveNext(nsdManager, resolveListener)
+                }
+
+                override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
+                    serviceInfo.toDiscoveredService()?.let { results.add(it) }
+                    synchronized(pending) { resolving = false }
+                    resolveNext(nsdManager, resolveListener)
+                }
+            }
+
+            val discoveryListener = object : NsdManager.DiscoveryListener {
+                override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) = Unit
+                override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) = Unit
+                override fun onDiscoveryStarted(serviceType: String) = Unit
+                override fun onDiscoveryStopped(serviceType: String) = Unit
+                override fun onServiceLost(serviceInfo: NsdServiceInfo) = Unit
+
+                override fun onServiceFound(serviceInfo: NsdServiceInfo) {
+                    synchronized(pending) { pending.addLast(serviceInfo) }
+                    resolveNext(nsdManager, resolveListener)
+                }
+            }
+
+            nsdManager.discoverServices(JETWHALE_SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+
+            continuation.invokeOnCancellation {
+                try {
+                    nsdManager.stopServiceDiscovery(discoveryListener)
+                } catch (e: Exception) {
+                    JetWhaleLogger.d("Failed to stop mDNS discovery", e)
+                }
+            }
+        }
+    }
+
+    return results.toList()
+}
+
+private fun NsdServiceInfo.toDiscoveredService(): DiscoveredService? {
+    val address = host?.hostAddress ?: return null
+    return DiscoveredService(
+        instanceName = serviceName,
+        advertisedHostName = attributes[TXT_KEY_HOST_NAME]?.decodeToString(),
+        address = address,
+        wsPort = attributes[TXT_KEY_WS_PORT]?.decodeToString()?.toIntOrNull(),
+        wssPort = attributes[TXT_KEY_WSS_PORT]?.decodeToString()?.toIntOrNull(),
+    )
+}
+
+/** Obtains the current application [Context] reflectively so no Context has to be passed in. */
+private fun currentApplicationContext(): Context? = try {
+    Class.forName("android.app.ActivityThread")
+        .getMethod("currentApplication")
+        .invoke(null) as? Context
+} catch (e: Exception) {
+    JetWhaleLogger.d("Reflective Context lookup failed", e)
+    null
+}

--- a/jetwhale-agent-runtime/src/androidMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.android.kt
+++ b/jetwhale-agent-runtime/src/androidMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.android.kt
@@ -19,17 +19,11 @@ private const val NSD_SERVICE_TYPE = "$JETWHALE_SERVICE_TYPE."
  * Every instance found and resolved within the timeout window is returned; resolves are serialized
  * because older API levels reject a resolve while another is in flight.
  */
-internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> {
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): DiscoveryResult {
     val context = currentApplicationContext()
-    if (context == null) {
-        JetWhaleLogger.w("mDNS host discovery unavailable: could not obtain the application Context; using the configured host")
-        return emptyList()
-    }
+        ?: return DiscoveryResult.Unavailable("the application Context could not be obtained")
     val nsdManager = context.getSystemService(Context.NSD_SERVICE) as? NsdManager
-    if (nsdManager == null) {
-        JetWhaleLogger.w("mDNS host discovery unavailable: NsdManager not present; using the configured host")
-        return emptyList()
-    }
+        ?: return DiscoveryResult.Unavailable("NsdManager is not present on this device")
 
     val results = Collections.synchronizedList(mutableListOf<DiscoveredService>())
     // A single-slot serialized resolve queue: NsdManager rejects concurrent resolveService calls on
@@ -92,7 +86,7 @@ internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<Di
         }
     }
 
-    return results.toList()
+    return DiscoveryResult.Browsed(results.toList())
 }
 
 private fun NsdServiceInfo.toDiscoveredService(): DiscoveredService? {

--- a/jetwhale-agent-runtime/src/appleMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.apple.kt
+++ b/jetwhale-agent-runtime/src/appleMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.apple.kt
@@ -1,0 +1,101 @@
+@file:OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+
+package com.kitakkun.jetwhale.agent.runtime
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import platform.Foundation.NSNetService
+import platform.Foundation.NSNetServiceBrowser
+import platform.Foundation.NSNetServiceBrowserDelegateProtocol
+import platform.Foundation.NSNetServiceDelegateProtocol
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.create
+import platform.darwin.NSObject
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
+
+private const val SERVICE_TYPE_DOT = "$JETWHALE_SERVICE_TYPE."
+private const val SEARCH_DOMAIN = "local."
+private const val RESOLVE_TIMEOUT_SECONDS = 5.0
+
+/**
+ * Apple (iOS/macOS) mDNS host discovery via [NSNetServiceBrowser] + [NSNetService] resolution.
+ *
+ * The browser and its delegate callbacks run on the main run loop, so the browse is started via the
+ * main dispatch queue and every instance resolved within the timeout window is collected. iOS
+ * requires `_jetwhale._tcp` under `NSBonjourServices` in Info.plist, otherwise the OS silently blocks
+ * the browse.
+ */
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> {
+    val results = mutableListOf<DiscoveredService>()
+    // Strong references kept for the whole browse so the delegates and services outlive the enclosing
+    // frame; their callbacks fire asynchronously on the run loop.
+    val resolvingServices = mutableListOf<NSNetService>()
+
+    withTimeoutOrNull(timeoutMillis) {
+        suspendCancellableCoroutine<Unit> { continuation ->
+            lateinit var browser: NSNetServiceBrowser
+
+            val serviceDelegate = object : NSObject(), NSNetServiceDelegateProtocol {
+                override fun netServiceDidResolveAddress(sender: NSNetService) {
+                    sender.toDiscoveredService()?.let { results.add(it) }
+                }
+
+                override fun netService(sender: NSNetService, didNotResolve: Map<Any?, *>) {
+                    JetWhaleLogger.d("mDNS resolve failed for ${sender.name}")
+                }
+            }
+
+            val browserDelegate = object : NSObject(), NSNetServiceBrowserDelegateProtocol {
+                override fun netServiceBrowser(
+                    browser: NSNetServiceBrowser,
+                    didFindService: NSNetService,
+                    moreComing: Boolean,
+                ) {
+                    didFindService.delegate = serviceDelegate
+                    resolvingServices.add(didFindService)
+                    didFindService.resolveWithTimeout(RESOLVE_TIMEOUT_SECONDS)
+                }
+
+                override fun netServiceBrowserDidStopSearch(browser: NSNetServiceBrowser) = Unit
+            }
+
+            dispatch_async(dispatch_get_main_queue()) {
+                browser = NSNetServiceBrowser().apply {
+                    delegate = browserDelegate
+                    searchForServicesOfType(SERVICE_TYPE_DOT, inDomain = SEARCH_DOMAIN)
+                }
+            }
+
+            continuation.invokeOnCancellation {
+                dispatch_async(dispatch_get_main_queue()) {
+                    browser.stop()
+                }
+            }
+        }
+    }
+
+    return results.toList()
+}
+
+private fun NSNetService.toDiscoveredService(): DiscoveredService? {
+    val host = hostName ?: return null
+    val txt = TXTRecordData()?.let { NSNetService.dictionaryFromTXTRecordData(it) }
+    return DiscoveredService(
+        instanceName = name,
+        advertisedHostName = txt?.get(TXT_KEY_HOST_NAME)?.toDecodedString(),
+        address = host.removeSuffix("."),
+        wsPort = txt?.get(TXT_KEY_WS_PORT)?.toDecodedString()?.toIntOrNull(),
+        wssPort = txt?.get(TXT_KEY_WSS_PORT)?.toDecodedString()?.toIntOrNull(),
+    )
+}
+
+/** TXT record values arrive as `NSData`; decode them as UTF-8 strings. */
+private fun Any?.toDecodedString(): String? {
+    val data = this as? platform.Foundation.NSData ?: return null
+    @Suppress("CAST_NEVER_SUCCEEDS")
+    return NSString.create(data, NSUTF8StringEncoding) as? String
+}

--- a/jetwhale-agent-runtime/src/appleMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.apple.kt
+++ b/jetwhale-agent-runtime/src/appleMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.apple.kt
@@ -37,7 +37,13 @@ internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<Di
 
     withTimeoutOrNull(timeoutMillis) {
         suspendCancellableCoroutine<Unit> { continuation ->
-            lateinit var browser: NSNetServiceBrowser
+            // browser is created asynchronously on the main queue, and cancellation also stops it on
+            // the main queue. Both mutate these fields only from that single serial queue, so creation
+            // and stop can never race: whichever runs first wins, and the other observes the result
+            // (a browser created after cancellation is stopped immediately; a cancellation before
+            // creation flips [cancelled] so no browser is ever started).
+            var browser: NSNetServiceBrowser? = null
+            var cancelled = false
 
             val serviceDelegate = object : NSObject(), NSNetServiceDelegateProtocol {
                 override fun netServiceDidResolveAddress(sender: NSNetService) {
@@ -64,6 +70,8 @@ internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<Di
             }
 
             dispatch_async(dispatch_get_main_queue()) {
+                // Already cancelled before we got scheduled: do not start a browser that would leak.
+                if (cancelled) return@dispatch_async
                 browser = NSNetServiceBrowser().apply {
                     delegate = browserDelegate
                     searchForServicesOfType(SERVICE_TYPE_DOT, inDomain = SEARCH_DOMAIN)
@@ -72,7 +80,10 @@ internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<Di
 
             continuation.invokeOnCancellation {
                 dispatch_async(dispatch_get_main_queue()) {
-                    browser.stop()
+                    cancelled = true
+                    // No-op when the browser was never created (cancelled before init).
+                    browser?.stop()
+                    browser = null
                 }
             }
         }

--- a/jetwhale-agent-runtime/src/appleMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.apple.kt
+++ b/jetwhale-agent-runtime/src/appleMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.apple.kt
@@ -29,7 +29,7 @@ private const val RESOLVE_TIMEOUT_SECONDS = 5.0
  * requires `_jetwhale._tcp` under `NSBonjourServices` in Info.plist, otherwise the OS silently blocks
  * the browse.
  */
-internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> {
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): DiscoveryResult {
     val results = mutableListOf<DiscoveredService>()
     // Strong references kept for the whole browse so the delegates and services outlive the enclosing
     // frame; their callbacks fire asynchronously on the run loop.
@@ -89,7 +89,7 @@ internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<Di
         }
     }
 
-    return results.toList()
+    return DiscoveryResult.Browsed(results.toList())
 }
 
 private fun NSNetService.toDiscoveredService(): DiscoveredService? {

--- a/jetwhale-agent-runtime/src/appleMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.apple.kt
+++ b/jetwhale-agent-runtime/src/appleMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.apple.kt
@@ -3,9 +3,14 @@
 package com.kitakkun.jetwhale.agent.runtime
 
 import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UnsafeNumber
+import kotlinx.cinterop.get
+import kotlinx.cinterop.reinterpret
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
+import platform.Foundation.NSData
 import platform.Foundation.NSNetService
 import platform.Foundation.NSNetServiceBrowser
 import platform.Foundation.NSNetServiceBrowserDelegateProtocol
@@ -16,10 +21,17 @@ import platform.Foundation.create
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
+import platform.posix.AF_INET
 
 private const val SERVICE_TYPE_DOT = "$JETWHALE_SERVICE_TYPE."
 private const val SEARCH_DOMAIN = "local."
 private const val RESOLVE_TIMEOUT_SECONDS = 5.0
+
+// Darwin `sockaddr_in` layout: sa_len, sin_family, sin_port[2], sin_addr[4].
+private const val SIN_FAMILY_OFFSET = 1
+private const val SIN_ADDR_OFFSET = 4
+private const val IPV4_OCTETS = 4
+private const val IPV4_SOCKADDR_LENGTH = SIN_ADDR_OFFSET + IPV4_OCTETS
 
 /**
  * Apple (iOS/macOS) mDNS host discovery via [NSNetServiceBrowser] + [NSNetService] resolution.
@@ -93,15 +105,39 @@ internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): Discove
 }
 
 private fun NSNetService.toDiscoveredService(): DiscoveredService? {
-    val host = hostName ?: return null
+    // The resolved IPv4 address, not [hostName]. The host's certificate carries its addresses as IP
+    // SANs, and the mDNS host name is whatever the advertising stack synthesised — jmDNS names its
+    // host record after the address, e.g. "192-168-3-9.local." — which no certificate covers, so
+    // dialling it fails hostname verification. Using the address also makes `allowAddress` mean what
+    // it says on this platform.
+    val address = resolvedIpv4Address() ?: return null
     val txt = TXTRecordData()?.let { NSNetService.dictionaryFromTXTRecordData(it) }
     return DiscoveredService(
         instanceName = name,
         advertisedHostName = txt?.get(TXT_KEY_HOST_NAME)?.toDecodedString(),
-        address = host.removeSuffix("."),
+        address = address,
         wsPort = txt?.get(TXT_KEY_WS_PORT)?.toDecodedString()?.toIntOrNull(),
         wssPort = txt?.get(TXT_KEY_WSS_PORT)?.toDecodedString()?.toIntOrNull(),
     )
+}
+
+/**
+ * The first IPv4 address this service resolved to, read out of the `sockaddr` blobs it carries.
+ *
+ * The bytes are read positionally rather than through the `sockaddr_in` bindings: the address is
+ * already in network byte order there, so taking the four octets in place is both simpler and free of
+ * any endianness assumption.
+ */
+@OptIn(UnsafeNumber::class)
+private fun NSNetService.resolvedIpv4Address(): String? {
+    val sockaddrs = addresses?.filterIsInstance<NSData>() ?: return null
+    for (data in sockaddrs) {
+        if (data.length.toInt() < IPV4_SOCKADDR_LENGTH) continue
+        val bytes = data.bytes?.reinterpret<ByteVar>() ?: continue
+        if (bytes[SIN_FAMILY_OFFSET].toInt() != AF_INET) continue
+        return (0 until IPV4_OCTETS).joinToString(".") { bytes[SIN_ADDR_OFFSET + it].toUByte().toInt().toString() }
+    }
+    return null
 }
 
 /** TXT record values arrive as `NSData`; decode them as UTF-8 strings. */

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
@@ -22,17 +22,16 @@ internal class DefaultJetWhaleMessagingService(
     private var keepAwakeJob: Job? = null
     private var retryCount = 0
 
-    override fun startService(host: String, port: Int, discovery: HostDiscoveryConfig?) {
+    override fun startService(resolver: EndpointResolver) {
         JetWhaleLogger.i("Starting JetWhale Messaging Service")
         keepAwakeJob?.cancel()
         keepAwakeJob = coroutineScope.launch {
-            val resolver = HostResolver(fallbackHost = host, fallbackPort = port, discovery = discovery)
             while (isActive) {
                 try {
-                    // Resolved per attempt rather than once up front: a host started after the app, or
-                    // one that came back on a different port, is only reached by browsing again.
-                    val (resolvedHost, resolvedPort) = resolver.resolve()
-                    openConnection(resolvedHost, resolvedPort)
+                    // Asked per attempt rather than once up front: an address that only becomes
+                    // correct later is reached without restarting the session.
+                    val resolved = resolver.resolve()
+                    openConnection(resolved.host, resolved.port)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (_: Throwable) {

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
@@ -26,15 +26,12 @@ internal class DefaultJetWhaleMessagingService(
         JetWhaleLogger.i("Starting JetWhale Messaging Service")
         keepAwakeJob?.cancel()
         keepAwakeJob = coroutineScope.launch {
-            // Resolve the host once before the connect/retry loop: discovery browses the LAN for an
-            // advertised host and falls back to the configured host/port when disabled or unresolved.
-            val (resolvedHost, resolvedPort) = resolveHost(
-                fallbackHost = host,
-                fallbackPort = port,
-                discovery = discovery,
-            )
+            val resolver = HostResolver(fallbackHost = host, fallbackPort = port, discovery = discovery)
             while (isActive) {
                 try {
+                    // Resolved per attempt rather than once up front: a host started after the app, or
+                    // one that came back on a different port, is only reached by browsing again.
+                    val (resolvedHost, resolvedPort) = resolver.resolve()
                     openConnection(resolvedHost, resolvedPort)
                 } catch (e: CancellationException) {
                     throw e

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
@@ -22,13 +22,20 @@ internal class DefaultJetWhaleMessagingService(
     private var keepAwakeJob: Job? = null
     private var retryCount = 0
 
-    override fun startService(host: String, port: Int) {
+    override fun startService(host: String, port: Int, discovery: HostDiscoveryConfig?) {
         JetWhaleLogger.i("Starting JetWhale Messaging Service")
         keepAwakeJob?.cancel()
         keepAwakeJob = coroutineScope.launch {
+            // Resolve the host once before the connect/retry loop: discovery browses the LAN for an
+            // advertised host and falls back to the configured host/port when disabled or unresolved.
+            val (resolvedHost, resolvedPort) = resolveHost(
+                fallbackHost = host,
+                fallbackPort = port,
+                discovery = discovery,
+            )
             while (isActive) {
                 try {
-                    openConnection(host, port)
+                    openConnection(resolvedHost, resolvedPort)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (_: Throwable) {

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
@@ -21,20 +21,24 @@ internal class DefaultJetWhaleMessagingService(
     private val coroutineScope: CoroutineScope = CoroutineScope(messagingServiceCoroutineDispatcher() + SupervisorJob())
     private var keepAwakeJob: Job? = null
     private var retryCount = 0
+    private var lastReportedFailure: String? = null
 
     override fun startService(resolver: EndpointResolver) {
         JetWhaleLogger.i("Starting JetWhale Messaging Service")
         keepAwakeJob?.cancel()
         keepAwakeJob = coroutineScope.launch {
             while (isActive) {
+                var attempted: ResolvedEndpoint? = null
                 try {
                     // Asked per attempt rather than once up front: an address that only becomes
                     // correct later is reached without restarting the session.
                     val resolved = resolver.resolve()
+                    attempted = resolved
                     openConnection(resolved.host, resolved.port)
                 } catch (e: CancellationException) {
                     throw e
-                } catch (_: Throwable) {
+                } catch (e: Throwable) {
+                    reportFailure(attempted, e)
                     pluginService.disconnectAll()
                     retryCount++
                     val delayMillis = (retryCount * RETRY_DELAY_INCREMENT_MILLIS).coerceAtMost(MAX_RECONNECT_DELAY_MILLIS)
@@ -63,10 +67,27 @@ internal class DefaultJetWhaleMessagingService(
         }
     }
 
+    /**
+     * Reports why an attempt failed. The socket client rethrows without logging, so this is the only
+     * place a refused host, a wrong port or a failed TLS handshake becomes visible — and at the
+     * default WARN level, the only sign the agent is doing anything at all.
+     *
+     * The same cause repeats on every retry, so it is reported once and again only when it changes,
+     * or when a connection succeeded in between.
+     */
+    private fun reportFailure(attempted: ResolvedEndpoint?, cause: Throwable) {
+        val where = attempted?.toString() ?: "the JetWhale host"
+        val message = "Could not connect to $where: $cause"
+        if (message == lastReportedFailure) return
+        lastReportedFailure = message
+        JetWhaleLogger.w("$message. Retrying with backoff until it succeeds.")
+    }
+
     private suspend fun openConnection(host: String, port: Int) {
         val connection = socketClient.openConnection(host, port)
 
         retryCount = 0
+        lastReportedFailure = null
 
         pluginService.startConnection(
             scope = coroutineScope,

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/EndpointResolver.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/EndpointResolver.kt
@@ -1,0 +1,21 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+/** A concrete address to dial — what resolution produces. */
+internal data class ResolvedEndpoint(val host: String, val port: Int) {
+    override fun toString(): String = "$host:$port"
+}
+
+/**
+ * Supplies the address for the next connection attempt.
+ *
+ * Asked before every attempt rather than once per session, so an address that only becomes correct
+ * later is still reached without restarting the session.
+ */
+internal fun interface EndpointResolver {
+    suspend fun resolve(): ResolvedEndpoint
+}
+
+/** Resolves to the same literal address every time. */
+internal class FixedEndpointResolver(private val endpoint: ResolvedEndpoint) : EndpointResolver {
+    override suspend fun resolve(): ResolvedEndpoint = endpoint
+}

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
@@ -1,0 +1,94 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+/** DNS-SD service type the host advertises the debug server under. */
+internal const val JETWHALE_SERVICE_TYPE: String = "_jetwhale._tcp"
+
+/** TXT record key for the plain-ws port. */
+internal const val TXT_KEY_WS_PORT: String = "wsPort"
+
+/** TXT record key for the wss port (absent when the host has wss disabled). */
+internal const val TXT_KEY_WSS_PORT: String = "wssPort"
+
+/**
+ * TXT record key for the host machine's hostname. Carried separately from the mDNS instance name
+ * because the instance name can be uniquified on collision (e.g. "name (2)"), whereas this stays the
+ * raw hostname that `hostName` filtering compares against.
+ */
+internal const val TXT_KEY_HOST_NAME: String = "hostName"
+
+/** How long host discovery browses before giving up and falling back to the configured host. */
+internal const val HOST_DISCOVERY_TIMEOUT_MILLIS: Long = 5_000L
+
+/** A JetWhale debug server instance discovered and resolved over mDNS/DNS-SD. */
+internal data class DiscoveredService(
+    /** The mDNS instance name (possibly uniquified by collision handling). */
+    val instanceName: String,
+    /** The host machine's hostname from the TXT records, or null when not advertised. */
+    val advertisedHostName: String?,
+    /** The resolved IP address. */
+    val address: String,
+    /** The advertised plain-ws port, or null. */
+    val wsPort: Int?,
+    /** The advertised wss port, or null when the host has wss disabled. */
+    val wssPort: Int?,
+)
+
+/**
+ * Browses the local network for JetWhale debug servers advertised over mDNS/DNS-SD and returns every
+ * instance resolved within [timeoutMillis]. Returns an empty list when none are found or the platform
+ * does not support mDNS discovery.
+ */
+internal expect suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService>
+
+/**
+ * Resolves the effective host/port, preferring an mDNS-discovered host and falling back to
+ * [fallbackHost]/[fallbackPort] when discovery is disabled or finds no matching host in time.
+ */
+internal suspend fun resolveHost(
+    fallbackHost: String,
+    fallbackPort: Int,
+    discovery: HostDiscoveryConfig?,
+): Pair<String, Int> {
+    if (discovery == null) return fallbackHost to fallbackPort
+
+    val services = browseJetWhaleServices(HOST_DISCOVERY_TIMEOUT_MILLIS)
+    val matches = services.filter { it.matches(discovery) }
+
+    if (matches.isEmpty()) {
+        JetWhaleLogger.w("mDNS host discovery found no matching host within ${HOST_DISCOVERY_TIMEOUT_MILLIS}ms; falling back to $fallbackHost:$fallbackPort")
+        return fallbackHost to fallbackPort
+    }
+
+    // With no filter, first-match can be ambiguous when several hosts advertise on the network; make
+    // the ambiguity visible instead of silently picking one.
+    if (!discovery.hasFilter && matches.size > 1) {
+        val listed = matches.joinToString { "${it.displayName()}@${it.address}" }
+        JetWhaleLogger.w("mDNS discovery found ${matches.size} JetWhale hosts and no filter was set; using the first. Discovered: $listed. Constrain with discoverHost { hostName(...) } or address(...).")
+    }
+
+    val chosen = matches.first()
+    val port = chosen.selectPort(discovery.preferWss)
+    if (port == null) {
+        JetWhaleLogger.w("Discovered host ${chosen.displayName()} advertised no usable port; falling back to $fallbackHost:$fallbackPort")
+        return fallbackHost to fallbackPort
+    }
+    JetWhaleLogger.i("Discovered JetWhale host over mDNS: ${chosen.displayName()} at ${chosen.address}:$port")
+    return chosen.address to port
+}
+
+private fun DiscoveredService.displayName(): String = advertisedHostName ?: instanceName
+
+private fun DiscoveredService.matches(discovery: HostDiscoveryConfig): Boolean {
+    // hostName filter: exact, case-insensitive, compared against the advertised hostname (falling
+    // back to the instance name when the host advertised no hostName TXT record).
+    if (discovery.hostName != null && !displayName().equals(discovery.hostName, ignoreCase = true)) {
+        return false
+    }
+    // address allowlist: the resolved address must be one of the configured addresses.
+    if (discovery.addresses.isNotEmpty() && address !in discovery.addresses) {
+        return false
+    }
+    return true
+}
+
+private fun DiscoveredService.selectPort(preferWss: Boolean): Int? = if (preferWss) wssPort ?: wsPort else wsPort ?: wssPort

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
@@ -130,16 +130,16 @@ internal class MdnsEndpointResolver(
         if (!ambiguous) return chosen
         val listed = services.joinToString { "${it.displayName()}@${it.address}" }
         return "$chosen — but ${services.size} hosts advertised and no filter was set. Discovered: $listed. " +
-            "Narrow with discovered(fallback) { matchHostName(...) } or allowAddress(...)."
+            "Narrow with discovered(fallback) { allowHostName(...) } or allowAddress(...)."
     }
 }
 
 private fun DiscoveredService.displayName(): String = advertisedHostName ?: instanceName
 
 private fun DiscoveredService.matches(discovery: HostDiscoveryConfig): Boolean {
-    // hostName filter: exact, case-insensitive, compared against the advertised hostname (falling
+    // hostName allowlist: exact, case-insensitive, compared against the advertised hostname (falling
     // back to the instance name when the host advertised no hostName TXT record).
-    if (discovery.hostName != null && !displayName().equals(discovery.hostName, ignoreCase = true)) {
+    if (discovery.hostNames.isNotEmpty() && discovery.hostNames.none { displayName().equals(it, ignoreCase = true) }) {
         return false
     }
     // address allowlist: the resolved address must be one of the configured addresses.

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
@@ -33,47 +33,109 @@ internal data class DiscoveredService(
     val wssPort: Int?,
 )
 
-/**
- * Browses the local network for JetWhale debug servers advertised over mDNS/DNS-SD and returns every
- * instance resolved within [timeoutMillis]. Returns an empty list when none are found or the platform
- * does not support mDNS discovery.
- */
-internal expect suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService>
+/** What one browse attempt yielded. */
+internal sealed interface DiscoveryResult {
+    /** The network was browsed and these instances resolved within the timeout — possibly none. */
+    data class Browsed(val services: List<DiscoveredService>) : DiscoveryResult
+
+    /**
+     * Browsing could not be performed at all, either because the platform has no mDNS backend or
+     * because the backend could not be reached. [reason] completes the sentence "mDNS host discovery
+     * is unavailable because …".
+     */
+    data class Unavailable(val reason: String) : DiscoveryResult
+}
 
 /**
- * Resolves the effective host/port, preferring an mDNS-discovered host and falling back to
- * [fallbackHost]/[fallbackPort] when discovery is disabled or finds no matching host in time.
+ * Browses the local network for JetWhale debug servers advertised over mDNS/DNS-SD, returning every
+ * instance resolved within [timeoutMillis].
  */
-internal suspend fun resolveHost(
-    fallbackHost: String,
-    fallbackPort: Int,
-    discovery: HostDiscoveryConfig?,
-): Pair<String, Int> {
-    if (discovery == null) return fallbackHost to fallbackPort
+internal expect suspend fun browseJetWhaleServices(timeoutMillis: Long): DiscoveryResult
 
-    val services = browseJetWhaleServices(HOST_DISCOVERY_TIMEOUT_MILLIS)
-    val matches = services.filter { it.matches(discovery) }
+/** A discovered host paired with the port to reach it on. */
+internal data class SelectedHost(val service: DiscoveredService, val port: Int)
 
-    if (matches.isEmpty()) {
-        JetWhaleLogger.w("mDNS host discovery found no matching host within ${HOST_DISCOVERY_TIMEOUT_MILLIS}ms; falling back to $fallbackHost:$fallbackPort")
-        return fallbackHost to fallbackPort
+/**
+ * Picks the host to connect to among [services], or null when none can serve this agent.
+ *
+ * A host qualifies only when it satisfies every configured filter **and** advertises the port for the
+ * scheme the connection will use. The scheme comes from the `ssl {}` block alone, so an ssl-configured
+ * agent cannot use a host that advertises no wss port: dialling `wss://` at its plain-ws port would
+ * fail every handshake. Such a host is skipped rather than chosen, leaving the next match a chance.
+ */
+internal fun selectHost(services: List<DiscoveredService>, discovery: HostDiscoveryConfig): SelectedHost? = services.asSequence()
+    .filter { it.matches(discovery) }
+    .mapNotNull { service -> service.portFor(discovery.useWss)?.let { SelectedHost(service, it) } }
+    .firstOrNull()
+
+/**
+ * Resolves the address to connect to, preferring an mDNS-discovered host over
+ * [fallbackHost]/[fallbackPort].
+ *
+ * Consulted before every connection attempt, because a host started after the app — or one that came
+ * back on a different port — is only reached by browsing again. That makes it repetitive by nature,
+ * so it remembers the outcome it last reported and stays quiet while nothing changes.
+ */
+internal class HostResolver(
+    private val fallbackHost: String,
+    private val fallbackPort: Int,
+    private val discovery: HostDiscoveryConfig?,
+) {
+    private var lastReported: String? = null
+
+    suspend fun resolve(): Pair<String, Int> {
+        if (discovery == null) return fallbackHost to fallbackPort
+
+        return when (val result = browseJetWhaleServices(HOST_DISCOVERY_TIMEOUT_MILLIS)) {
+            is DiscoveryResult.Unavailable -> {
+                report("mDNS host discovery is unavailable because ${result.reason}; using $fallback", warn = true)
+                fallbackHost to fallbackPort
+            }
+
+            is DiscoveryResult.Browsed -> {
+                val selected = selectHost(result.services, discovery)
+                if (selected == null) {
+                    report(noHostMessage(result.services, discovery), warn = true)
+                    fallbackHost to fallbackPort
+                } else {
+                    val ambiguous = !discovery.hasFilter && result.services.size > 1
+                    report(chosenMessage(selected, result.services, ambiguous), warn = ambiguous)
+                    selected.service.address to selected.port
+                }
+            }
+        }
     }
 
-    // With no filter, first-match can be ambiguous when several hosts advertise on the network; make
-    // the ambiguity visible instead of silently picking one.
-    if (!discovery.hasFilter && matches.size > 1) {
-        val listed = matches.joinToString { "${it.displayName()}@${it.address}" }
-        JetWhaleLogger.w("mDNS discovery found ${matches.size} JetWhale hosts and no filter was set; using the first. Discovered: $listed. Narrow with discovered(fallback) { matchHostName(...) } or allowAddress(...).")
+    private val fallback: String get() = "$fallbackHost:$fallbackPort"
+
+    private fun report(message: String, warn: Boolean) {
+        if (message == lastReported) return
+        lastReported = message
+        if (warn) JetWhaleLogger.w(message) else JetWhaleLogger.i(message)
     }
 
-    val chosen = matches.first()
-    val port = chosen.selectPort(discovery.preferWss)
-    if (port == null) {
-        JetWhaleLogger.w("Discovered host ${chosen.displayName()} advertised no usable port; falling back to $fallbackHost:$fallbackPort")
-        return fallbackHost to fallbackPort
+    private fun noHostMessage(services: List<DiscoveredService>, discovery: HostDiscoveryConfig): String {
+        val matched = services.filter { it.matches(discovery) }
+        if (matched.isEmpty()) {
+            return "mDNS host discovery found no matching host within ${HOST_DISCOVERY_TIMEOUT_MILLIS}ms; using $fallback"
+        }
+        // Matched but unusable is worth spelling out: the agent would otherwise look like it simply
+        // found nothing, when in fact the host is there and only its wss connector is missing.
+        val scheme = if (discovery.useWss) "wss" else "ws"
+        val listed = matched.joinToString { it.displayName() }
+        return "mDNS host discovery matched ${matched.size} host(s) ($listed) but none advertised a $scheme port; using $fallback. " +
+            "A host advertises its wss port only while wss is enabled in its settings."
     }
-    JetWhaleLogger.i("Discovered JetWhale host over mDNS: ${chosen.displayName()} at ${chosen.address}:$port")
-    return chosen.address to port
+
+    private fun chosenMessage(selected: SelectedHost, services: List<DiscoveredService>, ambiguous: Boolean): String {
+        val chosen = "Discovered JetWhale host over mDNS: ${selected.service.displayName()} at ${selected.service.address}:${selected.port}"
+        // With no filter, first-match is ambiguous when several hosts advertise; make that visible
+        // instead of silently picking one.
+        if (!ambiguous) return chosen
+        val listed = services.joinToString { "${it.displayName()}@${it.address}" }
+        return "$chosen — but ${services.size} hosts advertised and no filter was set. Discovered: $listed. " +
+            "Narrow with discovered(fallback) { matchHostName(...) } or allowAddress(...)."
+    }
 }
 
 private fun DiscoveredService.displayName(): String = advertisedHostName ?: instanceName
@@ -91,4 +153,4 @@ private fun DiscoveredService.matches(discovery: HostDiscoveryConfig): Boolean {
     return true
 }
 
-private fun DiscoveredService.selectPort(preferWss: Boolean): Int? = if (preferWss) wssPort ?: wsPort else wsPort ?: wssPort
+private fun DiscoveredService.portFor(useWss: Boolean): Int? = if (useWss) wssPort else wsPort

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
@@ -63,7 +63,7 @@ internal suspend fun resolveHost(
     // the ambiguity visible instead of silently picking one.
     if (!discovery.hasFilter && matches.size > 1) {
         val listed = matches.joinToString { "${it.displayName()}@${it.address}" }
-        JetWhaleLogger.w("mDNS discovery found ${matches.size} JetWhale hosts and no filter was set; using the first. Discovered: $listed. Constrain with discoverHost { hostName(...) } or address(...).")
+        JetWhaleLogger.w("mDNS discovery found ${matches.size} JetWhale hosts and no filter was set; using the first. Discovered: $listed. Narrow with discovered(fallback) { matchHostName(...) } or allowAddress(...).")
     }
 
     val chosen = matches.first()

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
@@ -69,44 +69,40 @@ internal fun selectHost(services: List<DiscoveredService>, discovery: HostDiscov
     .firstOrNull()
 
 /**
- * Resolves the address to connect to, preferring an mDNS-discovered host over
- * [fallbackHost]/[fallbackPort].
+ * Browses for a JetWhale host over mDNS, standing [fallback] in whenever a browse yields none that
+ * this agent can use.
  *
- * Consulted before every connection attempt, because a host started after the app — or one that came
- * back on a different port — is only reached by browsing again. That makes it repetitive by nature,
- * so it remembers the outcome it last reported and stays quiet while nothing changes.
+ * Browsing on every call is the point: a host started after the app, or one that came back on a
+ * different port, is only reached by looking again. That makes the outcome repetitive by nature, so
+ * the resolver remembers what it last reported and stays quiet while nothing changes.
  */
-internal class HostResolver(
-    private val fallbackHost: String,
-    private val fallbackPort: Int,
-    private val discovery: HostDiscoveryConfig?,
-) {
+internal class MdnsEndpointResolver(
+    val discovery: HostDiscoveryConfig,
+    val fallback: ResolvedEndpoint,
+) : EndpointResolver {
     private var lastReported: String? = null
 
-    suspend fun resolve(): Pair<String, Int> {
-        if (discovery == null) return fallbackHost to fallbackPort
-
-        return when (val result = browseJetWhaleServices(HOST_DISCOVERY_TIMEOUT_MILLIS)) {
+    override suspend fun resolve(): ResolvedEndpoint {
+        val result = browseJetWhaleServices(HOST_DISCOVERY_TIMEOUT_MILLIS)
+        return when (result) {
             is DiscoveryResult.Unavailable -> {
                 report("mDNS host discovery is unavailable because ${result.reason}; using $fallback", warn = true)
-                fallbackHost to fallbackPort
+                fallback
             }
 
             is DiscoveryResult.Browsed -> {
                 val selected = selectHost(result.services, discovery)
                 if (selected == null) {
-                    report(noHostMessage(result.services, discovery), warn = true)
-                    fallbackHost to fallbackPort
+                    report(noHostMessage(result.services), warn = true)
+                    fallback
                 } else {
                     val ambiguous = !discovery.hasFilter && result.services.size > 1
                     report(chosenMessage(selected, result.services, ambiguous), warn = ambiguous)
-                    selected.service.address to selected.port
+                    ResolvedEndpoint(selected.service.address, selected.port)
                 }
             }
         }
     }
-
-    private val fallback: String get() = "$fallbackHost:$fallbackPort"
 
     private fun report(message: String, warn: Boolean) {
         if (message == lastReported) return
@@ -114,7 +110,7 @@ internal class HostResolver(
         if (warn) JetWhaleLogger.w(message) else JetWhaleLogger.i(message)
     }
 
-    private fun noHostMessage(services: List<DiscoveredService>, discovery: HostDiscoveryConfig): String {
+    private fun noHostMessage(services: List<DiscoveredService>): String {
         val matched = services.filter { it.matches(discovery) }
         if (matched.isEmpty()) {
             return "mDNS host discovery found no matching host within ${HOST_DISCOVERY_TIMEOUT_MILLIS}ms; using $fallback"

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
@@ -7,10 +7,14 @@ internal interface JetWhaleMessagingService {
     /**
      * Starts the messaging service to connect to the JetWhale debugger server.
      *
-     * @param host The hostname or IP address of the JetWhale debugger server.
-     * @param port The port number of the JetWhale debugger server.
+     * @param host The hostname or IP address of the JetWhale debugger server, used when [discovery]
+     *   is null or finds no advertised host in time.
+     * @param port The port number of the JetWhale debugger server, used alongside [host] as the
+     *   fallback.
+     * @param discovery When non-null, mDNS host discovery is attempted before connecting and its
+     *   result overrides [host]/[port]; when null, [host]/[port] are used directly.
      */
-    fun startService(host: String, port: Int)
+    fun startService(host: String, port: Int, discovery: HostDiscoveryConfig?)
 
     /**
      * Stops the messaging service: the reconnect loop is torn down, the current connection is closed
@@ -20,4 +24,21 @@ internal interface JetWhaleMessagingService {
      * scheduled, and repeated calls are ignored.
      */
     fun stopService()
+}
+
+/**
+ * Configures mDNS host discovery for the agent.
+ *
+ * @property hostName When non-null, only a host whose advertised hostname matches this (exact,
+ *   case-insensitive) is selected.
+ * @property addresses When non-empty, only a host resolving to one of these IP addresses is selected.
+ * @property preferWss Whether to prefer the advertised wss port (true when `ssl {}` is configured).
+ */
+internal data class HostDiscoveryConfig(
+    val hostName: String?,
+    val addresses: List<String>,
+    val preferWss: Boolean,
+) {
+    /** True when at least one selection filter narrows the discovered hosts. */
+    val hasFilter: Boolean get() = hostName != null || addresses.isNotEmpty()
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
@@ -7,14 +7,11 @@ internal interface JetWhaleMessagingService {
     /**
      * Starts the messaging service to connect to the JetWhale debugger server.
      *
-     * @param host The hostname or IP address of the JetWhale debugger server, used when [discovery]
-     *   is null or finds no advertised host in time.
-     * @param port The port number of the JetWhale debugger server, used alongside [host] as the
-     *   fallback.
-     * @param discovery When non-null, mDNS host discovery is attempted before connecting and its
-     *   result overrides [host]/[port]; when null, [host]/[port] are used directly.
+     * @param resolver Asked for an address before every connection attempt. How that address is
+     *   arrived at — a literal one, or one browsed for over mDNS with a fallback — is the resolver's
+     *   business, not the service's.
      */
-    fun startService(host: String, port: Int, discovery: HostDiscoveryConfig?)
+    fun startService(resolver: EndpointResolver)
 
     /**
      * Stops the messaging service: the reconnect loop is torn down, the current connection is closed
@@ -27,7 +24,7 @@ internal interface JetWhaleMessagingService {
 }
 
 /**
- * Configures mDNS host discovery for the agent.
+ * Which advertised host the agent will accept, and on which port.
  *
  * @property hostName When non-null, only a host whose advertised hostname matches this (exact,
  *   case-insensitive) is selected.

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
@@ -26,17 +26,17 @@ internal interface JetWhaleMessagingService {
 /**
  * Which advertised host the agent will accept, and on which port.
  *
- * @property hostName When non-null, only a host whose advertised hostname matches this (exact,
+ * @property hostNames When non-empty, only a host advertising one of these hostnames (exact,
  *   case-insensitive) is selected.
  * @property addresses When non-empty, only a host resolving to one of these IP addresses is selected.
  * @property useWss Whether the connection will use wss (true when `ssl {}` is configured). A host is
  *   usable only when it advertises the port for that scheme, since the scheme is not negotiable.
  */
 internal data class HostDiscoveryConfig(
-    val hostName: String?,
+    val hostNames: List<String>,
     val addresses: List<String>,
     val useWss: Boolean,
 ) {
-    /** True when at least one selection filter narrows the discovered hosts. */
-    val hasFilter: Boolean get() = hostName != null || addresses.isNotEmpty()
+    /** True when at least one allowlist narrows the discovered hosts. */
+    val hasFilter: Boolean get() = hostNames.isNotEmpty() || addresses.isNotEmpty()
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
@@ -32,12 +32,13 @@ internal interface JetWhaleMessagingService {
  * @property hostName When non-null, only a host whose advertised hostname matches this (exact,
  *   case-insensitive) is selected.
  * @property addresses When non-empty, only a host resolving to one of these IP addresses is selected.
- * @property preferWss Whether to prefer the advertised wss port (true when `ssl {}` is configured).
+ * @property useWss Whether the connection will use wss (true when `ssl {}` is configured). A host is
+ *   usable only when it advertises the port for that scheme, since the scheme is not negotiable.
  */
 internal data class HostDiscoveryConfig(
     val hostName: String?,
     val addresses: List<String>,
-    val preferWss: Boolean,
+    val useWss: Boolean,
 ) {
     /** True when at least one selection filter narrows the discovered hosts. */
     val hasFilter: Boolean get() = hostName != null || addresses.isNotEmpty()

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -59,6 +59,15 @@ public fun startJetWhale(configure: JetWhaleConfigurationScope.() -> Unit): JetW
     service.startService(
         host = configuration.connection.host,
         port = configuration.connection.port,
+        discovery = configuration.connection.discoveryConfiguration?.let { filter ->
+            HostDiscoveryConfig(
+                hostName = filter.hostName,
+                addresses = filter.addresses,
+                // Prefer the advertised wss port when SSL is configured, so a discovered LAN host is
+                // reached over the encrypted connector rather than plain ws.
+                preferWss = configuration.connection.sslConfiguration.isEnabled,
+            )
+        },
     )
     return MessagingServiceSession(service)
 }
@@ -113,12 +122,54 @@ public interface JetWhaleConnectionConfigurationScope {
     public var port: Int
 
     /**
+     * Enables zero-config host discovery over mDNS/DNS-SD (Bonjour). When enabled, the agent browses
+     * the local network for a `_jetwhale._tcp` service the host advertises while its debug server
+     * runs, resolves that host's address and port, and connects to it instead of [host]/[port].
+     *
+     * The wss port advertised by the host is used when `ssl {}` is configured, otherwise the plain-ws
+     * port. When no host is discovered within a short timeout, or the platform does not support mDNS
+     * (JS/Wasm/Linux/Windows), the connection falls back to the configured [host]/[port] with a
+     * warning log, so an explicit host stays a valid override (e.g. `localhost` for emulator/ADB).
+     *
+     * iOS requires `_jetwhale._tcp` to be listed under `NSBonjourServices` in `Info.plist` alongside
+     * `NSLocalNetworkUsageDescription`, otherwise the OS blocks the browse.
+     *
+     * When several JetWhale hosts advertise on the network, constrain the selection with [configure]
+     * (see [JetWhaleHostDiscoveryScope]); with no filter the first discovered host is used and an
+     * explicit warning listing all discovered hosts is logged when more than one is found.
+     *
+     * @param configure Optional filter for which discovered host to connect to.
+     */
+    public fun discoverHost(configure: JetWhaleHostDiscoveryScope.() -> Unit = {})
+
+    /**
      * Configures SSL settings for the connection. When at least one trusted certificate is
      * registered, the connection is established over wss instead of plain ws.
      *
      * @param configure A lambda function to configure SSL settings.
      */
     public fun ssl(configure: JetWhaleSslConfigurationScope.() -> Unit)
+}
+
+@JetWhaleDsl
+public interface JetWhaleHostDiscoveryScope {
+    /**
+     * Restricts discovery to a host whose advertised hostname matches [name] exactly, compared
+     * case-insensitively. The compared value is the host machine's hostname (the mDNS instance name,
+     * or the `hostName` TXT record when the instance name was uniquified on collision).
+     *
+     * @param name The host machine's hostname to match.
+     */
+    public fun hostName(name: String)
+
+    /**
+     * Adds an IP address to the allowlist: a discovered host is only accepted when it resolves to one
+     * of the added addresses. Repeatable. Use this to pin discovery to a specific machine, e.g. your
+     * build machine's LAN IP.
+     *
+     * @param ip The IP address a discovered host must resolve to.
+     */
+    public fun address(ip: String)
 }
 
 @JetWhaleDsl
@@ -207,8 +258,31 @@ private class JetWhaleConnectionConfiguration : JetWhaleConnectionConfigurationS
     override var port: Int = 8080
     val sslConfiguration: JetWhaleSslConfiguration = JetWhaleSslConfiguration()
 
+    var discoveryConfiguration: JetWhaleHostDiscoveryConfiguration? = null
+        private set
+
+    override fun discoverHost(configure: JetWhaleHostDiscoveryScope.() -> Unit) {
+        discoveryConfiguration = JetWhaleHostDiscoveryConfiguration().apply(configure)
+    }
+
     override fun ssl(configure: JetWhaleSslConfigurationScope.() -> Unit) {
         sslConfiguration.configure()
+    }
+}
+
+internal class JetWhaleHostDiscoveryConfiguration : JetWhaleHostDiscoveryScope {
+    var hostName: String? = null
+        private set
+
+    private val mutableAddresses: MutableList<String> = mutableListOf()
+    val addresses: List<String> get() = mutableAddresses
+
+    override fun hostName(name: String) {
+        hostName = name
+    }
+
+    override fun address(ip: String) {
+        mutableAddresses.add(ip)
     }
 }
 

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -56,20 +56,37 @@ public fun startJetWhale(configure: JetWhaleConfigurationScope.() -> Unit): JetW
                 plugins = configuration.plugins.plugins,
             ),
         )
-    service.startService(
-        host = configuration.connection.host,
-        port = configuration.connection.port,
-        discovery = configuration.connection.discoveryConfiguration?.let { filter ->
-            HostDiscoveryConfig(
-                hostName = filter.hostName,
-                addresses = filter.addresses,
-                // Prefer the advertised wss port when SSL is configured, so a discovered LAN host is
-                // reached over the encrypted connector rather than plain ws.
-                preferWss = configuration.connection.sslConfiguration.isEnabled,
-            )
-        },
-    )
+    val target = configuration.connection.resolveTarget()
+    service.startService(host = target.host, port = target.port, discovery = target.discovery)
     return MessagingServiceSession(service)
+}
+
+/** The [JetWhaleMessagingService.startService] arguments a configured [endpoint] amounts to. */
+internal data class ResolvedConnectionTarget(
+    val host: String,
+    val port: Int,
+    val discovery: HostDiscoveryConfig?,
+)
+
+internal fun JetWhaleConnectionConfiguration.resolveTarget(): ResolvedConnectionTarget = when (val endpoint = endpoint) {
+    is JetWhaleFixedEndpoint -> ResolvedConnectionTarget(
+        host = endpoint.host,
+        port = endpoint.port,
+        discovery = null,
+    )
+
+    is JetWhaleDiscoveredEndpoint -> ResolvedConnectionTarget(
+        host = endpoint.fallback.host,
+        port = endpoint.fallback.port,
+        discovery = HostDiscoveryConfig(
+            hostName = endpoint.hostName,
+            addresses = endpoint.addresses,
+            // Prefer the advertised wss port when SSL is configured, so a discovered LAN host is
+            // reached over the encrypted connector rather than plain ws. Read here rather than in
+            // `discovered()` so `ssl {}` and `endpoint =` can appear in either order.
+            preferWss = sslConfiguration.isEnabled,
+        ),
+    )
 }
 
 private class MessagingServiceSession(private val service: JetWhaleMessagingService) : JetWhaleSession {
@@ -118,29 +135,64 @@ public interface JetWhaleAppConfigurationScope {
 
 @JetWhaleDsl
 public interface JetWhaleConnectionConfigurationScope {
+    /**
+     * The JetWhale host this agent connects to. Assign either [at] for a literal address, or
+     * [discovered] to find the host on the local network over mDNS/Bonjour.
+     *
+     * Defaults to `fixed("localhost", 8080)`.
+     */
+    public var endpoint: JetWhaleEndpoint
+
+    @Deprecated(
+        message = "Superseded by 'endpoint'. Assign endpoint = fixed(host, port) instead. " +
+            "Setting host/port still works and is equivalent to that assignment.",
+        level = DeprecationLevel.WARNING,
+    )
     public var host: String
+
+    @Deprecated(
+        message = "Superseded by 'endpoint'. Assign endpoint = fixed(host, port) instead. " +
+            "Setting host/port still works and is equivalent to that assignment.",
+        level = DeprecationLevel.WARNING,
+    )
     public var port: Int
 
     /**
-     * Enables zero-config host discovery over mDNS/DNS-SD (Bonjour). When enabled, the agent browses
-     * the local network for a `_jetwhale._tcp` service the host advertises while its debug server
-     * runs, resolves that host's address and port, and connects to it instead of [host]/[port].
+     * A literal address to connect to, e.g. `localhost` for an emulator/simulator or an
+     * ADB-forwarded device.
      *
-     * The wss port advertised by the host is used when `ssl {}` is configured, otherwise the plain-ws
-     * port. When no host is discovered within a short timeout, or the platform does not support mDNS
-     * (JS/Wasm/Linux/Windows), the connection falls back to the configured [host]/[port] with a
-     * warning log, so an explicit host stays a valid override (e.g. `localhost` for emulator/ADB).
+     * @param host The hostname or IP address of the JetWhale host.
+     * @param port The port the JetWhale host's debug server listens on.
+     */
+    public fun fixed(host: String, port: Int): JetWhaleFixedEndpoint
+
+    /**
+     * A host found by zero-config discovery over mDNS/DNS-SD (Bonjour): the agent browses the local
+     * network for the `_jetwhale._tcp` service the host advertises while its debug server runs, and
+     * connects to the address and port it advertises. Use this for physical LAN devices, which cannot
+     * reach the host over `localhost`.
+     *
+     * The advertised wss port is used when `ssl {}` is configured, otherwise the plain-ws port — so
+     * discovery resolves the port too, and [fallback]'s port applies only when discovery finds nothing.
+     *
+     * Discovery is best-effort, which is why [fallback] is required: when no matching host is found
+     * within a short timeout, or the platform does not support mDNS (JS/Wasm/Linux/Windows), the
+     * connection falls back to it with a warning log.
      *
      * iOS requires `_jetwhale._tcp` to be listed under `NSBonjourServices` in `Info.plist` alongside
      * `NSLocalNetworkUsageDescription`, otherwise the OS blocks the browse.
      *
-     * When several JetWhale hosts advertise on the network, constrain the selection with [configure]
-     * (see [JetWhaleHostDiscoveryScope]); with no filter the first discovered host is used and an
-     * explicit warning listing all discovered hosts is logged when more than one is found.
+     * When several JetWhale hosts advertise on the network, narrow the selection with [configure]
+     * (see [JetWhaleDiscoveredEndpointScope]); with no filter the first discovered host is used and a
+     * warning listing all discovered hosts is logged when more than one is found.
      *
-     * @param configure Optional filter for which discovered host to connect to.
+     * @param fallback Used when discovery finds no matching host in time, or the platform lacks mDNS.
+     * @param configure Optional filters narrowing which discovered host is accepted.
      */
-    public fun discoverHost(configure: JetWhaleHostDiscoveryScope.() -> Unit = {})
+    public fun discovered(
+        fallback: JetWhaleFixedEndpoint,
+        configure: JetWhaleDiscoveredEndpointScope.() -> Unit = {},
+    ): JetWhaleEndpoint
 
     /**
      * Configures SSL settings for the connection. When at least one trusted certificate is
@@ -151,25 +203,41 @@ public interface JetWhaleConnectionConfigurationScope {
     public fun ssl(configure: JetWhaleSslConfigurationScope.() -> Unit)
 }
 
+/**
+ * Where the agent connects to. Build one with [JetWhaleConnectionConfigurationScope.at] or
+ * [JetWhaleConnectionConfigurationScope.discovered].
+ */
+public sealed interface JetWhaleEndpoint
+
+/** A literal host/port, as built by [JetWhaleConnectionConfigurationScope.at]. */
+public class JetWhaleFixedEndpoint internal constructor(
+    internal val host: String,
+    internal val port: Int,
+) : JetWhaleEndpoint
+
+/**
+ * Filters narrowing which discovered host is accepted. Every filter set here must match, and a host
+ * that matches none of them is skipped rather than connected to.
+ */
 @JetWhaleDsl
-public interface JetWhaleHostDiscoveryScope {
+public interface JetWhaleDiscoveredEndpointScope {
     /**
-     * Restricts discovery to a host whose advertised hostname matches [name] exactly, compared
-     * case-insensitively. The compared value is the host machine's hostname (the mDNS instance name,
-     * or the `hostName` TXT record when the instance name was uniquified on collision).
+     * Accepts only a host whose advertised hostname equals [name], compared case-insensitively. The
+     * compared value is the host machine's hostname (the `hostName` TXT record, falling back to the
+     * mDNS instance name).
      *
      * @param name The host machine's hostname to match.
      */
-    public fun hostName(name: String)
+    public fun matchHostName(name: String)
 
     /**
-     * Adds an IP address to the allowlist: a discovered host is only accepted when it resolves to one
+     * Adds an IP address to the allowlist: a discovered host is accepted only when it resolves to one
      * of the added addresses. Repeatable. Use this to pin discovery to a specific machine, e.g. your
      * build machine's LAN IP.
      *
-     * @param ip The IP address a discovered host must resolve to.
+     * @param ip An IP address a discovered host is allowed to resolve to.
      */
-    public fun address(ip: String)
+    public fun allowAddress(ip: String)
 }
 
 @JetWhaleDsl
@@ -253,16 +321,41 @@ private class JetWhaleAppConfiguration : JetWhaleAppConfigurationScope {
     )
 }
 
-private class JetWhaleConnectionConfiguration : JetWhaleConnectionConfigurationScope {
+/** A host to be discovered over mDNS, as built by [JetWhaleConnectionConfigurationScope.discovered]. */
+internal class JetWhaleDiscoveredEndpoint(
+    val hostName: String?,
+    val addresses: List<String>,
+    val fallback: JetWhaleFixedEndpoint,
+) : JetWhaleEndpoint
+
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+internal class JetWhaleConnectionConfiguration : JetWhaleConnectionConfigurationScope {
     override var host: String = "localhost"
     override var port: Int = 8080
     val sslConfiguration: JetWhaleSslConfiguration = JetWhaleSslConfiguration()
 
-    var discoveryConfiguration: JetWhaleHostDiscoveryConfiguration? = null
-        private set
+    private var assignedEndpoint: JetWhaleEndpoint? = null
 
-    override fun discoverHost(configure: JetWhaleHostDiscoveryScope.() -> Unit) {
-        discoveryConfiguration = JetWhaleHostDiscoveryConfiguration().apply(configure)
+    // Falling back to host/port keeps the deprecated properties working: leaving `endpoint` unassigned
+    // resolves to whatever they hold, defaults included.
+    override var endpoint: JetWhaleEndpoint
+        get() = assignedEndpoint ?: fixed(host, port)
+        set(value) {
+            assignedEndpoint = value
+        }
+
+    override fun fixed(host: String, port: Int): JetWhaleFixedEndpoint = JetWhaleFixedEndpoint(host, port)
+
+    override fun discovered(
+        fallback: JetWhaleFixedEndpoint,
+        configure: JetWhaleDiscoveredEndpointScope.() -> Unit,
+    ): JetWhaleEndpoint {
+        val filters = JetWhaleDiscoveredEndpointConfiguration().apply(configure)
+        return JetWhaleDiscoveredEndpoint(
+            hostName = filters.hostName,
+            addresses = filters.addresses,
+            fallback = fallback,
+        )
     }
 
     override fun ssl(configure: JetWhaleSslConfigurationScope.() -> Unit) {
@@ -270,18 +363,18 @@ private class JetWhaleConnectionConfiguration : JetWhaleConnectionConfigurationS
     }
 }
 
-internal class JetWhaleHostDiscoveryConfiguration : JetWhaleHostDiscoveryScope {
+private class JetWhaleDiscoveredEndpointConfiguration : JetWhaleDiscoveredEndpointScope {
     var hostName: String? = null
         private set
 
     private val mutableAddresses: MutableList<String> = mutableListOf()
     val addresses: List<String> get() = mutableAddresses
 
-    override fun hostName(name: String) {
+    override fun matchHostName(name: String) {
         hostName = name
     }
 
-    override fun address(ip: String) {
+    override fun allowAddress(ip: String) {
         mutableAddresses.add(ip)
     }
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -81,10 +81,10 @@ internal fun JetWhaleConnectionConfiguration.resolveTarget(): ResolvedConnection
         discovery = HostDiscoveryConfig(
             hostName = endpoint.hostName,
             addresses = endpoint.addresses,
-            // Prefer the advertised wss port when SSL is configured, so a discovered LAN host is
-            // reached over the encrypted connector rather than plain ws. Read here rather than in
-            // `discovered()` so `ssl {}` and `endpoint =` can appear in either order.
-            preferWss = sslConfiguration.isEnabled,
+            // The connection uses wss exactly when SSL is configured, so a discovered host has to
+            // advertise that scheme's port. Read here rather than in `discovered()` so `ssl {}` and
+            // `endpoint =` can appear in either order.
+            useWss = sslConfiguration.isEnabled,
         ),
     )
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -56,28 +56,15 @@ public fun startJetWhale(configure: JetWhaleConfigurationScope.() -> Unit): JetW
                 plugins = configuration.plugins.plugins,
             ),
         )
-    val target = configuration.connection.resolveTarget()
-    service.startService(host = target.host, port = target.port, discovery = target.discovery)
+    service.startService(configuration.connection.endpointResolver())
     return MessagingServiceSession(service)
 }
 
-/** The [JetWhaleMessagingService.startService] arguments a configured [endpoint] amounts to. */
-internal data class ResolvedConnectionTarget(
-    val host: String,
-    val port: Int,
-    val discovery: HostDiscoveryConfig?,
-)
+/** The resolver a configured `endpoint` amounts to, once `ssl {}` is known. */
+internal fun JetWhaleConnectionConfiguration.endpointResolver(): EndpointResolver = when (val endpoint = endpoint) {
+    is JetWhaleFixedEndpoint -> FixedEndpointResolver(endpoint.resolved())
 
-internal fun JetWhaleConnectionConfiguration.resolveTarget(): ResolvedConnectionTarget = when (val endpoint = endpoint) {
-    is JetWhaleFixedEndpoint -> ResolvedConnectionTarget(
-        host = endpoint.host,
-        port = endpoint.port,
-        discovery = null,
-    )
-
-    is JetWhaleDiscoveredEndpoint -> ResolvedConnectionTarget(
-        host = endpoint.fallback.host,
-        port = endpoint.fallback.port,
+    is JetWhaleDiscoveredEndpoint -> MdnsEndpointResolver(
         discovery = HostDiscoveryConfig(
             hostName = endpoint.hostName,
             addresses = endpoint.addresses,
@@ -86,8 +73,11 @@ internal fun JetWhaleConnectionConfiguration.resolveTarget(): ResolvedConnection
             // `endpoint =` can appear in either order.
             useWss = sslConfiguration.isEnabled,
         ),
+        fallback = endpoint.fallback.resolved(),
     )
 }
+
+private fun JetWhaleFixedEndpoint.resolved(): ResolvedEndpoint = ResolvedEndpoint(host, port)
 
 private class MessagingServiceSession(private val service: JetWhaleMessagingService) : JetWhaleSession {
     override fun stop() {

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -66,7 +66,7 @@ internal fun JetWhaleConnectionConfiguration.endpointResolver(): EndpointResolve
 
     is JetWhaleDiscoveredEndpoint -> MdnsEndpointResolver(
         discovery = HostDiscoveryConfig(
-            hostName = endpoint.hostName,
+            hostNames = endpoint.hostNames,
             addresses = endpoint.addresses,
             // The connection uses wss exactly when SSL is configured, so a discovered host has to
             // advertise that scheme's port. Read here rather than in `discovered()` so `ssl {}` and
@@ -206,19 +206,21 @@ public class JetWhaleFixedEndpoint internal constructor(
 ) : JetWhaleEndpoint
 
 /**
- * Filters narrowing which discovered host is accepted. Every filter set here must match, and a host
- * that matches none of them is skipped rather than connected to.
+ * Allowlists narrowing which discovered host is accepted. Each is repeatable and independently
+ * optional; a host has to satisfy every allowlist that has entries, and one that does not is skipped
+ * rather than connected to.
  */
 @JetWhaleDsl
 public interface JetWhaleDiscoveredEndpointScope {
     /**
-     * Accepts only a host whose advertised hostname equals [name], compared case-insensitively. The
-     * compared value is the host machine's hostname (the `hostName` TXT record, falling back to the
-     * mDNS instance name).
+     * Adds a hostname to the allowlist: a discovered host is accepted only when its advertised
+     * hostname equals one of the added names, compared case-insensitively. Repeatable. The compared
+     * value is the host machine's hostname (the `hostName` TXT record, falling back to the mDNS
+     * instance name).
      *
-     * @param name The host machine's hostname to match.
+     * @param name A hostname a discovered host is allowed to advertise.
      */
-    public fun matchHostName(name: String)
+    public fun allowHostName(name: String)
 
     /**
      * Adds an IP address to the allowlist: a discovered host is accepted only when it resolves to one
@@ -313,7 +315,7 @@ private class JetWhaleAppConfiguration : JetWhaleAppConfigurationScope {
 
 /** A host to be discovered over mDNS, as built by [JetWhaleConnectionConfigurationScope.discovered]. */
 internal class JetWhaleDiscoveredEndpoint(
-    val hostName: String?,
+    val hostNames: List<String>,
     val addresses: List<String>,
     val fallback: JetWhaleFixedEndpoint,
 ) : JetWhaleEndpoint
@@ -342,7 +344,7 @@ internal class JetWhaleConnectionConfiguration : JetWhaleConnectionConfiguration
     ): JetWhaleEndpoint {
         val filters = JetWhaleDiscoveredEndpointConfiguration().apply(configure)
         return JetWhaleDiscoveredEndpoint(
-            hostName = filters.hostName,
+            hostNames = filters.hostNames,
             addresses = filters.addresses,
             fallback = fallback,
         )
@@ -354,14 +356,14 @@ internal class JetWhaleConnectionConfiguration : JetWhaleConnectionConfiguration
 }
 
 private class JetWhaleDiscoveredEndpointConfiguration : JetWhaleDiscoveredEndpointScope {
-    var hostName: String? = null
-        private set
+    private val mutableHostNames: MutableList<String> = mutableListOf()
+    val hostNames: List<String> get() = mutableHostNames
 
     private val mutableAddresses: MutableList<String> = mutableListOf()
     val addresses: List<String> get() = mutableAddresses
 
-    override fun matchHostName(name: String) {
-        hostName = name
+    override fun allowHostName(name: String) {
+        mutableHostNames.add(name)
     }
 
     override fun allowAddress(ip: String) {

--- a/jetwhale-agent-runtime/src/jvmMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.jvm.kt
+++ b/jetwhale-agent-runtime/src/jvmMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.jvm.kt
@@ -1,0 +1,44 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.InetAddress
+import javax.jmdns.JmDNS
+import javax.jmdns.ServiceInfo
+
+private const val SERVICE_TYPE_LOCAL = "$JETWHALE_SERVICE_TYPE.local."
+
+/**
+ * JVM mDNS host discovery via jmDNS. Browses for `_jetwhale._tcp.local.` and returns every instance
+ * resolved within the timeout window.
+ */
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> = withContext(Dispatchers.IO) {
+    var jmdns: JmDNS? = null
+    try {
+        jmdns = JmDNS.create(InetAddress.getLocalHost())
+        // Blocking browse: returns the services resolved within the timeout window.
+        jmdns.list(SERVICE_TYPE_LOCAL, timeoutMillis).mapNotNull { it.toDiscoveredService() }
+    } catch (e: Exception) {
+        JetWhaleLogger.w("mDNS host discovery failed", e)
+        emptyList()
+    } finally {
+        try {
+            jmdns?.close()
+        } catch (e: Exception) {
+            JetWhaleLogger.d("Failed to close jmDNS", e)
+        }
+    }
+}
+
+private fun ServiceInfo.toDiscoveredService(): DiscoveredService? {
+    val address = inet4Addresses.firstOrNull()?.hostAddress
+        ?: hostAddresses.firstOrNull()
+        ?: return null
+    return DiscoveredService(
+        instanceName = name,
+        advertisedHostName = getPropertyString(TXT_KEY_HOST_NAME),
+        address = address,
+        wsPort = getPropertyString(TXT_KEY_WS_PORT)?.toIntOrNull(),
+        wssPort = getPropertyString(TXT_KEY_WSS_PORT)?.toIntOrNull(),
+    )
+}

--- a/jetwhale-agent-runtime/src/jvmMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.jvm.kt
+++ b/jetwhale-agent-runtime/src/jvmMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.jvm.kt
@@ -12,15 +12,17 @@ private const val SERVICE_TYPE_LOCAL = "$JETWHALE_SERVICE_TYPE.local."
  * JVM mDNS host discovery via jmDNS. Browses for `_jetwhale._tcp.local.` and returns every instance
  * resolved within the timeout window.
  */
-internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> = withContext(Dispatchers.IO) {
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): DiscoveryResult = withContext(Dispatchers.IO) {
     var jmdns: JmDNS? = null
     try {
         jmdns = JmDNS.create(InetAddress.getLocalHost())
         // Blocking browse: returns the services resolved within the timeout window.
-        jmdns.list(SERVICE_TYPE_LOCAL, timeoutMillis).mapNotNull { it.toDiscoveredService() }
+        DiscoveryResult.Browsed(jmdns.list(SERVICE_TYPE_LOCAL, timeoutMillis).mapNotNull { it.toDiscoveredService() })
     } catch (e: Exception) {
-        JetWhaleLogger.w("mDNS host discovery failed", e)
-        emptyList()
+        // The detail goes to debug; the caller reports the failure itself, deduplicated across the
+        // retries that would otherwise repeat it forever.
+        JetWhaleLogger.d("jmDNS browse failed", e)
+        DiscoveryResult.Unavailable("the jmDNS browse failed (${e.message})")
     } finally {
         try {
             jmdns?.close()

--- a/jetwhale-agent-runtime/src/jvmMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.jvm.kt
+++ b/jetwhale-agent-runtime/src/jvmMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.jvm.kt
@@ -2,7 +2,6 @@ package com.kitakkun.jetwhale.agent.runtime
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.net.InetAddress
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceInfo
 
@@ -13,9 +12,12 @@ private const val SERVICE_TYPE_LOCAL = "$JETWHALE_SERVICE_TYPE.local."
  * resolved within the timeout window.
  */
 internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): DiscoveryResult = withContext(Dispatchers.IO) {
+    val address = primaryMulticastAddress()
+        ?: return@withContext DiscoveryResult.Unavailable("no multicast-capable network interface is available")
+
     var jmdns: JmDNS? = null
     try {
-        jmdns = JmDNS.create(InetAddress.getLocalHost())
+        jmdns = JmDNS.create(address)
         // Blocking browse: returns the services resolved within the timeout window.
         DiscoveryResult.Browsed(jmdns.list(SERVICE_TYPE_LOCAL, timeoutMillis).mapNotNull { it.toDiscoveredService() })
     } catch (e: Exception) {

--- a/jetwhale-agent-runtime/src/jvmMain/kotlin/com/kitakkun/jetwhale/agent/runtime/MulticastAddress.jvm.kt
+++ b/jetwhale-agent-runtime/src/jvmMain/kotlin/com/kitakkun/jetwhale/agent/runtime/MulticastAddress.jvm.kt
@@ -1,0 +1,46 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import java.net.DatagramSocket
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.NetworkInterface
+import java.util.Collections
+
+/** RFC 5737 documentation address: never routable, but enough for the kernel to pick a source address. */
+private const val ROUTE_PROBE_ADDRESS = "192.0.2.1"
+
+/**
+ * The address to speak mDNS on: the one the OS would use to reach the network, since that is where
+ * anything looking for this machine is.
+ *
+ * `InetAddress.getLocalHost()` is not it. On a machine whose hostname resolves to loopback — the
+ * default on macOS and common on Linux — it returns `127.0.0.1`, so the stack joins the multicast
+ * group on `lo0` alone and neither hears nor is heard by anything on the network.
+ *
+ * One address, not one per interface: jmDNS gives each stack its own identity, so two stacks on the
+ * same machine probe for the same name and declare a conflict against each other.
+ *
+ * @return null when the machine has no multicast-capable interface at all.
+ */
+internal fun primaryMulticastAddress(): Inet4Address? {
+    val candidates = multicastInterfaceAddresses()
+    val routed = routedSourceAddress()
+    return candidates.firstOrNull { it == routed } ?: candidates.firstOrNull()
+}
+
+/** Every IPv4 address mDNS can usefully be spoken on: up, multicast-capable, not loopback or a tunnel. */
+private fun multicastInterfaceAddresses(): List<Inet4Address> = Collections.list(NetworkInterface.getNetworkInterfaces())
+    .filter { it.isUp && !it.isLoopback && !it.isPointToPoint && it.supportsMulticast() }
+    .flatMap { Collections.list(it.inetAddresses) }
+    .filterIsInstance<Inet4Address>()
+
+/** The source address the OS would route from. Connecting a UDP socket sends nothing over the wire. */
+private fun routedSourceAddress(): InetAddress? = try {
+    DatagramSocket().use { socket ->
+        socket.connect(InetAddress.getByName(ROUTE_PROBE_ADDRESS), 9)
+        socket.localAddress
+    }
+} catch (e: Exception) {
+    JetWhaleLogger.d("Could not determine the routed source address", e)
+    null
+}

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
@@ -1,50 +1,54 @@
 package com.kitakkun.jetwhale.agent.runtime
 
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import kotlin.test.assertIs
 
 class ConnectionEndpointTest {
     private fun connection(
         configure: JetWhaleConnectionConfigurationScope.() -> Unit,
-    ): ResolvedConnectionTarget = JetWhaleConnectionConfiguration().apply(configure).resolveTarget()
+    ): EndpointResolver = JetWhaleConnectionConfiguration().apply(configure).endpointResolver()
+
+    private fun fixedEndpoint(
+        configure: JetWhaleConnectionConfigurationScope.() -> Unit,
+    ): ResolvedEndpoint = runBlocking { assertIs<FixedEndpointResolver>(connection(configure)).resolve() }
+
+    private fun mdns(
+        configure: JetWhaleConnectionConfigurationScope.() -> Unit,
+    ): MdnsEndpointResolver = assertIs<MdnsEndpointResolver>(connection(configure))
 
     @Test
     fun `an unconfigured connection targets the default host and port`() {
-        val target = connection { }
-
-        assertEquals("localhost", target.host)
-        assertEquals(8080, target.port)
-        assertNull(target.discovery)
+        assertEquals(ResolvedEndpoint("localhost", 8080), fixedEndpoint { })
     }
 
     @Suppress("DEPRECATION")
     @Test
-    fun `the deprecated host and port amount to the same target as a fixed endpoint`() {
-        val legacy = connection {
+    fun `the deprecated host and port amount to the same address as a fixed endpoint`() {
+        val legacy = fixedEndpoint {
             host = "192.168.3.26"
             port = 5443
         }
 
-        assertEquals(connection { endpoint = fixed("192.168.3.26", 5443) }, legacy)
+        assertEquals(fixedEndpoint { endpoint = fixed("192.168.3.26", 5443) }, legacy)
     }
 
     @Suppress("DEPRECATION")
     @Test
     fun `an assigned endpoint wins over the deprecated host and port`() {
-        val target = connection {
+        val resolved = fixedEndpoint {
             host = "ignored"
             port = 1
             endpoint = fixed("192.168.3.26", 5443)
         }
 
-        assertEquals("192.168.3.26", target.host)
-        assertEquals(5443, target.port)
+        assertEquals(ResolvedEndpoint("192.168.3.26", 5443), resolved)
     }
 
     @Test
-    fun `a discovered endpoint carries its filters and falls back to its fixed endpoint`() {
-        val target = connection {
+    fun `a discovered endpoint carries its filters and its fallback`() {
+        val resolver = mdns {
             endpoint = discovered(fallback = fixed("localhost", 5443)) {
                 matchHostName("build-machine")
                 allowAddress("192.168.3.26")
@@ -52,35 +56,34 @@ class ConnectionEndpointTest {
             }
         }
 
-        assertEquals("localhost", target.host)
-        assertEquals(5443, target.port)
-        assertEquals("build-machine", target.discovery?.hostName)
-        assertEquals(listOf("192.168.3.26", "192.168.3.27"), target.discovery?.addresses)
+        assertEquals(ResolvedEndpoint("localhost", 5443), resolver.fallback)
+        assertEquals("build-machine", resolver.discovery.hostName)
+        assertEquals(listOf("192.168.3.26", "192.168.3.27"), resolver.discovery.addresses)
     }
 
     @Test
     fun `a discovered endpoint without filters accepts any advertised host`() {
-        val target = connection { endpoint = discovered(fallback = fixed("localhost", 5443)) }
+        val resolver = mdns { endpoint = discovered(fallback = fixed("localhost", 5443)) }
 
-        assertNull(target.discovery?.hostName)
-        assertEquals(emptyList(), target.discovery?.addresses)
-        assertEquals(false, target.discovery?.hasFilter)
+        assertEquals(null, resolver.discovery.hostName)
+        assertEquals(emptyList(), resolver.discovery.addresses)
+        assertEquals(false, resolver.discovery.hasFilter)
     }
 
     @Test
     fun `ssl declared after the endpoint still uses wss`() {
-        val target = connection {
+        val resolver = mdns {
             endpoint = discovered(fallback = fixed("localhost", 5443))
             ssl { trustServerCertificate() }
         }
 
-        assertEquals(true, target.discovery?.useWss)
+        assertEquals(true, resolver.discovery.useWss)
     }
 
     @Test
     fun `an endpoint without ssl uses plain ws`() {
-        val target = connection { endpoint = discovered(fallback = fixed("localhost", 5080)) }
+        val resolver = mdns { endpoint = discovered(fallback = fixed("localhost", 5080)) }
 
-        assertEquals(false, target.discovery?.useWss)
+        assertEquals(false, resolver.discovery.useWss)
     }
 }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
@@ -1,0 +1,86 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ConnectionEndpointTest {
+    private fun connection(
+        configure: JetWhaleConnectionConfigurationScope.() -> Unit,
+    ): ResolvedConnectionTarget = JetWhaleConnectionConfiguration().apply(configure).resolveTarget()
+
+    @Test
+    fun `an unconfigured connection targets the default host and port`() {
+        val target = connection { }
+
+        assertEquals("localhost", target.host)
+        assertEquals(8080, target.port)
+        assertNull(target.discovery)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `the deprecated host and port amount to the same target as a fixed endpoint`() {
+        val legacy = connection {
+            host = "192.168.3.26"
+            port = 5443
+        }
+
+        assertEquals(connection { endpoint = fixed("192.168.3.26", 5443) }, legacy)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `an assigned endpoint wins over the deprecated host and port`() {
+        val target = connection {
+            host = "ignored"
+            port = 1
+            endpoint = fixed("192.168.3.26", 5443)
+        }
+
+        assertEquals("192.168.3.26", target.host)
+        assertEquals(5443, target.port)
+    }
+
+    @Test
+    fun `a discovered endpoint carries its filters and falls back to its fixed endpoint`() {
+        val target = connection {
+            endpoint = discovered(fallback = fixed("localhost", 5443)) {
+                matchHostName("build-machine")
+                allowAddress("192.168.3.26")
+                allowAddress("192.168.3.27")
+            }
+        }
+
+        assertEquals("localhost", target.host)
+        assertEquals(5443, target.port)
+        assertEquals("build-machine", target.discovery?.hostName)
+        assertEquals(listOf("192.168.3.26", "192.168.3.27"), target.discovery?.addresses)
+    }
+
+    @Test
+    fun `a discovered endpoint without filters accepts any advertised host`() {
+        val target = connection { endpoint = discovered(fallback = fixed("localhost", 5443)) }
+
+        assertNull(target.discovery?.hostName)
+        assertEquals(emptyList(), target.discovery?.addresses)
+        assertEquals(false, target.discovery?.hasFilter)
+    }
+
+    @Test
+    fun `ssl declared after the endpoint still selects the advertised wss port`() {
+        val target = connection {
+            endpoint = discovered(fallback = fixed("localhost", 5443))
+            ssl { trustServerCertificate() }
+        }
+
+        assertEquals(true, target.discovery?.preferWss)
+    }
+
+    @Test
+    fun `an endpoint without ssl selects the advertised plain-ws port`() {
+        val target = connection { endpoint = discovered(fallback = fixed("localhost", 5080)) }
+
+        assertEquals(false, target.discovery?.preferWss)
+    }
+}

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
@@ -50,14 +50,16 @@ class ConnectionEndpointTest {
     fun `a discovered endpoint carries its filters and its fallback`() {
         val resolver = mdns {
             endpoint = discovered(fallback = fixed("localhost", 5443)) {
-                matchHostName("build-machine")
+                allowHostName("build-machine")
+                allowHostName("spare-machine")
                 allowAddress("192.168.3.26")
                 allowAddress("192.168.3.27")
             }
         }
 
         assertEquals(ResolvedEndpoint("localhost", 5443), resolver.fallback)
-        assertEquals("build-machine", resolver.discovery.hostName)
+        // Both allowlists accumulate, so neither call silently drops the one before it.
+        assertEquals(listOf("build-machine", "spare-machine"), resolver.discovery.hostNames)
         assertEquals(listOf("192.168.3.26", "192.168.3.27"), resolver.discovery.addresses)
     }
 
@@ -65,7 +67,7 @@ class ConnectionEndpointTest {
     fun `a discovered endpoint without filters accepts any advertised host`() {
         val resolver = mdns { endpoint = discovered(fallback = fixed("localhost", 5443)) }
 
-        assertEquals(null, resolver.discovery.hostName)
+        assertEquals(emptyList(), resolver.discovery.hostNames)
         assertEquals(emptyList(), resolver.discovery.addresses)
         assertEquals(false, resolver.discovery.hasFilter)
     }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
@@ -68,19 +68,19 @@ class ConnectionEndpointTest {
     }
 
     @Test
-    fun `ssl declared after the endpoint still selects the advertised wss port`() {
+    fun `ssl declared after the endpoint still uses wss`() {
         val target = connection {
             endpoint = discovered(fallback = fixed("localhost", 5443))
             ssl { trustServerCertificate() }
         }
 
-        assertEquals(true, target.discovery?.preferWss)
+        assertEquals(true, target.discovery?.useWss)
     }
 
     @Test
-    fun `an endpoint without ssl selects the advertised plain-ws port`() {
+    fun `an endpoint without ssl uses plain ws`() {
         val target = connection { endpoint = discovered(fallback = fixed("localhost", 5080)) }
 
-        assertEquals(false, target.discovery?.preferWss)
+        assertEquals(false, target.discovery?.useWss)
     }
 }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscoveryJvmTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscoveryJvmTest.kt
@@ -1,0 +1,52 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import kotlinx.coroutines.runBlocking
+import java.net.InetAddress
+import javax.jmdns.JmDNS
+import javax.jmdns.ServiceInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HostDiscoveryJvmTest {
+    @Test
+    fun `browse resolves a jmDNS-advertised JetWhale host round-trip`() = runBlocking {
+        val instanceName = "jetwhale-test-${System.nanoTime()}"
+        var jmdns: JmDNS? = null
+        try {
+            jmdns = JmDNS.create(InetAddress.getLocalHost())
+            val serviceInfo = ServiceInfo.create(
+                "_jetwhale._tcp.local.",
+                instanceName,
+                8080,
+                0,
+                0,
+                mapOf(
+                    "v" to "1",
+                    TXT_KEY_WS_PORT to "8080",
+                    TXT_KEY_WSS_PORT to "8443",
+                    TXT_KEY_HOST_NAME to instanceName,
+                ),
+            )
+            jmdns.registerService(serviceInfo)
+
+            val discovered = browseJetWhaleServices(timeoutMillis = 6_000)
+            val match = discovered.firstOrNull { it.instanceName.contains(instanceName) }
+
+            if (match == null) {
+                // CI machines sometimes block multicast; skip gracefully rather than failing.
+                println("Skipping round-trip assertion: no mDNS response (multicast likely unavailable)")
+                return@runBlocking
+            }
+
+            assertEquals(8080, match.wsPort)
+            assertEquals(8443, match.wssPort)
+            assertEquals(instanceName, match.advertisedHostName)
+        } catch (e: Exception) {
+            // Environment lacks a usable multicast stack; treat as a skipped test.
+            println("Skipping mDNS round-trip test: ${e.message}")
+        } finally {
+            jmdns?.unregisterAllServices()
+            jmdns?.close()
+        }
+    }
+}

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscoveryJvmTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscoveryJvmTest.kt
@@ -30,7 +30,9 @@ class HostDiscoveryJvmTest {
             jmdns.registerService(serviceInfo)
 
             val discovered = browseJetWhaleServices(timeoutMillis = 6_000)
-            val match = discovered.firstOrNull { it.instanceName.contains(instanceName) }
+            val match = (discovered as? DiscoveryResult.Browsed)
+                ?.services
+                ?.firstOrNull { it.instanceName.contains(instanceName) }
 
             if (match == null) {
                 // CI machines sometimes block multicast; skip gracefully rather than failing.

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscoveryJvmTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscoveryJvmTest.kt
@@ -1,7 +1,6 @@
 package com.kitakkun.jetwhale.agent.runtime
 
 import kotlinx.coroutines.runBlocking
-import java.net.InetAddress
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceInfo
 import kotlin.test.Test
@@ -11,9 +10,17 @@ class HostDiscoveryJvmTest {
     @Test
     fun `browse resolves a jmDNS-advertised JetWhale host round-trip`() = runBlocking {
         val instanceName = "jetwhale-test-${System.nanoTime()}"
+        // Advertise on the same kind of address the browse listens on. Binding this to
+        // InetAddress.getLocalHost() would put the service on loopback wherever the hostname resolves
+        // there, so the assertion below would be skipped forever instead of ever running.
+        val address = primaryMulticastAddress()
+        if (address == null) {
+            println("Skipping mDNS round-trip test: no multicast-capable interface")
+            return@runBlocking
+        }
         var jmdns: JmDNS? = null
         try {
-            jmdns = JmDNS.create(InetAddress.getLocalHost())
+            jmdns = JmDNS.create(address)
             val serviceInfo = ServiceInfo.create(
                 "_jetwhale._tcp.local.",
                 instanceName,

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
@@ -1,0 +1,90 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
+import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggeeEvent
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.util.Collections
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val RESOLUTION_TIMEOUT_MILLIS = 10_000L
+
+/** A socket client that never connects, so the service keeps retrying and keeps re-resolving. */
+private class UnreachableSocketClient : JetWhaleSocketClient {
+    val attemptedEndpoints: MutableList<ResolvedEndpoint> = Collections.synchronizedList(mutableListOf())
+    val secondAttempt: CompletableDeferred<Unit> = CompletableDeferred()
+
+    override suspend fun sendDebuggeeEvent(event: JetWhaleDebuggeeEvent) = Unit
+
+    override suspend fun openConnection(host: String, port: Int): JetWhaleConnection {
+        attemptedEndpoints.add(ResolvedEndpoint(host, port))
+        if (attemptedEndpoints.size >= 2) secondAttempt.complete(Unit)
+        throw IllegalStateException("unreachable")
+    }
+
+    override suspend fun closeConnection() = Unit
+}
+
+/** Hands out each address in turn, standing on the last one once they run out. */
+private class ScriptedEndpointResolver(private val script: List<ResolvedEndpoint>) : EndpointResolver {
+    val calls: Channel<Unit> = Channel(Channel.UNLIMITED)
+    private var index = 0
+
+    override suspend fun resolve(): ResolvedEndpoint {
+        calls.send(Unit)
+        return script[minOf(index++, script.lastIndex)]
+    }
+}
+
+@OptIn(InternalJetWhaleApi::class)
+class MessagingServiceResolutionTest {
+    private fun service(socketClient: JetWhaleSocketClient, resolver: EndpointResolver) = DefaultJetWhaleMessagingService(
+        socketClient = socketClient,
+        pluginService = JetWhaleAgentPluginService(plugins = emptyList()),
+    ).also { it.startService(resolver) }
+
+    @Test
+    fun `the address is resolved again for every connection attempt`() = runBlocking {
+        val socketClient = UnreachableSocketClient()
+        val resolver = ScriptedEndpointResolver(listOf(ResolvedEndpoint("first", 1), ResolvedEndpoint("second", 2)))
+        val service = service(socketClient, resolver)
+
+        try {
+            withTimeout(RESOLUTION_TIMEOUT_MILLIS) {
+                resolver.calls.receive()
+                resolver.calls.receive()
+            }
+        } finally {
+            service.stopService()
+        }
+
+        // A resolver consulted once per session would have produced "first" twice.
+        assertTrue(socketClient.attemptedEndpoints.size >= 2, "expected a retry, got ${socketClient.attemptedEndpoints}")
+        assertEquals(ResolvedEndpoint("first", 1), socketClient.attemptedEndpoints[0])
+        assertEquals(ResolvedEndpoint("second", 2), socketClient.attemptedEndpoints[1])
+    }
+
+    @Test
+    fun `an address that only becomes reachable later is still dialled`() = runBlocking {
+        // The host was not up at startup, so the first resolution yields the unreachable fallback and a
+        // later one yields the host that has since appeared. Without per-attempt resolution the session
+        // would stay pinned to the fallback for good.
+        val socketClient = UnreachableSocketClient()
+        val resolver = ScriptedEndpointResolver(
+            listOf(ResolvedEndpoint("localhost", 5443), ResolvedEndpoint("192.168.3.26", 5443)),
+        )
+        val service = service(socketClient, resolver)
+
+        try {
+            withTimeout(RESOLUTION_TIMEOUT_MILLIS) { socketClient.secondAttempt.await() }
+        } finally {
+            service.stopService()
+        }
+
+        assertEquals(ResolvedEndpoint("192.168.3.26", 5443), socketClient.attemptedEndpoints[1])
+    }
+}

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
@@ -3,7 +3,6 @@ package com.kitakkun.jetwhale.agent.runtime
 import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
 import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggeeEvent
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.util.Collections
@@ -31,13 +30,9 @@ private class UnreachableSocketClient : JetWhaleSocketClient {
 
 /** Hands out each address in turn, standing on the last one once they run out. */
 private class ScriptedEndpointResolver(private val script: List<ResolvedEndpoint>) : EndpointResolver {
-    val calls: Channel<Unit> = Channel(Channel.UNLIMITED)
     private var index = 0
 
-    override suspend fun resolve(): ResolvedEndpoint {
-        calls.send(Unit)
-        return script[minOf(index++, script.lastIndex)]
-    }
+    override suspend fun resolve(): ResolvedEndpoint = script[minOf(index++, script.lastIndex)]
 }
 
 @OptIn(InternalJetWhaleApi::class)
@@ -54,10 +49,10 @@ class MessagingServiceResolutionTest {
         val service = service(socketClient, resolver)
 
         try {
-            withTimeout(RESOLUTION_TIMEOUT_MILLIS) {
-                resolver.calls.receive()
-                resolver.calls.receive()
-            }
+            // Wait for the second *attempt*, not the second resolution: resolve() returns before the
+            // address it produced has been dialled, so waiting on the resolver would leave a window
+            // where only one attempt has been recorded.
+            withTimeout(RESOLUTION_TIMEOUT_MILLIS) { socketClient.secondAttempt.await() }
         } finally {
             service.stopService()
         }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceStopTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceStopTest.kt
@@ -74,7 +74,7 @@ class MessagingServiceStopTest {
     ): JetWhaleMessagingService = DefaultJetWhaleMessagingService(
         socketClient = socketClient,
         pluginService = JetWhaleAgentPluginService(plugins = listOf(plugin)),
-    ).also { it.startService(host = "localhost", port = 1, discovery = null) }
+    ).also { it.startService(FixedEndpointResolver(ResolvedEndpoint(host = "localhost", port = 1))) }
 
     @Test
     fun `stopService closes the socket so the host sees the session go away`() = runBlocking {

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceStopTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceStopTest.kt
@@ -74,7 +74,7 @@ class MessagingServiceStopTest {
     ): JetWhaleMessagingService = DefaultJetWhaleMessagingService(
         socketClient = socketClient,
         pluginService = JetWhaleAgentPluginService(plugins = listOf(plugin)),
-    ).also { it.startService(host = "localhost", port = 1) }
+    ).also { it.startService(host = "localhost", port = 1, discovery = null) }
 
     @Test
     fun `stopService closes the socket so the host sees the session go away`() = runBlocking {

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/SelectHostTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/SelectHostTest.kt
@@ -1,0 +1,97 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+private fun service(
+    hostName: String,
+    address: String,
+    wsPort: Int?,
+    wssPort: Int?,
+) = DiscoveredService(
+    instanceName = hostName,
+    advertisedHostName = hostName,
+    address = address,
+    wsPort = wsPort,
+    wssPort = wssPort,
+)
+
+private fun discovery(
+    hostName: String? = null,
+    addresses: List<String> = emptyList(),
+    useWss: Boolean = false,
+) = HostDiscoveryConfig(hostName = hostName, addresses = addresses, useWss = useWss)
+
+class SelectHostTest {
+    private val plainOnly = service("plain-host", "192.168.3.26", wsPort = 5080, wssPort = null)
+    private val bothPorts = service("secure-host", "192.168.3.27", wsPort = 5080, wssPort = 5443)
+
+    @Test
+    fun `no advertised host means nothing to select`() {
+        assertNull(selectHost(emptyList(), discovery()))
+    }
+
+    @Test
+    fun `a plain connection takes the advertised ws port`() {
+        assertEquals(5080, selectHost(listOf(bothPorts), discovery(useWss = false))?.port)
+    }
+
+    @Test
+    fun `an ssl connection takes the advertised wss port`() {
+        assertEquals(5443, selectHost(listOf(bothPorts), discovery(useWss = true))?.port)
+    }
+
+    @Test
+    fun `an ssl connection skips a host that advertises no wss port`() {
+        // Dialling wss at the plain-ws port would fail every handshake, so the host is not a candidate
+        // at all rather than a candidate reached on the wrong port.
+        assertNull(selectHost(listOf(plainOnly), discovery(useWss = true)))
+    }
+
+    @Test
+    fun `an ssl connection passes over a plain host to reach one that serves wss`() {
+        val selected = selectHost(listOf(plainOnly, bothPorts), discovery(useWss = true))
+
+        assertEquals("192.168.3.27", selected?.service?.address)
+        assertEquals(5443, selected?.port)
+    }
+
+    @Test
+    fun `hostName is matched case-insensitively`() {
+        assertEquals("192.168.3.26", selectHost(listOf(plainOnly, bothPorts), discovery(hostName = "PLAIN-HOST"))?.service?.address)
+    }
+
+    @Test
+    fun `a hostName that matches nothing selects nothing`() {
+        assertNull(selectHost(listOf(plainOnly, bothPorts), discovery(hostName = "absent-host")))
+    }
+
+    @Test
+    fun `the address allowlist admits only hosts resolving to one of its entries`() {
+        assertEquals("192.168.3.27", selectHost(listOf(plainOnly, bothPorts), discovery(addresses = listOf("192.168.3.27")))?.service?.address)
+        assertNull(selectHost(listOf(plainOnly, bothPorts), discovery(addresses = listOf("10.0.0.1"))))
+    }
+
+    @Test
+    fun `hostName and address must both match when both are set`() {
+        assertNull(selectHost(listOf(plainOnly), discovery(hostName = "plain-host", addresses = listOf("10.0.0.1"))))
+        assertEquals(
+            "192.168.3.26",
+            selectHost(listOf(plainOnly), discovery(hostName = "plain-host", addresses = listOf("192.168.3.26")))?.service?.address,
+        )
+    }
+
+    @Test
+    fun `the instance name stands in when no hostName is advertised`() {
+        val unnamed = DiscoveredService(
+            instanceName = "fallback-name",
+            advertisedHostName = null,
+            address = "192.168.3.28",
+            wsPort = 5080,
+            wssPort = null,
+        )
+
+        assertEquals("192.168.3.28", selectHost(listOf(unnamed), discovery(hostName = "fallback-name"))?.service?.address)
+    }
+}

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/SelectHostTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/SelectHostTest.kt
@@ -18,10 +18,10 @@ private fun service(
 )
 
 private fun discovery(
-    hostName: String? = null,
+    hostNames: List<String> = emptyList(),
     addresses: List<String> = emptyList(),
     useWss: Boolean = false,
-) = HostDiscoveryConfig(hostName = hostName, addresses = addresses, useWss = useWss)
+) = HostDiscoveryConfig(hostNames = hostNames, addresses = addresses, useWss = useWss)
 
 class SelectHostTest {
     private val plainOnly = service("plain-host", "192.168.3.26", wsPort = 5080, wssPort = null)
@@ -59,12 +59,19 @@ class SelectHostTest {
 
     @Test
     fun `hostName is matched case-insensitively`() {
-        assertEquals("192.168.3.26", selectHost(listOf(plainOnly, bothPorts), discovery(hostName = "PLAIN-HOST"))?.service?.address)
+        assertEquals("192.168.3.26", selectHost(listOf(plainOnly, bothPorts), discovery(hostNames = listOf("PLAIN-HOST")))?.service?.address)
     }
 
     @Test
     fun `a hostName that matches nothing selects nothing`() {
-        assertNull(selectHost(listOf(plainOnly, bothPorts), discovery(hostName = "absent-host")))
+        assertNull(selectHost(listOf(plainOnly, bothPorts), discovery(hostNames = listOf("absent-host"))))
+    }
+
+    @Test
+    fun `the hostName allowlist admits a host matching any of its entries`() {
+        val allowed = discovery(hostNames = listOf("absent-host", "secure-host"))
+
+        assertEquals("192.168.3.27", selectHost(listOf(plainOnly, bothPorts), allowed)?.service?.address)
     }
 
     @Test
@@ -75,10 +82,10 @@ class SelectHostTest {
 
     @Test
     fun `hostName and address must both match when both are set`() {
-        assertNull(selectHost(listOf(plainOnly), discovery(hostName = "plain-host", addresses = listOf("10.0.0.1"))))
+        assertNull(selectHost(listOf(plainOnly), discovery(hostNames = listOf("plain-host"), addresses = listOf("10.0.0.1"))))
         assertEquals(
             "192.168.3.26",
-            selectHost(listOf(plainOnly), discovery(hostName = "plain-host", addresses = listOf("192.168.3.26")))?.service?.address,
+            selectHost(listOf(plainOnly), discovery(hostNames = listOf("plain-host"), addresses = listOf("192.168.3.26")))?.service?.address,
         )
     }
 
@@ -92,6 +99,6 @@ class SelectHostTest {
             wssPort = null,
         )
 
-        assertEquals("192.168.3.28", selectHost(listOf(unnamed), discovery(hostName = "fallback-name"))?.service?.address)
+        assertEquals("192.168.3.28", selectHost(listOf(unnamed), discovery(hostNames = listOf("fallback-name")))?.service?.address)
     }
 }

--- a/jetwhale-agent-runtime/src/linuxMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.linux.kt
+++ b/jetwhale-agent-runtime/src/linuxMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.linux.kt
@@ -1,0 +1,10 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+/**
+ * mDNS host discovery is not implemented on Linux. Returns an empty list so the caller falls back to
+ * the configured host.
+ */
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> {
+    JetWhaleLogger.w("mDNS host discovery is not supported on this platform (Linux); using the configured host")
+    return emptyList()
+}

--- a/jetwhale-agent-runtime/src/linuxMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.linux.kt
+++ b/jetwhale-agent-runtime/src/linuxMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.linux.kt
@@ -1,10 +1,4 @@
 package com.kitakkun.jetwhale.agent.runtime
 
-/**
- * mDNS host discovery is not implemented on Linux. Returns an empty list so the caller falls back to
- * the configured host.
- */
-internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> {
-    JetWhaleLogger.w("mDNS host discovery is not supported on this platform (Linux); using the configured host")
-    return emptyList()
-}
+/** mDNS host discovery is not implemented on Linux, so the caller uses the configured host. */
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): DiscoveryResult = DiscoveryResult.Unavailable("Linux has no mDNS backend")

--- a/jetwhale-agent-runtime/src/mingwMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.mingw.kt
+++ b/jetwhale-agent-runtime/src/mingwMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.mingw.kt
@@ -1,0 +1,10 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+/**
+ * mDNS host discovery is not implemented on Windows. Returns an empty list so the caller falls back
+ * to the configured host.
+ */
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> {
+    JetWhaleLogger.w("mDNS host discovery is not supported on this platform (Windows); using the configured host")
+    return emptyList()
+}

--- a/jetwhale-agent-runtime/src/mingwMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.mingw.kt
+++ b/jetwhale-agent-runtime/src/mingwMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.mingw.kt
@@ -1,10 +1,4 @@
 package com.kitakkun.jetwhale.agent.runtime
 
-/**
- * mDNS host discovery is not implemented on Windows. Returns an empty list so the caller falls back
- * to the configured host.
- */
-internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> {
-    JetWhaleLogger.w("mDNS host discovery is not supported on this platform (Windows); using the configured host")
-    return emptyList()
-}
+/** mDNS host discovery is not implemented on Windows, so the caller uses the configured host. */
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): DiscoveryResult = DiscoveryResult.Unavailable("Windows has no mDNS backend")

--- a/jetwhale-agent-runtime/src/webMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.web.kt
+++ b/jetwhale-agent-runtime/src/webMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.web.kt
@@ -1,0 +1,10 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+/**
+ * mDNS host discovery is not available on JS/Wasm (browser sandbox has no multicast access). Returns
+ * an empty list so the caller falls back to the configured host.
+ */
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> {
+    JetWhaleLogger.w("mDNS host discovery is not supported on this platform (JS/Wasm); using the configured host")
+    return emptyList()
+}

--- a/jetwhale-agent-runtime/src/webMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.web.kt
+++ b/jetwhale-agent-runtime/src/webMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.web.kt
@@ -1,10 +1,4 @@
 package com.kitakkun.jetwhale.agent.runtime
 
-/**
- * mDNS host discovery is not available on JS/Wasm (browser sandbox has no multicast access). Returns
- * an empty list so the caller falls back to the configured host.
- */
-internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): List<DiscoveredService> {
-    JetWhaleLogger.w("mDNS host discovery is not supported on this platform (JS/Wasm); using the configured host")
-    return emptyList()
-}
+/** mDNS host discovery is out of reach on JS/Wasm, so the caller uses the configured host. */
+internal actual suspend fun browseJetWhaleServices(timeoutMillis: Long): DiscoveryResult = DiscoveryResult.Unavailable("the browser sandbox has no multicast access")

--- a/jetwhale-host/core/data/build.gradle.kts
+++ b/jetwhale-host/core/data/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.logbackClassic)
     implementation(libs.bouncyCastleBcprov)
     implementation(libs.bouncyCastleBcpkix)
+    implementation(libs.jmdns)
     implementation(libs.kotlinTest)
     testImplementation(libs.ktorClientMock)
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/DefaultHostDiscoveryAdvertiser.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/DefaultHostDiscoveryAdvertiser.kt
@@ -59,7 +59,10 @@ class DefaultHostDiscoveryAdvertiser(
     override fun stop() {
         observeJob?.cancel()
         observeJob = null
-        unregister()
+        advertisedPorts = null
+        // Fully release the mDNS stack (not just unregister) so sockets/threads do not leak across
+        // debug server restarts. JmDNS.close() can block, so run it off the caller's thread.
+        coroutineScope.launch { registrar.close() }
     }
 
     private fun advertise(wsPort: Int, wssPort: Int?) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/DefaultHostDiscoveryAdvertiser.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/DefaultHostDiscoveryAdvertiser.kt
@@ -1,0 +1,92 @@
+package com.kitakkun.jetwhale.host.data.discovery
+
+import com.kitakkun.jetwhale.host.model.DebugServerStatusProvider
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
+import com.kitakkun.jetwhale.host.model.HostDiscoveryAdvertiser
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import java.net.InetAddress
+
+/**
+ * A [HostDiscoveryAdvertiser] that observes the debug server status and keeps a `_jetwhale._tcp`
+ * service registered (via [MdnsRegistrar]) while the server is running, re-registering whenever the
+ * advertised ports change.
+ *
+ * The service is registered with the plain-ws port as its primary port and carries the ws/wss ports
+ * in TXT records so an agent can pick the connector matching its transport (wss when configured with
+ * `ssl {}`, else ws).
+ */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+@Inject
+class DefaultHostDiscoveryAdvertiser(
+    private val statusProvider: DebugServerStatusProvider,
+    private val registrar: MdnsRegistrar,
+) : HostDiscoveryAdvertiser {
+    private val logger = LoggerFactory.getLogger(DefaultHostDiscoveryAdvertiser::class.java)
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+
+    private var observeJob: Job? = null
+
+    // The ports the currently registered service was advertised with, used to skip redundant
+    // re-registration when the status flow re-emits an equivalent Started state.
+    private var advertisedPorts: Pair<Int, Int?>? = null
+
+    override fun start() {
+        if (observeJob != null) return
+        observeJob = coroutineScope.launch {
+            statusProvider.statusFlow.collect { status ->
+                when (status) {
+                    is DebugWebSocketServerStatus.Started -> advertise(status.port, status.wssPort)
+
+                    is DebugWebSocketServerStatus.Stopped,
+                    is DebugWebSocketServerStatus.Error,
+                    -> unregister()
+
+                    else -> Unit
+                }
+            }
+        }
+    }
+
+    override fun stop() {
+        observeJob?.cancel()
+        observeJob = null
+        unregister()
+    }
+
+    private fun advertise(wsPort: Int, wssPort: Int?) {
+        if (advertisedPorts == (wsPort to wssPort)) return
+        registrar.register(instanceName(), wsPort, wssPort)
+        advertisedPorts = wsPort to wssPort
+    }
+
+    private fun unregister() {
+        if (advertisedPorts == null) return
+        registrar.unregister()
+        advertisedPorts = null
+    }
+
+    /**
+     * The advertised instance name. The machine hostname keeps it recognizable to a developer picking
+     * a host from multiple advertised machines and lets the agent's `hostName` filter target it; it
+     * falls back to a constant when the hostname is unavailable.
+     */
+    private fun instanceName(): String = try {
+        InetAddress.getLocalHost().hostName
+    } catch (e: Exception) {
+        logger.debug("Could not resolve local hostname for mDNS instance name; using default", e)
+        DEFAULT_INSTANCE_NAME
+    }
+
+    private companion object {
+        const val DEFAULT_INSTANCE_NAME = "JetWhale"
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/DefaultHostDiscoveryAdvertiser.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/DefaultHostDiscoveryAdvertiser.kt
@@ -81,9 +81,15 @@ class DefaultHostDiscoveryAdvertiser(
      * The advertised instance name. The machine hostname keeps it recognizable to a developer picking
      * a host from multiple advertised machines and lets the agent's `hostName` filter target it; it
      * falls back to a constant when the hostname is unavailable.
+     *
+     * Only the first label is used. A DNS-SD instance name is a single label, and the local hostname
+     * is often qualified — `getLocalHost().hostName` returns `machine.local` on macOS — so keeping the
+     * domain would embed an unescaped dot. jmDNS reads such a name back happily, but strict responders
+     * do not: Apple's `mDNSResponder` drops it, which silently hides the host from exactly the iOS and
+     * Android agents discovery exists to serve.
      */
     private fun instanceName(): String = try {
-        InetAddress.getLocalHost().hostName
+        InetAddress.getLocalHost().hostName.substringBefore('.').ifEmpty { DEFAULT_INSTANCE_NAME }
     } catch (e: Exception) {
         logger.debug("Could not resolve local hostname for mDNS instance name; using default", e)
         DEFAULT_INSTANCE_NAME

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/MdnsRegistrar.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/MdnsRegistrar.kt
@@ -20,8 +20,15 @@ interface MdnsRegistrar {
      */
     fun register(instanceName: String, wsPort: Int, wssPort: Int?)
 
-    /** Unregisters the currently registered service, if any. */
+    /** Unregisters the currently registered service, if any, keeping the stack alive for re-use. */
     fun unregister()
+
+    /**
+     * Unregisters and releases the underlying mDNS stack (sockets/threads). Idempotent. A subsequent
+     * [register] transparently recreates the stack. May block, so callers should invoke it off any
+     * latency-sensitive thread.
+     */
+    fun close()
 }
 
 /** jmDNS-backed [MdnsRegistrar]. The [JmDNS] instance is created lazily on the first registration. */
@@ -67,6 +74,18 @@ class JmDnsRegistrar : MdnsRegistrar {
             }
         }
         registeredService = null
+    }
+
+    override fun close() {
+        unregister()
+        // Idempotent: once closed, jmdns is null and a later register() recreates it on demand.
+        val instance = jmdns ?: return
+        jmdns = null
+        try {
+            instance.close()
+        } catch (e: Exception) {
+            logger.warn("Failed to close jmDNS", e)
+        }
     }
 
     companion object {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/MdnsRegistrar.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/MdnsRegistrar.kt
@@ -1,0 +1,80 @@
+package com.kitakkun.jetwhale.host.data.discovery
+
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import org.slf4j.LoggerFactory
+import java.net.InetAddress
+import javax.jmdns.JmDNS
+import javax.jmdns.ServiceInfo
+
+/**
+ * A thin seam over the mDNS/DNS-SD stack so the advertising logic (status observation, port tracking)
+ * can be unit-tested without a real multicast network.
+ */
+interface MdnsRegistrar {
+    /**
+     * Registers (or re-registers) the `_jetwhale._tcp.local.` service with the given ports. Replaces
+     * any previously registered service.
+     */
+    fun register(instanceName: String, wsPort: Int, wssPort: Int?)
+
+    /** Unregisters the currently registered service, if any. */
+    fun unregister()
+}
+
+/** jmDNS-backed [MdnsRegistrar]. The [JmDNS] instance is created lazily on the first registration. */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+@Inject
+class JmDnsRegistrar : MdnsRegistrar {
+    private val logger = LoggerFactory.getLogger(JmDnsRegistrar::class.java)
+
+    private var jmdns: JmDNS? = null
+    private var registeredService: ServiceInfo? = null
+
+    override fun register(instanceName: String, wsPort: Int, wssPort: Int?) {
+        unregister()
+        try {
+            val instance = jmdns ?: JmDNS.create(InetAddress.getLocalHost()).also { jmdns = it }
+            val props = buildMap {
+                put(TXT_KEY_PROTOCOL_VERSION, PROTOCOL_VERSION)
+                put(TXT_KEY_WS_PORT, wsPort.toString())
+                if (wssPort != null) put(TXT_KEY_WSS_PORT, wssPort.toString())
+                // Carry the hostname in a TXT record too: mDNS may uniquify the instance name on
+                // collision (e.g. "name (2)"), but agent-side hostName filtering needs the stable
+                // raw hostname.
+                put(TXT_KEY_HOST_NAME, instanceName)
+            }
+            val serviceInfo = ServiceInfo.create(SERVICE_TYPE, instanceName, wsPort, 0, 0, props)
+            instance.registerService(serviceInfo)
+            registeredService = serviceInfo
+            logger.info("Advertising JetWhale host over mDNS: $SERVICE_TYPE ws=$wsPort wss=$wssPort")
+        } catch (e: Exception) {
+            // mDNS advertising is a convenience; a failure (e.g. multicast blocked) must not stop the
+            // debug server. Explicit host/port configuration remains the fallback for agents.
+            logger.warn("Failed to advertise JetWhale host over mDNS; agents must use an explicit host", e)
+        }
+    }
+
+    override fun unregister() {
+        registeredService?.let { service ->
+            try {
+                jmdns?.unregisterService(service)
+            } catch (e: Exception) {
+                logger.warn("Failed to unregister JetWhale mDNS service", e)
+            }
+        }
+        registeredService = null
+    }
+
+    companion object {
+        const val SERVICE_TYPE: String = "_jetwhale._tcp.local."
+        const val TXT_KEY_PROTOCOL_VERSION: String = "v"
+        const val PROTOCOL_VERSION: String = "1"
+        const val TXT_KEY_WS_PORT: String = "wsPort"
+        const val TXT_KEY_WSS_PORT: String = "wssPort"
+        const val TXT_KEY_HOST_NAME: String = "hostName"
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/MdnsRegistrar.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/discovery/MdnsRegistrar.kt
@@ -5,9 +5,52 @@ import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import org.slf4j.LoggerFactory
+import java.net.DatagramSocket
+import java.net.Inet4Address
 import java.net.InetAddress
+import java.net.NetworkInterface
+import java.util.Collections
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceInfo
+
+/** RFC 5737 documentation address: never routable, but enough for the kernel to pick a source address. */
+private const val ROUTE_PROBE_ADDRESS = "192.0.2.1"
+
+/**
+ * The address to advertise on: the one the OS would use to reach the network, since that is where the
+ * devices looking for this host are.
+ *
+ * `InetAddress.getLocalHost()` is not it. On a machine whose hostname resolves to loopback — the
+ * default on macOS and common on Linux — it returns `127.0.0.1`, so the service is announced on `lo0`
+ * and advertises `127.0.0.1` as its address: invisible to the network, and useless to anything that
+ * did see it.
+ *
+ * One address, not one per interface: jmDNS gives each stack its own identity, so two stacks on the
+ * same machine probe for the same instance name and declare a conflict against each other.
+ *
+ * @return null when the machine has no multicast-capable interface at all.
+ */
+internal fun primaryMulticastAddress(): Inet4Address? {
+    val candidates = multicastInterfaceAddresses()
+    val routed = routedSourceAddress()
+    return candidates.firstOrNull { it == routed } ?: candidates.firstOrNull()
+}
+
+/** Every IPv4 address mDNS can usefully be spoken on: up, multicast-capable, not loopback or a tunnel. */
+private fun multicastInterfaceAddresses(): List<Inet4Address> = Collections.list(NetworkInterface.getNetworkInterfaces())
+    .filter { it.isUp && !it.isLoopback && !it.isPointToPoint && it.supportsMulticast() }
+    .flatMap { Collections.list(it.inetAddresses) }
+    .filterIsInstance<Inet4Address>()
+
+/** The source address the OS would route from. Connecting a UDP socket sends nothing over the wire. */
+private fun routedSourceAddress(): InetAddress? = try {
+    DatagramSocket().use { socket ->
+        socket.connect(InetAddress.getByName(ROUTE_PROBE_ADDRESS), 9)
+        socket.localAddress
+    }
+} catch (e: Exception) {
+    null
+}
 
 /**
  * A thin seam over the mDNS/DNS-SD stack so the advertising logic (status observation, port tracking)
@@ -31,7 +74,7 @@ interface MdnsRegistrar {
     fun close()
 }
 
-/** jmDNS-backed [MdnsRegistrar]. The [JmDNS] instance is created lazily on the first registration. */
+/** jmDNS-backed [MdnsRegistrar]. The [JmDNS] stacks are created lazily on the first registration. */
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 @Inject
@@ -44,7 +87,12 @@ class JmDnsRegistrar : MdnsRegistrar {
     override fun register(instanceName: String, wsPort: Int, wssPort: Int?) {
         unregister()
         try {
-            val instance = jmdns ?: JmDNS.create(InetAddress.getLocalHost()).also { jmdns = it }
+            val address = primaryMulticastAddress()
+            if (address == null) {
+                logger.warn("No multicast-capable network interface to advertise on; agents must use an explicit host")
+                return
+            }
+            val instance = jmdns ?: JmDNS.create(address).also { jmdns = it }
             val props = buildMap {
                 put(TXT_KEY_PROTOCOL_VERSION, PROTOCOL_VERSION)
                 put(TXT_KEY_WS_PORT, wsPort.toString())
@@ -57,7 +105,9 @@ class JmDnsRegistrar : MdnsRegistrar {
             val serviceInfo = ServiceInfo.create(SERVICE_TYPE, instanceName, wsPort, 0, 0, props)
             instance.registerService(serviceInfo)
             registeredService = serviceInfo
-            logger.info("Advertising JetWhale host over mDNS: $SERVICE_TYPE ws=$wsPort wss=$wssPort")
+            logger.info(
+                "Advertising JetWhale host over mDNS: $SERVICE_TYPE ws=$wsPort wss=$wssPort on ${address.hostAddress}",
+            )
         } catch (e: Exception) {
             // mDNS advertising is a convenience; a failure (e.g. multicast blocked) must not stop the
             // debug server. Explicit host/port configuration remains the fallback for agents.

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultDebugWebSocketServer.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultDebugWebSocketServer.kt
@@ -5,6 +5,7 @@ import com.kitakkun.jetwhale.host.model.DebugSessionRepository
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
 import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.HostDiscoveryAdvertiser
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.model.PluginReconciliationEvent
 import com.kitakkun.jetwhale.host.model.PluginSessionReconciliationService
@@ -32,6 +33,7 @@ class DefaultDebugWebSocketServer(
     private val settingsRepository: DebuggerSettingsRepository,
     private val reconciliationService: PluginSessionReconciliationService,
     private val ktorWebSocketServer: KtorWebSocketServer,
+    private val hostDiscoveryAdvertiser: HostDiscoveryAdvertiser,
 ) : DebugWebSocketServer {
     private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
     override val statusFlow: StateFlow<DebugWebSocketServerStatus> get() = ktorWebSocketServer.statusFlow
@@ -43,6 +45,9 @@ class DefaultDebugWebSocketServer(
 
     override suspend fun start(host: String, port: Int, wssPort: Int?) {
         subscribeServerEvents()
+        // Advertise the server over mDNS while it runs so LAN devices can discover it. The advertiser
+        // tracks statusFlow itself, so it registers once the connectors report Started.
+        hostDiscoveryAdvertiser.start()
         ktorWebSocketServer.start(
             host = host,
             port = port,
@@ -53,6 +58,7 @@ class DefaultDebugWebSocketServer(
     override suspend fun stop() {
         serverMonitoringJob?.cancel()
         serverMonitoringJob = null
+        hostDiscoveryAdvertiser.stop()
         ktorWebSocketServer.stop()
         sessionRepository.markAllSessionsInactive()
         pluginInstanceService.clearAllPluginInstances()

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/KtorWebSocketServer.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/KtorWebSocketServer.kt
@@ -2,6 +2,7 @@ package com.kitakkun.jetwhale.host.data.server
 
 import com.kitakkun.jetwhale.host.data.server.negotiation.ServerSessionNegotiationResult
 import com.kitakkun.jetwhale.host.data.server.negotiation.ServerSessionNegotiationStrategy
+import com.kitakkun.jetwhale.host.model.DebugServerStatusProvider
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
 import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
 import com.kitakkun.jetwhale.host.model.SslCertificateManager
@@ -9,6 +10,7 @@ import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggeeEvent
 import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggerEvent
 import com.kitakkun.jetwhale.protocol.serialization.decodeFromStringOrNull
 import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import io.ktor.http.ContentType
@@ -78,12 +80,13 @@ import kotlin.coroutines.cancellation.CancellationException
  * reconnect against the new certificate.
  */
 @SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 @Inject
 class KtorWebSocketServer(
     private val json: Json,
     private val negotiationStrategy: ServerSessionNegotiationStrategy,
     private val sslCertificateManager: SslCertificateManager,
-) {
+) : DebugServerStatusProvider {
     private val logger = LoggerFactory.getLogger(KtorWebSocketServer::class.java)
 
     private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -103,7 +106,7 @@ class KtorWebSocketServer(
     private val sessions: ConcurrentHashMap<String, WebSocketServerSession> = ConcurrentHashMap()
 
     private val mutableStatusFlow: MutableStateFlow<DebugWebSocketServerStatus> = MutableStateFlow(DebugWebSocketServerStatus.Stopped)
-    val statusFlow: StateFlow<DebugWebSocketServerStatus> = mutableStatusFlow
+    override val statusFlow: StateFlow<DebugWebSocketServerStatus> = mutableStatusFlow
 
     private val mutableDebuggeeEventFlow: MutableSharedFlow<Pair<String, JetWhaleDebuggeeEvent>> = MutableSharedFlow()
     val debuggeeEventFlow: SharedFlow<Pair<String, JetWhaleDebuggeeEvent>> = mutableDebuggeeEventFlow

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/discovery/DefaultHostDiscoveryAdvertiserTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/discovery/DefaultHostDiscoveryAdvertiserTest.kt
@@ -1,0 +1,83 @@
+package com.kitakkun.jetwhale.host.data.discovery
+
+import com.kitakkun.jetwhale.host.model.DebugServerStatusProvider
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DefaultHostDiscoveryAdvertiserTest {
+    private class FakeStatusProvider : DebugServerStatusProvider {
+        val mutableStatusFlow: MutableStateFlow<DebugWebSocketServerStatus> =
+            MutableStateFlow(DebugWebSocketServerStatus.Stopped)
+        override val statusFlow: StateFlow<DebugWebSocketServerStatus> = mutableStatusFlow
+    }
+
+    private class FakeMdnsRegistrar : MdnsRegistrar {
+        val registrations: MutableList<Triple<String, Int, Int?>> = mutableListOf()
+        var unregisterCount: Int = 0
+
+        override fun register(instanceName: String, wsPort: Int, wssPort: Int?) {
+            registrations.add(Triple(instanceName, wsPort, wssPort))
+        }
+
+        override fun unregister() {
+            unregisterCount++
+        }
+    }
+
+    @Test
+    fun `registers on Started and unregisters on Stopped`() = runBlocking {
+        val statusProvider = FakeStatusProvider()
+        val registrar = FakeMdnsRegistrar()
+        val advertiser = DefaultHostDiscoveryAdvertiser(statusProvider, registrar)
+
+        advertiser.start()
+
+        statusProvider.mutableStatusFlow.value = DebugWebSocketServerStatus.Started("localhost", 8080, 8443)
+        awaitUntil { registrar.registrations.size == 1 }
+        assertEquals(8080, registrar.registrations.last().second)
+        assertEquals(8443, registrar.registrations.last().third)
+
+        statusProvider.mutableStatusFlow.value = DebugWebSocketServerStatus.Stopped
+        awaitUntil { registrar.unregisterCount == 1 }
+
+        advertiser.stop()
+    }
+
+    @Test
+    fun `re-registers only when the advertised ports change`() = runBlocking {
+        val statusProvider = FakeStatusProvider()
+        val registrar = FakeMdnsRegistrar()
+        val advertiser = DefaultHostDiscoveryAdvertiser(statusProvider, registrar)
+
+        advertiser.start()
+
+        statusProvider.mutableStatusFlow.value = DebugWebSocketServerStatus.Started("localhost", 8080, null)
+        awaitUntil { registrar.registrations.size == 1 }
+
+        // Re-emitting an equivalent Started must not re-register.
+        statusProvider.mutableStatusFlow.value = DebugWebSocketServerStatus.Started("localhost", 8080, null)
+        delay(200)
+        assertEquals(1, registrar.registrations.size)
+
+        // A wss port appearing (e.g. certificate loaded) must re-register.
+        statusProvider.mutableStatusFlow.value = DebugWebSocketServerStatus.Started("localhost", 8080, 8443)
+        awaitUntil { registrar.registrations.size == 2 }
+        assertEquals(8443, registrar.registrations.last().third)
+
+        advertiser.stop()
+    }
+
+    private suspend fun awaitUntil(condition: () -> Boolean) {
+        withTimeout(5_000) {
+            while (!condition()) delay(20)
+        }
+        assertTrue(condition())
+    }
+}

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/discovery/DefaultHostDiscoveryAdvertiserTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/discovery/DefaultHostDiscoveryAdvertiserTest.kt
@@ -21,6 +21,7 @@ class DefaultHostDiscoveryAdvertiserTest {
     private class FakeMdnsRegistrar : MdnsRegistrar {
         val registrations: MutableList<Triple<String, Int, Int?>> = mutableListOf()
         var unregisterCount: Int = 0
+        var closeCount: Int = 0
 
         override fun register(instanceName: String, wsPort: Int, wssPort: Int?) {
             registrations.add(Triple(instanceName, wsPort, wssPort))
@@ -28,6 +29,10 @@ class DefaultHostDiscoveryAdvertiserTest {
 
         override fun unregister() {
             unregisterCount++
+        }
+
+        override fun close() {
+            closeCount++
         }
     }
 
@@ -47,7 +52,9 @@ class DefaultHostDiscoveryAdvertiserTest {
         statusProvider.mutableStatusFlow.value = DebugWebSocketServerStatus.Stopped
         awaitUntil { registrar.unregisterCount == 1 }
 
+        // stop() must fully close the mDNS stack (not just unregister) so it does not leak.
         advertiser.stop()
+        awaitUntil { registrar.closeCount == 1 }
     }
 
     @Test

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugServerStatusProvider.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugServerStatusProvider.kt
@@ -1,0 +1,8 @@
+package com.kitakkun.jetwhale.host.model
+
+import kotlinx.coroutines.flow.StateFlow
+
+/** Exposes the current debug server status so collaborators can react to lifecycle transitions. */
+interface DebugServerStatusProvider {
+    val statusFlow: StateFlow<DebugWebSocketServerStatus>
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/HostDiscoveryAdvertiser.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/HostDiscoveryAdvertiser.kt
@@ -1,0 +1,20 @@
+package com.kitakkun.jetwhale.host.model
+
+/**
+ * Advertises the running debug server on the local network via mDNS/DNS-SD (Bonjour) so agents on
+ * physical devices can discover the host without hardcoding its LAN IP address.
+ *
+ * The advertiser tracks the debug server status: it registers a `_jetwhale._tcp` service while the
+ * server is running and unregisters it when the server stops. Port changes re-register the service
+ * with the updated TXT records.
+ */
+interface HostDiscoveryAdvertiser {
+    /**
+     * Begins tracking the debug server status and advertising it while it runs. Idempotent: calling
+     * it again while already active has no effect.
+     */
+    fun start()
+
+    /** Stops advertising and releases the underlying mDNS resources. */
+    fun stop()
+}

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaApp.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaApp.kt
@@ -70,8 +70,7 @@ internal fun startQaApp(name: String, options: QaAgentOptions): QaApp {
             deviceId = QA_DEVICE_ID
         }
         connection {
-            host = options.hostName
-            port = options.hostPort
+            endpoint = fixed(options.hostName, options.hostPort)
             ssl {
                 trustServerCertificate()
             }


### PR DESCRIPTION
## Motivation

A physical iOS/Android device on the LAN currently has to hardcode the host machine's IP in
`startJetWhale { connection { host = "192.168.x.x" } }`. That is machine-specific and brittle. This
PR adds zero-config discovery of the host over mDNS/DNS-SD (Bonjour), so an agent can find the host
without knowing its address.

## Host side

While the debug server runs, the host advertises a `_jetwhale._tcp.local.` service (via jmDNS). The
instance name is the machine hostname. TXT records:

| key | value |
|-----|-------|
| `v` | protocol version, `1` |
| `wsPort` | plain-ws port |
| `wssPort` | wss port (omitted when wss is disabled) |
| `hostName` | machine hostname (stable even if the instance name is uniquified on collision) |

`DefaultHostDiscoveryAdvertiser` (`core/model` interface `HostDiscoveryAdvertiser`, `core/data`
default via `@ContributesBinding`) observes the server status through a new
`DebugServerStatusProvider` (implemented by `KtorWebSocketServer`) and registers on `Started`,
unregisters on `Stopped`/`Error`, and re-registers when the ports change. The jmDNS calls sit behind
an `MdnsRegistrar` seam so the advertiser is unit-testable without multicast.

## Agent side

Assign a `discovered(...)` endpoint:

```kotlin
connection {
    endpoint = discovered(fallback = fixed("localhost", 5443)) {
        allowHostName("my-macbook")   // optional, repeatable
        allowAddress("192.168.3.26")  // optional, repeatable
    }
    ssl { trustServerCertificate() }
}
```

The agent browses the LAN, keeps the hosts its allowlists admit, and connects to the first one that
can serve it.

### The connection target is now one property

`endpoint` replaces the `host`/`port` pair, which stay as deprecated aliases meaning exactly
`endpoint = fixed(host, port)`. The pair could not express this feature honestly: an opt-in discovery
block would have silently overridden them with nothing in the code saying which won, and `port` was
dead whenever discovery was enabled, since discovery resolves the port from the advertised
`wsPort`/`wssPort` TXT records.

A property assignment makes "fixed address" and "discovered address" mutually exclusive by
construction, so no invalid combination is representable. `fallback` is a required argument rather
than a sibling property, which states the precedence in the code and stops a discovered endpoint from
being left without one, while keeping the filter block purely predicates. `fixed()` and `discovered()`
are members of the connection scope rather than top-level functions, so neither is reachable outside
`connection {}` nor able to collide with names from other libraries.

No `ReplaceWith` on the deprecations: merging two independent property assignments into one cannot be
rewritten from either declaration alone.

### Filters are allowlists

`allowHostName` and `allowAddress` both accumulate. An empty allowlist means "no restriction on this
axis", so a host has to satisfy every allowlist that has entries — name **and** address when both are
set, any entry within each. Repeating a call widens the allowlist instead of replacing the earlier
value, which also keeps the DSL's rule that functions accumulate and properties hold a single value.

### Discovery resolves the port, and the scheme is not negotiable

The agent uses wss exactly when an `ssl { }` block is configured, and that choice drives the URL
scheme on its own. So a host counts as a candidate only if it advertises the port for that scheme: an
ssl-configured agent **skips** a host whose wss is disabled rather than dialling `wss://` at its
plain-ws port, which would fail every handshake. Skipping leaves later matches a chance, and when
every match is skipped the warning names them and says why.

### Per-platform support

| Platform | Browse backend |
|----------|----------------|
| JVM (Desktop) | jmDNS |
| Android | `NsdManager` (Context obtained reflectively via `ActivityThread.currentApplication()`) |
| iOS / macOS | `NSNetServiceBrowser` + `NSNetService` |
| JS / Wasm / Linux / Windows | Not supported — reported as `DiscoveryResult.Unavailable`, falls back |

### Resolution is per attempt, not once per session

The address is resolved before **every** connection attempt, not once before the retry loop. Resolving
once would have pinned the fallback for the life of the process the moment the first browse came up
empty — so an app started before the host would have retried an address it could never reach, on a
physical device an unreachable `localhost`, contradicting the reconnect behaviour the guide promises
("just leave the app running until the host comes up"). Per-attempt resolution also picks up a host
that restarts on a different port.

That makes resolution repetitive by nature, so `MdnsEndpointResolver` remembers the outcome it last
reported and stays quiet while nothing changes: an unreachable host logs once, not every ~10s forever.
The platform stubs no longer log for themselves and return `DiscoveryResult.Unavailable(reason)`,
which also distinguishes "cannot browse here" from "browsed and found nothing".

### Connection failures are no longer silent

The reconnect loop caught `Throwable` and discarded it, and `KtorWebSocketClient.openConnection`
rethrows without logging, so a refused host, a wrong port or a failed TLS handshake produced no output
at all at the default WARN level — the agent looked idle rather than stuck. (Only two neighbouring
cases said anything: a failed CA fetch under `trustServerCertificate()`, and a failed negotiation.)
The cause is now reported, deduplicated the same way, and reset once a connection succeeds.

### `startService` takes a resolver

`JetWhaleMessagingService.startService` used to take `(host, port, discovery)`, where `host`/`port`
meant the address or the fallback depending on whether `discovery` was null. It now takes an
`EndpointResolver`, so the service knows only that something hands it an address before each attempt;
mDNS, allowlists, fallback and their logging all stay behind that one method. It resolves an
*endpoint*, not a host — `host` excludes the port (RFC 3986), which is the same reason the DSL says
`endpoint`. `HostDiscoveryConfig` and `selectHost` keep "host": those really do pick a host among the
advertised ones and carry its port as a separate field.

## iOS requirement

Browsing requires `_jetwhale._tcp` under `NSBonjourServices` in `Info.plist` (added to
`demo/ios-cmp/ios-cmp/Info.plist`), alongside the existing `NSLocalNetworkUsageDescription`.

## Tests

- `SelectHostTest` — host selection as a pure function: ws/wss port choice, skipping a host that
  advertises no wss port while passing over it to one that does, case-insensitive name matching, both
  allowlists including the any-entry and both-axes cases, and the instance-name fallback.
- `ConnectionEndpointTest` — what a configured `endpoint` amounts to: the default, the deprecated
  `host`/`port` bridge and its precedence against an assigned endpoint, allowlist accumulation, and
  that `ssl {}` selects wss regardless of where it sits in the block.
- `MessagingServiceResolutionTest` — drives the reconnect loop with a scripted resolver and an
  unreachable socket, asserting the second attempt dials the second address. One-shot resolution
  cannot produce that, so this is the regression test for the behaviour above.
- `HostDiscoveryJvmTest` — jmDNS advertise + `browseJetWhaleServices` round-trip in one process,
  skipped gracefully when the environment blocks multicast.
- `DefaultHostDiscoveryAdvertiserTest` — register/unregister on status transitions and re-registration
  only on port changes, using a fake status provider + fake `MdnsRegistrar`.

## What running it on real devices found

Discovery was exercised end-to-end against a headless host, with the demo's fallback pointed at an
unreachable address so that a connection could only come from discovery. Three bugs turned up, each
of which alone kept the feature from working, and none of which a JVM-to-JVM test can see:

1. **It spoke mDNS on loopback.** Both sides opened jmDNS with `InetAddress.getLocalHost()`, which is
   `127.0.0.1` wherever the hostname resolves to loopback — the default on macOS. The service was
   announced on `lo0` advertising `127.0.0.1`. Nothing on the network could see it, and discovery had
   never worked on any platform, desktop-to-desktop included.
2. **The instance name carried a dot.** `getLocalHost().hostName` is qualified (`machine.local`), and
   a DNS-SD instance name is a single label. jmDNS round-trips such a name with itself, so JVM checks
   passed; Apple's `mDNSResponder` drops it, taking iOS `NSNetServiceBrowser` and Android
   `NsdManager` with it. The host was invisible to precisely the devices this feature is for.
3. **Apple dialled the mDNS host name.** `NSNetService.hostName` is whatever the advertising stack
   named its host record — `192-168-3-9.local` from jmDNS — which the host's certificate (IP SANs)
   does not cover, so the wss handshake failed hostname verification and reported it as an untrusted
   CA. Fixed by connecting to the resolved IP, which also makes `allowAddress` work on Apple for the
   first time.

With those fixed, a session was established from all three:

| Platform | Result |
|----------|--------|
| JVM (Desktop) | `Discovered JetWhale host over mDNS: … at 192.168.3.9:5443` → `WebSocket session established` |
| iOS, physical iPhone 13 | `WebSocket session established`; host logged the protocol negotiation |
| Android, physical Pixel 6 Pro | `WebSocket session established` |

Independently corroborated with macOS's own responder: `dns-sd -B` lists the service and `dns-sd -L`
resolves it with its TXT records intact.

## Verification

`:jetwhale-host:core:data:test`, `:jetwhale-agent-runtime:jvmTest`, `compileKotlinMetadata`,
`compileKotlinIosArm64`, `compileKotlinMacosArm64`, `compileKotlinJs`, `compileKotlinWasmJs`,
`compileKotlinLinuxX64`, `compileKotlinMingwX64`, `checkKotlinAbi`, `:tools:qa-agent:compileKotlin`,
`:demo:shared:compileKotlinJvm` and `spotlessCheck` all pass locally, with no new warnings. ABI dumps
updated for both the JVM and klib surfaces.

`compileAndroidMain` was not run locally (no Android SDK in the working environment) — left to CI.

`compat-test` is deliberately untouched: it compiles against the published
`com.kitakkun.jetwhale:jetwhale-agent-runtime:$jetwhaleVersion`, so it has to keep using `host`/`port`
to stay compilable against existing releases.

## Follow-up

A companion PR adds build-machine IP auto-injection via the JetWhale Gradle plugin as the primary
zero-config path, with mDNS discovery here as the optional last resort.
