### PR TITLE
feat(host): persist window size and position across launches

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
@@ -8,7 +8,12 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.awaitApplication
@@ -16,8 +21,12 @@ import com.kitakkun.jetwhale.host.cli.CommandLineArgumentsParser
 import com.kitakkun.jetwhale.host.component.InitializingDialog
 import com.kitakkun.jetwhale.host.component.ShuttingDownDialog
 import com.kitakkun.jetwhale.host.di.JetWhaleAppGraph
+import com.kitakkun.jetwhale.host.model.PersistedWindowState
 import com.kitakkun.jetwhale.host.ui.isShortcutModifierPressed
 import dev.zacsweers.metro.createGraph
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.painterResource
 import java.awt.Taskbar
@@ -43,6 +52,9 @@ private fun configureAppMetadata() {
     }
 }
 
+private val DefaultWindowSize = DpSize(1280.dp, 800.dp)
+
+@OptIn(FlowPreview::class)
 fun main(args: Array<String>) = runBlocking {
     configureAppMetadata()
 
@@ -54,6 +66,15 @@ fun main(args: Array<String>) = runBlocking {
     appGraph.logCaptureService.startCapture()
 
     appGraph.applicationLifecycleOwner.initialize()
+
+    val persistedWindowState = appGraph.windowStateRepository.loadWindowState()
+    val initialWindowSize = persistedWindowState
+        ?.let { DpSize(it.width.dp, it.height.dp) }
+        ?: DefaultWindowSize
+    val initialWindowPosition = persistedWindowState
+        ?.takeIf { it.x != null && it.y != null }
+        ?.let { WindowPosition(it.x!!.dp, it.y!!.dp) }
+        ?: WindowPosition.Aligned(Alignment.Center)
 
     awaitApplication {
         val applicationState by appGraph
@@ -72,10 +93,34 @@ fun main(args: Array<String>) = runBlocking {
                 }
         }
 
+        val windowState = remember {
+            WindowState(size = initialWindowSize, position = initialWindowPosition)
+        }
+
+        LaunchedEffect(windowState) {
+            snapshotFlow { Triple(windowState.size, windowState.position, windowState.placement) }
+                // Only persist normal window geometry; maximized/fullscreen must not overwrite it.
+                .map { (size, position, placement) ->
+                    if (placement != WindowPlacement.Floating) return@map null
+                    PersistedWindowState(
+                        width = size.width.value,
+                        height = size.height.value,
+                        x = position.takeIf { it.isSpecified }?.x?.value,
+                        y = position.takeIf { it.isSpecified }?.y?.value,
+                    )
+                }
+                .debounce(500)
+                .collect { state ->
+                    if (state != null) {
+                        appGraph.windowStateRepository.saveWindowState(state)
+                    }
+                }
+        }
+
         Window(
             title = "JetWhale",
             icon = painterResource(Res.drawable.app_icon),
-            state = WindowState(position = WindowPosition.Aligned(Alignment.Center)),
+            state = windowState,
             onCloseRequest = appGraph.applicationLifecycleOwner::shutdown,
             onPreviewKeyEvent = { keyEvent ->
                 if (keyEvent.type == KeyEventType.KeyDown && keyEvent.isShortcutModifierPressed && keyEvent.key == Key.Q) {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
@@ -3,13 +3,13 @@ package com.kitakkun.jetwhale.host
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
@@ -16,6 +16,7 @@ import com.kitakkun.jetwhale.host.model.PluginHotReloadService
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.model.ThemeSubscriptionKey
 import com.kitakkun.jetwhale.host.model.UpdateCheckMutationKey
+import com.kitakkun.jetwhale.host.model.WindowStateRepository
 import com.kitakkun.jetwhale.host.plugin.PluginScreenContext
 import com.kitakkun.jetwhale.host.settings.SettingsScreenContext
 import com.kitakkun.jetwhale.host.settings.licenses.LicensesScreenContext
@@ -50,6 +51,7 @@ interface JetWhaleAppGraph : ScreenContext {
     val enabledPluginsRepository: EnabledPluginsRepository
     val debuggerSettingsRepository: DebuggerSettingsRepository
     val updateCheckMutationKey: UpdateCheckMutationKey
+    val windowStateRepository: WindowStateRepository
 
     @Provides
     fun provideSwrClient(): SwrClientPlus = SwrCachePlus(SwrCachePlusPolicy(SwrCacheScope()))

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/DataStoreDependencyProvider.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/DataStoreDependencyProvider.kt
@@ -21,6 +21,9 @@ annotation class ThemeDataStoreQualifier
 @Qualifier
 annotation class EnabledPluginsDataStoreQualifier
 
+@Qualifier
+annotation class WindowStateDataStoreQualifier
+
 @ContributesTo(AppScope::class)
 interface DataStoreDependencyProvider {
     @DebuggerSettingsDataStoreQualifier
@@ -49,4 +52,13 @@ interface DataStoreDependencyProvider {
         corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
         scope = CoroutineScope(Dispatchers.IO),
     ) { appDataDirectoryProvider.resolveDataStoreFilePath("enabled_plugins.preferences_pb") }
+
+    @WindowStateDataStoreQualifier
+    @Provides
+    fun provideWindowStateDataStore(
+        appDataDirectoryProvider: AppDataDirectoryProvider,
+    ): DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath(
+        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+        scope = CoroutineScope(Dispatchers.IO),
+    ) { appDataDirectoryProvider.resolveDataStoreFilePath("window_state.preferences_pb") }
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/window/DefaultWindowStateRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/window/DefaultWindowStateRepository.kt
@@ -1,0 +1,54 @@
+package com.kitakkun.jetwhale.host.data.window
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import com.kitakkun.jetwhale.host.data.WindowStateDataStoreQualifier
+import com.kitakkun.jetwhale.host.model.PersistedWindowState
+import com.kitakkun.jetwhale.host.model.WindowStateRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.first
+
+@ContributesBinding(AppScope::class)
+@SingleIn(AppScope::class)
+@Inject
+class DefaultWindowStateRepository(
+    @param:WindowStateDataStoreQualifier
+    private val dataStore: DataStore<Preferences>,
+) : WindowStateRepository {
+    override suspend fun loadWindowState(): PersistedWindowState? {
+        val preferences = dataStore.data.first()
+        val width = preferences[widthPreferencesKey] ?: return null
+        val height = preferences[heightPreferencesKey] ?: return null
+        return PersistedWindowState(
+            width = width,
+            height = height,
+            x = preferences[xPreferencesKey],
+            y = preferences[yPreferencesKey],
+        )
+    }
+
+    override suspend fun saveWindowState(state: PersistedWindowState) {
+        val x = state.x
+        val y = state.y
+        dataStore.edit { prefs ->
+            prefs[widthPreferencesKey] = state.width
+            prefs[heightPreferencesKey] = state.height
+            if (x != null && y != null) {
+                prefs[xPreferencesKey] = x
+                prefs[yPreferencesKey] = y
+            }
+        }
+    }
+
+    companion object {
+        private val widthPreferencesKey = floatPreferencesKey("window_width")
+        private val heightPreferencesKey = floatPreferencesKey("window_height")
+        private val xPreferencesKey = floatPreferencesKey("window_x")
+        private val yPreferencesKey = floatPreferencesKey("window_y")
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/window/DefaultWindowStateRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/window/DefaultWindowStateRepository.kt
@@ -41,6 +41,11 @@ class DefaultWindowStateRepository(
             if (x != null && y != null) {
                 prefs[xPreferencesKey] = x
                 prefs[yPreferencesKey] = y
+            } else {
+                // An unspecified position means "no position recorded"; drop any stale keys so the
+                // next launch falls back to centered placement.
+                prefs.remove(xPreferencesKey)
+                prefs.remove(yPreferencesKey)
             }
         }
     }

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/window/DefaultWindowStateRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/window/DefaultWindowStateRepositoryTest.kt
@@ -1,0 +1,66 @@
+package com.kitakkun.jetwhale.host.data.window
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.kitakkun.jetwhale.host.model.PersistedWindowState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DefaultWindowStateRepositoryTest {
+    private fun newRepository(): DefaultWindowStateRepository {
+        val tempDir = Files.createTempDirectory("jetwhale-window-state-test")
+        val dataStore: DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath(
+            scope = CoroutineScope(Dispatchers.IO),
+        ) { tempDir.resolve("window_state.preferences_pb").toString().toPath() }
+        return DefaultWindowStateRepository(dataStore)
+    }
+
+    @Test
+    fun `returns null when nothing is saved`() = runBlocking {
+        assertNull(newRepository().loadWindowState())
+    }
+
+    @Test
+    fun `saves and restores size and position`() = runBlocking {
+        val repository = newRepository()
+
+        repository.saveWindowState(PersistedWindowState(width = 1440f, height = 900f, x = 10f, y = 20f))
+
+        assertEquals(
+            PersistedWindowState(width = 1440f, height = 900f, x = 10f, y = 20f),
+            repository.loadWindowState(),
+        )
+    }
+
+    @Test
+    fun `saving without a position clears a previously saved position`() = runBlocking {
+        val repository = newRepository()
+        repository.saveWindowState(PersistedWindowState(width = 1280f, height = 800f, x = 10f, y = 20f))
+
+        repository.saveWindowState(PersistedWindowState(width = 1024f, height = 768f, x = null, y = null))
+
+        assertEquals(
+            PersistedWindowState(width = 1024f, height = 768f, x = null, y = null),
+            repository.loadWindowState(),
+        )
+    }
+
+    @Test
+    fun `partial position is not persisted`() = runBlocking {
+        val repository = newRepository()
+
+        repository.saveWindowState(PersistedWindowState(width = 1280f, height = 800f, x = 10f, y = null))
+
+        assertEquals(
+            PersistedWindowState(width = 1280f, height = 800f, x = null, y = null),
+            repository.loadWindowState(),
+        )
+    }
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/WindowStateRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/WindowStateRepository.kt
@@ -1,0 +1,19 @@
+package com.kitakkun.jetwhale.host.model
+
+/**
+ * Persisted main window geometry, expressed in dp values.
+ *
+ * A null [x]/[y] means no position was recorded and the window should fall back to a centered
+ * placement on the next launch.
+ */
+data class PersistedWindowState(
+    val width: Float,
+    val height: Float,
+    val x: Float?,
+    val y: Float?,
+)
+
+interface WindowStateRepository {
+    suspend fun loadWindowState(): PersistedWindowState?
+    suspend fun saveWindowState(state: PersistedWindowState)
+}


### PR DESCRIPTION
## Summary
- Increase the default main window size from Compose's 800x600 default to **1280x800 dp**, centered.
- Persist window size and position to DataStore (`window_state.preferences_pb`) and restore them on next launch.
- New `WindowStateRepository` interface in `core/model` with `DefaultWindowStateRepository` in `core/data`, wired via Metro DI following the existing repository pattern.
- Geometry changes are observed with `snapshotFlow` and debounced (500ms); maximized/fullscreen geometry is never persisted so the floating size survives.

## Test plan
- [x] Launch the app fresh → window opens 1280x800 centered
- [x] Resize/move the window, quit, relaunch → geometry restored
- [x] Maximize, quit, relaunch → previous floating size restored (not the maximized size)