### PR TITLE
feat(settings): show idb / idb_companion setup status in health check

### DIFF
--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDiagnosticsQueryKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDiagnosticsQueryKey.kt
@@ -2,6 +2,8 @@ package com.kitakkun.jetwhale.host.data.settings
 
 import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
 import com.kitakkun.jetwhale.host.data.util.findAdbPath
+import com.kitakkun.jetwhale.host.data.util.findIdbCompanionPath
+import com.kitakkun.jetwhale.host.data.util.findIdbPath
 import com.kitakkun.jetwhale.host.model.DebuggingToolsDiagnostics
 import com.kitakkun.jetwhale.host.model.DiagnosticsQueryKey
 import dev.zacsweers.metro.AppScope
@@ -21,6 +23,8 @@ class DefaultDiagnosticsQueryKey(
         val appDataPath = appDataDirectoryProvider.getAppDataPath()
         DebuggingToolsDiagnostics(
             adbPath = adbPath,
+            idbPath = findIdbPath(),
+            idbCompanionPath = findIdbCompanionPath(),
             appDataPath = appDataPath,
         )
     },

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/util/IdbUtil.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/util/IdbUtil.kt
@@ -1,0 +1,37 @@
+package com.kitakkun.jetwhale.host.data.util
+
+import java.io.File
+
+/**
+ * Finds the absolute path to the idb client executable (Facebook's iOS debug bridge, used to
+ * drive iOS simulator input), checking common installation locations and then the PATH.
+ *
+ * @return The absolute path to idb if found, otherwise an empty string
+ */
+fun findIdbPath(): String = findExecutable(
+    name = "idb",
+    candidatePaths = listOf(
+        "/usr/local/bin/idb",
+        "/opt/homebrew/bin/idb",
+    ),
+)
+
+/**
+ * Finds the absolute path to the idb_companion executable (the gRPC daemon the idb client talks
+ * to; installed separately, typically via `brew install idb-companion`).
+ *
+ * @return The absolute path to idb_companion if found, otherwise an empty string
+ */
+fun findIdbCompanionPath(): String = findExecutable(
+    name = "idb_companion",
+    candidatePaths = listOf(
+        "/usr/local/bin/idb_companion",
+        "/opt/homebrew/bin/idb_companion",
+    ),
+)
+
+private fun findExecutable(name: String, candidatePaths: List<String>): String {
+    candidatePaths.firstOrNull { File(it).canExecute() }?.let { return it }
+    val pathDirs = System.getenv("PATH")?.split(File.pathSeparator).orEmpty()
+    return pathDirs.map { File(it, name) }.firstOrNull { it.canExecute() }?.absolutePath.orEmpty()
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggingToolsDiagnostics.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggingToolsDiagnostics.kt
@@ -2,5 +2,8 @@ package com.kitakkun.jetwhale.host.model
 
 data class DebuggingToolsDiagnostics(
     val adbPath: String,
+    // Empty when the tool is not installed.
+    val idbPath: String,
+    val idbCompanionPath: String,
     val appDataPath: String,
 )

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -61,6 +61,10 @@
     <string name="health_check">ヘルスチェック</string>
     <string name="adb_executable_path">ADB実行可能ファイルのパス</string>
     <string name="adb_unavailable">ADBコマンドが見つかりません</string>
+    <string name="idb_executable_path">idb実行可能ファイルのパス</string>
+    <string name="idb_unavailable">idbコマンドが見つかりません</string>
+    <string name="idb_companion_executable_path">idb_companion実行可能ファイルのパス</string>
+    <string name="idb_companion_unavailable">idb_companionコマンドが見つかりません</string>
     <string name="view_application_logs">アプリケーションログを表示</string>
     <string name="log_viewer_filter_placeholder">ログをフィルター…</string>
     <string name="log_viewer_filter_icon">フィルター</string>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
@@ -61,6 +61,10 @@
     <string name="health_check">Health Check</string>
     <string name="adb_executable_path">ADB Executable Path</string>
     <string name="adb_unavailable">ADB command not found</string>
+    <string name="idb_executable_path">idb Executable Path</string>
+    <string name="idb_unavailable">idb command not found</string>
+    <string name="idb_companion_executable_path">idb_companion Executable Path</string>
+    <string name="idb_companion_unavailable">idb_companion command not found</string>
     <string name="view_application_logs">View Application Logs</string>
     <string name="log_viewer_filter_placeholder">Filter logs…</string>
     <string name="log_viewer_filter_icon">Filter</string>

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreen.kt
@@ -46,6 +46,10 @@ import com.kitakkun.jetwhale.host.settings.component.SettingsItemRow
 import com.kitakkun.jetwhale.host.settings.component.SwitchSettingsItemView
 import com.kitakkun.jetwhale.host.settings.current_version
 import com.kitakkun.jetwhale.host.settings.health_check
+import com.kitakkun.jetwhale.host.settings.idb_companion_executable_path
+import com.kitakkun.jetwhale.host.settings.idb_companion_unavailable
+import com.kitakkun.jetwhale.host.settings.idb_executable_path
+import com.kitakkun.jetwhale.host.settings.idb_unavailable
 import com.kitakkun.jetwhale.host.settings.install_update
 import com.kitakkun.jetwhale.host.settings.language_option
 import com.kitakkun.jetwhale.host.settings.maintenance
@@ -152,20 +156,41 @@ fun GeneralSettingsScreen(
         }
         item {
             SettingOptionView(stringResource(Res.string.health_check)) {
-                SettingsItemRow(stringResource(Res.string.adb_executable_path)) {
-                    Text(
-                        text = uiState.adbPath.ifEmpty { stringResource(Res.string.adb_unavailable) },
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    if (uiState.adbPath.isNotEmpty()) {
-                        Icon(
-                            imageVector = Icons.Default.Check,
-                            tint = MaterialTheme.colorScheme.primary,
-                            contentDescription = null,
-                        )
-                    }
-                }
+                ToolPathRow(
+                    label = stringResource(Res.string.adb_executable_path),
+                    path = uiState.adbPath,
+                    unavailableText = stringResource(Res.string.adb_unavailable),
+                )
+                ToolPathRow(
+                    label = stringResource(Res.string.idb_executable_path),
+                    path = uiState.idbPath,
+                    unavailableText = stringResource(Res.string.idb_unavailable),
+                )
+                ToolPathRow(
+                    label = stringResource(Res.string.idb_companion_executable_path),
+                    path = uiState.idbCompanionPath,
+                    unavailableText = stringResource(Res.string.idb_companion_unavailable),
+                )
             }
+        }
+    }
+}
+
+@Composable
+private fun ToolPathRow(
+    label: String,
+    path: String,
+    unavailableText: String,
+) {
+    SettingsItemRow(label) {
+        Text(text = path.ifEmpty { unavailableText })
+        Spacer(Modifier.width(8.dp))
+        if (path.isNotEmpty()) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                tint = MaterialTheme.colorScheme.primary,
+                contentDescription = null,
+            )
         }
     }
 }
@@ -253,6 +278,8 @@ private fun GeneralSettingsScreenPreview() {
             language = AppLanguage.English,
             appDataPath = "~/.jetwhale",
             adbPath = "/path/to/adb",
+            idbPath = "/path/to/idb",
+            idbCompanionPath = "",
             currentVersion = "1.0.0-alpha08",
             checkForUpdatesOnStartup = true,
             isCheckingForUpdates = false,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenPresenter.kt
@@ -62,6 +62,8 @@ fun generalSettingsScreenPresenter(
         language = appearanceSettings.appLanguage,
         appDataPath = diagnostics.appDataPath,
         adbPath = diagnostics.adbPath,
+        idbPath = diagnostics.idbPath,
+        idbCompanionPath = diagnostics.idbCompanionPath,
         currentVersion = presenterContext.hostVersionInfo.version,
         checkForUpdatesOnStartup = debuggerBehaviorSettings.checkForUpdatesOnStartup,
         isCheckingForUpdates = updateCheckMutation.isPending,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenUiState.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenUiState.kt
@@ -12,6 +12,8 @@ data class GeneralSettingsScreenUiState(
     val availableColorSchemes: ImmutableList<JetWhaleColorSchemeId>,
     val appDataPath: String,
     val adbPath: String,
+    val idbPath: String,
+    val idbCompanionPath: String,
     val currentVersion: String,
     val checkForUpdatesOnStartup: Boolean,
     val isCheckingForUpdates: Boolean,


### PR DESCRIPTION
## Summary

Adds idb and idb_companion detection to the General settings **Health Check** section, alongside the existing ADB row. iOS simulator input control (used by the upcoming Device Mirror plugin, #149) requires both the pip-installed `idb` client and the brew-installed `idb_companion` daemon — a two-part setup that is easy to get half-done, so each is shown as its own row.

- `DebuggingToolsDiagnostics` gains `idbPath` / `idbCompanionPath` (empty = not installed), fetched via a new `IdbUtil.kt` (well-known locations + PATH lookup).
- The health-check row layout is extracted into a shared `ToolPathRow` composable instead of duplicating it three times.
- Strings added in English and Japanese (`idb` kept as-is per naming convention).

## Test plan
- [x] `:jetwhale-host:feature:settings:build`, `:jetwhale-host:core:data:build`, `:jetwhale-host:app:compileKotlin`, and `spotlessCheck` pass
- [ ] Manual: open Settings → General and confirm the three health-check rows (on this machine idb resolves via the pyenv shim and idb_companion shows as not found)