### PR TITLE
docs: reflect recent main features in documentation

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -77,10 +77,10 @@ export default defineConfig({
       {
         text: 'Guide',
         items: [
-          { text: 'ADB Auto Port Mapping', link: '/guide/adb-auto-port-mapping' },
           { text: 'Network Inspector', link: '/guide/network-inspector' },
           { text: 'MCP Server', link: '/guide/mcp-server' },
           { text: 'Host Settings', link: '/guide/host-settings' },
+          { text: 'ADB Auto Port Mapping', link: '/guide/adb-auto-port-mapping' },
         ],
       },
       {

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -92,6 +92,29 @@ setup with a shared `initializeJetWhale()` function.
 An optional `logging { }` block controls agent-side logging
 (`enabled = true`, `logLevel = LogLevel.WARN` by default).
 
+### Session metadata
+
+The agent reports app/device metadata to the host during connection, and the host uses it to label
+and group sessions (for example, all sessions from the same physical device). Everything is
+resolved automatically on a best-effort basis — the app name on Android/iOS/macOS, a stable device
+identifier and the device name per platform — so usually you configure nothing.
+
+To override any of it (or supply values on platforms where auto-resolution is unavailable), add an
+`app { }` block; explicit values always win over the auto-resolved defaults:
+
+```kotlin
+startJetWhale {
+    connection { /* ... */ }
+    app {
+        appName = "My App (staging)"
+        deviceName = "CI emulator"
+        // deviceId = "..."            // stable id used to group sessions per device
+        // appIconPng = iconPngBytes   // PNG, at most 64x64 px; dropped if base64 exceeds 32KB
+    }
+    plugins { /* ... */ }
+}
+```
+
 ## Secure connections (wss)
 
 By default the agent connects over plain **ws** (port **5080**). The host can additionally serve

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -2,12 +2,46 @@
 
 The JetWhale host's behavior is configured from its **Settings** screen.
 
+::: tip Window size and position
+The host remembers its window size and position across launches automatically (when the window is
+in normal floating state — maximized/fullscreen state is not persisted). There is nothing to
+configure.
+:::
+
 ## General
+
+The **Settings → General** screen groups the host-wide options:
+
+### Appearance
+
+| Setting | Description |
+|---------|-------------|
+| **Language** | UI language of the host: **English** or **Japanese**. |
+| **Theme** | Color scheme: the built-in `dynamic`, `light`, or `dark` schemes, plus any custom schemes available. |
+
+### ADB support
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | **ADB auto port mapping** | off | Automatically runs `adb reverse` for Android devices as they connect. See [ADB Auto Port Mapping](/guide/adb-auto-port-mapping). |
-| **Persist data** | off | Not yet implemented — the toggle exists but has no effect in the current release. |
+
+### Maintenance
+
+- **Application data directory** — shows the host's app-data path (normally `~/.jetwhale/`) with a
+  shortcut to open it in your file manager.
+- **View application logs** — opens the built-in log viewer.
+
+### Updates
+
+- **Current version** — the running host version.
+- **Check for updates on startup** — toggle the automatic update check.
+- **Check for updates** — check immediately; when an update is found you can install it or open the
+  download page.
+
+### Health check
+
+- **adb executable path** — shows where JetWhale found `adb` (see
+  [How adb is found](/guide/adb-auto-port-mapping#how-adb-is-found)), or that it is unavailable.
 
 ## Server
 

--- a/docs/guide/network-inspector.md
+++ b/docs/guide/network-inspector.md
@@ -5,8 +5,11 @@ and for **mocking responses** without touching your backend.
 
 - 📡 Live view of HTTP transactions (request/response headers, bodies, timing)
 - 🔍 JSON body viewer for structured responses
-- 📋 Copy transactions for sharing or reproducing requests
+- 📋 Copy transactions for sharing or reproducing requests — the detail pane is fully
+  text-selectable
 - 🎭 Response mocking with configurable rules, toggled from the host UI
+- 🙈 [Redaction rules](#redacting-sensitive-values) to keep secrets (auth headers, tokens,
+  passwords) out of captured traffic
 
 It works with **Ktor** and **OkHttp** clients.
 
@@ -82,6 +85,36 @@ Open the **Network Inspector** plugin in the JetWhale host and select your app's
 transaction appears live as your app makes requests. Select a transaction to inspect its request
 and response — headers, bodies (with a dedicated JSON view), and status. Use **copy** on a
 transaction to share it or reproduce the request elsewhere.
+
+## Redacting sensitive values
+
+Captured traffic often contains secrets — `Authorization` headers, session cookies, tokens in query
+parameters, passwords in JSON bodies. Pass **redaction rules** to the agent plugin to strip them:
+
+```kotlin
+val networkAgent = JetWhaleNetworkAgentPlugin(
+    redaction = NetworkRedactionRules {
+        header("Authorization", "Cookie")
+        header("X-Session-Id", scope = RedactionScope.MCP_ONLY)
+        urlQueryParam("token", strategy = RedactionStrategy.MASK)
+        bodyJsonField("password", "access_token")
+    },
+)
+```
+
+Three rule targets are available — `header(...)`, `urlQueryParam(...)`, and `bodyJsonField(...)`
+(matches the field name anywhere in a JSON body). Name matching is case-insensitive, and each rule
+takes two options:
+
+- **`scope`** — where the rule is enforced:
+  - `EVERYWHERE` (default): applied at capture time on the agent, so the value never leaves the
+    debuggee process.
+  - `MCP_ONLY`: the value stays visible in the host UI, but is hidden from AI agents connected via
+    the [MCP server](/guide/mcp-server).
+- **`strategy`** — how the redacted value is rendered: `PLACEHOLDER` (default, a `<redacted>`
+  marker) or `MASK` (one `*` per character, preserving the value's length).
+
+Without a `redaction` argument no rules apply and captured data is forwarded verbatim.
 
 ## Mocking responses
 

--- a/docs/guide/what-is-jetwhale.md
+++ b/docs/guide/what-is-jetwhale.md
@@ -22,7 +22,9 @@ JetWhale consists of two sides connected over a WebSocket:
   to the host and exchanges type-safe messages powered by kotlinx.serialization.
 
 One host can debug **multiple sessions simultaneously** — for example an Android device and a
-desktop app at the same time.
+desktop app at the same time. Each session is labeled with the app's name and icon and grouped by
+the device it runs on — resolved automatically, and customizable via the agent's
+[`app { }` block](/guide/getting-started#session-metadata).
 
 The connection is plain **ws** by default, and can be upgraded to **secure WebSocket (wss)** with a
 locally-issued certificate — see [Secure connections](/guide/getting-started#secure-connections-wss).

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -20,9 +20,15 @@ The negotiation phase consists of the following steps:
 
 1. **Protocol Version Exchange**: The debuggee sends its supported protocol version to the
    debugger. The debugger accepts or rejects the version based on its own supported versions.
-2. **Session ID Exchange**: The debugger assigns a unique session ID to distinguish each debuggee.
+2. **Session Exchange**: The debugger assigns a unique session ID to distinguish each debuggee.
    The debuggee needs to get assigned a session ID from the debugger. If the debuggee wants to
-   resume a previous session, it can provide the existing session ID.
+   resume a previous session, it can provide the existing session ID. Alongside the session
+   request, the debuggee reports its **app/device metadata** — all fields optional: `appName`,
+   `deviceId` (a stable per-device identifier the debugger uses to group sessions), `deviceName`,
+   and `appIconPngBase64` (a small app icon, at most 64×64 px; icons whose base64 form exceeds
+   32KB are dropped to keep the negotiation payload small). See
+   [Session metadata](/guide/getting-started#session-metadata) for how the agent resolves and
+   overrides these values.
 3. **Capabilities Exchange**: Both the debugger and debuggee exchange their capabilities to
    understand what features are supported during the debugging session.
 4. **Plugin Compatibility Check**: The debuggee sends a list of registered plugins to the debugger.


### PR DESCRIPTION
## Summary

Updates the documentation to cover features recently merged into `main`, and tidies the section structure for readability.

- **Host Settings** — rewrote the outdated General section (it only listed ADB auto port mapping and the removed "Persist data" toggle) to match the current UI: Appearance (language/theme), ADB support, Maintenance, Updates, and Health check. Added a note that window size/position now persists across launches (#147).
- **Session metadata** (#145) — documented the agent's `app { }` DSL (`appName` / `deviceId` / `deviceName` / `appIconPng` with the 64×64 / 32KB limits) in Getting Started, the negotiation payload in the protocol reference, and session grouping in What is JetWhale?.
- **Network Inspector** — added a redaction-rules section (`header` / `urlQueryParam` / `bodyJsonField`, `EVERYWHERE` vs `MCP_ONLY` scopes, `PLACEHOLDER` vs `MASK` strategies) and mentioned the selectable detail pane (#143).
- **Sidebar** — reordered the Guide section to follow the reader flow: Network Inspector → MCP Server → Host Settings → ADB Auto Port Mapping.

## Verification

`npx vitepress build` in `docs-site/` passes.