### PR TITLE
docs: list theme options exactly as the settings dropdown renders them

### DIFF
--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -17,7 +17,7 @@ The **Settings → General** screen groups the host-wide options:
 | Setting | Description |
 |---------|-------------|
 | **Language** | UI language of the host: **English** or **Japanese**. |
-| **Theme** | Color scheme: the built-in `dynamic`, `light`, or `dark` schemes, plus any custom schemes available. |
+| **Theme** | Color scheme: `builtin:dynamic`, `builtin:light`, or `builtin:dark`. |
 
 ### ADB support
 


### PR DESCRIPTION
Addresses https://github.com/kitakkun/JetWhale/pull/151#discussion_r3609212236 (left on the already-merged #151).

The Theme row in Host Settings claimed built-in `dynamic` / `light` / `dark` schemes plus custom schemes, but the settings dropdown renders the raw scheme ids — `builtin:dynamic`, `builtin:light`, `builtin:dark` — and only the built-ins exist today. The doc now matches the UI verbatim and drops the custom-scheme claim.