### PR TITLE
feat(build): run the host app on Java 21

### DIFF
--- a/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
@@ -34,6 +34,14 @@ tasks.register<JavaExec>("runJetWhaleLocal") {
     classpath = jetwhaleHostRuntime
     mainClass.set("com.kitakkun.jetwhale.host.MainKt")
 
+    // The host app targets Java 21; without this the launcher defaults to the plugin module's
+    // 17 toolchain and fails on the host's class files.
+    javaLauncher.set(
+        project.extensions.getByType(JavaToolchainService::class.java).launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        },
+    )
+
     // Point the host at the dev plugins directory; this enables dev-mode loading + hot reload.
     // Supplied lazily via a CommandLineArgumentProvider so the task stays configuration-cache safe.
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,9 @@ mcpKotlinSdk = "0.14.0"
 logback = "1.5.38"
 kermit = "2.1.0"
 
-aboutLibraries = "15.0.4"
+# Pinned to the last release built for Java 17 (14.0.0+ ships class-file 65 / Java 21, which the
+# JDK 17 toolchain runtime cannot load).
+aboutLibraries = "13.2.1"
 spotless = "8.8.0"
 conveyor = "2.0"
 conveyorControl = "1.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,9 +34,7 @@ mcpKotlinSdk = "0.14.0"
 logback = "1.5.38"
 kermit = "2.1.0"
 
-# Pinned to the last release built for Java 17 (14.0.0+ ships class-file 65 / Java 21, which the
-# JDK 17 toolchain runtime cannot load).
-aboutLibraries = "13.2.1"
+aboutLibraries = "15.0.4"
 spotless = "8.8.0"
 conveyor = "2.0"
 conveyorControl = "1.1"

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -255,16 +255,16 @@ fun registerRunTask(name: String, taskDescription: String, hot: Boolean) = tasks
     classpath = files(hostJarProvider)
     mainClass.set("com.kitakkun.jetwhale.host.MainKt")
 
-    // Run the host on the JetBrains Runtime (provisioned via Gradle toolchains; add the foojay
-    // resolver to settings to auto-download it) so it can redefine structural changes in place.
-    if (hot) {
-        javaLauncher.set(
-            project.extensions.getByType(JavaToolchainService::class.java).launcherFor {
-                languageVersion.set(JavaLanguageVersion.of(21))
-                vendor.set(JvmVendorSpec.JETBRAINS)
-            },
-        )
-    }
+    // The host app targets Java 21, so both variants need a 21 launcher regardless of the plugin
+    // module's own toolchain. `hot` additionally runs on the JetBrains Runtime (provisioned via
+    // Gradle toolchains; add the foojay resolver to settings to auto-download it) so it can
+    // redefine structural changes in place.
+    javaLauncher.set(
+        project.extensions.getByType(JavaToolchainService::class.java).launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(21))
+            if (hot) vendor.set(JvmVendorSpec.JETBRAINS)
+        },
+    )
 
     val devDirProvider = devPluginsDir.map { it.asFile.absolutePath }
     // An isolated, disposable app-data root for this plugin project. The host runs against it instead

--- a/jetwhale-host/app/build.gradle.kts
+++ b/jetwhale-host/app/build.gradle.kts
@@ -81,6 +81,13 @@ compose.desktop {
     }
 }
 
+// Merging signed dependency jars (e.g. BouncyCastle) into an uber jar invalidates their
+// signatures; leftover META-INF signature files then make the JVM reject the jar at launch
+// with "Invalid signature file digest for Manifest main attributes".
+tasks.withType<org.gradle.jvm.tasks.Jar>().matching { it.name.contains("UberJar") }.configureEach {
+    exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
+}
+
 compose.resources {
     packageOfResClass = "com.kitakkun.jetwhale.host"
 }

--- a/jetwhale-host/app/build.gradle.kts
+++ b/jetwhale-host/app/build.gradle.kts
@@ -88,10 +88,12 @@ compose.resources {
 val aboutLibrariesDir = layout.buildDirectory.dir("generated/aboutlibraries")
 
 kotlin {
-    // Vendor pin makes Conveyor bundle a maintained Corretto build
-    // instead of the stale OpenJDK GA archive it would pick by default.
+    // 21 (not the repo-wide 17): app-runtime dependencies such as aboutlibraries 14+ ship Java 21
+    // bytecode, and the Metro build plugins already require a 21 build JVM anyway. Published
+    // SDK/agent artifacts stay on 17 for consumer compatibility. Vendor pin makes Conveyor bundle
+    // a maintained Corretto build instead of the stale OpenJDK GA archive it would pick by default.
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
         vendor.set(JvmVendorSpec.AMAZON)
     }
 


### PR DESCRIPTION
## Summary

Supersedes the original 13.2.1 pin (first commit): instead of holding `aboutlibraries` back, the **app toolchain moves to Java 21** and the pin is reverted.

Rationale:
- The licenses screen crashed because aboutlibraries 14+ ships Java 21 bytecode while the app ran on the repo-wide JDK 17 toolchain.
- The 17 pin dates back to the initial prototype commit with no recorded constraint; the only deliberate choice was the Corretto vendor pin (kept).
- Metro's gradle/compiler plugins already require a **21 build JVM** (verified: class-file 65; its `runtime-jvm` is class-file 55), so developer environment requirements do not change.
- `runJetWhaleHot` already provisions JBR **21**; hot reload (byte-buddy self-attach) is unaffected.

Changes:
- `jetwhale-host/app`: toolchain 17 → **Corretto 21** (comment explains why it diverges from the repo-wide 17).
- `runJetWhaleLocal` and `runJetWhale`/`runJetWhaleHot` get an explicit Java 21 launcher — they previously inherited the plugin module's 17 toolchain and would fail to start a 21-built host.
- `aboutLibraries` back to 15.0.4.
- Published SDK/agent artifacts stay on 17 so external plugin authors/consumers on JDK 17 keep working.

## Test plan
- [x] `:jetwhale-host:app:build` passes; `MainKt.class` is class-file 65
- [x] `runJetWhaleLocal` configures with the 21 launcher (dry run)
- [x] JVM-side module builds pass (network/example plugins, feature/settings)
- [x] Manual: launch the host, open the licenses screen, and exercise hot reload