### PR TITLE
docs: cover the MCP tool surface added since alpha07

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -252,6 +252,57 @@ own capabilities — extend the plain `JetWhaleHostPlugin` (not `JetWhaleMessagi
 `messenger`; it is made available for every active session. See
 `ExampleHostOnlyPlugin` in `jetwhale-plugins/example/host`.
 
+## Exposing MCP tools <Badge type="warning" text="experimental" />
+
+A host plugin can contribute tools to the host's [MCP server](/guide/mcp-server) by implementing
+`JetWhaleMcpCapablePlugin`. Each tool is a `JetWhaleMcpCommand`: a self-contained class holding the
+tool's name, description, parameter schema, and execution logic. Parameters are declared as
+delegated properties — the property name becomes the parameter name shown to the AI agent, and the
+same property reads the value back, so each parameter has exactly one, compile-time-checked
+definition:
+
+```kotlin
+@OptIn(ExperimentalJetWhaleApi::class)
+class InspectWidgetCommand(private val widgets: WidgetStore) : JetWhaleMcpCommand() {
+    override val name = "com.example.myplugin.inspectWidget"
+    override val description = "Inspect the selected widget"
+
+    private val widgetId by string("The widget ID")
+    private val verbose by booleanOrNull("Include layout details.")
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        return widgets.describeAsJson(id = arguments[widgetId], verbose = arguments[verbose] ?: false)
+    }
+}
+
+class MyPlugin : JetWhaleMessagingHostPlugin(), JetWhaleMcpCapablePlugin {
+    override val mcpCommands = listOf(InspectWidgetCommand(widgets))
+}
+```
+
+Things to know:
+
+- **Names must be globally unique** — prefix them with your `pluginId` by convention.
+- **`sessionId` is injected for you.** JetWhale adds a required `sessionId` parameter to every
+  plugin tool's schema and routes the call to the right plugin instance, so your command runs
+  against the correct session without handling it yourself.
+- **`execute` returns a string** (plain text or JSON). Throw `JetWhaleMcpArgumentException` for
+  caller mistakes — it is rendered as an `{"error": ...}` payload instead of failing the server.
+- **Messaging works from tool handlers.** `messenger` is valid for the whole instance lifetime, so
+  a command can `request` the agent directly.
+- The MCP APIs are marked `@ExperimentalJetWhaleApi` and may change between releases.
+
+The Network Inspector's own tools (`com.kitakkun.jetwhale.network.*`) are a complete in-repo
+example — see `jetwhale-plugins/network/host`.
+
+### Hiding sensitive UI from MCP screenshots
+
+`jetwhale.screenshot` renders the same Compose scene the host window shows. If your plugin UI
+displays values that AI agents should not see, read the `LocalIsScreenshotCapture`
+CompositionLocal — it is `true` only while the scene is being rendered for an MCP screenshot
+capture — and blank or mask the sensitive content while it is raised. The interactive window never
+observes the raised state, so there is no on-screen flicker.
+
 ## Persistent storage
 
 Every host plugin instance gets a persistent key-value store via the protected `storage` property,

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -39,7 +39,19 @@ required `sessionId` parameter — call `jetwhale.listSessions` first to find th
 Host plugins can expose their own MCP tools by implementing `JetWhaleMcpCapablePlugin`. Their tools
 are registered alongside the built-ins; JetWhale automatically injects a required `sessionId`
 parameter into each plugin tool's schema so an AI agent can target a specific connected device with
-your custom debugging features too. See [Developing Plugins](/guide/developing-plugins).
+your custom debugging features too. See
+[Developing Plugins → Exposing MCP tools](/guide/developing-plugins#exposing-mcp-tools) for how to
+write one.
+
+The [Network Inspector](/guide/network-inspector#mcp-tools) ships a full set of plugin tools
+(`com.kitakkun.jetwhale.network.*`) for reading captured traffic and managing mock rules.
+
+::: tip Sensitive values
+Plugin UIs can hide sensitive content from `jetwhale.screenshot` captures via the
+`LocalIsScreenshotCapture` CompositionLocal, and the Network Inspector's
+[redaction rules](/guide/network-inspector#redacting-sensitive-values) support an `MCP_ONLY` scope
+that keeps values visible to you but hidden from AI agents.
+:::
 
 ::: warning
 The MCP server is experimental — tool names and behavior may change between releases.

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -1,8 +1,9 @@
 # MCP Server <Badge type="warning" text="experimental" />
 
 The JetWhale host embeds an **MCP (Model Context Protocol) server**, so AI agents such as Claude
-can inspect and drive your debuggee apps directly — take screenshots, click, type, scroll, and read
-the accessibility tree.
+can inspect and drive your debugging sessions. The built-in tools operate on a **plugin's UI inside
+the host** — capture it, click, type, scroll, and read its semantics tree — so an agent can use any
+plugin the way you do (and, through a plugin's own capabilities, reach the debuggee app itself).
 
 ## Connecting an AI agent
 
@@ -24,15 +25,16 @@ claude mcp add --transport sse jetwhale http://localhost:7080/sse
 |------|--------------|
 | `jetwhale.listSessions` | Lists connected debug sessions; other tools take a `sessionId` from here |
 | `jetwhale.listPlugins` | Lists the plugins available in a session |
-| `jetwhale.screenshot` | Captures the debuggee's screen |
-| `jetwhale.click` | Clicks/taps at a position or element |
-| `jetwhale.type` | Types text |
-| `jetwhale.scroll` | Scrolls |
-| `jetwhale.drag` | Performs a drag gesture |
-| `jetwhale.getAccessibilityTree` | Returns the accessibility (semantics) tree of the current UI |
+| `jetwhale.screenshot` | Captures the current rendered frame of a plugin's Compose UI as a PNG |
+| `jetwhale.click` | Dispatches a mouse click at pixel coordinates in a plugin's UI |
+| `jetwhale.type` | Types text or a special key into a plugin's UI |
+| `jetwhale.scroll` | Dispatches a scroll event in a plugin's UI |
+| `jetwhale.drag` | Simulates a drag gesture in a plugin's UI |
+| `jetwhale.getAccessibilityTree` | Returns the Compose semantics (accessibility) tree of a plugin's UI |
 
-Because a single host can debug multiple apps at once, every tool that targets a device takes a
-required `sessionId` parameter — call `jetwhale.listSessions` first to find the session you want.
+Because a single host can debug multiple apps at once — each with several plugins — every tool that
+targets a plugin UI takes required `sessionId` **and** `pluginId` parameters: call
+`jetwhale.listSessions` first, then `jetwhale.listPlugins` to pick the plugin.
 
 ## Plugin-provided tools
 

--- a/docs/guide/network-inspector.md
+++ b/docs/guide/network-inspector.md
@@ -122,3 +122,24 @@ The Mocks view lets you define **mock rules** on the host and push them to the r
 mocking is enabled, requests matching a rule get the mocked response instead of hitting the
 network. This is handy for reproducing error states, empty lists, or slow-path payloads without a
 test backend. Toggle mocking on/off at any time from the host — no app restart needed.
+
+## MCP tools
+
+The Network Inspector contributes its own tools to the host's [MCP server](/guide/mcp-server), so
+an AI agent can read captured traffic and manage mock rules for a session:
+
+| Tool | What it does |
+|------|--------------|
+| `com.kitakkun.jetwhale.network.listTransactions` | Lists captured HTTP transactions |
+| `com.kitakkun.jetwhale.network.getTransaction` | Returns one transaction in full (headers, bodies, timing) |
+| `com.kitakkun.jetwhale.network.clearTransactions` | Clears the captured transaction list |
+| `com.kitakkun.jetwhale.network.getMockConfig` | Returns the current mock rules and whether mocking is enabled |
+| `com.kitakkun.jetwhale.network.addMockRule` | Adds a mock rule |
+| `com.kitakkun.jetwhale.network.removeMockRule` | Removes a mock rule |
+| `com.kitakkun.jetwhale.network.setMockingEnabled` | Turns mocking on or off |
+
+Like every MCP tool, they take a required `sessionId` (from `jetwhale.listSessions`).
+
+[Redaction rules](#redacting-sensitive-values) apply to MCP output as well: values redacted with
+`RedactionScope.MCP_ONLY` are hidden from these tools' results **and** from `jetwhale.screenshot`
+captures of the Network Inspector UI, while staying visible to you in the host window.


### PR DESCRIPTION
Pre-alpha08 docs polish. The docs were already up to date for most of the alpha08 changes (messaging, storage, plugin install/trust, wss, sandbox); the remaining gap was the MCP tool surface from #122 / #141 / #142:

- **Network Inspector** — documents the plugin's MCP tools (`com.kitakkun.jetwhale.network.*`) and clarifies that `RedactionScope.MCP_ONLY` also hides values from `jetwhale.screenshot` captures.
- **Developing Plugins** — new *Exposing MCP tools* section: `JetWhaleMcpCapablePlugin`, `JetWhaleMcpCommand` with delegated parameter declarations, automatic `sessionId` injection, error rendering via `JetWhaleMcpArgumentException`, and `LocalIsScreenshotCapture` for hiding sensitive UI from captures. The MCP Server page linked here for plugin tools, but no such section existed.
- **MCP Server** — links both sections and adds a tip on the sensitive-value controls.

Verified with `npm run docs:build` (VitePress dead-link check passes).