### PR TITLE
ci: give Conveyor the GitHub token so make copied-site succeeds

### DIFF
--- a/.github/workflows/distribute-desktop-app.yaml
+++ b/.github/workflows/distribute-desktop-app.yaml
@@ -54,6 +54,10 @@ jobs:
         run: ./gradlew :jetwhale-host:app:jar
       - name: Build download site with Conveyor
         uses: hydraulic-software/conveyor/actions/build@v22.0
+        env:
+          # conveyor.conf reads this for app.site.github.oauth-token; a GitHub site base-url
+          # makes Conveyor require it even for `make copied-site`.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           command: make copied-site
           signing_key: ${{ secrets.CONVEYOR_SIGNING_KEY }}

--- a/.github/workflows/distribute-desktop-app.yaml
+++ b/.github/workflows/distribute-desktop-app.yaml
@@ -3,6 +3,10 @@ on:
   push:
     tags:
       - "*"
+  # Manual runs let us validate the build + Conveyor packaging without cutting a tag
+  # (which would also trigger the Maven publish). The release job below is tag-only, so a
+  # manual run builds and signs everything but creates no GitHub release.
+  workflow_dispatch:
 permissions:
   contents: write
 jobs:
@@ -46,6 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     # CONVEYOR_SIGNING_KEY is an environment secret on `Publish`.
     environment: Publish
+    # `make copied-site` only reads release metadata to render the site; it never writes
+    # to the repo (the draft release is created by the `release` job). Keep this job read-only.
+    permissions:
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -57,7 +65,7 @@ jobs:
         env:
           # conveyor.conf reads this for app.site.github.oauth-token; a GitHub site base-url
           # makes Conveyor require it even for `make copied-site`.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           command: make copied-site
           signing_key: ${{ secrets.CONVEYOR_SIGNING_KEY }}
@@ -72,6 +80,8 @@ jobs:
     name: Create Draft Release and Attach Artifacts
     runs-on: ubuntu-latest
     needs: [build-uber-jars, build-packages]
+    # Only cut a release for real tag pushes; manual (workflow_dispatch) runs are build-only tests.
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -11,6 +11,12 @@ app {
   // Serve updates from the latest GitHub release assets.
   site.base-url = "https://github.com/kitakkun/JetWhale/releases/latest/download"
 
+  // A GitHub release base-url makes Conveyor activate its GitHub integration, so even
+  // `make copied-site` (which only renders the site into output/) requires a token to
+  // authenticate against the API. Read the Actions-provided token from the environment;
+  // the release itself is still created separately as a draft by the workflow.
+  site.github.oauth-token = ${env.GITHUB_TOKEN}
+
   // Never update behind the user's back: users may intentionally pin an older host
   // to match an older agent SDK. Updates are only applied when explicitly triggered
   // from the in-app updates section (via the Conveyor control API).


### PR DESCRIPTION
The `1.0.0-alpha08` tag's **Distribute Desktop Application** run [failed](https://github.com/kitakkun/JetWhale/actions/runs/29678986452) at the final step:

```
Error: Task failed: Copied Site: Releasing to GitHub requires an OAuth token.
Please set it in your config at key `app.site.github.oauth-token`.
```

All platform packages built and signed fine — only the site-render step failed. Because `app.site.base-url` points at `github.com/.../releases/latest/download`, Conveyor activates its GitHub integration and requires an OAuth token even for `make copied-site` (which only writes the site into `output/`).

## Fix
- `conveyor.conf`: `app.site.github.oauth-token = ${env.GITHUB_TOKEN}`
- workflow: pass the built-in `GITHUB_TOKEN` (already have `contents: write`) as env to the Conveyor step

No new secret needed. The draft release is still created separately by the `release` job, so Conveyor is not doing the actual GitHub release — it just needs the token to authenticate.

## Re-release note
Maven Central for alpha08 has not been released from the Portal yet, so after merging this we can delete + re-push the `1.0.0-alpha08` tag to rerun both Publish and Distribute cleanly.