### PR TITLE
fix(network): keep traffic-row URLs on one line (ellipsis instead of wrapping)

### DIFF
--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
@@ -199,6 +200,11 @@ private fun TransactionRow(tx: HttpTransaction, selected: Boolean, onClick: () -
             text = tx.request.url,
             style = MaterialTheme.typography.bodySmall,
             maxLines = 1,
+            // softWrap = false keeps the URL on one line so a narrow column truncates it with an
+            // ellipsis at the edge; with the default softWrap the text wraps at the "//" first and
+            // maxLines = 1 then leaves only the "https://" scheme visible.
+            softWrap = false,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )
         if (tx.response?.fromMock == true) {


### PR DESCRIPTION
Popping out the Network Inspector into a narrow window showed traffic rows with just `https://` as the URL — reported as the "DELETE title looks off" but it affected every row; DELETE only looked different because each row wraps at a slightly different point.

## Cause
The traffic-row URL `Text` set `maxLines = 1` but left the default `softWrap = true`. Compose wraps first, then truncates to `maxLines`: the URL breaks at the `//`, and the kept first line is just `https://`. In a wide column the whole URL fits on one line so nothing wraps — which is why it only showed in the popped-out (narrow) window. The captured data was always correct (verified via the `com.kitakkun.jetwhale.network.listTransactions` MCP tool).

## Fix
`TrafficView.kt` — the URL `Text` now uses `softWrap = false` + `overflow = TextOverflow.Ellipsis`, so it stays on one line and truncates with an ellipsis at the column edge.

## Verification
Hot-reloaded into a running host and captured the plugin UI via the `jetwhale.screenshot` MCP tool at narrow/medium widths:
- Before: rows showed `GET https://`.
- After: rows show `GET https://jsonplaceholder.ty…` consistently across GET/DELETE.

`:jetwhale-plugins:network:host:test` passes.