### PR TITLE
fix(host): pin the collapsed-drawer expand icon to 24.dp

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ShrunkToolingDrawerView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ShrunkToolingDrawerView.kt
@@ -68,6 +68,10 @@ fun ShrunkToolingDrawerView(
             Icon(
                 painter = painterResource(Res.drawable.sidebar_unfold),
                 contentDescription = null,
+                // Material Icon skips its 24.dp default for a painter that already reports an
+                // intrinsic size (an SVG does), so this SVG would render at its own size and look
+                // larger than the sibling ImageVector icons. Pin it to match, like the plugin icons.
+                modifier = Modifier.size(24.dp),
             )
         }
         Box {


### PR DESCRIPTION
The top icon in the collapsed tooling drawer (the sidebar-expand button) rendered larger than the icons below it (Devices / Settings / Info).

## Cause
Material `Icon` only applies its 24.dp default size when the painter has **no** intrinsic size. An SVG painter (`Res.drawable.sidebar_unfold`) reports its own intrinsic size, so `Icon` skipped the default and drew it at that size — larger than the sibling Material `ImageVector` icons. The plugin icons in the same rail already work around this with `Modifier.size(24.dp)`; this spot just missed it.

## Fix
`ShrunkToolingDrawerView.kt` — add `Modifier.size(24.dp)` to the `sidebar_unfold` icon so it matches the rest of the rail.

Scope is the size only — no icon/design change. `:jetwhale-host:app:compileKotlin` passes.