### PR TITLE
ci: give the Conveyor job contents: write for GitHub Releases access

### DIFF
--- a/.github/workflows/distribute-desktop-app.yaml
+++ b/.github/workflows/distribute-desktop-app.yaml
@@ -50,10 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     # CONVEYOR_SIGNING_KEY is an environment secret on `Publish`.
     environment: Publish
-    # `make copied-site` only reads release metadata to render the site; it never writes
-    # to the repo (the draft release is created by the `release` job). Keep this job read-only.
+    # Conveyor's GitHub integration hits the Releases API even for `make copied-site`, and that
+    # access needs write scope — with contents: read it fails with "Resource not accessible by
+    # integration". The actual draft release is still created by the `release` job.
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up to #156. The manual Conveyor smoke-test got past the OAuth-token error but then failed with:

```
Error: Task failed: Copied Site: Error interacting with GitHub: Resource not accessible by integration
```

The `contents: read` least-privilege scope I added in #156 (per review feedback) was too tight — Conveyor's GitHub integration hits the **Releases API** even for `make copied-site`, and that needs `contents: write`. With read-only the token exists but lacks permission.

## Fix
`build-packages` job → `permissions: contents: write` (matches the workflow-level default; the token itself is still the built-in `github.token`). The actual draft release is still created by the separate `release` job.

Once merged Ill re-run the manual Distribute workflow to confirm the Conveyor step goes green before re-tagging alpha08.