### PR TITLE
fix(host): packaged app crash on startup (missing java.instrument) + bump to alpha09

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jetwhale = "1.0.0-alpha08"
+jetwhale = "1.0.0-alpha09"
 mavenPublish = "0.37.0"
 
 # kotlin

--- a/jetwhale-host/app/build.gradle.kts
+++ b/jetwhale-host/app/build.gradle.kts
@@ -58,6 +58,9 @@ compose.desktop {
             modules("jdk.unsupported")
             modules("java.naming")
             modules("java.sql")
+            // java.lang.instrument.Instrumentation (ByteBuddy self-attach for plugin hot-reload)
+            // lives in java.instrument; without it the packaged app crashes on startup.
+            modules("java.instrument")
 
             targetFormats(
                 TargetFormat.Dmg,


### PR DESCRIPTION
The packaged desktop app (`.dmg`/`.msi`/`.deb`) crashed immediately on startup:

```
Exception in thread "main" java.lang.NoClassDefFoundError: java/lang/instrument/Instrumentation
    at ...DefaultPluginFactoryRepository.<init>(DefaultPluginFactoryRepository.kt:335)
Caused by: java.lang.ClassNotFoundException: java.lang.instrument.Instrumentation
Failed to launch JVM
```

## Cause
`DefaultPluginFactoryRepository` self-attaches a ByteBuddy agent (`java.lang.instrument.Instrumentation`) for plugin hot-reload. That class is in the **`java.instrument`** module, which the jpackage `nativeDistributions.modules` block did not declare (only `jdk.unsupported`/`java.naming`/`java.sql`). The jlink runtime image therefore omitted it and the app failed to launch. Conveyor auto-detects modules, which masked this — reverting distribution to jpackage (#160) re-exposed it. The uber-jar is unaffected (it runs on the users full JDK), which is why `runJetWhaleLocal` never showed it.

## Fix
- Add `modules("java.instrument")` to the packaged runtime image.
- Bump the version to **1.0.0-alpha09** to re-publish.

## Verification
Rebuilt the `.app` locally (JBR 21) and launched it: it now runs past startup with no `NoClassDefFoundError` and no further missing-module errors (the broken build died in <1s; the fixed one stays up). The `alpha08` desktop assets should be treated as broken.