### PR TITLE
chore: bump version to 1.0.0-alpha10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jetwhale = "1.0.0-alpha09"
+jetwhale = "1.0.0-alpha10"
 mavenPublish = "0.37.0"
 
 # kotlin


### PR DESCRIPTION
Bump the `jetwhale` version to `1.0.0-alpha10` for the next development cycle, following the 1.0.0-alpha09 release.