### PR TITLE
fix(plugin): keep plugin scene focused across session switches

### DIFF
--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreen.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.scene.ComposeScenePointer
@@ -33,10 +34,6 @@ fun PluginScreen(pluginComposeScene: PluginComposeScene) {
     val catchThrowHost = LocalCatchThrowHost.current
     var frameNanoTime by remember(pluginComposeScene) { mutableLongStateOf(0L) }
     val focusRequester = remember { FocusRequester() }
-
-    LaunchedEffect(pluginComposeScene) {
-        focusRequester.requestFocus()
-    }
 
     LaunchedEffect(pluginComposeScene) {
         while (true) {
@@ -67,6 +64,10 @@ fun PluginScreen(pluginComposeScene: PluginComposeScene) {
             }
             .focusRequester(focusRequester)
             .focusable()
+            // Re-acquire focus once the node is actually placed: on a session switch the swapped-in
+            // Canvas is not yet placed when composition runs, so a single-shot requestFocus is a
+            // silently-dropped no-op. Driving it from placement makes the request survive the swap.
+            .onPlaced { focusRequester.requestFocus() }
             // Key on the scene (not Unit): on hot reload the scene instance is replaced, and a
             // Unit-keyed pointerInput would keep dispatching to the old, now-closed scene — leaving
             // the freshly reloaded UI unresponsive to clicks.


### PR DESCRIPTION
## Problem

Plugin keyboard input breaks when switching sessions.

Repro: open Plugin A while Device A is selected, then switch to Device B (the host auto-composes Device B's instance of Plugin A). The newly shown plugin scene does not receive focus, so keyboard input is dropped.

## Root cause

Focus was requested single-shot:

```kotlin
LaunchedEffect(pluginComposeScene) { focusRequester.requestFocus() }
```

On a session switch a new `PluginScreen` is created and this effect runs, but the new `Canvas` focusable node is typically **not yet placed/attached** at that instant (and the outgoing entry may still hold focus during the ~100ms nav fade). `FocusRequester.requestFocus()` on an unplaced node is a **silently-dropped no-op** that was never retried, so once the outgoing entry is disposed no node holds focus and `onKeyEvent` never fires.

First-open works because there is no competing outgoing scene.

## Fix

Drive the focus request from **placement** instead of a single-shot effect: add `Modifier.onPlaced { focusRequester.requestFocus() }` to the same Canvas node that carries `.focusRequester(focusRequester).focusable()`. Focus is then (re)acquired once the node is actually placed after the swap, which also covers first-open, so the redundant `LaunchedEffect` is removed.

The change is localized to `PluginScreen.kt`; pointer/key forwarding is unchanged.

## Verification

`./gradlew :jetwhale-host:feature:plugin:compileKotlin --console=plain` -> BUILD SUCCESSFUL.