### PR TITLE
feat(network): theme-aware detail colors and Body-first tabbed detail pane

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -303,6 +303,12 @@ CompositionLocal — it is `true` only while the scene is being rendered for an 
 capture — and blank or mask the sensitive content while it is raised. The interactive window never
 observes the raised state, so there is no on-screen flicker.
 
+The `LocalJetWhaleDarkTheme` CompositionLocal tells your plugin whether the host is rendering it in
+a dark theme — the host provides the authoritative value from its actually-applied color scheme.
+Read it (`LocalJetWhaleDarkTheme.current`) to pick theme-appropriate colors instead of
+`isSystemInDarkTheme()`, which reflects the OS setting and can disagree with the host's own Theme
+option.
+
 ## Persistent storage
 
 Every host plugin instance gets a persistent key-value store via the protected `storage` property,

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -1,3 +1,7 @@
+public final class com/kitakkun/jetwhale/host/sdk/DarkThemeKt {
+	public static final fun getLocalJetWhaleDarkTheme ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
 public abstract interface annotation class com/kitakkun/jetwhale/host/sdk/ExperimentalJetWhaleApi : java/lang/annotation/Annotation {
 }
 

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/DarkTheme.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/DarkTheme.kt
@@ -1,0 +1,14 @@
+package com.kitakkun.jetwhale.host.sdk
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * True when the host is rendering this plugin in a dark theme.
+ *
+ * Consume this (e.g. `LocalJetWhaleDarkTheme.current`) to pick theme-appropriate colors, instead of
+ * `isSystemInDarkTheme()` — that reflects the OS setting, which can disagree with the host's own
+ * Theme option (builtin:light / builtin:dark / builtin:dynamic). The host provides the authoritative
+ * value from its actually-applied color scheme.
+ */
+public val LocalJetWhaleDarkTheme: ProvidableCompositionLocal<Boolean> = compositionLocalOf { false }

--- a/jetwhale-host/core/ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/ColorSchemeConverter.kt
+++ b/jetwhale-host/core/ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/ColorSchemeConverter.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import com.kitakkun.jetwhale.host.model.JetWhaleColorScheme
 import com.kitakkun.jetwhale.host.model.ThemeColorTokens
 
@@ -78,5 +79,26 @@ fun JetWhaleColorScheme.toMaterial3ColorScheme(): ColorScheme = when (this) {
                 onTertiaryFixedVariant = colors[ThemeColorTokens.OnTertiaryFixedVariant] ?: Color.Unspecified,
             )
         }
+    }
+}
+
+/**
+ * Whether this scheme renders dark, decided from the scheme itself rather than a luminance guess of
+ * the resolved surface: [JetWhaleColorScheme.Static.Light]/[JetWhaleColorScheme.Static.Dark] are
+ * definitive, and [JetWhaleColorScheme.Dynamic] follows the OS exactly as [toMaterial3ColorScheme]
+ * does. A [JetWhaleColorScheme.Static.Custom] scheme carries no light/dark label, so as a fallback
+ * it is judged by the luminance of its declared surface (or background) color.
+ */
+@Composable
+fun JetWhaleColorScheme.isDarkTheme(): Boolean = when (this) {
+    is JetWhaleColorScheme.Dynamic -> if (isSystemInDarkTheme()) darkColorScheme.isDarkTheme() else lightColorScheme.isDarkTheme()
+
+    is JetWhaleColorScheme.Static.Light -> false
+
+    is JetWhaleColorScheme.Static.Dark -> true
+
+    is JetWhaleColorScheme.Static.Custom -> {
+        val surfaceArgb = colors[ThemeColorTokens.Surface] ?: colors[ThemeColorTokens.Background]
+        surfaceArgb?.let { Color(it).luminance() < 0.5f } ?: false
     }
 }

--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/DefaultDynamicPluginBridgeProvider.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/DefaultDynamicPluginBridgeProvider.kt
@@ -1,12 +1,16 @@
 package com.kitakkun.jetwhale.host.plugin
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.luminance
 import com.kitakkun.jetwhale.host.architecture.ExplicitScreenContextUsage
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.withScreenContext
 import com.kitakkun.jetwhale.host.model.AppearanceSettingsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.DynamicPluginBridgeProvider
 import com.kitakkun.jetwhale.host.model.ThemeSubscriptionKey
+import com.kitakkun.jetwhale.host.sdk.LocalJetWhaleDarkTheme
 import com.kitakkun.jetwhale.host.ui.AppEnvironment
 import com.kitakkun.jetwhale.host.ui.JetWhaleTheme
 import dev.zacsweers.metro.AppScope
@@ -33,8 +37,12 @@ class DefaultDynamicPluginBridgeProvider(
                     state2 = rememberSubscription(appearanceSettingsSubscriptionKey),
                 ) { theme, appearanceSettings ->
                     JetWhaleTheme(theme.colorScheme) {
-                        AppEnvironment(appearanceSettings.appLanguage) {
-                            content()
+                        CompositionLocalProvider(
+                            LocalJetWhaleDarkTheme provides (MaterialTheme.colorScheme.surface.luminance() < 0.5f),
+                        ) {
+                            AppEnvironment(appearanceSettings.appLanguage) {
+                                content()
+                            }
                         }
                     }
                 }

--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/DefaultDynamicPluginBridgeProvider.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/DefaultDynamicPluginBridgeProvider.kt
@@ -1,9 +1,7 @@
 package com.kitakkun.jetwhale.host.plugin
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.graphics.luminance
 import com.kitakkun.jetwhale.host.architecture.ExplicitScreenContextUsage
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.withScreenContext
@@ -13,6 +11,7 @@ import com.kitakkun.jetwhale.host.model.ThemeSubscriptionKey
 import com.kitakkun.jetwhale.host.sdk.LocalJetWhaleDarkTheme
 import com.kitakkun.jetwhale.host.ui.AppEnvironment
 import com.kitakkun.jetwhale.host.ui.JetWhaleTheme
+import com.kitakkun.jetwhale.host.ui.isDarkTheme
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -38,7 +37,9 @@ class DefaultDynamicPluginBridgeProvider(
                 ) { theme, appearanceSettings ->
                     JetWhaleTheme(theme.colorScheme) {
                         CompositionLocalProvider(
-                            LocalJetWhaleDarkTheme provides (MaterialTheme.colorScheme.surface.luminance() < 0.5f),
+                            // Decided from the scheme itself (definitive for Light/Dark, OS for
+                            // Dynamic), not a luminance guess of the resolved surface.
+                            LocalJetWhaleDarkTheme provides theme.colorScheme.isDarkTheme(),
                         ) {
                             AppEnvironment(appearanceSettings.appLanguage) {
                                 content()

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/JsonBodyView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/JsonBodyView.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.plugins.network.host
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -67,10 +68,11 @@ internal fun BodyBlock(label: String, body: String?, truncated: Boolean) {
             modifier = Modifier.fillMaxWidth(),
         ) {
             Box(Modifier.padding(10.dp)) {
+                val colors = rememberJsonColors()
                 if (json != null && mode == BodyMode.Tree) {
-                    Column { JsonTreeNode(json, label = label) }
+                    Column { JsonTreeNode(json, label = label, colors = colors) }
                 } else {
-                    val rendered = remember(json, body) { json?.let { highlightedJson(it) } }
+                    val rendered = remember(json, body, colors) { json?.let { highlightedJson(it, colors) } }
                     Text(
                         text = rendered ?: AnnotatedString(body + if (truncated) "\n… (truncated)" else ""),
                         style = MaterialTheme.typography.bodySmall,
@@ -89,15 +91,16 @@ private enum class BodyMode { Tree, Raw }
 // ---------------------------------------------------------------------------------------
 
 @Composable
-private fun JsonTreeNode(element: JsonElement, label: String?, depth: Int = 0) {
+private fun JsonTreeNode(element: JsonElement, label: String?, colors: JsonColors, depth: Int = 0) {
     when (element) {
         is JsonObject -> JsonBranch(
             label = label,
             isArray = false,
             size = element.size,
             depth = depth,
+            colors = colors,
         ) {
-            element.forEach { (key, value) -> JsonTreeNode(value, key, depth + 1) }
+            element.forEach { (key, value) -> JsonTreeNode(value, key, colors, depth + 1) }
         }
 
         is JsonArray -> JsonBranch(
@@ -105,11 +108,12 @@ private fun JsonTreeNode(element: JsonElement, label: String?, depth: Int = 0) {
             isArray = true,
             size = element.size,
             depth = depth,
+            colors = colors,
         ) {
-            element.forEachIndexed { index, value -> JsonTreeNode(value, "[$index]", depth + 1) }
+            element.forEachIndexed { index, value -> JsonTreeNode(value, "[$index]", colors, depth + 1) }
         }
 
-        else -> JsonLeaf(label, element as JsonPrimitive, depth)
+        else -> JsonLeaf(label, element as JsonPrimitive, colors, depth)
     }
 }
 
@@ -119,6 +123,7 @@ private fun JsonBranch(
     isArray: Boolean,
     size: Int,
     depth: Int,
+    colors: JsonColors,
     children: @Composable () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(depth < 1) }
@@ -133,14 +138,14 @@ private fun JsonBranch(
     ) {
         Text(
             text = if (expanded) "▾" else "▸",
-            color = JsonColors.punctuation,
+            color = colors.punctuation,
             style = MaterialTheme.typography.bodySmall,
             fontFamily = FontFamily.Monospace,
         )
         Text(
             buildAnnotatedString {
-                if (label != null) withStyle(SpanStyle(color = JsonColors.key)) { append(label) }
-                withStyle(SpanStyle(color = JsonColors.punctuation)) {
+                if (label != null) withStyle(SpanStyle(color = colors.key)) { append(label) }
+                withStyle(SpanStyle(color = colors.punctuation)) {
                     append(if (isArray) "  [$size]" else "  {$size}")
                 }
             },
@@ -152,14 +157,14 @@ private fun JsonBranch(
 }
 
 @Composable
-private fun JsonLeaf(label: String?, primitive: JsonPrimitive, depth: Int) {
+private fun JsonLeaf(label: String?, primitive: JsonPrimitive, colors: JsonColors, depth: Int) {
     Text(
         buildAnnotatedString {
             if (label != null) {
-                withStyle(SpanStyle(color = JsonColors.key)) { append(label) }
-                withStyle(SpanStyle(color = JsonColors.punctuation)) { append(": ") }
+                withStyle(SpanStyle(color = colors.key)) { append(label) }
+                withStyle(SpanStyle(color = colors.punctuation)) { append(": ") }
             }
-            append(primitiveAnnotated(primitive))
+            append(primitiveAnnotated(primitive, colors))
         },
         style = MaterialTheme.typography.bodySmall,
         fontFamily = FontFamily.Monospace,
@@ -171,12 +176,13 @@ private fun JsonLeaf(label: String?, primitive: JsonPrimitive, depth: Int) {
 // Raw (syntax-highlighted, pretty-printed)
 // ---------------------------------------------------------------------------------------
 
-private fun highlightedJson(element: JsonElement): AnnotatedString = buildAnnotatedString { appendJson(element, 0) }
+private fun highlightedJson(element: JsonElement, colors: JsonColors): AnnotatedString =
+    buildAnnotatedString { appendJson(element, 0, colors) }
 
-private fun AnnotatedString.Builder.appendJson(element: JsonElement, indent: Int) {
+private fun AnnotatedString.Builder.appendJson(element: JsonElement, indent: Int, colors: JsonColors) {
     val pad = "  ".repeat(indent)
     val pad1 = "  ".repeat(indent + 1)
-    fun punct(text: String) = withStyle(SpanStyle(color = JsonColors.punctuation)) { append(text) }
+    fun punct(text: String) = withStyle(SpanStyle(color = colors.punctuation)) { append(text) }
     when (element) {
         is JsonObject -> {
             if (element.isEmpty()) {
@@ -186,9 +192,9 @@ private fun AnnotatedString.Builder.appendJson(element: JsonElement, indent: Int
             punct("{\n")
             element.entries.forEachIndexed { index, (key, value) ->
                 append(pad1)
-                withStyle(SpanStyle(color = JsonColors.key)) { append("\"$key\"") }
+                withStyle(SpanStyle(color = colors.key)) { append("\"$key\"") }
                 punct(": ")
-                appendJson(value, indent + 1)
+                appendJson(value, indent + 1, colors)
                 if (index < element.size - 1) punct(",")
                 append("\n")
             }
@@ -204,7 +210,7 @@ private fun AnnotatedString.Builder.appendJson(element: JsonElement, indent: Int
             punct("[\n")
             element.forEachIndexed { index, value ->
                 append(pad1)
-                appendJson(value, indent + 1)
+                appendJson(value, indent + 1, colors)
                 if (index < element.size - 1) punct(",")
                 append("\n")
             }
@@ -212,26 +218,41 @@ private fun AnnotatedString.Builder.appendJson(element: JsonElement, indent: Int
             punct("]")
         }
 
-        else -> append(primitiveAnnotated(element as JsonPrimitive))
+        else -> append(primitiveAnnotated(element as JsonPrimitive, colors))
     }
 }
 
-private fun primitiveAnnotated(primitive: JsonPrimitive): AnnotatedString = buildAnnotatedString {
+private fun primitiveAnnotated(primitive: JsonPrimitive, colors: JsonColors): AnnotatedString = buildAnnotatedString {
     val color = when {
-        primitive is JsonNull -> JsonColors.keyword
-        primitive.isString -> JsonColors.string
-        primitive.content == "true" || primitive.content == "false" -> JsonColors.keyword
-        else -> JsonColors.number
+        primitive is JsonNull -> colors.keyword
+        primitive.isString -> colors.string
+        primitive.content == "true" || primitive.content == "false" -> colors.keyword
+        else -> colors.number
     }
     withStyle(SpanStyle(color = color)) { append(primitive.toString()) }
 }
 
-private object JsonColors {
-    val key = Color(0xFF0B6E99)
-    val string = Color(0xFF2E7D32)
-    val number = Color(0xFF1565C0)
-    val keyword = Color(0xFF8E24AA)
-    val punctuation = Color(0xFF8A8A8A)
+private data class JsonColors(
+    val key: Color,
+    val string: Color,
+    val number: Color,
+    val keyword: Color,
+    val punctuation: Color,
+)
+
+@Composable
+private fun rememberJsonColors(): JsonColors {
+    val dark = isSystemInDarkTheme()
+    val punctuation = MaterialTheme.colorScheme.onSurfaceVariant
+    return remember(dark, punctuation) {
+        JsonColors(
+            key = if (dark) Color(0xFF4FC3F7) else Color(0xFF0B6E99),
+            string = if (dark) Color(0xFF81C784) else Color(0xFF2E7D32),
+            number = if (dark) Color(0xFF64B5F6) else Color(0xFF1565C0),
+            keyword = if (dark) Color(0xFFCE93D8) else Color(0xFF8E24AA),
+            punctuation = punctuation,
+        )
+    }
 }
 
 private val lenientJson = Json {

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/JsonBodyView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/JsonBodyView.kt
@@ -176,8 +176,7 @@ private fun JsonLeaf(label: String?, primitive: JsonPrimitive, colors: JsonColor
 // Raw (syntax-highlighted, pretty-printed)
 // ---------------------------------------------------------------------------------------
 
-private fun highlightedJson(element: JsonElement, colors: JsonColors): AnnotatedString =
-    buildAnnotatedString { appendJson(element, 0, colors) }
+private fun highlightedJson(element: JsonElement, colors: JsonColors): AnnotatedString = buildAnnotatedString { appendJson(element, 0, colors) }
 
 private fun AnnotatedString.Builder.appendJson(element: JsonElement, indent: Int, colors: JsonColors) {
     val pad = "  ".repeat(indent)

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/JsonBodyView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/JsonBodyView.kt
@@ -1,7 +1,6 @@
 package com.kitakkun.jetwhale.plugins.network.host
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -241,7 +240,7 @@ private data class JsonColors(
 
 @Composable
 private fun rememberJsonColors(): JsonColors {
-    val dark = isSystemInDarkTheme()
+    val dark = isDarkTheme()
     val punctuation = MaterialTheme.colorScheme.onSurfaceVariant
     return remember(dark, punctuation) {
         JsonColors(

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ThemeColors.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ThemeColors.kt
@@ -1,0 +1,12 @@
+package com.kitakkun.jetwhale.plugins.network.host
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Returns [dark] under a dark theme and [light] otherwise, so fixed brand hues stay legible against
+ * both surfaces while keeping their hue.
+ */
+@Composable
+internal fun themeColor(light: Color, dark: Color): Color = if (isSystemInDarkTheme()) dark else light

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ThemeColors.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ThemeColors.kt
@@ -1,18 +1,17 @@
 package com.kitakkun.jetwhale.plugins.network.host
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
+import com.kitakkun.jetwhale.host.sdk.LocalJetWhaleDarkTheme
 
 /**
- * True when the **applied** Material theme is dark — derived from the color scheme's own surface
- * luminance, not the OS setting (`isSystemInDarkTheme`). The host has its own Theme option
- * (builtin:light / builtin:dark / builtin:dynamic), so the OS value can disagree with what's on
- * screen; reading the actual scheme keeps these colors in step with the in-app theme.
+ * True when the host is rendering this plugin in a dark theme. Reads the authoritative
+ * [LocalJetWhaleDarkTheme] the host provides from its actually-applied color scheme, not the OS
+ * setting (`isSystemInDarkTheme`) — the host has its own Theme option (builtin:light / builtin:dark
+ * / builtin:dynamic), which can disagree with what's on screen.
  */
 @Composable
-internal fun isDarkTheme(): Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+internal fun isDarkTheme(): Boolean = LocalJetWhaleDarkTheme.current
 
 /**
  * Returns [dark] under a dark theme and [light] otherwise, so fixed brand hues stay legible against

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ThemeColors.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ThemeColors.kt
@@ -1,12 +1,22 @@
 package com.kitakkun.jetwhale.plugins.network.host
 
-import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+
+/**
+ * True when the **applied** Material theme is dark — derived from the color scheme's own surface
+ * luminance, not the OS setting (`isSystemInDarkTheme`). The host has its own Theme option
+ * (builtin:light / builtin:dark / builtin:dynamic), so the OS value can disagree with what's on
+ * screen; reading the actual scheme keeps these colors in step with the in-app theme.
+ */
+@Composable
+internal fun isDarkTheme(): Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5f
 
 /**
  * Returns [dark] under a dark theme and [light] otherwise, so fixed brand hues stay legible against
  * both surfaces while keeping their hue.
  */
 @Composable
-internal fun themeColor(light: Color, dark: Color): Color = if (isSystemInDarkTheme()) dark else light
+internal fun themeColor(light: Color, dark: Color): Color = if (isDarkTheme()) dark else light

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -251,7 +250,7 @@ private fun MockChip() {
 @Composable
 private fun Pill(label: String, color: Color) {
     // 14% of a dark hue on a dark surface nearly vanishes, so give the fill more presence in dark mode.
-    val fillAlpha = if (isSystemInDarkTheme()) 0.22f else 0.14f
+    val fillAlpha = if (isDarkTheme()) 0.22f else 0.14f
     Surface(
         color = color.copy(alpha = fillAlpha),
         contentColor = color,

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
@@ -227,13 +227,17 @@ private fun TransactionRow(tx: HttpTransaction, selected: Boolean, onClick: () -
 private fun StatusBadge(tx: HttpTransaction) {
     val (label, color) = when {
         tx.failure != null -> "ERR" to MaterialTheme.colorScheme.error
+
         tx.response == null -> "···" to MaterialTheme.colorScheme.outline
+
         tx.response.statusCode in 200..299 ->
             tx.response.statusCode.toString() to themeColor(Color(0xFF2E7D32), Color(0xFF66BB6A))
 
         tx.response.statusCode in 300..399 ->
             tx.response.statusCode.toString() to themeColor(Color(0xFF1565C0), Color(0xFF64B5F6))
+
         tx.response.statusCode >= 400 -> tx.response.statusCode.toString() to MaterialTheme.colorScheme.error
+
         else -> tx.response.statusCode.toString() to MaterialTheme.colorScheme.onSurface
     }
     Pill(label = label, color = color)
@@ -272,7 +276,9 @@ private enum class DetailTab(val title: String) {
 private fun TransactionDetail(tx: HttpTransaction, onCreateMock: () -> Unit) {
     val queryParams = remember(tx.request.url) { parseQueryParams(tx.request.url) }
     val hasResponseBody = !tx.response?.body.isNullOrEmpty()
-    var selectedTab by remember(tx.txId) {
+    // Key on hasResponseBody too: the body often arrives after the row is first selected (same
+    // txId), and the default should follow it to Body once it exists.
+    var selectedTab by remember(tx.txId, hasResponseBody) {
         mutableStateOf(if (hasResponseBody) DetailTab.Body else DetailTab.Headers)
     }
 
@@ -348,13 +354,19 @@ private fun TransactionDetail(tx: HttpTransaction, onCreateMock: () -> Unit) {
 private fun BodyTab(tx: HttpTransaction) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         when {
-            tx.failure != null || (tx.response != null && tx.response.body.isNullOrEmpty()) -> Text(
-                text = "No response body",
+            // The failure detail itself is shown above the tabs; here just note there is no body.
+            tx.failure != null -> Text(
+                text = "Request failed — no response body",
                 color = MaterialTheme.colorScheme.outline,
             )
 
             tx.response == null -> Text(
                 text = "Pending…",
+                color = MaterialTheme.colorScheme.outline,
+            )
+
+            tx.response.body.isNullOrEmpty() -> Text(
+                text = "No response body",
                 color = MaterialTheme.colorScheme.outline,
             )
 

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
@@ -323,23 +323,24 @@ private fun TransactionDetail(tx: HttpTransaction, onCreateMock: () -> Unit) {
             )
         }
 
-        TabRow(selectedTabIndex = selectedTab.ordinal) {
-            Tab(
-                selected = selectedTab == DetailTab.Body,
-                onClick = { selectedTab = DetailTab.Body },
-                text = { Text(DetailTab.Body.title) },
-            )
-            Tab(
-                selected = selectedTab == DetailTab.Headers,
-                onClick = { selectedTab = DetailTab.Headers },
-                text = { Text(DetailTab.Headers.title) },
-            )
-            Tab(
-                selected = selectedTab == DetailTab.Query,
-                onClick = { selectedTab = DetailTab.Query },
-                enabled = queryParams.isNotEmpty(),
-                text = { Text(DetailTab.Query.title) },
-            )
+        // Only surface the Query tab when the URL actually has query params — a permanently
+        // disabled tab reads as broken. selectedTab only ever becomes Query while it is visible,
+        // and it resets to Body/Headers per transaction, so it can't get stuck on a hidden tab.
+        val tabs = remember(queryParams) {
+            buildList {
+                add(DetailTab.Body)
+                add(DetailTab.Headers)
+                if (queryParams.isNotEmpty()) add(DetailTab.Query)
+            }
+        }
+        TabRow(selectedTabIndex = tabs.indexOf(selectedTab).coerceAtLeast(0)) {
+            tabs.forEach { tab ->
+                Tab(
+                    selected = selectedTab == tab,
+                    onClick = { selectedTab = tab },
+                    text = { Text(tab.title) },
+                )
+            }
         }
 
         when (selectedTab) {

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -25,6 +26,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
@@ -225,8 +228,11 @@ private fun StatusBadge(tx: HttpTransaction) {
     val (label, color) = when {
         tx.failure != null -> "ERR" to MaterialTheme.colorScheme.error
         tx.response == null -> "···" to MaterialTheme.colorScheme.outline
-        tx.response.statusCode in 200..299 -> tx.response.statusCode.toString() to Color(0xFF2E7D32)
-        tx.response.statusCode in 300..399 -> tx.response.statusCode.toString() to Color(0xFF1565C0)
+        tx.response.statusCode in 200..299 ->
+            tx.response.statusCode.toString() to themeColor(Color(0xFF2E7D32), Color(0xFF66BB6A))
+
+        tx.response.statusCode in 300..399 ->
+            tx.response.statusCode.toString() to themeColor(Color(0xFF1565C0), Color(0xFF64B5F6))
         tx.response.statusCode >= 400 -> tx.response.statusCode.toString() to MaterialTheme.colorScheme.error
         else -> tx.response.statusCode.toString() to MaterialTheme.colorScheme.onSurface
     }
@@ -235,13 +241,15 @@ private fun StatusBadge(tx: HttpTransaction) {
 
 @Composable
 private fun MockChip() {
-    Pill(label = "MOCK", color = Color(0xFF8E24AA))
+    Pill(label = "MOCK", color = themeColor(Color(0xFF8E24AA), Color(0xFFCE93D8)))
 }
 
 @Composable
 private fun Pill(label: String, color: Color) {
+    // 14% of a dark hue on a dark surface nearly vanishes, so give the fill more presence in dark mode.
+    val fillAlpha = if (isSystemInDarkTheme()) 0.22f else 0.14f
     Surface(
-        color = color.copy(alpha = 0.14f),
+        color = color.copy(alpha = fillAlpha),
         contentColor = color,
         shape = RoundedCornerShape(6.dp),
     ) {
@@ -254,8 +262,20 @@ private fun Pill(label: String, color: Color) {
     }
 }
 
+private enum class DetailTab(val title: String) {
+    Body("Body"),
+    Headers("Headers"),
+    Query("Query"),
+}
+
 @Composable
 private fun TransactionDetail(tx: HttpTransaction, onCreateMock: () -> Unit) {
+    val queryParams = remember(tx.request.url) { parseQueryParams(tx.request.url) }
+    val hasResponseBody = !tx.response?.body.isNullOrEmpty()
+    var selectedTab by remember(tx.txId) {
+        mutableStateOf(if (hasResponseBody) DetailTab.Body else DetailTab.Headers)
+    }
+
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -280,46 +300,99 @@ private fun TransactionDetail(tx: HttpTransaction, onCreateMock: () -> Unit) {
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-
-        SectionTitle("Request")
-        QueryParamBlock(tx.request.url)
-        HeaderBlock(tx.request.headers)
-        BodyBlock(label = "body", body = tx.request.body, truncated = tx.request.bodyTruncated)
-
-        SectionTitle("Response")
         when {
             tx.failure != null -> Text(
                 text = "Failed: ${tx.failure.message}",
                 color = MaterialTheme.colorScheme.error,
             )
 
-            tx.response != null -> {
-                Text(
-                    text = "${tx.response.statusCode} ${tx.response.statusDescription}  •  ${tx.response.durationMs}ms",
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                HeaderBlock(tx.response.headers)
-                BodyBlock(label = "body", body = tx.response.body, truncated = tx.response.bodyTruncated)
-            }
+            tx.response != null -> Text(
+                text = "${tx.response.statusCode} ${tx.response.statusDescription}  •  ${tx.response.durationMs}ms",
+                style = MaterialTheme.typography.bodyMedium,
+            )
 
             else -> Text(
                 text = "Pending…",
                 color = MaterialTheme.colorScheme.outline,
             )
         }
+
+        TabRow(selectedTabIndex = selectedTab.ordinal) {
+            Tab(
+                selected = selectedTab == DetailTab.Body,
+                onClick = { selectedTab = DetailTab.Body },
+                text = { Text(DetailTab.Body.title) },
+            )
+            Tab(
+                selected = selectedTab == DetailTab.Headers,
+                onClick = { selectedTab = DetailTab.Headers },
+                text = { Text(DetailTab.Headers.title) },
+            )
+            Tab(
+                selected = selectedTab == DetailTab.Query,
+                onClick = { selectedTab = DetailTab.Query },
+                enabled = queryParams.isNotEmpty(),
+                text = { Text(DetailTab.Query.title) },
+            )
+        }
+
+        when (selectedTab) {
+            DetailTab.Body -> BodyTab(tx)
+            DetailTab.Headers -> HeadersTab(tx)
+            DetailTab.Query -> QueryParamBlock(queryParams)
+        }
     }
 }
 
 @Composable
-private fun QueryParamBlock(url: String) {
-    val params = remember(url) { parseQueryParams(url) }
-    if (params.isEmpty()) return
+private fun BodyTab(tx: HttpTransaction) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        when {
+            tx.failure != null || (tx.response != null && tx.response.body.isNullOrEmpty()) -> Text(
+                text = "No response body",
+                color = MaterialTheme.colorScheme.outline,
+            )
+
+            tx.response == null -> Text(
+                text = "Pending…",
+                color = MaterialTheme.colorScheme.outline,
+            )
+
+            else -> BodyBlock(label = "body", body = tx.response.body, truncated = tx.response.bodyTruncated)
+        }
+        if (!tx.request.body.isNullOrEmpty()) {
+            MinorLabel("Request body")
+            BodyBlock(label = "body", body = tx.request.body, truncated = tx.request.bodyTruncated)
+        }
+    }
+}
+
+@Composable
+private fun HeadersTab(tx: HttpTransaction) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        SectionTitle("Request")
+        if (tx.request.headers.isEmpty()) {
+            EmptyHint("No request headers")
+        } else {
+            HeaderBlock(tx.request.headers)
+        }
+
+        SectionTitle("Response")
+        when {
+            tx.response == null -> EmptyHint("No response yet")
+            tx.response.headers.isEmpty() -> EmptyHint("No response headers")
+            else -> HeaderBlock(tx.response.headers)
+        }
+    }
+}
+
+@Composable
+private fun QueryParamBlock(params: List<Pair<String, String>>) {
+    if (params.isEmpty()) {
+        EmptyHint("No query parameters")
+        return
+    }
     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        Text(
-            text = "Query",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.primary,
-        )
         params.forEach { (key, value) ->
             Text(
                 text = "$key = $value",
@@ -328,6 +401,24 @@ private fun QueryParamBlock(url: String) {
             )
         }
     }
+}
+
+@Composable
+private fun MinorLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+    )
+}
+
+@Composable
+private fun EmptyHint(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.outline,
+    )
 }
 
 @Composable


### PR DESCRIPTION
## Summary

Two UI/UX improvements to the Network Inspector host plugin's detail pane.

### 1. Dark-mode / theme-aware colors
Hardcoded `Color(0x…)` hues did not adapt to the theme and washed out on dark surfaces.

- Added a small `themeColor(light, dark)` helper (`ThemeColors.kt`) that picks a hue via `isSystemInDarkTheme()`.
- `StatusBadge`: 2xx `#2E7D32`→dark `#66BB6A`; 3xx `#1565C0`→dark `#64B5F6` (4xx/ERR keep `colorScheme.error`).
- `MockChip`: `#8E24AA`→dark `#CE93D8`.
- `JsonColors` now resolves per-theme via `rememberJsonColors()`: key `#0B6E99`→`#4FC3F7`, string `#2E7D32`→`#81C784`, number `#1565C0`→`#64B5F6`, keyword `#8E24AA`→`#CE93D8`, and punctuation now uses `colorScheme.onSurfaceVariant`. The JSON render/tree functions take the colors as a parameter.
- `Pill` fill alpha bumps from 0.14 to 0.22 in dark mode so badges stay legible.

### 2. Tabbed detail pane, Body-first
The detail pane was one long scroll with the response body buried last under all headers.

- A persistent status/method/url + "Mock this" header stays above a `Body | Headers | Query` `TabRow`.
- Defaults to **Body** when a response body exists, else **Headers**. The **Query** tab enables only when the URL has parameters.
- **Body** tab shows the response body (existing Tree/Raw `BodyBlock`) plus the request body under a "Request body" label. **Headers** tab keeps `HeaderBlock` under "Request"/"Response" subheadings. **Query** tab shows the params.
- Pending and error states show sensible placeholders instead of crashing.

Preserved: `SelectionContainer` text selection, context-menu copy actions, the "Mock this" button, and the Tree/Raw toggle.

## Verification
- `./gradlew :jetwhale-plugins:network:host:compileKotlin` — BUILD SUCCESSFUL
- `./gradlew :jetwhale-plugins:network:host:test` — BUILD SUCCESSFUL