### PR TITLE
fix(network): Ktor mock response crashes debuggee (StandaloneCoroutine cannot be cast to CompletableJob)

### DIFF
--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
@@ -24,6 +24,7 @@ import io.ktor.util.StringValues
 import io.ktor.util.date.GMTDate
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.InternalAPI
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
@@ -111,6 +112,12 @@ private fun JetWhaleNetworkAgentPlugin.recordRequest(request: HttpRequestBuilder
 @OptIn(InternalAPI::class) // HttpClientCall's constructor is needed to synthesize mock responses.
 private suspend fun serveMock(client: HttpClient, request: HttpRequestBuilder, mock: MockResponseSpec): HttpClientCall {
     if (mock.delayMs > 0) delay(mock.delayMs.milliseconds)
+    // Ktor completes the call context's Job when the response is done, so it must be a
+    // CompletableJob. The Send-pipeline coroutine's own Job is a StandaloneCoroutine, and handing
+    // that over crashes with "StandaloneCoroutine cannot be cast to CompletableJob" the moment the
+    // caller reads the mocked response — so give the call its own Job(parent), exactly as a real
+    // client engine builds its call context.
+    val parentContext = currentCoroutineContext()
     val responseData = HttpResponseData(
         statusCode = HttpStatusCode.fromValue(mock.statusCode),
         requestTime = GMTDate(),
@@ -119,7 +126,7 @@ private suspend fun serveMock(client: HttpClient, request: HttpRequestBuilder, m
         }.build(),
         version = HttpProtocolVersion.HTTP_1_1,
         body = ByteReadChannel(mock.body.encodeToByteArray()),
-        callContext = currentCoroutineContext(),
+        callContext = parentContext + Job(parentContext[Job]),
     )
     return HttpClientCall(client, request.build(), responseData)
 }

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
@@ -4,6 +4,9 @@ import com.kitakkun.jetwhale.agent.sdk.messaging.JetWhaleOfflineCapableMessenger
 import com.kitakkun.jetwhale.agent.sdk.messaging.OfflineSendPolicy
 import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
 import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
+import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
+import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
+import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.plugins.network.protocol.RequestFailed
 import com.kitakkun.jetwhale.plugins.network.protocol.RequestSent
 import com.kitakkun.jetwhale.plugins.network.protocol.ResponseReceived
@@ -32,6 +35,7 @@ import io.ktor.websocket.close
 import io.ktor.websocket.readText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.StringFormat
@@ -48,6 +52,42 @@ class JetWhaleNetworkKtorPluginTest {
         val recorder = RecordingMessenger(java.util.Collections.synchronizedList(mutableListOf()))
         agent.bindMessenger(recorder)
         return agent to recorder.events
+    }
+
+    // The agent's mock rules are set by the host over messaging in production; a unit test can't
+    // drive that internal path, so seed the state directly for the mock-serving case.
+    @Suppress("UNCHECKED_CAST")
+    private fun JetWhaleNetworkAgentPlugin.seedMockRules(rules: List<MockRule>) {
+        val field = JetWhaleNetworkAgentPlugin::class.java.getDeclaredField("mockRules").apply { isAccessible = true }
+        (field.get(this) as MutableStateFlow<List<MockRule>>).value = rules
+    }
+
+    @Test
+    fun `serves a mock response whose body reads back without a coroutine-job cast crash`() = runBlocking {
+        val (agent, _) = agentWithEvents()
+        agent.seedMockRules(
+            listOf(
+                MockRule(
+                    id = "1",
+                    matcher = MockMatcher(urlPattern = "/todos/1"),
+                    response = MockResponseSpec(statusCode = 200, body = "{\"ok\":true}"),
+                ),
+            ),
+        )
+        val client = HttpClient(
+            // The real engine must never be hit — the mock is served before proceed().
+            MockEngine { respond(content = "unmocked", status = HttpStatusCode.InternalServerError) },
+        ) {
+            install(agent.ktorClientPlugin())
+        }
+
+        val response = client.get("http://example/todos/1")
+
+        // Before the fix, the synthesized call carried the Send-pipeline's StandaloneCoroutine as its
+        // callContext Job, so reading the mocked body threw "StandaloneCoroutine cannot be cast to
+        // CompletableJob".
+        assertEquals(200, response.status.value)
+        assertEquals("{\"ok\":true}", response.bodyAsText())
     }
 
     @Test


### PR DESCRIPTION
Mocking a request from the host (e.g. 404 → 200) crashed the debuggee app when it read the mocked response:

```
class kotlinx.coroutines.StandaloneCoroutine cannot be cast to class kotlinx.coroutines.CompletableJob
```

## Cause
`serveMock` built the synthesized `HttpResponseData` with `callContext = currentCoroutineContext()`. That context carries the Ktor **Send-pipeline coroutine**'s own `Job`, which is a `StandaloneCoroutine` (from `launch`). Ktor completes the call context's Job when the response is consumed and casts it to `CompletableJob` — so the first read of a mocked body throws.

## Fix
Give the synthesized call its **own** `Job(parent)` (a `CompletableJob`), exactly as a real client engine builds its call context: `callContext = parentContext + Job(parentContext[Job])`.

## Test
The mock-serving path (`serveMock`) had **no** test coverage — the existing tests use `MockEngine` for pass-through capture, not JetWhale mock rules — which is how this shipped. Added a regression test that seeds a mock rule, serves it, and reads `bodyAsText()` (would throw the cast crash before the fix).

Affects alpha08/alpha09. `:jetwhale-plugins:network:agent-ktor:jvmTest` + spotless pass.