### PR TITLE
feat(host-sdk): add LocalJetWhaleDarkTheme CompositionLocal

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -303,6 +303,12 @@ CompositionLocal — it is `true` only while the scene is being rendered for an 
 capture — and blank or mask the sensitive content while it is raised. The interactive window never
 observes the raised state, so there is no on-screen flicker.
 
+The `LocalJetWhaleDarkTheme` CompositionLocal tells your plugin whether the host is rendering it in
+a dark theme — the host provides the authoritative value from its actually-applied color scheme.
+Read it (`LocalJetWhaleDarkTheme.current`) to pick theme-appropriate colors instead of
+`isSystemInDarkTheme()`, which reflects the OS setting and can disagree with the host's own Theme
+option.
+
 ## Persistent storage
 
 Every host plugin instance gets a persistent key-value store via the protected `storage` property,

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -1,3 +1,7 @@
+public final class com/kitakkun/jetwhale/host/sdk/DarkThemeKt {
+	public static final fun getLocalJetWhaleDarkTheme ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
 public abstract interface annotation class com/kitakkun/jetwhale/host/sdk/ExperimentalJetWhaleApi : java/lang/annotation/Annotation {
 }
 

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/DarkTheme.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/DarkTheme.kt
@@ -1,0 +1,14 @@
+package com.kitakkun.jetwhale.host.sdk
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * True when the host is rendering this plugin in a dark theme.
+ *
+ * Consume this (e.g. `LocalJetWhaleDarkTheme.current`) to pick theme-appropriate colors, instead of
+ * `isSystemInDarkTheme()` — that reflects the OS setting, which can disagree with the host's own
+ * Theme option (builtin:light / builtin:dark / builtin:dynamic). The host provides the authoritative
+ * value from its actually-applied color scheme.
+ */
+public val LocalJetWhaleDarkTheme: ProvidableCompositionLocal<Boolean> = compositionLocalOf { false }

--- a/jetwhale-host/core/ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/ColorSchemeConverter.kt
+++ b/jetwhale-host/core/ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/ColorSchemeConverter.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import com.kitakkun.jetwhale.host.model.JetWhaleColorScheme
 import com.kitakkun.jetwhale.host.model.ThemeColorTokens
 
@@ -78,5 +79,26 @@ fun JetWhaleColorScheme.toMaterial3ColorScheme(): ColorScheme = when (this) {
                 onTertiaryFixedVariant = colors[ThemeColorTokens.OnTertiaryFixedVariant] ?: Color.Unspecified,
             )
         }
+    }
+}
+
+/**
+ * Whether this scheme renders dark, decided from the scheme itself rather than a luminance guess of
+ * the resolved surface: [JetWhaleColorScheme.Static.Light]/[JetWhaleColorScheme.Static.Dark] are
+ * definitive, and [JetWhaleColorScheme.Dynamic] follows the OS exactly as [toMaterial3ColorScheme]
+ * does. A [JetWhaleColorScheme.Static.Custom] scheme carries no light/dark label, so as a fallback
+ * it is judged by the luminance of its declared surface (or background) color.
+ */
+@Composable
+fun JetWhaleColorScheme.isDarkTheme(): Boolean = when (this) {
+    is JetWhaleColorScheme.Dynamic -> if (isSystemInDarkTheme()) darkColorScheme.isDarkTheme() else lightColorScheme.isDarkTheme()
+
+    is JetWhaleColorScheme.Static.Light -> false
+
+    is JetWhaleColorScheme.Static.Dark -> true
+
+    is JetWhaleColorScheme.Static.Custom -> {
+        val surfaceArgb = colors[ThemeColorTokens.Surface] ?: colors[ThemeColorTokens.Background]
+        surfaceArgb?.let { Color(it).luminance() < 0.5f } ?: false
     }
 }

--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/DefaultDynamicPluginBridgeProvider.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/DefaultDynamicPluginBridgeProvider.kt
@@ -1,12 +1,16 @@
 package com.kitakkun.jetwhale.host.plugin
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.luminance
 import com.kitakkun.jetwhale.host.architecture.ExplicitScreenContextUsage
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.withScreenContext
 import com.kitakkun.jetwhale.host.model.AppearanceSettingsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.DynamicPluginBridgeProvider
 import com.kitakkun.jetwhale.host.model.ThemeSubscriptionKey
+import com.kitakkun.jetwhale.host.sdk.LocalJetWhaleDarkTheme
 import com.kitakkun.jetwhale.host.ui.AppEnvironment
 import com.kitakkun.jetwhale.host.ui.JetWhaleTheme
 import dev.zacsweers.metro.AppScope
@@ -33,8 +37,12 @@ class DefaultDynamicPluginBridgeProvider(
                     state2 = rememberSubscription(appearanceSettingsSubscriptionKey),
                 ) { theme, appearanceSettings ->
                     JetWhaleTheme(theme.colorScheme) {
-                        AppEnvironment(appearanceSettings.appLanguage) {
-                            content()
+                        CompositionLocalProvider(
+                            LocalJetWhaleDarkTheme provides (MaterialTheme.colorScheme.surface.luminance() < 0.5f),
+                        ) {
+                            AppEnvironment(appearanceSettings.appLanguage) {
+                                content()
+                            }
                         }
                     }
                 }

--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/DefaultDynamicPluginBridgeProvider.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/DefaultDynamicPluginBridgeProvider.kt
@@ -1,9 +1,7 @@
 package com.kitakkun.jetwhale.host.plugin
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.graphics.luminance
 import com.kitakkun.jetwhale.host.architecture.ExplicitScreenContextUsage
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.withScreenContext
@@ -13,6 +11,7 @@ import com.kitakkun.jetwhale.host.model.ThemeSubscriptionKey
 import com.kitakkun.jetwhale.host.sdk.LocalJetWhaleDarkTheme
 import com.kitakkun.jetwhale.host.ui.AppEnvironment
 import com.kitakkun.jetwhale.host.ui.JetWhaleTheme
+import com.kitakkun.jetwhale.host.ui.isDarkTheme
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -38,7 +37,9 @@ class DefaultDynamicPluginBridgeProvider(
                 ) { theme, appearanceSettings ->
                     JetWhaleTheme(theme.colorScheme) {
                         CompositionLocalProvider(
-                            LocalJetWhaleDarkTheme provides (MaterialTheme.colorScheme.surface.luminance() < 0.5f),
+                            // Decided from the scheme itself (definitive for Light/Dark, OS for
+                            // Dynamic), not a luminance guess of the resolved surface.
+                            LocalJetWhaleDarkTheme provides theme.colorScheme.isDarkTheme(),
                         ) {
                             AppEnvironment(appearanceSettings.appLanguage) {
                                 content()

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ThemeColors.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ThemeColors.kt
@@ -1,18 +1,17 @@
 package com.kitakkun.jetwhale.plugins.network.host
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
+import com.kitakkun.jetwhale.host.sdk.LocalJetWhaleDarkTheme
 
 /**
- * True when the **applied** Material theme is dark — derived from the color scheme's own surface
- * luminance, not the OS setting (`isSystemInDarkTheme`). The host has its own Theme option
- * (builtin:light / builtin:dark / builtin:dynamic), so the OS value can disagree with what's on
- * screen; reading the actual scheme keeps these colors in step with the in-app theme.
+ * True when the host is rendering this plugin in a dark theme. Reads the authoritative
+ * [LocalJetWhaleDarkTheme] the host provides from its actually-applied color scheme, not the OS
+ * setting (`isSystemInDarkTheme`) — the host has its own Theme option (builtin:light / builtin:dark
+ * / builtin:dynamic), which can disagree with what's on screen.
  */
 @Composable
-internal fun isDarkTheme(): Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+internal fun isDarkTheme(): Boolean = LocalJetWhaleDarkTheme.current
 
 /**
  * Returns [dark] under a dark theme and [light] otherwise, so fixed brand hues stay legible against


### PR DESCRIPTION
## Summary

Adds an official host-sdk CompositionLocal, `LocalJetWhaleDarkTheme`, that tells a plugin whether the host is rendering it in a dark theme. Plugins can read `LocalJetWhaleDarkTheme.current` to pick theme-appropriate colors instead of guessing via `isSystemInDarkTheme()`, which reflects the OS setting and can disagree with the host's own Theme option (builtin:light / builtin:dark / builtin:dynamic).

Stacks on #164, which added the network plugin's theme-color work. This PR finishes that work by switching the network plugin off its local luminance heuristic and onto the new official API.

## Changes

- **host-sdk**: new `DarkTheme.kt` exposing `public val LocalJetWhaleDarkTheme` (mirrors `ScreenshotCapture.kt`).
- **Host provides it**: `DefaultDynamicPluginBridgeProvider` provides the local inside `JetWhaleTheme { }`, derived from the resolved `MaterialTheme.colorScheme.surface.luminance() < 0.5f`, so it reflects the actually-applied color scheme.
- **Network plugin consumes it**: `ThemeColors.isDarkTheme()` now returns `LocalJetWhaleDarkTheme.current` instead of computing surface luminance itself; the 3 call sites are unchanged.
- **ABI dump**: regenerated `jetwhale-host-sdk.api` — it now lists the new public `LocalJetWhaleDarkTheme`.
- **Docs**: added a note in `developing-plugins.md` next to `LocalIsScreenshotCapture`.

## Verification

All green: `:jetwhale-host-sdk:compileKotlin`, `:jetwhale-host:feature:plugin:compileKotlin`, `:jetwhale-plugins:network:host:compileKotlin`, `:jetwhale-plugins:network:host:test`, `spotlessApply`, `spotlessCheck`, and the host-sdk ABI check (`checkLegacyAbi`).