### PR TITLE
fix(settings): app-data-directory label wraps to one char per line in a narrow window

### DIFF
--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -110,9 +111,22 @@ fun GeneralSettingsScreen(
         }
         item {
             SettingOptionView(stringResource(Res.string.maintenance)) {
-                SettingsItemRow(stringResource(Res.string.application_data_directory)) {
-                    Card {
-                        Text(uiState.appDataPath)
+                // Not SettingsItemRow here: the path can be very long. The label keeps a min width so
+                // it can't be starved down to one character per line, and the path Card takes the
+                // remaining space (weight) and wraps within it.
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = stringResource(Res.string.application_data_directory),
+                        modifier = Modifier.widthIn(min = 120.dp),
+                    )
+                    Card(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = uiState.appDataPath,
+                            modifier = Modifier.padding(8.dp),
+                        )
                     }
                     IconButton(onClick = onClickOpenAppDataPath) {
                         Icon(Icons.Default.FolderOpen, null)


### PR DESCRIPTION
In the Settings → General screen, a narrow window rendered the **Application Data Directory** label one character per line ("A p p l i c a t i o n …").

## Cause
The row used the shared `SettingsItemRow`, whose label has `weight(1f)`. The control was `Card { Text(longPath) }` with **no** weight, so the greedy path text was measured first and took nearly the whole row, leaving the weighted label ~0 width → one char per line.

## Fix
For this row (which has an unusually long value) the label now keeps a `widthIn(min = 120.dp)` so it can never be starved, and the path `Card` takes the remaining space via `weight(1f)` and wraps within it. The folder button stays at the end.