### PR TITLE
fix(host): keep pop-out windows and dialogs stable across navigation

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavDisplay.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavDisplay.kt
@@ -15,7 +15,6 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.scene.DialogSceneStrategy
 import androidx.navigation3.ui.NavDisplay
 import com.kitakkun.jetwhale.host.di.JetWhaleAppGraph
 
@@ -27,7 +26,7 @@ fun JetWhaleNavDisplay(
     modifier: Modifier = Modifier,
 ) {
     val listDetailSceneStrategy = rememberListDetailSceneStrategy<NavKey>()
-    val dialogSceneStrategy = remember { DialogSceneStrategy<NavKey>() }
+    val dialogSceneStrategy = remember { StableDialogSceneStrategy<NavKey>() }
     val windowSceneStrategy = remember(backStack) {
         WindowSceneStrategy<NavKey> { contentKey ->
             backStack.removeAll { it.toString() == contentKey.toString() }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavEntries.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavEntries.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.scene.DialogSceneStrategy
 import com.kitakkun.jetwhale.host.LocalComposeWindow
 import com.kitakkun.jetwhale.host.Res
 import com.kitakkun.jetwhale.host.di.JetWhaleAppGraph
@@ -29,7 +28,7 @@ fun EntryProviderScope<NavKey>.infoEntry(
     onClickOSSLicenses: () -> Unit,
 ) {
     entry<InfoNavKey>(
-        metadata = DialogSceneStrategy.dialog(),
+        metadata = StableDialogSceneStrategy.dialog(),
     ) {
         InfoScreen(
             onClickOSSLicenses = onClickOSSLicenses,
@@ -116,7 +115,7 @@ fun EntryProviderScope<NavKey>.settingsEntry(
     onOpenLogViewer: () -> Unit,
 ) {
     entry<SettingsNavKey>(
-        metadata = DialogSceneStrategy.dialog(
+        metadata = StableDialogSceneStrategy.dialog(
             dialogProperties = DialogProperties(
                 usePlatformDefaultWidth = false,
             ),
@@ -141,7 +140,7 @@ fun EntryProviderScope<NavKey>.licensesEntry(
     onClickBack: () -> Unit,
 ) {
     entry<LicensesNavKey>(
-        metadata = DialogSceneStrategy.dialog(
+        metadata = StableDialogSceneStrategy.dialog(
             dialogProperties = DialogProperties(
                 usePlatformDefaultWidth = false,
             ),

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/StableDialogSceneStrategy.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/StableDialogSceneStrategy.kt
@@ -1,0 +1,77 @@
+package com.kitakkun.jetwhale.host.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.scene.OverlayScene
+import androidx.navigation3.scene.Scene
+import androidx.navigation3.scene.SceneStrategy
+import androidx.navigation3.scene.SceneStrategyScope
+
+// A dialog OverlayScene whose identity is only the dialog entry's content key. NavDisplay tracks overlay
+// scenes by object equality, and the built-in DialogScene also compares previousEntries/overlaidEntries.
+// Those are the entries drawn *below* the overlay, so navigating the underlying back stack changes them
+// and makes the scene unequal, which makes NavDisplay tear the dialog down and rebuild it in a fresh slot
+// — a visible flash. Comparing only the content key keeps the dialog stable across unrelated navigation,
+// mirroring [WindowOverlayScene].
+internal class StableDialogScene<T : Any>(
+    override val key: Any,
+    private val entry: NavEntry<T>,
+    override val previousEntries: List<NavEntry<T>>,
+    override val overlaidEntries: List<NavEntry<T>>,
+    private val dialogProperties: DialogProperties,
+    private val onBack: () -> Unit,
+) : OverlayScene<T> {
+    override val entries: List<NavEntry<T>> = listOf(entry)
+
+    override val content: @Composable () -> Unit = {
+        // NavDisplay provides a lifecycle owner around this overlay's content; re-provide it inside the
+        // Dialog's sub-composition so the entry content keeps the same lifecycle.
+        val lifecycleOwner = LocalLifecycleOwner.current
+        Dialog(onDismissRequest = onBack, properties = dialogProperties) {
+            CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                entry.Content()
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is StableDialogScene<*>) return false
+
+        return key == other.key
+    }
+
+    override fun hashCode(): Int = key.hashCode()
+}
+
+/**
+ * Displays entries that carry [dialog] metadata within a [Dialog], keeping the dialog stable while the
+ * underlying back stack changes (unlike the built-in `DialogSceneStrategy`).
+ */
+class StableDialogSceneStrategy<T : Any> : SceneStrategy<T> {
+    override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
+        val lastEntry = entries.lastOrNull() ?: return null
+        val dialogProperties = lastEntry.metadata[DIALOG_KEY] as? DialogProperties ?: return null
+
+        return StableDialogScene(
+            key = lastEntry.contentKey,
+            entry = lastEntry,
+            previousEntries = entries.dropLast(1),
+            overlaidEntries = entries.dropLast(1),
+            dialogProperties = dialogProperties,
+            onBack = onBack,
+        )
+    }
+
+    companion object {
+        fun dialog(
+            dialogProperties: DialogProperties = DialogProperties(),
+        ): Map<String, Any> = mapOf(DIALOG_KEY to dialogProperties)
+
+        const val DIALOG_KEY = "dialog"
+    }
+}

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/WindowSceneStrategy.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/WindowSceneStrategy.kt
@@ -3,7 +3,6 @@ package com.kitakkun.jetwhale.host.navigation
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.key
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -34,100 +33,81 @@ internal data class WindowEntry<T : Any>(
     val properties: WindowProperties,
 )
 
+// An OverlayScene that renders a single window. Each window is its own scene (like the built-in
+// DialogScene), so its identity is only its own content key: it is independent of the entries drawn
+// below it (overlaidEntries) and of every other window, and NavDisplay never tears it down on unrelated
+// navigation. Because the scene stays alive, the per-window [rememberWindowState] survives too, so each
+// window keeps its position and size.
 internal class WindowOverlayScene<T : Any>(
-    private val windowEntries: List<WindowEntry<T>>,
+    private val windowEntry: WindowEntry<T>,
     override val previousEntries: List<NavEntry<T>>,
     override val overlaidEntries: List<NavEntry<T>>,
     private val onCloseRequest: (NavEntry<T>) -> Unit,
 ) : OverlayScene<T> {
-    override val key: Any = windowEntries.map { it.entry.contentKey }.joinToString(separator = "_")
+    override val key: Any = windowEntry.entry.contentKey
 
     override val content: @Composable () -> Unit = {
-        windowEntries.forEach { windowEntry ->
-            key(windowEntry.entry.contentKey) {
-                val windowState = rememberWindowState(
-                    placement = windowEntry.properties.windowPlacement,
-                    width = windowEntry.properties.width,
-                    height = windowEntry.properties.height,
-                )
+        val windowState = rememberWindowState(
+            placement = windowEntry.properties.windowPlacement,
+            width = windowEntry.properties.width,
+            height = windowEntry.properties.height,
+        )
 
-                Window(
-                    state = windowState,
-                    icon = painterResource(Res.drawable.app_icon),
-                    onCloseRequest = { onCloseRequest(windowEntry.entry) },
-                    onPreviewKeyEvent = { keyEvent ->
-                        if (keyEvent.type == KeyEventType.KeyDown && keyEvent.isShortcutModifierPressed && keyEvent.key == Key.W) {
-                            onCloseRequest(windowEntry.entry)
-                            true
-                        } else {
-                            false
-                        }
-                    },
-                ) {
-                    CompositionLocalProvider(LocalComposeWindow provides this.window) {
-                        Surface {
-                            windowEntry.entry.Content()
-                        }
-                    }
+        Window(
+            state = windowState,
+            icon = painterResource(Res.drawable.app_icon),
+            onCloseRequest = { onCloseRequest(windowEntry.entry) },
+            onPreviewKeyEvent = { keyEvent ->
+                if (keyEvent.type == KeyEventType.KeyDown && keyEvent.isShortcutModifierPressed && keyEvent.key == Key.W) {
+                    onCloseRequest(windowEntry.entry)
+                    true
+                } else {
+                    false
+                }
+            },
+        ) {
+            CompositionLocalProvider(LocalComposeWindow provides this.window) {
+                Surface {
+                    windowEntry.entry.Content()
                 }
             }
         }
     }
 
-    override val entries: List<NavEntry<T>> = windowEntries.map { it.entry }
+    override val entries: List<NavEntry<T>> = listOf(windowEntry.entry)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
+        if (other !is WindowOverlayScene<*>) return false
 
-        other as WindowOverlayScene<*>
-
-        if (windowEntries != other.windowEntries) return false
-        if (previousEntries != other.previousEntries) return false
-        if (overlaidEntries != other.overlaidEntries) return false
-        if (key != other.key) return false
-        if (content != other.content) return false
-        if (entries != other.entries) return false
-
-        return true
+        return key == other.key
     }
 
-    override fun hashCode(): Int {
-        var result = windowEntries.hashCode()
-        result = 31 * result + previousEntries.hashCode()
-        result = 31 * result + overlaidEntries.hashCode()
-        result = 31 * result + key.hashCode()
-        result = 31 * result + content.hashCode()
-        result = 31 * result + entries.hashCode()
-        return result
-    }
+    override fun hashCode(): Int = key.hashCode()
 }
 
 class WindowSceneStrategy<T : Any>(
     private val onCloseRequestForContentKey: (Any) -> Unit,
 ) : SceneStrategy<T> {
     override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
-        if (entries.isEmpty()) return null
+        // Render one window per scene. The framework re-runs the scene strategies over overlaidEntries, so
+        // returning the topmost window here and leaving the rest below lets each window become its own
+        // independent overlay scene, stacked in order.
+        val windowIndex = entries.indexOfLast { it.metadata[WINDOW_KEY] is WindowProperties }
+        if (windowIndex == -1) return null
 
-        val windowEntries = entries.mapNotNull { entry ->
-            val windowProperties = entry.metadata[WINDOW_KEY] as? WindowProperties ?: return@mapNotNull null
-            WindowEntry(entry, windowProperties)
-        }
+        val entry = entries[windowIndex]
+        val properties = entry.metadata[WINDOW_KEY] as WindowProperties
+        val overlaidEntries = entries.filterIndexed { index, _ -> index != windowIndex }
 
-        if (windowEntries.isEmpty()) return null
-
-        val nonWindowEntries = entries.filterNot { entry ->
-            entry.metadata[WINDOW_KEY] is WindowProperties
-        }
-
-        val onCloseRequest: (NavEntry<T>) -> Unit = { entry ->
-            onCloseRequestForContentKey(entry.contentKey)
+        val onCloseRequest: (NavEntry<T>) -> Unit = { closedEntry ->
+            onCloseRequestForContentKey(closedEntry.contentKey)
         }
 
         return WindowOverlayScene(
-            windowEntries = windowEntries,
-            previousEntries = nonWindowEntries,
-            overlaidEntries = nonWindowEntries,
+            windowEntry = WindowEntry(entry, properties),
+            previousEntries = overlaidEntries,
+            overlaidEntries = overlaidEntries,
             onCloseRequest = onCloseRequest,
         )
     }


### PR DESCRIPTION
## Summary

Pop-out plugin windows lost their position/size — and briefly **disappeared entirely** — whenever the main back stack changed (opening Settings, switching plugin, pushing/popping entries). Dialogs (Settings/Info/Licenses) flashed for the same underlying reason.

## Root cause

`NavDisplay` (navigation3 1.1.1) tracks overlay scenes by **object equality**:
- `currentOverlayScenes.contains(it)` gates whether a scene is (re)added — `NavDisplay.kt:685`
- `overlayScene !in overlayScenes` decides removal — `NavDisplay.kt:912`
- `key(overlayScene) { overlayScene.content() }` uses the scene object as the Compose group key — `NavDisplay.kt:892`

`rememberSceneState` recomputes scenes on every entries change (`remember(..., decoratedEntries)` — `SceneState.kt:104`), so a **new** scene instance is produced on every navigation. If its `equals` depends on anything that changes with unrelated navigation, NavDisplay disposes the old overlay and rebuilds it — re-running `rememberWindowState(...)` (position/size reset) and recreating the OS window (the flash).

Two things made the overlays unstable:
- `WindowSceneStrategy` bundled **every** window into one `WindowOverlayScene` whose identity was the list of **all** window content keys, so opening/closing any one window recreated the others.
- Every overlay's identity — including the built-in `DialogScene` — also depended on the **overlaid** entries (the ones drawn below it), which change on any underlying navigation.

## Fix

- **One window per scene.** `WindowSceneStrategy` now returns a single-window `WindowOverlayScene` and leaves the rest in `overlaidEntries`; the framework re-runs the strategies over those, so each window becomes an independent overlay scene, stacked in order. A window's identity is **only its own content key**, so it is unaffected by unrelated navigation and by other windows. The scene stays alive, so its `rememberWindowState` survives and the window keeps its position/size — no separate state hoisting required.
- **`StableDialogSceneStrategy`.** A drop-in replacement for the built-in `DialogSceneStrategy` whose scene identity is likewise only the dialog entry's content key (it does not compare `previousEntries`/`overlaidEntries`). Dialogs no longer flash when the underlying back stack changes. Entries keep using the same `dialog()` metadata helper, so no entry definitions change beyond the import.

## Verification

- `./gradlew :jetwhale-host:app:compileKotlin` succeeds; root `spotlessApply` produces no changes.
- Runtime confirmed: pop out a plugin, move/resize it, then navigate the main window and/or open a dialog — the window keeps its position and neither the window nor the dialogs flash. Opening/closing a second window no longer disturbs the first.
