### PR TITLE
fix(host): reconcile plugin instances when a plugin is loaded

### DIFF
--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
@@ -17,6 +17,7 @@ import com.kitakkun.jetwhale.host.model.PluginComposeSceneService
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.model.WindowInfoUpdater
 import com.kitakkun.jetwhale.host.sdk.InternalJetWhaleHostApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
 import com.kitakkun.jetwhale.host.sdk.LocalIsScreenshotCapture
 import com.kitakkun.jetwhale.host.sdk.LocalJetWhalePluginStorage
@@ -35,7 +36,13 @@ class DefaultPluginComposeSceneService(
     private val pluginBridgeProvider: DynamicPluginBridgeProvider,
     private val pluginInstanceService: PluginInstanceService,
 ) : PluginComposeSceneService {
-    private val pluginScenes = mutableMapOf<String, PluginComposeScene>()
+    /** A scene together with the plugin instance it composes, so a replaced instance invalidates it. */
+    private class CachedScene(
+        val pluginInstance: JetWhaleHostPlugin,
+        val scene: PluginComposeScene,
+    )
+
+    private val pluginScenes = mutableMapOf<String, CachedScene>()
 
     override suspend fun getOrCreatePluginScene(
         pluginId: String,
@@ -48,39 +55,46 @@ class DefaultPluginComposeSceneService(
             error("Plugin instance not found for pluginId=$pluginId, sessionId=$sessionId")
         }
         return withContext(Dispatchers.Main) {
-            pluginScenes.getOrPut("$pluginId:$sessionId") {
-                val windowUpdatableContext = DynamicWindowInfoPlatformContext()
-                val composeScene = CanvasLayersComposeScene(platformContext = windowUpdatableContext)
-                val isScreenshotCapture = mutableStateOf(false)
+            val sceneKey = "$pluginId:$sessionId"
+            val cached = pluginScenes[sceneKey]
+            if (cached != null && cached.pluginInstance === pluginInstance) return@withContext cached.scene
+            // A reinstalled or reloaded plugin is served by a new instance from a new classloader; a
+            // scene still composing the previous one would keep rendering discarded code.
+            cached?.scene?.composeScene?.close()
 
-                composeScene.setContent {
-                    // Expose the plugin's own pluginId-scoped storage so rememberPersistent can reach it.
-                    CompositionLocalProvider(
-                        LocalJetWhalePluginStorage provides pluginInstance.boundStorageForRuntime(),
-                        LocalIsScreenshotCapture provides isScreenshotCapture.value,
-                    ) {
-                        pluginBridgeProvider.PluginEntryPoint {
-                            // Headless plugins (not a JetWhaleHostPluginUi) render no content.
-                            val ui = pluginInstance as? JetWhaleHostPluginUi ?: return@PluginEntryPoint
-                            ui.Content()
-                        }
+            val windowUpdatableContext = DynamicWindowInfoPlatformContext()
+            val composeScene = CanvasLayersComposeScene(platformContext = windowUpdatableContext)
+            val isScreenshotCapture = mutableStateOf(false)
+
+            composeScene.setContent {
+                // Expose the plugin's own pluginId-scoped storage so rememberPersistent can reach it.
+                CompositionLocalProvider(
+                    LocalJetWhalePluginStorage provides pluginInstance.boundStorageForRuntime(),
+                    LocalIsScreenshotCapture provides isScreenshotCapture.value,
+                ) {
+                    pluginBridgeProvider.PluginEntryPoint {
+                        // Headless plugins (not a JetWhaleHostPluginUi) render no content.
+                        val ui = pluginInstance as? JetWhaleHostPluginUi ?: return@PluginEntryPoint
+                        ui.Content()
                     }
                 }
-
-                PluginComposeScene(
-                    composeScene = composeScene,
-                    windowInfoUpdater = windowUpdatableContext,
-                    semanticsOwners = windowUpdatableContext.semanticsOwners,
-                    isScreenshotCapture = isScreenshotCapture,
-                )
             }
+
+            val scene = PluginComposeScene(
+                composeScene = composeScene,
+                windowInfoUpdater = windowUpdatableContext,
+                semanticsOwners = windowUpdatableContext.semanticsOwners,
+                isScreenshotCapture = isScreenshotCapture,
+            )
+            pluginScenes[sceneKey] = CachedScene(pluginInstance, scene)
+            scene
         }
     }
 
     override fun disposePluginSceneForSession(sessionId: String) {
         val keysToRemove = pluginScenes.keys.filter { it.endsWith(":$sessionId") }
         for (key in keysToRemove) {
-            pluginScenes[key]?.composeScene?.close()
+            pluginScenes[key]?.scene?.composeScene?.close()
             pluginScenes.remove(key)
         }
     }
@@ -88,14 +102,14 @@ class DefaultPluginComposeSceneService(
     override fun disposePluginScenesForPlugin(pluginId: String) {
         val keysToRemove = pluginScenes.keys.filter { it.startsWith("$pluginId:") }
         for (key in keysToRemove) {
-            pluginScenes[key]?.composeScene?.close()
+            pluginScenes[key]?.scene?.composeScene?.close()
             pluginScenes.remove(key)
         }
     }
 
     override fun disposeAllPluginScenes() {
-        for (scene in pluginScenes.values) {
-            scene.composeScene.close()
+        for (cached in pluginScenes.values) {
+            cached.scene.composeScene.close()
         }
         pluginScenes.clear()
     }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstanceService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstanceService.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.host.data.plugin
 
 import com.kitakkun.jetwhale.host.model.HostPluginFrameSender
+import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
 import com.kitakkun.jetwhale.host.model.LoadedPluginInstance
 import com.kitakkun.jetwhale.host.model.PluginDataStoreRepository
 import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
@@ -8,6 +9,7 @@ import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.sdk.InternalJetWhaleHostApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMessagingHostPlugin
 import com.kitakkun.jetwhale.protocol.messaging.JetWhalePluginPeer
 import com.kitakkun.jetwhale.protocol.messaging.PluginFrame
@@ -18,6 +20,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -39,6 +42,8 @@ private data class PluginInstanceKey(val pluginId: String, val sessionId: String
  * frames are sent to this instance's session; inbound frames are routed to it by the server.
  */
 private class LoadedInstance(
+    /** The factory that produced [plugin]; identifies the classloader generation this instance belongs to. */
+    val factory: JetWhaleHostPluginFactory,
     val plugin: JetWhaleHostPlugin,
     // null for a pure (non-messaging) plugin: no peer is created for it.
     val peer: JetWhalePluginPeer?,
@@ -76,13 +81,32 @@ class DefaultPluginInstanceService(
     override fun initializePluginInstancesForSessionsIfNeeded(pluginId: String, sessionIds: Set<String>): Set<String> {
         val loaded = pluginFactoryRepository.loadedPlugins[pluginId] ?: return emptySet()
 
+        // Reinstalling or reloading a jar yields a new factory behind a new classloader; instances the
+        // previous factory produced hold classes from a classloader that is already closed, so drop
+        // them and let the loop below rebuild them from the current code.
+        loadedPlugins.entries
+            .filter { (key, instance) -> key.pluginId == pluginId && instance.factory !== loaded.factory }
+            .map { it.key }
+            .forEach { disposeInstance(it) }
+
         val newlyInitializedSessions = mutableSetOf<String>()
         for (sessionId in sessionIds) {
             val key = PluginInstanceKey(pluginId, sessionId)
-            loadedPlugins.computeIfAbsent(key) {
-                newlyInitializedSessions += sessionId
-                createInstance(pluginId, sessionId, loaded.factory.createPlugin(), loaded.manifest.requiresAgent)
+            var created = false
+            try {
+                loadedPlugins.computeIfAbsent(key) {
+                    created = true
+                    createInstance(pluginId, sessionId, loaded)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // A factory (or plugin constructor) that throws must not abort the caller's
+                // reconciliation loop — every other plugin and session still needs its instance.
+                logger.log(Level.WARNING, "Creating an instance of plugin '$pluginId' for session '$sessionId' failed", e)
+                continue
             }
+            if (created) newlyInitializedSessions += sessionId
         }
 
         newlyInitializedSessions.forEach { sessionId ->
@@ -91,8 +115,9 @@ class DefaultPluginInstanceService(
         return newlyInitializedSessions
     }
 
-    private fun createInstance(pluginId: String, sessionId: String, plugin: JetWhaleHostPlugin, requiresAgent: Boolean): LoadedInstance {
-        if (!requiresAgent && plugin is JetWhaleMessagingHostPlugin) {
+    private fun createInstance(pluginId: String, sessionId: String, loaded: LoadedHostPlugin): LoadedInstance {
+        val plugin = loaded.factory.createPlugin()
+        if (!loaded.manifest.requiresAgent && plugin is JetWhaleMessagingHostPlugin) {
             // A messaging plugin without an agent counterpart waits out its prepare timeout on every
             // session and gets "not active" failures for every request — surface the misconfiguration
             // instead of degrading silently.
@@ -157,7 +182,7 @@ class DefaultPluginInstanceService(
         } else {
             null
         }
-        return LoadedInstance(plugin, peer, prepareJob, instanceScope)
+        return LoadedInstance(loaded.factory, plugin, peer, prepareJob, instanceScope)
     }
 
     override suspend fun routeFrame(sessionId: String, frame: PluginFrame) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationService.kt
@@ -46,7 +46,13 @@ class DefaultPluginSessionReconciliationService(
             combine(
                 enabledPluginsRepository.enabledPluginIdsFlow,
                 sessionRepository.debugSessionsFlow.map { sessions -> sessions.filter { it.isActive } },
-            ) { enabledPluginIds, activeSessions -> enabledPluginIds to activeSessions }
+                // Loading a plugin is a reconciliation trigger in its own right. The enabled set only
+                // ever grows (nothing removes an id when a jar is deleted or its trust revoked), so
+                // installing a jar whose pluginId is already enabled changes neither of the flows
+                // above — without this the freshly loaded plugin would never get an instance, and
+                // opening it would fail until the next enable toggle, session, or app restart.
+                pluginFactoryRepository.loadedPluginsFlow,
+            ) { enabledPluginIds, activeSessions, _ -> enabledPluginIds to activeSessions }
                 .collect { (enabledPluginIds, activeSessions) ->
                     enabledPluginIds.forEach { pluginId ->
                         val activatedSessionIds = pluginInstanceService.initializePluginInstancesForSessionsIfNeeded(

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationServiceTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationServiceTest.kt
@@ -1,0 +1,164 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.model.DebugSession
+import com.kitakkun.jetwhale.host.model.DebugSessionRepository
+import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.FailedPluginJar
+import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
+import com.kitakkun.jetwhale.host.model.LoadedPluginInstance
+import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
+import com.kitakkun.jetwhale.host.model.PluginInstanceService
+import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifest
+import com.kitakkun.jetwhale.protocol.messaging.PluginFrame
+import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata
+import com.kitakkun.jetwhale.protocol.negotiation.JetWhalePluginInfo
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultPluginSessionReconciliationServiceTest {
+    private val pluginId = "com.example.plugin"
+    private val sessionId = "session-1"
+
+    private val activeSession = DebugSession(
+        id = sessionId,
+        name = "test",
+        isActive = true,
+        transportSecurity = SessionTransportSecurity.LOOPBACK,
+        installedPlugins = persistentListOf(JetWhalePluginInfo(pluginId, "1.0.0")),
+    )
+
+    private val loadedPlugin = LoadedHostPlugin(
+        manifest = JetWhaleHostPluginManifest(
+            pluginId = pluginId,
+            pluginName = "Test",
+            version = "1.0.0",
+            factoryClass = "com.example.TestFactory",
+        ),
+        factory = object : JetWhaleHostPluginFactory {
+            override fun createPlugin(): JetWhaleHostPlugin = object : JetWhaleHostPlugin() {}
+        },
+    )
+
+    /**
+     * A plugin installed while its id is already in the enabled set changes neither the enabled set
+     * nor the session list, so loading it must be a reconciliation trigger of its own. Without it the
+     * plugin never gets an instance and opening it fails until the app is restarted.
+     */
+    @Test
+    fun `loading a plugin whose id is already enabled initializes its instances`() = runBlocking {
+        val factoryRepository = FakePluginFactoryRepository()
+        val instanceService = FakePluginInstanceService(factoryRepository)
+        val service = DefaultPluginSessionReconciliationService(
+            sessionRepository = FakeDebugSessionRepository(MutableStateFlow(persistentListOf(activeSession))),
+            enabledPluginsRepository = FakeEnabledPluginsRepository(setOf(pluginId)),
+            pluginFactoryRepository = factoryRepository,
+            pluginInstanceService = instanceService,
+        )
+
+        val collectJob = launch { service.reconciliationEvents().collect { } }
+
+        // The enabled id is reconciled from the start, but nothing is loaded yet, so no instance.
+        assertEquals(emptySet(), withTimeout(TIMEOUT_MILLIS) { instanceService.calls.receive() })
+
+        factoryRepository.load(loadedPlugin)
+
+        assertEquals(setOf(sessionId), withTimeout(TIMEOUT_MILLIS) { instanceService.calls.receive() })
+
+        collectJob.cancel()
+    }
+
+    private class FakeDebugSessionRepository(
+        override val debugSessionsFlow: MutableStateFlow<ImmutableList<DebugSession>>,
+    ) : DebugSessionRepository {
+        override suspend fun registerDebugSession(
+            sessionId: String,
+            sessionName: String?,
+            transportSecurity: SessionTransportSecurity,
+            installedPlugins: List<JetWhalePluginInfo>,
+            appMetadata: JetWhaleAppMetadata,
+        ) = Unit
+
+        override fun unregisterDebugSession(sessionId: String) = Unit
+        override fun markAllSessionsInactive() = Unit
+    }
+
+    private class FakeEnabledPluginsRepository(enabled: Set<String>) : EnabledPluginsRepository {
+        override val enabledPluginIdsFlow: MutableStateFlow<Set<String>> = MutableStateFlow(enabled)
+        override val disabledPluginIdFlow: MutableSharedFlow<String> = MutableSharedFlow()
+
+        override suspend fun setPluginEnabled(pluginId: String, enabled: Boolean) {
+            enabledPluginIdsFlow.value = if (enabled) {
+                enabledPluginIdsFlow.value + pluginId
+            } else {
+                enabledPluginIdsFlow.value - pluginId
+            }
+        }
+
+        override suspend fun isPluginEnabled(pluginId: String): Boolean = pluginId in enabledPluginIdsFlow.value
+    }
+
+    private class FakePluginFactoryRepository : PluginFactoryRepository {
+        private val plugins: MutableStateFlow<Map<String, LoadedHostPlugin>> = MutableStateFlow(emptyMap())
+        override val loadedPluginsFlow: Flow<Map<String, LoadedHostPlugin>> = plugins
+        override val loadedPlugins: Map<String, LoadedHostPlugin> get() = plugins.value
+        override val failedJarsFlow: Flow<List<FailedPluginJar>> = MutableStateFlow(emptyList())
+
+        fun load(plugin: LoadedHostPlugin) {
+            plugins.value = plugins.value + (plugin.manifest.pluginId to plugin)
+        }
+
+        override suspend fun loadPlugin(pluginJarPath: String) = Unit
+        override suspend fun unloadPlugin(pluginId: String) = Unit
+        override fun findPluginIdsByJarPath(pluginJarPath: String): List<String> = emptyList()
+        override suspend fun reloadPlugin(pluginJarPath: String): List<String> = emptyList()
+        override fun tryRedefinePlugin(pluginJarPath: String): List<String> = emptyList()
+    }
+
+    private class FakePluginInstanceService(
+        private val factoryRepository: PluginFactoryRepository,
+    ) : PluginInstanceService {
+        /** The session ids newly initialized by each reconciliation pass, in order. */
+        val calls: Channel<Set<String>> = Channel(Channel.UNLIMITED)
+
+        private val initializedSessionIds = mutableSetOf<String>()
+
+        override val pluginInstanceEventFlow: SharedFlow<PluginInstanceEvent> = MutableSharedFlow()
+
+        override fun initializePluginInstancesForSessionsIfNeeded(pluginId: String, sessionIds: Set<String>): Set<String> {
+            // Mirrors the real service: an id with no loaded plugin yields no instance.
+            val newSessionIds = if (factoryRepository.loadedPlugins[pluginId] == null) {
+                emptySet()
+            } else {
+                sessionIds - initializedSessionIds
+            }
+            initializedSessionIds += newSessionIds
+            calls.trySend(newSessionIds)
+            return newSessionIds
+        }
+
+        override fun getLoadedPluginInstances(): List<LoadedPluginInstance> = emptyList()
+        override fun unloadPluginInstanceForSession(sessionId: String) = Unit
+        override fun getPluginInstanceForSession(pluginId: String, sessionId: String): JetWhaleHostPlugin? = null
+        override fun unloadPluginInstancesForPlugin(pluginId: String) = Unit
+        override fun clearAllPluginInstances() = Unit
+        override suspend fun routeFrame(sessionId: String, frame: PluginFrame) = Unit
+    }
+
+    private companion object {
+        const val TIMEOUT_MILLIS = 5_000L
+    }
+}


### PR DESCRIPTION
## Problem

Installing a plugin whose `pluginId` is **already in the enabled set** left it without any instance: opening it failed with `Plugin instance not found for pluginId=...` and stayed broken until the next enable toggle, a new session, or an app restart.

`DefaultPluginSessionReconciliationService` combined only `enabledPluginIdsFlow` and `debugSessionsFlow`. Loading a plugin changes neither, so the combine never re-emitted and `initializePluginInstancesForSessionsIfNeeded` was never called for it.

Ids are never removed from the enabled set — nothing touches `enabled_plugin_ids` when a jar is deleted or its trust revoked — so this is the normal path for reinstalling a plugin, not an edge case.

## Changes

- **`DefaultPluginSessionReconciliationService`** — add `loadedPluginsFlow` to the combine, making a plugin load a reconciliation trigger of its own. This is the actual fix.
- **`DefaultPluginInstanceService`** — track the factory that produced each instance and replace instances whose factory no longer matches the loaded one. A reinstall or reload swaps in a new factory behind a new classloader, and instances from the previous one hold classes from a classloader that is already closed.
- **`DefaultPluginInstanceService`** — guard instance creation. A factory (or plugin constructor) that throws previously escaped the reconciliation `collect` and killed the `channelFlow`, stopping reconciliation for *every* plugin for the rest of the session.
- **`DefaultPluginComposeSceneService`** — tie a cached scene to the instance it composes, so a replaced instance rebuilds its scene instead of rendering code from a discarded classloader.

Hot reload is unaffected: `tryRedefinePlugin` keeps the same factory (instance state is preserved as designed), and the full-reload path disposes instances before reloading, so nothing is disposed twice.

## Test

`DefaultPluginSessionReconciliationServiceTest` covers the regression — it times out on the pre-fix code and passes with the fix.

`:jetwhale-host:core:data:test`, `:jetwhale-host:core:mcp:test`, `:jetwhale-host:app:test` and `spotlessCheck` all pass.