### PR TITLE
fix(network): default mock Content-Type to application/json when absent

### DIFF
--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
@@ -15,6 +15,7 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.HttpResponseData
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
 import io.ktor.http.HeadersBuilder
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpProtocolVersion
@@ -123,6 +124,12 @@ private suspend fun serveMock(client: HttpClient, request: HttpRequestBuilder, m
         requestTime = GMTDate(),
         headers = HeadersBuilder().apply {
             mock.headers.forEach { (key, value) -> append(key, value) }
+            // A mock without a Content-Type synthesizes a response whose header is null, which makes
+            // a client using ContentNegotiation reject the body. Default it so headerless JSON mocks
+            // stay usable, without overriding a Content-Type the mock already sets.
+            if (mock.headers.keys.none { it.equals(HttpHeaders.ContentType, ignoreCase = true) }) {
+                append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            }
         }.build(),
         version = HttpProtocolVersion.HTTP_1_1,
         body = ByteReadChannel(mock.body.encodeToByteArray()),

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
@@ -91,6 +91,59 @@ class JetWhaleNetworkKtorPluginTest {
     }
 
     @Test
+    fun `defaults a headerless mock's Content-Type to application json`() = runBlocking {
+        val (agent, _) = agentWithEvents()
+        agent.seedMockRules(
+            listOf(
+                MockRule(
+                    id = "1",
+                    matcher = MockMatcher(urlPattern = "/todos/1"),
+                    response = MockResponseSpec(statusCode = 200, body = "{\"ok\":true}"),
+                ),
+            ),
+        )
+        val client = HttpClient(
+            MockEngine { respond(content = "unmocked", status = HttpStatusCode.InternalServerError) },
+        ) {
+            install(agent.ktorClientPlugin())
+        }
+
+        val response = client.get("http://example/todos/1")
+
+        // Without the default, a headerless mock synthesizes Content-Type: null and a
+        // ContentNegotiation client rejects the body with NoTransformationFoundException.
+        assertEquals("application/json", response.headers[HttpHeaders.ContentType])
+    }
+
+    @Test
+    fun `preserves an explicit Content-Type on a mock`() = runBlocking {
+        val (agent, _) = agentWithEvents()
+        agent.seedMockRules(
+            listOf(
+                MockRule(
+                    id = "1",
+                    matcher = MockMatcher(urlPattern = "/plain"),
+                    response = MockResponseSpec(
+                        statusCode = 200,
+                        headers = mapOf("content-type" to "text/plain"),
+                        body = "hello",
+                    ),
+                ),
+            ),
+        )
+        val client = HttpClient(
+            MockEngine { respond(content = "unmocked", status = HttpStatusCode.InternalServerError) },
+        ) {
+            install(agent.ktorClientPlugin())
+        }
+
+        val response = client.get("http://example/plain")
+
+        // A Content-Type the mock already sets (even lower-cased) is never overridden by the default.
+        assertEquals("text/plain", response.headers[HttpHeaders.ContentType])
+    }
+
+    @Test
     fun `returns an SSE response without buffering its body`() = runBlocking {
         val (agent, events) = agentWithEvents()
         // A channel that receives data but is never closed — save() would suspend on it forever.


### PR DESCRIPTION
## Problem

`serveMock` in the Ktor network agent forwarded only `mock.headers` and set no default. When a mock has no `Content-Type` header, the synthesized response has `Content-Type: null`, so a client using `ContentNegotiation(json)` fails to deserialize the body:

```
NoTransformationFoundException: ... Response header `ContentType: null`
```

This makes any headerless JSON mock unusable, regardless of how it was created (UI or MCP).

## Fix

In `serveMock`, when the mock's headers contain no `Content-Type` (case-insensitive), default it to `application/json`. An explicit `Content-Type` the mock already sets is never overridden.

## Tests

Added to `JetWhaleNetworkKtorPluginTest`:
- `defaults a headerless mock's Content-Type to application json`
- `preserves an explicit Content-Type on a mock`

Both use the existing reflection-based `seedMockRules` helper and `MockEngine`.

## Verification

- `:jetwhale-plugins:network:agent-ktor:jvmTest` — passes
- `:spotlessKotlinCheck` — passes

Closes #173