### PR TITLE
feat: structured MCP parameter DSL + mock-rule headers/editing

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -292,6 +292,44 @@ Things to know:
   a command can `request` the agent directly.
 - The MCP APIs are marked `@ExperimentalJetWhaleApi` and may change between releases.
 
+### Structured parameters
+
+Beyond scalars (`string`, `int`, `long`, `boolean`, `enum`), a parameter can take structured input.
+When the shape is known, declare it as a `@Serializable` type with `serializable<T>()`:
+
+```kotlin
+private val rules by serializable<List<MockRule>>("The mock rules to apply.")
+```
+
+The argument is decoded for you, and the parameter's JSON Schema is derived from the type's
+serializer — nested objects, enum entries, and which properties are required (those without a
+default value) are all advertised to the AI agent. You never have to restate the shape in the tool's
+description, so it cannot drift from the model. A payload that doesn't fit the type raises a
+`JetWhaleMcpArgumentException` naming the parameter.
+
+Document individual properties with `@McpDescription`; the text lands in the schema next to the
+field it describes:
+
+```kotlin
+@Serializable
+data class MockMatcher(
+    @McpDescription("HTTP method to match (case-insensitive). Matches any method if omitted.")
+    val method: String? = null,
+    @McpDescription("URL pattern to match, interpreted per matchType.")
+    val urlPattern: String,
+)
+```
+
+A sealed hierarchy is advertised as a `oneOf` over its subclasses, each pinning the class
+discriminator (`"type"` by default, or whatever `@JsonClassDiscriminator` sets) to a `const` — the
+same flattened shape `Json` reads and writes, so the agent can construct any variant from the schema
+alone. Open polymorphic types have no statically known subclasses and fall back to an unconstrained
+`object`.
+
+`stringList` and `stringMap` cover the common flat containers. For payloads whose shape is not known
+ahead of time, `jsonObject` and `jsonArray` hand back the raw `JsonElement` — but they can only
+advertise `object` / `array`, so reach for `serializable` whenever the shape is known.
+
 The Network Inspector's own tools (`com.kitakkun.jetwhale.network.*`) are a complete in-repo
 example — see `jetwhale-plugins/network/host`.
 

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -330,6 +330,27 @@ alone. Open polymorphic types have no statically known subclasses and fall back 
 ahead of time, `jsonObject` and `jsonArray` hand back the raw `JsonElement` — but they can only
 advertise `object` / `array`, so reach for `serializable` whenever the shape is known.
 
+### Choosing the format
+
+Arguments are decoded with `DefaultArgumentJson`, tuned for input written by an AI agent: unknown
+keys are ignored, a scalar of the wrong JSON type is accepted where the value is unambiguous, enum
+entries match case-insensitively, and trailing commas and comments are tolerated. (`coerceInputValues`
+is deliberately off — it would swap an unrecognized enum entry for the property's default, turning a
+caller mistake into a silently different result.)
+
+Pass your own instance to the command's constructor when you need a `SerializersModule` (for
+contextual or open polymorphic types), a different class discriminator, or a naming strategy:
+
+```kotlin
+class InspectWidgetCommand : JetWhaleMcpCommand(
+    Json(from = DefaultArgumentJson) { serializersModule = widgetModule },
+) { /* ... */ }
+```
+
+The schema is derived from the same instance, so the names and discriminator advertised to the
+agent are the ones the command actually decodes. The format is also available to `execute` as the
+protected `json` property, for encoding the result.
+
 The Network Inspector's own tools (`com.kitakkun.jetwhale.network.*`) are a complete in-repo
 example — see `jetwhale-plugins/network/host`.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugi
 kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
 # kotlinx
+kotlinxSerializationCore = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationJson" }
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinxCollectionsImmutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }

--- a/jetwhale-annotations/api/jetwhale-annotations.klib.api
+++ b/jetwhale-annotations/api/jetwhale-annotations.klib.api
@@ -9,3 +9,10 @@
 open annotation class com.kitakkun.jetwhale.annotations/InternalJetWhaleApi : kotlin/Annotation { // com.kitakkun.jetwhale.annotations/InternalJetWhaleApi|null[0]
     constructor <init>() // com.kitakkun.jetwhale.annotations/InternalJetWhaleApi.<init>|<init>(){}[0]
 }
+
+open annotation class com.kitakkun.jetwhale.annotations/McpDescription : kotlin/Annotation { // com.kitakkun.jetwhale.annotations/McpDescription|null[0]
+    constructor <init>(kotlin/String) // com.kitakkun.jetwhale.annotations/McpDescription.<init>|<init>(kotlin.String){}[0]
+
+    final val value // com.kitakkun.jetwhale.annotations/McpDescription.value|{}value[0]
+        final fun <get-value>(): kotlin/String // com.kitakkun.jetwhale.annotations/McpDescription.value.<get-value>|<get-value>(){}[0]
+}

--- a/jetwhale-annotations/api/jvm/jetwhale-annotations.api
+++ b/jetwhale-annotations/api/jvm/jetwhale-annotations.api
@@ -1,3 +1,7 @@
 public abstract interface annotation class com/kitakkun/jetwhale/annotations/InternalJetWhaleApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class com/kitakkun/jetwhale/annotations/McpDescription : java/lang/annotation/Annotation {
+	public abstract fun value ()Ljava/lang/String;
+}
+

--- a/jetwhale-annotations/build.gradle.kts
+++ b/jetwhale-annotations/build.gradle.kts
@@ -14,6 +14,12 @@ kotlin {
     }
 
     android.namespace = "com.kitakkun.jetwhale.annotations"
+
+    sourceSets.commonMain.dependencies {
+        // Exposed in public API: McpDescription is a @SerialInfo annotation, and consumers read it
+        // back off a SerialDescriptor.
+        api(libs.kotlinxSerializationCore)
+    }
 }
 
 jetwhalePublish {

--- a/jetwhale-annotations/src/commonMain/kotlin/com/kitakkun/jetwhale/annotations/McpDescription.kt
+++ b/jetwhale-annotations/src/commonMain/kotlin/com/kitakkun/jetwhale/annotations/McpDescription.kt
@@ -1,0 +1,28 @@
+package com.kitakkun.jetwhale.annotations
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialInfo
+
+/**
+ * Documents a `@Serializable` property or class for AI agents. JetWhale copies [value] into the
+ * `description` of the generated JSON Schema when the type is used as an MCP tool parameter, so
+ * the documentation lives next to the field it describes instead of being restated in the tool's
+ * own description.
+ *
+ * ```kotlin
+ * @Serializable
+ * data class MockMatcher(
+ *     @McpDescription("HTTP method to match (case-insensitive). Matches any method if omitted.")
+ *     val method: String? = null,
+ * )
+ * ```
+ *
+ * [AnnotationTarget.VALUE_PARAMETER] is deliberately not an allowed target: the Kotlin compiler
+ * prioritizes it over [AnnotationTarget.PROPERTY], and a serial info annotation resolved to the
+ * value parameter is not preserved in the `SerialDescriptor`. Restricting the targets makes the
+ * annotation land on the property even when written on a constructor parameter.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+public annotation class McpDescription(val value: String)

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -176,7 +176,7 @@ public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpArgumentException :
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpArguments {
 	public static final field $stable I
-	public fun <init> (Ljava/util/Map;)V
+	public fun <init> (Lkotlinx/serialization/json/JsonObject;)V
 	public final fun get (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameter;)Ljava/lang/Object;
 }
 
@@ -202,12 +202,28 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
 	public static synthetic fun int$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun intOrNull (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun intOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun jsonArray (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public static synthetic fun jsonArray$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun jsonArrayOrNull (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public static synthetic fun jsonArrayOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun jsonObject (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public static synthetic fun jsonObject$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun jsonObjectOrNull (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public static synthetic fun jsonObjectOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun long (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun long$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun longOrNull (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun longOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun string (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun string$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun stringList (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public static synthetic fun stringList$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun stringListOrNull (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public static synthetic fun stringListOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun stringMap (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public static synthetic fun stringMap$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun stringMapOrNull (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public static synthetic fun stringMapOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun stringOrNull (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun stringOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public final fun toDescriptor ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor;
@@ -216,9 +232,11 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameter {
 	public static final field $stable I
 	public final fun getDescription ()Ljava/lang/String;
+	public final fun getItemsType ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getRequired ()Z
 	public final fun getType ()Ljava/lang/String;
+	public final fun getValueType ()Ljava/lang/String;
 }
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration : kotlin/properties/PropertyDelegateProvider {
@@ -229,17 +247,21 @@ public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaratio
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Z)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;
-	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
+	public final fun getItemsType ()Ljava/lang/String;
 	public final fun getRequired ()Z
 	public final fun getType ()Ljava/lang/String;
+	public final fun getValueType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -2,6 +2,10 @@ public final class com/kitakkun/jetwhale/host/sdk/DarkThemeKt {
 	public static final fun getLocalJetWhaleDarkTheme ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
+public final class com/kitakkun/jetwhale/host/sdk/DefaultArgumentJsonKt {
+	public static final fun getDefaultArgumentJson ()Lkotlinx/serialization/json/Json;
+}
+
 public abstract interface annotation class com/kitakkun/jetwhale/host/sdk/ExperimentalJetWhaleApi : java/lang/annotation/Annotation {
 }
 
@@ -187,6 +191,8 @@ public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapabl
 public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
 	public static final field $stable I
 	public fun <init> ()V
+	public fun <init> (Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected final fun boolean (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun boolean$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun booleanOrNull (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
@@ -197,6 +203,7 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
 	public static synthetic fun enumOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public abstract fun execute (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpArguments;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getDescription ()Ljava/lang/String;
+	protected final fun getJson ()Lkotlinx/serialization/json/Json;
 	public abstract fun getName ()Ljava/lang/String;
 	protected final fun int (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun int$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -214,6 +214,10 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
 	public static synthetic fun long$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun longOrNull (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun longOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun serializable (Lkotlinx/serialization/KSerializer;Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public static synthetic fun serializable$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun serializableOrNull (Lkotlinx/serialization/KSerializer;Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public static synthetic fun serializableOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun string (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun string$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun stringList (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
@@ -232,11 +236,9 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameter {
 	public static final field $stable I
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getItemsType ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getRequired ()Z
-	public final fun getType ()Ljava/lang/String;
-	public final fun getValueType ()Ljava/lang/String;
+	public final fun getSchema ()Lkotlinx/serialization/json/JsonObject;
 }
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration : kotlin/properties/PropertyDelegateProvider {
@@ -247,21 +249,17 @@ public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaratio
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
+	public fun <init> (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonObject;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Z
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;
-	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;
+	public final fun copy (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Z)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ZILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getItemsType ()Ljava/lang/String;
 	public final fun getRequired ()Z
-	public final fun getType ()Ljava/lang/String;
-	public final fun getValueType ()Ljava/lang/String;
+	public final fun getSchema ()Lkotlinx/serialization/json/JsonObject;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/jetwhale-host-sdk/build.gradle.kts
+++ b/jetwhale-host-sdk/build.gradle.kts
@@ -20,10 +20,12 @@ kotlin {
 
 dependencies {
     implementation(libs.jetbrainsComposeRuntime)
-    implementation(libs.kotlinxSerializationJson)
+    // Exposed in public API: the MCP parameter DSL takes KSerializer and hands back JsonObject.
+    api(libs.kotlinxSerializationJson)
     // Exposed in public API: JetWhalePluginStorage returns Flow and rememberPersistent uses coroutines.
     api(libs.kotlinxCoroutinesCore)
     api(projects.jetwhaleProtocol.core)
+    testImplementation(libs.kotlinTest)
 }
 
 jetwhalePublish {

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/DefaultArgumentJson.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/DefaultArgumentJson.kt
@@ -1,0 +1,29 @@
+package com.kitakkun.jetwhale.host.sdk
+
+import kotlinx.serialization.json.Json
+
+/**
+ * Default format for [JetWhaleMcpCommand] arguments, tuned for input written by an AI agent: it
+ * ignores unknown keys (so a value read back from another tool round-trips even if the agent
+ * annotated it), accepts a scalar of the wrong JSON type where the value is unambiguous, and
+ * matches enum entries case-insensitively — the same tolerance the scalar `enum` declarator has.
+ *
+ * Trailing commas and comments are accepted too. Those are lexer settings, so they do not affect
+ * tool arguments — the MCP transport hands those over already parsed — but they do apply when a
+ * command uses this same format from [JetWhaleMcpCommand.execute] to parse a string that holds
+ * JSON, such as a captured response body.
+ *
+ * `coerceInputValues` is deliberately off: it would swap an unrecognized enum entry for the
+ * property's default, turning a caller mistake into a silently different result.
+ *
+ * Build a variant with `Json(from = DefaultArgumentJson) { ... }` and pass it to the command's
+ * constructor.
+ */
+@ExperimentalJetWhaleApi
+public val DefaultArgumentJson: Json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+    decodeEnumsCaseInsensitive = true
+    allowTrailingComma = true
+    allowComments = true
+}

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
@@ -46,13 +46,19 @@ public data class JetWhaleMcpToolDescriptor(
 /**
  * Describes a single parameter of an MCP tool.
  *
- * @param type        JSON Schema primitive type: "string", "number", "boolean", "integer".
+ * @param type        JSON Schema type: "string", "number", "boolean", "integer", "object", "array".
  * @param description Human-readable description of the parameter.
  * @param required    Whether the parameter is required. Defaults to true.
+ * @param itemsType   For [type] "array": the JSON Schema type of each element, or null when the
+ *                    element type is unconstrained.
+ * @param valueType   For [type] "object": the JSON Schema type of each value, or null when the
+ *                    value type is unconstrained.
  */
 @ExperimentalJetWhaleApi
 public data class JetWhaleMcpParameterDescriptor(
     val type: String,
     val description: String,
     val required: Boolean = true,
+    val itemsType: String? = null,
+    val valueType: String? = null,
 )

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
@@ -1,5 +1,7 @@
 package com.kitakkun.jetwhale.host.sdk
 
+import kotlinx.serialization.json.JsonObject
+
 /**
  * Optional interface that a [JetWhaleHostPlugin] can implement to advertise plugin-specific MCP
  * tools to the MCP server, as a list of [JetWhaleMcpCommand]s.
@@ -46,19 +48,16 @@ public data class JetWhaleMcpToolDescriptor(
 /**
  * Describes a single parameter of an MCP tool.
  *
- * @param type        JSON Schema type: "string", "number", "boolean", "integer", "object", "array".
+ * @param schema      JSON Schema fragment for the values the parameter accepts, e.g.
+ *                    `{"type":"string"}` or a full nested object schema. It carries no
+ *                    "description" of its own; the MCP server merges [description] in when it
+ *                    assembles the tool's input schema.
  * @param description Human-readable description of the parameter.
  * @param required    Whether the parameter is required. Defaults to true.
- * @param itemsType   For [type] "array": the JSON Schema type of each element, or null when the
- *                    element type is unconstrained.
- * @param valueType   For [type] "object": the JSON Schema type of each value, or null when the
- *                    value type is unconstrained.
  */
 @ExperimentalJetWhaleApi
 public data class JetWhaleMcpParameterDescriptor(
-    val type: String,
+    val schema: JsonObject,
     val description: String,
     val required: Boolean = true,
-    val itemsType: String? = null,
-    val valueType: String? = null,
 )

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -1,5 +1,10 @@
 package com.kitakkun.jetwhale.host.sdk
 
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.properties.PropertyDelegateProvider
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
@@ -24,6 +29,10 @@ import kotlin.reflect.KProperty
  *     }
  * }
  * ```
+ * Besides scalars, structured arguments are available: [stringList] / [stringMap] emit
+ * `array` / `object` JSON Schema types with a known element type, and [jsonObject] / [jsonArray]
+ * hand back the raw [JsonElement] so a command can decode it with kotlinx.serialization.
+ *
  * Expose commands through [JetWhaleMcpCapablePlugin]. A [JetWhaleMcpArgumentException] (thrown
  * by the argument accessors, or by [execute] directly for domain-level caller mistakes) is
  * rendered as an `{"error": ...}` payload instead of failing the MCP server.
@@ -61,55 +70,98 @@ public abstract class JetWhaleMcpCommand {
                     type = parameter.type,
                     description = parameter.description,
                     required = parameter.required,
+                    itemsType = parameter.itemsType,
+                    valueType = parameter.valueType,
                 )
             },
         )
     }
 
-    // -- Parameter declaration (use with `by` on a property; the property name is the parameter
+    // -- Scalar parameters (use with `by` on a property; the property name is the parameter
     // name unless overridden via the `name` argument) ---------------------------------------
 
-    protected fun string(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<String> = requiredDeclaration(name, "string", description) { _, value -> value }
+    protected fun string(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<String> = requiredScalar(name, "string", description) { _, value -> value }
 
-    protected fun stringOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<String?> = optionalDeclaration(name, "string", description) { _, value -> value }
+    protected fun stringOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<String?> = optionalScalar(name, "string", description) { _, value -> value }
 
-    protected fun int(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Int> = requiredDeclaration(name, "integer", description, ::parseInt)
+    protected fun int(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Int> = requiredScalar(name, "integer", description, ::parseInt)
 
-    protected fun intOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Int?> = optionalDeclaration(name, "integer", description, ::parseInt)
+    protected fun intOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Int?> = optionalScalar(name, "integer", description, ::parseInt)
 
-    protected fun long(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Long> = requiredDeclaration(name, "integer", description, ::parseLong)
+    protected fun long(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Long> = requiredScalar(name, "integer", description, ::parseLong)
 
-    protected fun longOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Long?> = optionalDeclaration(name, "integer", description, ::parseLong)
+    protected fun longOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Long?> = optionalScalar(name, "integer", description, ::parseLong)
 
-    protected fun boolean(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Boolean> = requiredDeclaration(name, "boolean", description, ::parseBoolean)
+    protected fun boolean(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Boolean> = requiredScalar(name, "boolean", description, ::parseBoolean)
 
-    protected fun booleanOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Boolean?> = optionalDeclaration(name, "boolean", description, ::parseBoolean)
-
-    /** Matches [entries] by enum name, case-insensitively. */
-    protected fun <T : Enum<T>> enum(description: String, entries: List<T>, name: String? = null): JetWhaleMcpParameterDeclaration<T> = requiredDeclaration(name, "string", description) { paramName, value -> parseEnum(paramName, value, entries) }
+    protected fun booleanOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Boolean?> = optionalScalar(name, "boolean", description, ::parseBoolean)
 
     /** Matches [entries] by enum name, case-insensitively. */
-    protected fun <T : Enum<T>> enumOrNull(description: String, entries: List<T>, name: String? = null): JetWhaleMcpParameterDeclaration<T?> = optionalDeclaration(name, "string", description) { paramName, value -> parseEnum(paramName, value, entries) }
+    protected fun <T : Enum<T>> enum(description: String, entries: List<T>, name: String? = null): JetWhaleMcpParameterDeclaration<T> = requiredScalar(name, "string", description) { paramName, value -> parseEnum(paramName, value, entries) }
 
-    private fun <T : Any> requiredDeclaration(name: String?, type: String, description: String, parse: (String, String) -> T): JetWhaleMcpParameterDeclaration<T> = JetWhaleMcpParameterDeclaration(
+    /** Matches [entries] by enum name, case-insensitively. */
+    protected fun <T : Enum<T>> enumOrNull(description: String, entries: List<T>, name: String? = null): JetWhaleMcpParameterDeclaration<T?> = optionalScalar(name, "string", description) { paramName, value -> parseEnum(paramName, value, entries) }
+
+    // -- Structured parameters ----------------------------------------------------------------
+
+    /** A JSON array of strings, e.g. `["a", "b"]`. */
+    protected fun stringList(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<List<String>> = requiredStructured(name, "array", description, itemsType = "string", valueType = null, parse = ::parseStringList)
+
+    /** A JSON array of strings, e.g. `["a", "b"]`. */
+    protected fun stringListOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<List<String>?> = optionalStructured(name, "array", description, itemsType = "string", valueType = null, parse = ::parseStringList)
+
+    /** A JSON object whose values are strings, e.g. `{"Content-Type":"application/json"}`. */
+    protected fun stringMap(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Map<String, String>> = requiredStructured(name, "object", description, itemsType = null, valueType = "string", parse = ::parseStringMap)
+
+    /** A JSON object whose values are strings, e.g. `{"Content-Type":"application/json"}`. */
+    protected fun stringMapOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Map<String, String>?> = optionalStructured(name, "object", description, itemsType = null, valueType = "string", parse = ::parseStringMap)
+
+    /** A raw JSON object, handed back for the command to decode with kotlinx.serialization. */
+    protected fun jsonObject(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonObject> = requiredStructured(name, "object", description, itemsType = null, valueType = null, parse = ::parseJsonObject)
+
+    /** A raw JSON object, handed back for the command to decode with kotlinx.serialization. */
+    protected fun jsonObjectOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonObject?> = optionalStructured(name, "object", description, itemsType = null, valueType = null, parse = ::parseJsonObject)
+
+    /** A raw JSON array, handed back for the command to decode with kotlinx.serialization. */
+    protected fun jsonArray(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonArray> = requiredStructured(name, "array", description, itemsType = null, valueType = null, parse = ::parseJsonArray)
+
+    /** A raw JSON array, handed back for the command to decode with kotlinx.serialization. */
+    protected fun jsonArrayOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonArray?> = optionalStructured(name, "array", description, itemsType = null, valueType = null, parse = ::parseJsonArray)
+
+    // -- Declaration builders -----------------------------------------------------------------
+
+    private fun <T : Any> requiredScalar(name: String?, type: String, description: String, parse: (String, String) -> T): JetWhaleMcpParameterDeclaration<T> = requiredStructured(name, type, description, itemsType = null, valueType = null) { paramName, element ->
+        parse(paramName, scalarContent(paramName, element))
+    }
+
+    private fun <T : Any> optionalScalar(name: String?, type: String, description: String, parse: (String, String) -> T): JetWhaleMcpParameterDeclaration<T?> = optionalStructured(name, type, description, itemsType = null, valueType = null) { paramName, element ->
+        parse(paramName, scalarContent(paramName, element))
+    }
+
+    private fun <T : Any> requiredStructured(name: String?, type: String, description: String, itemsType: String?, valueType: String?, parse: (String, JsonElement) -> T): JetWhaleMcpParameterDeclaration<T> = JetWhaleMcpParameterDeclaration(
         command = this,
         explicitName = name,
         type = type,
         description = description,
         required = true,
+        itemsType = itemsType,
+        valueType = valueType,
     ) { paramName, raw ->
-        raw[paramName]?.let { parse(paramName, it) }
+        val element = raw[paramName]?.takeUnless { it is JsonNull }
             ?: throw JetWhaleMcpArgumentException("missing required argument: $paramName")
+        parse(paramName, element)
     }
 
-    private fun <T : Any> optionalDeclaration(name: String?, type: String, description: String, parse: (String, String) -> T): JetWhaleMcpParameterDeclaration<T?> = JetWhaleMcpParameterDeclaration(
+    private fun <T : Any> optionalStructured(name: String?, type: String, description: String, itemsType: String?, valueType: String?, parse: (String, JsonElement) -> T): JetWhaleMcpParameterDeclaration<T?> = JetWhaleMcpParameterDeclaration(
         command = this,
         explicitName = name,
         type = type,
         description = description,
         required = false,
+        itemsType = itemsType,
+        valueType = valueType,
     ) { paramName, raw ->
-        raw[paramName]?.let { parse(paramName, it) }
+        raw[paramName]?.takeUnless { it is JsonNull }?.let { parse(paramName, it) }
     }
 
     internal fun <T> declare(parameter: JetWhaleMcpParameter<T>): JetWhaleMcpParameter<T> {
@@ -123,6 +175,9 @@ public abstract class JetWhaleMcpCommand {
         return parameter
     }
 
+    private fun scalarContent(name: String, element: JsonElement): String = (element as? JsonPrimitive)?.content
+        ?: throw JetWhaleMcpArgumentException("invalid $name: expected a scalar value")
+
     private fun parseInt(name: String, value: String): Int = value.toIntOrNull() ?: invalid(name, value, "an integer")
 
     private fun parseLong(name: String, value: String): Long = value.toLongOrNull() ?: invalid(name, value, "an integer")
@@ -131,6 +186,26 @@ public abstract class JetWhaleMcpCommand {
 
     private fun <T : Enum<T>> parseEnum(name: String, value: String, entries: List<T>): T = entries.firstOrNull { it.name.equals(value, ignoreCase = true) }
         ?: invalid(name, value, "one of ${entries.joinToString(", ") { it.name }}")
+
+    private fun parseStringList(name: String, element: JsonElement): List<String> {
+        val array = element as? JsonArray ?: throw JetWhaleMcpArgumentException("invalid $name: expected a JSON array")
+        return array.map { item ->
+            (item as? JsonPrimitive)?.content ?: throw JetWhaleMcpArgumentException("invalid $name: expected an array of strings")
+        }
+    }
+
+    private fun parseStringMap(name: String, element: JsonElement): Map<String, String> {
+        val obj = element as? JsonObject ?: throw JetWhaleMcpArgumentException("invalid $name: expected a JSON object")
+        return obj.mapValues { (_, value) ->
+            (value as? JsonPrimitive)?.content ?: throw JetWhaleMcpArgumentException("invalid $name: expected an object of string values")
+        }
+    }
+
+    private fun parseJsonObject(name: String, element: JsonElement): JsonObject = element as? JsonObject
+        ?: throw JetWhaleMcpArgumentException("invalid $name: expected a JSON object")
+
+    private fun parseJsonArray(name: String, element: JsonElement): JsonArray = element as? JsonArray
+        ?: throw JetWhaleMcpArgumentException("invalid $name: expected a JSON array")
 
     private fun invalid(name: String, value: String, expected: String): Nothing = throw JetWhaleMcpArgumentException("invalid $name: $value (expected $expected)")
 }
@@ -147,7 +222,9 @@ public class JetWhaleMcpParameterDeclaration<T> internal constructor(
     private val type: String,
     private val description: String,
     private val required: Boolean,
-    private val extract: (name: String, raw: Map<String, String>) -> T,
+    private val itemsType: String?,
+    private val valueType: String?,
+    private val extract: (name: String, raw: JsonObject) -> T,
 ) : PropertyDelegateProvider<Any?, ReadOnlyProperty<Any?, JetWhaleMcpParameter<T>>> {
     override fun provideDelegate(thisRef: Any?, property: KProperty<*>): ReadOnlyProperty<Any?, JetWhaleMcpParameter<T>> {
         val parameterName = explicitName ?: property.name
@@ -157,6 +234,8 @@ public class JetWhaleMcpParameterDeclaration<T> internal constructor(
                 type = type,
                 description = description,
                 required = required,
+                itemsType = itemsType,
+                valueType = valueType,
             ) { raw -> extract(parameterName, raw) },
         )
         return ReadOnlyProperty { _, _ -> parameter }
@@ -173,9 +252,15 @@ public class JetWhaleMcpParameter<T> internal constructor(
     public val type: String,
     public val description: String,
     public val required: Boolean,
-    private val extract: (Map<String, String>) -> T,
+    // For type "array": the JSON Schema type of each element. Null when the element type is
+    // unconstrained (raw arrays).
+    public val itemsType: String?,
+    // For type "object": the JSON Schema type of each value. Null when the value type is
+    // unconstrained (raw objects).
+    public val valueType: String?,
+    private val extract: (JsonObject) -> T,
 ) {
-    internal fun extractFrom(raw: Map<String, String>): T = extract(raw)
+    internal fun extractFrom(raw: JsonObject): T = extract(raw)
 }
 
 /** A caller mistake in a tool invocation (missing/invalid argument, unknown id, ...). */
@@ -188,6 +273,6 @@ public class JetWhaleMcpArgumentException(message: String) : Exception(message)
  * [JetWhaleMcpArgumentException] with a caller-facing message when it is missing or unparseable.
  */
 @ExperimentalJetWhaleApi
-public class JetWhaleMcpArguments(private val raw: Map<String, String>) {
+public class JetWhaleMcpArguments(private val raw: JsonObject) {
     public operator fun <T> get(parameter: JetWhaleMcpParameter<T>): T = parameter.extractFrom(raw)
 }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -46,9 +46,19 @@ import kotlin.reflect.KProperty
  * Expose commands through [JetWhaleMcpCapablePlugin]. A [JetWhaleMcpArgumentException] (thrown
  * by the argument accessors, or by [execute] directly for domain-level caller mistakes) is
  * rendered as an `{"error": ...}` payload instead of failing the MCP server.
+ *
+ * @param json Format used to decode [serializable] arguments and to derive their schema; also
+ *   available to [execute] for encoding results. Defaults to [DefaultArgumentJson]. Pass a custom
+ *   instance to register a [kotlinx.serialization.modules.SerializersModule] (needed for contextual
+ *   or open polymorphic types) or to change the class discriminator or naming strategy — the
+ *   derived schema follows the instance, so the two cannot drift apart.
  */
 @ExperimentalJetWhaleApi
-public abstract class JetWhaleMcpCommand {
+public abstract class JetWhaleMcpCommand(
+    // A constructor parameter rather than an open val: parameters are declared as property
+    // initializers, which run before a subclass' own property overrides would be assigned.
+    protected val json: Json = DefaultArgumentJson,
+) {
     /** Globally unique tool name; by convention prefixed with the pluginId. */
     public abstract val name: String
 
@@ -127,10 +137,10 @@ public abstract class JetWhaleMcpCommand {
     protected inline fun <reified T : Any> serializableOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<T?> = serializableOrNull(serializer<T>(), description, name)
 
     /** Explicit-serializer form of [serializable], for types whose serializer cannot be resolved from the type argument. */
-    protected fun <T : Any> serializable(serializer: KSerializer<T>, description: String, name: String? = null): JetWhaleMcpParameterDeclaration<T> = requiredStructured(name, serializer.descriptor.toJsonSchema(), description) { paramName, element -> decode(paramName, serializer, element) }
+    protected fun <T : Any> serializable(serializer: KSerializer<T>, description: String, name: String? = null): JetWhaleMcpParameterDeclaration<T> = requiredStructured(name, serializer.descriptor.toJsonSchema(json), description) { paramName, element -> decode(paramName, serializer, element) }
 
     /** Explicit-serializer form of [serializableOrNull]. */
-    protected fun <T : Any> serializableOrNull(serializer: KSerializer<T>, description: String, name: String? = null): JetWhaleMcpParameterDeclaration<T?> = optionalStructured(name, serializer.descriptor.toJsonSchema(), description) { paramName, element -> decode(paramName, serializer, element) }
+    protected fun <T : Any> serializableOrNull(serializer: KSerializer<T>, description: String, name: String? = null): JetWhaleMcpParameterDeclaration<T?> = optionalStructured(name, serializer.descriptor.toJsonSchema(json), description) { paramName, element -> decode(paramName, serializer, element) }
 
     /** A JSON array of strings, e.g. `["a", "b"]`. */
     protected fun stringList(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<List<String>> = requiredStructured(name, STRING_LIST_SCHEMA, description, parse = ::parseStringList)
@@ -240,7 +250,7 @@ public abstract class JetWhaleMcpCommand {
     // SerializationException is an IllegalArgumentException, so this covers both a malformed
     // payload and a value that does not fit the target type.
     private fun <T : Any> decode(name: String, serializer: KSerializer<T>, element: JsonElement): T = try {
-        argumentJson.decodeFromJsonElement(serializer, element)
+        json.decodeFromJsonElement(serializer, element)
     } catch (e: IllegalArgumentException) {
         throw JetWhaleMcpArgumentException("invalid $name: ${e.message}")
     }
@@ -248,10 +258,6 @@ public abstract class JetWhaleMcpCommand {
     private fun invalid(name: String, value: String, expected: String): Nothing = throw JetWhaleMcpArgumentException("invalid $name: $value (expected $expected)")
 
     private companion object {
-        // Tolerate extra fields so a value the agent read back from another tool round-trips even
-        // if it carries annotations of its own.
-        val argumentJson = Json { ignoreUnknownKeys = true }
-
         val STRING_SCHEMA = buildJsonObject { put("type", "string") }
         val INTEGER_SCHEMA = buildJsonObject { put("type", "integer") }
         val BOOLEAN_SCHEMA = buildJsonObject { put("type", "boolean") }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -1,10 +1,18 @@
 package com.kitakkun.jetwhale.host.sdk
 
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import kotlinx.serialization.serializer
 import kotlin.properties.PropertyDelegateProvider
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
@@ -29,9 +37,11 @@ import kotlin.reflect.KProperty
  *     }
  * }
  * ```
- * Besides scalars, structured arguments are available: [stringList] / [stringMap] emit
- * `array` / `object` JSON Schema types with a known element type, and [jsonObject] / [jsonArray]
- * hand back the raw [JsonElement] so a command can decode it with kotlinx.serialization.
+ * Besides scalars, structured arguments are available. [serializable] is the one to reach for when
+ * the shape is known: it decodes the argument into a `@Serializable` type and derives the
+ * parameter's JSON Schema from that type, so the shape never has to be restated in prose.
+ * [stringList] / [stringMap] cover the common flat containers, and [jsonObject] / [jsonArray] hand
+ * back the raw [JsonElement] for payloads whose shape is not known ahead of time.
  *
  * Expose commands through [JetWhaleMcpCapablePlugin]. A [JetWhaleMcpArgumentException] (thrown
  * by the argument accessors, or by [execute] directly for domain-level caller mistakes) is
@@ -67,11 +77,9 @@ public abstract class JetWhaleMcpCommand {
             description = description,
             parameters = declaredParameters.associate { parameter ->
                 parameter.name to JetWhaleMcpParameterDescriptor(
-                    type = parameter.type,
+                    schema = parameter.schema,
                     description = parameter.description,
                     required = parameter.required,
-                    itemsType = parameter.itemsType,
-                    valueType = parameter.valueType,
                 )
             },
         )
@@ -80,86 +88,108 @@ public abstract class JetWhaleMcpCommand {
     // -- Scalar parameters (use with `by` on a property; the property name is the parameter
     // name unless overridden via the `name` argument) ---------------------------------------
 
-    protected fun string(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<String> = requiredScalar(name, "string", description) { _, value -> value }
+    protected fun string(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<String> = requiredScalar(name, STRING_SCHEMA, description) { _, value -> value }
 
-    protected fun stringOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<String?> = optionalScalar(name, "string", description) { _, value -> value }
+    protected fun stringOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<String?> = optionalScalar(name, STRING_SCHEMA, description) { _, value -> value }
 
-    protected fun int(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Int> = requiredScalar(name, "integer", description, ::parseInt)
+    protected fun int(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Int> = requiredScalar(name, INTEGER_SCHEMA, description, ::parseInt)
 
-    protected fun intOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Int?> = optionalScalar(name, "integer", description, ::parseInt)
+    protected fun intOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Int?> = optionalScalar(name, INTEGER_SCHEMA, description, ::parseInt)
 
-    protected fun long(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Long> = requiredScalar(name, "integer", description, ::parseLong)
+    protected fun long(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Long> = requiredScalar(name, INTEGER_SCHEMA, description, ::parseLong)
 
-    protected fun longOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Long?> = optionalScalar(name, "integer", description, ::parseLong)
+    protected fun longOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Long?> = optionalScalar(name, INTEGER_SCHEMA, description, ::parseLong)
 
-    protected fun boolean(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Boolean> = requiredScalar(name, "boolean", description, ::parseBoolean)
+    protected fun boolean(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Boolean> = requiredScalar(name, BOOLEAN_SCHEMA, description, ::parseBoolean)
 
-    protected fun booleanOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Boolean?> = optionalScalar(name, "boolean", description, ::parseBoolean)
+    protected fun booleanOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Boolean?> = optionalScalar(name, BOOLEAN_SCHEMA, description, ::parseBoolean)
 
-    /** Matches [entries] by enum name, case-insensitively. */
-    protected fun <T : Enum<T>> enum(description: String, entries: List<T>, name: String? = null): JetWhaleMcpParameterDeclaration<T> = requiredScalar(name, "string", description) { paramName, value -> parseEnum(paramName, value, entries) }
+    /** Matches [entries] by enum name, case-insensitively; the entry names are advertised as the schema's `enum`. */
+    protected fun <T : Enum<T>> enum(description: String, entries: List<T>, name: String? = null): JetWhaleMcpParameterDeclaration<T> = requiredScalar(name, enumSchema(entries), description) { paramName, value -> parseEnum(paramName, value, entries) }
 
-    /** Matches [entries] by enum name, case-insensitively. */
-    protected fun <T : Enum<T>> enumOrNull(description: String, entries: List<T>, name: String? = null): JetWhaleMcpParameterDeclaration<T?> = optionalScalar(name, "string", description) { paramName, value -> parseEnum(paramName, value, entries) }
+    /** Matches [entries] by enum name, case-insensitively; the entry names are advertised as the schema's `enum`. */
+    protected fun <T : Enum<T>> enumOrNull(description: String, entries: List<T>, name: String? = null): JetWhaleMcpParameterDeclaration<T?> = optionalScalar(name, enumSchema(entries), description) { paramName, value -> parseEnum(paramName, value, entries) }
 
     // -- Structured parameters ----------------------------------------------------------------
 
-    /** A JSON array of strings, e.g. `["a", "b"]`. */
-    protected fun stringList(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<List<String>> = requiredStructured(name, "array", description, itemsType = "string", valueType = null, parse = ::parseStringList)
+    /**
+     * A value decoded into the `@Serializable` type [T]. The parameter's JSON Schema is derived
+     * from [T]'s serializer — nested objects, enum entries and which properties are required all
+     * come from the type itself, so the tool's description does not have to spell the shape out.
+     *
+     * Unknown JSON keys are ignored, so a value the agent read back from another tool round-trips
+     * even if it carries annotations of its own. A payload that does not fit [T] raises a
+     * [JetWhaleMcpArgumentException] naming the parameter.
+     */
+    protected inline fun <reified T : Any> serializable(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<T> = serializable(serializer<T>(), description, name)
+
+    /** @see serializable */
+    protected inline fun <reified T : Any> serializableOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<T?> = serializableOrNull(serializer<T>(), description, name)
+
+    /** Explicit-serializer form of [serializable], for types whose serializer cannot be resolved from the type argument. */
+    protected fun <T : Any> serializable(serializer: KSerializer<T>, description: String, name: String? = null): JetWhaleMcpParameterDeclaration<T> = requiredStructured(name, serializer.descriptor.toJsonSchema(), description) { paramName, element -> decode(paramName, serializer, element) }
+
+    /** Explicit-serializer form of [serializableOrNull]. */
+    protected fun <T : Any> serializableOrNull(serializer: KSerializer<T>, description: String, name: String? = null): JetWhaleMcpParameterDeclaration<T?> = optionalStructured(name, serializer.descriptor.toJsonSchema(), description) { paramName, element -> decode(paramName, serializer, element) }
 
     /** A JSON array of strings, e.g. `["a", "b"]`. */
-    protected fun stringListOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<List<String>?> = optionalStructured(name, "array", description, itemsType = "string", valueType = null, parse = ::parseStringList)
+    protected fun stringList(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<List<String>> = requiredStructured(name, STRING_LIST_SCHEMA, description, parse = ::parseStringList)
+
+    /** A JSON array of strings, e.g. `["a", "b"]`. */
+    protected fun stringListOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<List<String>?> = optionalStructured(name, STRING_LIST_SCHEMA, description, parse = ::parseStringList)
 
     /** A JSON object whose values are strings, e.g. `{"Content-Type":"application/json"}`. */
-    protected fun stringMap(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Map<String, String>> = requiredStructured(name, "object", description, itemsType = null, valueType = "string", parse = ::parseStringMap)
+    protected fun stringMap(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Map<String, String>> = requiredStructured(name, STRING_MAP_SCHEMA, description, parse = ::parseStringMap)
 
     /** A JSON object whose values are strings, e.g. `{"Content-Type":"application/json"}`. */
-    protected fun stringMapOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Map<String, String>?> = optionalStructured(name, "object", description, itemsType = null, valueType = "string", parse = ::parseStringMap)
+    protected fun stringMapOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<Map<String, String>?> = optionalStructured(name, STRING_MAP_SCHEMA, description, parse = ::parseStringMap)
 
-    /** A raw JSON object, handed back for the command to decode with kotlinx.serialization. */
-    protected fun jsonObject(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonObject> = requiredStructured(name, "object", description, itemsType = null, valueType = null, parse = ::parseJsonObject)
+    /**
+     * A raw JSON object, for payloads whose shape is not known ahead of time. The schema advertises
+     * only `object`, so prefer [serializable] whenever the shape is known.
+     */
+    protected fun jsonObject(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonObject> = requiredStructured(name, OBJECT_SCHEMA, description, parse = ::parseJsonObject)
 
-    /** A raw JSON object, handed back for the command to decode with kotlinx.serialization. */
-    protected fun jsonObjectOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonObject?> = optionalStructured(name, "object", description, itemsType = null, valueType = null, parse = ::parseJsonObject)
+    /** @see jsonObject */
+    protected fun jsonObjectOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonObject?> = optionalStructured(name, OBJECT_SCHEMA, description, parse = ::parseJsonObject)
 
-    /** A raw JSON array, handed back for the command to decode with kotlinx.serialization. */
-    protected fun jsonArray(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonArray> = requiredStructured(name, "array", description, itemsType = null, valueType = null, parse = ::parseJsonArray)
+    /**
+     * A raw JSON array, for payloads whose shape is not known ahead of time. The schema advertises
+     * only `array`, so prefer [serializable] whenever the shape is known.
+     */
+    protected fun jsonArray(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonArray> = requiredStructured(name, ARRAY_SCHEMA, description, parse = ::parseJsonArray)
 
-    /** A raw JSON array, handed back for the command to decode with kotlinx.serialization. */
-    protected fun jsonArrayOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonArray?> = optionalStructured(name, "array", description, itemsType = null, valueType = null, parse = ::parseJsonArray)
+    /** @see jsonArray */
+    protected fun jsonArrayOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonArray?> = optionalStructured(name, ARRAY_SCHEMA, description, parse = ::parseJsonArray)
 
     // -- Declaration builders -----------------------------------------------------------------
 
-    private fun <T : Any> requiredScalar(name: String?, type: String, description: String, parse: (String, String) -> T): JetWhaleMcpParameterDeclaration<T> = requiredStructured(name, type, description, itemsType = null, valueType = null) { paramName, element ->
+    private fun <T : Any> requiredScalar(name: String?, schema: JsonObject, description: String, parse: (String, String) -> T): JetWhaleMcpParameterDeclaration<T> = requiredStructured(name, schema, description) { paramName, element ->
         parse(paramName, scalarContent(paramName, element))
     }
 
-    private fun <T : Any> optionalScalar(name: String?, type: String, description: String, parse: (String, String) -> T): JetWhaleMcpParameterDeclaration<T?> = optionalStructured(name, type, description, itemsType = null, valueType = null) { paramName, element ->
+    private fun <T : Any> optionalScalar(name: String?, schema: JsonObject, description: String, parse: (String, String) -> T): JetWhaleMcpParameterDeclaration<T?> = optionalStructured(name, schema, description) { paramName, element ->
         parse(paramName, scalarContent(paramName, element))
     }
 
-    private fun <T : Any> requiredStructured(name: String?, type: String, description: String, itemsType: String?, valueType: String?, parse: (String, JsonElement) -> T): JetWhaleMcpParameterDeclaration<T> = JetWhaleMcpParameterDeclaration(
+    private fun <T : Any> requiredStructured(name: String?, schema: JsonObject, description: String, parse: (String, JsonElement) -> T): JetWhaleMcpParameterDeclaration<T> = JetWhaleMcpParameterDeclaration(
         command = this,
         explicitName = name,
-        type = type,
+        schema = schema,
         description = description,
         required = true,
-        itemsType = itemsType,
-        valueType = valueType,
     ) { paramName, raw ->
         val element = raw[paramName]?.takeUnless { it is JsonNull }
             ?: throw JetWhaleMcpArgumentException("missing required argument: $paramName")
         parse(paramName, element)
     }
 
-    private fun <T : Any> optionalStructured(name: String?, type: String, description: String, itemsType: String?, valueType: String?, parse: (String, JsonElement) -> T): JetWhaleMcpParameterDeclaration<T?> = JetWhaleMcpParameterDeclaration(
+    private fun <T : Any> optionalStructured(name: String?, schema: JsonObject, description: String, parse: (String, JsonElement) -> T): JetWhaleMcpParameterDeclaration<T?> = JetWhaleMcpParameterDeclaration(
         command = this,
         explicitName = name,
-        type = type,
+        schema = schema,
         description = description,
         required = false,
-        itemsType = itemsType,
-        valueType = valueType,
     ) { paramName, raw ->
         raw[paramName]?.takeUnless { it is JsonNull }?.let { parse(paramName, it) }
     }
@@ -207,7 +237,42 @@ public abstract class JetWhaleMcpCommand {
     private fun parseJsonArray(name: String, element: JsonElement): JsonArray = element as? JsonArray
         ?: throw JetWhaleMcpArgumentException("invalid $name: expected a JSON array")
 
+    // SerializationException is an IllegalArgumentException, so this covers both a malformed
+    // payload and a value that does not fit the target type.
+    private fun <T : Any> decode(name: String, serializer: KSerializer<T>, element: JsonElement): T = try {
+        argumentJson.decodeFromJsonElement(serializer, element)
+    } catch (e: IllegalArgumentException) {
+        throw JetWhaleMcpArgumentException("invalid $name: ${e.message}")
+    }
+
     private fun invalid(name: String, value: String, expected: String): Nothing = throw JetWhaleMcpArgumentException("invalid $name: $value (expected $expected)")
+
+    private companion object {
+        // Tolerate extra fields so a value the agent read back from another tool round-trips even
+        // if it carries annotations of its own.
+        val argumentJson = Json { ignoreUnknownKeys = true }
+
+        val STRING_SCHEMA = buildJsonObject { put("type", "string") }
+        val INTEGER_SCHEMA = buildJsonObject { put("type", "integer") }
+        val BOOLEAN_SCHEMA = buildJsonObject { put("type", "boolean") }
+        val OBJECT_SCHEMA = buildJsonObject { put("type", "object") }
+        val ARRAY_SCHEMA = buildJsonObject { put("type", "array") }
+
+        val STRING_LIST_SCHEMA = buildJsonObject {
+            put("type", "array")
+            putJsonObject("items") { put("type", "string") }
+        }
+
+        val STRING_MAP_SCHEMA = buildJsonObject {
+            put("type", "object")
+            putJsonObject("additionalProperties") { put("type", "string") }
+        }
+
+        fun <T : Enum<T>> enumSchema(entries: List<T>): JsonObject = buildJsonObject {
+            put("type", "string")
+            putJsonArray("enum") { entries.forEach { add(it.name) } }
+        }
+    }
 }
 
 /**
@@ -219,11 +284,9 @@ public abstract class JetWhaleMcpCommand {
 public class JetWhaleMcpParameterDeclaration<T> internal constructor(
     private val command: JetWhaleMcpCommand,
     private val explicitName: String?,
-    private val type: String,
+    private val schema: JsonObject,
     private val description: String,
     private val required: Boolean,
-    private val itemsType: String?,
-    private val valueType: String?,
     private val extract: (name: String, raw: JsonObject) -> T,
 ) : PropertyDelegateProvider<Any?, ReadOnlyProperty<Any?, JetWhaleMcpParameter<T>>> {
     override fun provideDelegate(thisRef: Any?, property: KProperty<*>): ReadOnlyProperty<Any?, JetWhaleMcpParameter<T>> {
@@ -231,11 +294,9 @@ public class JetWhaleMcpParameterDeclaration<T> internal constructor(
         val parameter = command.declare(
             JetWhaleMcpParameter(
                 name = parameterName,
-                type = type,
+                schema = schema,
                 description = description,
                 required = required,
-                itemsType = itemsType,
-                valueType = valueType,
             ) { raw -> extract(parameterName, raw) },
         )
         return ReadOnlyProperty { _, _ -> parameter }
@@ -249,15 +310,11 @@ public class JetWhaleMcpParameterDeclaration<T> internal constructor(
 @ExperimentalJetWhaleApi
 public class JetWhaleMcpParameter<T> internal constructor(
     public val name: String,
-    public val type: String,
+    // JSON Schema fragment for the values this parameter accepts; carries no "description" of its
+    // own, which the MCP server merges in from [description].
+    public val schema: JsonObject,
     public val description: String,
     public val required: Boolean,
-    // For type "array": the JSON Schema type of each element. Null when the element type is
-    // unconstrained (raw arrays).
-    public val itemsType: String?,
-    // For type "object": the JSON Schema type of each value. Null when the value type is
-    // unconstrained (raw objects).
-    public val valueType: String?,
     private val extract: (JsonObject) -> T,
 ) {
     internal fun extractFrom(raw: JsonObject): T = extract(raw)

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
@@ -8,8 +8,11 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.descriptors.elementNames
+import kotlinx.serialization.json.ClassDiscriminatorMode
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
@@ -17,9 +20,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
-
-/** The class discriminator `Json` writes for polymorphic values unless the type overrides it. */
-private const val DEFAULT_CLASS_DISCRIMINATOR = "type"
 
 /**
  * Derives a JSON Schema fragment describing the values this descriptor accepts, so a serializable
@@ -30,12 +30,29 @@ private const val DEFAULT_CLASS_DISCRIMINATOR = "type"
  * kotlinx.serialization decodes it. A sealed hierarchy becomes a `oneOf` over its subclasses, each
  * carrying the class discriminator as a `const`. Open polymorphic types are advertised as an
  * unconstrained `object`, since their subclasses are only known at runtime.
+ *
+ * The schema follows [json]'s configuration — its class discriminator and naming strategy — so the
+ * shape advertised to the caller is the shape the same format decodes.
  */
-internal fun SerialDescriptor.toJsonSchema(): JsonObject = buildSchema(mutableSetOf())
+@OptIn(ExperimentalSerializationApi::class)
+internal fun SerialDescriptor.toJsonSchema(json: Json): JsonObject = buildSchema(
+    SchemaContext(
+        classDiscriminator = json.configuration.classDiscriminator,
+        writesClassDiscriminator = json.configuration.classDiscriminatorMode != ClassDiscriminatorMode.NONE,
+        namingStrategy = json.configuration.namingStrategy,
+    ),
+    mutableSetOf(),
+)
 
-private fun SerialDescriptor.buildSchema(enclosingTypes: MutableSet<String>): JsonObject {
+private class SchemaContext(
+    val classDiscriminator: String,
+    val writesClassDiscriminator: Boolean,
+    val namingStrategy: JsonNamingStrategy?,
+)
+
+private fun SerialDescriptor.buildSchema(context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
     // A value class is transparent on the wire: it encodes as its single underlying element.
-    if (isInline) return getElementDescriptor(0).buildSchema(enclosingTypes)
+    if (isInline) return getElementDescriptor(0).buildSchema(context, enclosingTypes)
 
     val schema = when (kind) {
         PrimitiveKind.STRING, PrimitiveKind.CHAR -> typeOnly("string")
@@ -53,21 +70,21 @@ private fun SerialDescriptor.buildSchema(enclosingTypes: MutableSet<String>): Js
 
         StructureKind.LIST -> buildJsonObject {
             put("type", "array")
-            put("items", getElementDescriptor(0).buildSchema(enclosingTypes))
+            put("items", getElementDescriptor(0).buildSchema(context, enclosingTypes))
         }
 
         // Element 0 is the key descriptor, element 1 the value descriptor.
         StructureKind.MAP -> buildJsonObject {
             put("type", "object")
-            put("additionalProperties", getElementDescriptor(1).buildSchema(enclosingTypes))
+            put("additionalProperties", getElementDescriptor(1).buildSchema(context, enclosingTypes))
         }
 
         // Only these kinds can contain themselves, so only these are guarded against recursion.
         // Collections repeat their serial name at every nesting level
         // ("kotlin.collections.ArrayList"), so guarding them too would cut List<List<T>> short.
-        StructureKind.CLASS, StructureKind.OBJECT -> guarded(enclosingTypes) { classSchema(enclosingTypes) }
+        StructureKind.CLASS, StructureKind.OBJECT -> guarded(enclosingTypes) { classSchema(context, enclosingTypes) }
 
-        PolymorphicKind.SEALED -> guarded(enclosingTypes) { sealedSchema(enclosingTypes) }
+        PolymorphicKind.SEALED -> guarded(enclosingTypes) { sealedSchema(context, enclosingTypes) }
 
         else -> typeOnly("object")
     }
@@ -85,35 +102,39 @@ private inline fun SerialDescriptor.guarded(enclosingTypes: MutableSet<String>, 
     }
 }
 
-private fun SerialDescriptor.classSchema(enclosingTypes: MutableSet<String>): JsonObject = buildJsonObject {
+private fun SerialDescriptor.classSchema(context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject = buildJsonObject {
     put("type", "object")
     putJsonObject("properties") {
         for (index in 0 until elementsCount) {
-            put(getElementName(index), elementSchema(index, enclosingTypes))
+            put(context.jsonNameOf(this@classSchema, index), elementSchema(index, context, enclosingTypes))
         }
     }
-    val required = (0 until elementsCount).filterNot { isElementOptional(it) }.map { getElementName(it) }
+    val required = (0 until elementsCount)
+        .filterNot { isElementOptional(it) }
+        .map { context.jsonNameOf(this@classSchema, it) }
     if (required.isNotEmpty()) putJsonArray("required") { required.forEach { add(it) } }
 }
 
 /**
- * A sealed serializer's descriptor holds two elements: the discriminator ("type") and a contextual
- * holder whose elements are the subclasses, named by their serial names. `Json` writes the
- * discriminator flattened into the value's own object, so each variant is that subclass' object
- * schema with the discriminator pinned to a constant.
+ * A sealed serializer's descriptor holds two elements: the discriminator and a contextual holder
+ * whose elements are the subclasses, named by their serial names. `Json` writes the discriminator
+ * flattened into the value's own object, so each variant is that subclass' object schema with the
+ * discriminator pinned to a constant.
  */
 @OptIn(ExperimentalSerializationApi::class)
-private fun SerialDescriptor.sealedSchema(enclosingTypes: MutableSet<String>): JsonObject {
+private fun SerialDescriptor.sealedSchema(context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
+    // A type-level annotation overrides the format-wide discriminator, the same way Json resolves it.
     val discriminator = annotations.filterIsInstance<JsonClassDiscriminator>().firstOrNull()?.discriminator
-        ?: DEFAULT_CLASS_DISCRIMINATOR
+        ?: context.classDiscriminator
     val subclasses = getElementDescriptor(1)
     return buildJsonObject {
         putJsonArray("oneOf") {
             for (index in 0 until subclasses.elementsCount) {
                 add(
                     subclasses.getElementDescriptor(index).variantSchema(
-                        discriminator = discriminator,
+                        discriminator = discriminator.takeIf { context.writesClassDiscriminator },
                         serialName = subclasses.getElementName(index),
+                        context = context,
                         enclosingTypes = enclosingTypes,
                     ),
                 )
@@ -122,14 +143,17 @@ private fun SerialDescriptor.sealedSchema(enclosingTypes: MutableSet<String>): J
     }
 }
 
-private fun SerialDescriptor.variantSchema(discriminator: String, serialName: String, enclosingTypes: MutableSet<String>): JsonObject {
-    val schema = buildSchema(enclosingTypes)
+private fun SerialDescriptor.variantSchema(discriminator: String?, serialName: String, context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
+    val schema = buildSchema(context, enclosingTypes)
+    val properties = schema["properties"] as? JsonObject ?: JsonObject(emptyMap())
+    val required = (schema["required"] as? JsonArray).orEmpty().map { (it as JsonPrimitive).content }
+    // ClassDiscriminatorMode.NONE writes no discriminator, so advertising one would describe input
+    // this format cannot produce; the variant shapes are still worth showing.
+    if (discriminator == null) return schema
     val discriminatorSchema = buildJsonObject {
         put("type", "string")
         put("const", serialName)
     }
-    val properties = schema["properties"] as? JsonObject ?: JsonObject(emptyMap())
-    val required = (schema["required"] as? JsonArray).orEmpty().map { (it as JsonPrimitive).content }
     return buildJsonObject {
         put("type", "object")
         put("properties", JsonObject(mapOf(discriminator to discriminatorSchema) + properties))
@@ -138,11 +162,17 @@ private fun SerialDescriptor.variantSchema(discriminator: String, serialName: St
     }
 }
 
-private fun SerialDescriptor.elementSchema(index: Int, enclosingTypes: MutableSet<String>): JsonObject {
-    val schema = getElementDescriptor(index).buildSchema(enclosingTypes)
+private fun SerialDescriptor.elementSchema(index: Int, context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
+    val schema = getElementDescriptor(index).buildSchema(context, enclosingTypes)
     // The property's own annotation wins over one inherited from the property type's class.
     val description = getElementAnnotations(index).mcpDescription() ?: return schema
     return schema.withDescription(description)
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private fun SchemaContext.jsonNameOf(descriptor: SerialDescriptor, index: Int): String {
+    val serialName = descriptor.getElementName(index)
+    return namingStrategy?.serialNameForJson(descriptor, index, serialName) ?: serialName
 }
 
 private fun List<Annotation>.mcpDescription(): String? = filterIsInstance<McpDescription>().firstOrNull()?.value

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
@@ -1,0 +1,152 @@
+package com.kitakkun.jetwhale.host.sdk
+
+import com.kitakkun.jetwhale.annotations.McpDescription
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.elementNames
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/** The class discriminator `Json` writes for polymorphic values unless the type overrides it. */
+private const val DEFAULT_CLASS_DISCRIMINATOR = "type"
+
+/**
+ * Derives a JSON Schema fragment describing the values this descriptor accepts, so a serializable
+ * type advertises its own shape to MCP clients instead of it being restated in prose.
+ *
+ * A property is listed in `required` when it has no default value; a nullable property without a
+ * default is therefore required (it must be present, and may be `null`), which matches how
+ * kotlinx.serialization decodes it. A sealed hierarchy becomes a `oneOf` over its subclasses, each
+ * carrying the class discriminator as a `const`. Open polymorphic types are advertised as an
+ * unconstrained `object`, since their subclasses are only known at runtime.
+ */
+internal fun SerialDescriptor.toJsonSchema(): JsonObject = buildSchema(mutableSetOf())
+
+private fun SerialDescriptor.buildSchema(enclosingTypes: MutableSet<String>): JsonObject {
+    // A value class is transparent on the wire: it encodes as its single underlying element.
+    if (isInline) return getElementDescriptor(0).buildSchema(enclosingTypes)
+
+    val schema = when (kind) {
+        PrimitiveKind.STRING, PrimitiveKind.CHAR -> typeOnly("string")
+
+        PrimitiveKind.BYTE, PrimitiveKind.SHORT, PrimitiveKind.INT, PrimitiveKind.LONG -> typeOnly("integer")
+
+        PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> typeOnly("number")
+
+        PrimitiveKind.BOOLEAN -> typeOnly("boolean")
+
+        SerialKind.ENUM -> buildJsonObject {
+            put("type", "string")
+            putJsonArray("enum") { elementNames.forEach { add(it) } }
+        }
+
+        StructureKind.LIST -> buildJsonObject {
+            put("type", "array")
+            put("items", getElementDescriptor(0).buildSchema(enclosingTypes))
+        }
+
+        // Element 0 is the key descriptor, element 1 the value descriptor.
+        StructureKind.MAP -> buildJsonObject {
+            put("type", "object")
+            put("additionalProperties", getElementDescriptor(1).buildSchema(enclosingTypes))
+        }
+
+        // Only these kinds can contain themselves, so only these are guarded against recursion.
+        // Collections repeat their serial name at every nesting level
+        // ("kotlin.collections.ArrayList"), so guarding them too would cut List<List<T>> short.
+        StructureKind.CLASS, StructureKind.OBJECT -> guarded(enclosingTypes) { classSchema(enclosingTypes) }
+
+        PolymorphicKind.SEALED -> guarded(enclosingTypes) { sealedSchema(enclosingTypes) }
+
+        else -> typeOnly("object")
+    }
+
+    val classDescription = annotations.mcpDescription() ?: return schema
+    return schema.withDescription(classDescription)
+}
+
+private inline fun SerialDescriptor.guarded(enclosingTypes: MutableSet<String>, build: () -> JsonObject): JsonObject {
+    if (!enclosingTypes.add(serialName)) return typeOnly("object")
+    try {
+        return build()
+    } finally {
+        enclosingTypes.remove(serialName)
+    }
+}
+
+private fun SerialDescriptor.classSchema(enclosingTypes: MutableSet<String>): JsonObject = buildJsonObject {
+    put("type", "object")
+    putJsonObject("properties") {
+        for (index in 0 until elementsCount) {
+            put(getElementName(index), elementSchema(index, enclosingTypes))
+        }
+    }
+    val required = (0 until elementsCount).filterNot { isElementOptional(it) }.map { getElementName(it) }
+    if (required.isNotEmpty()) putJsonArray("required") { required.forEach { add(it) } }
+}
+
+/**
+ * A sealed serializer's descriptor holds two elements: the discriminator ("type") and a contextual
+ * holder whose elements are the subclasses, named by their serial names. `Json` writes the
+ * discriminator flattened into the value's own object, so each variant is that subclass' object
+ * schema with the discriminator pinned to a constant.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+private fun SerialDescriptor.sealedSchema(enclosingTypes: MutableSet<String>): JsonObject {
+    val discriminator = annotations.filterIsInstance<JsonClassDiscriminator>().firstOrNull()?.discriminator
+        ?: DEFAULT_CLASS_DISCRIMINATOR
+    val subclasses = getElementDescriptor(1)
+    return buildJsonObject {
+        putJsonArray("oneOf") {
+            for (index in 0 until subclasses.elementsCount) {
+                add(
+                    subclasses.getElementDescriptor(index).variantSchema(
+                        discriminator = discriminator,
+                        serialName = subclasses.getElementName(index),
+                        enclosingTypes = enclosingTypes,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+private fun SerialDescriptor.variantSchema(discriminator: String, serialName: String, enclosingTypes: MutableSet<String>): JsonObject {
+    val schema = buildSchema(enclosingTypes)
+    val discriminatorSchema = buildJsonObject {
+        put("type", "string")
+        put("const", serialName)
+    }
+    val properties = schema["properties"] as? JsonObject ?: JsonObject(emptyMap())
+    val required = (schema["required"] as? JsonArray).orEmpty().map { (it as JsonPrimitive).content }
+    return buildJsonObject {
+        put("type", "object")
+        put("properties", JsonObject(mapOf(discriminator to discriminatorSchema) + properties))
+        putJsonArray("required") { (listOf(discriminator) + required).forEach { add(it) } }
+        schema["description"]?.let { put("description", it) }
+    }
+}
+
+private fun SerialDescriptor.elementSchema(index: Int, enclosingTypes: MutableSet<String>): JsonObject {
+    val schema = getElementDescriptor(index).buildSchema(enclosingTypes)
+    // The property's own annotation wins over one inherited from the property type's class.
+    val description = getElementAnnotations(index).mcpDescription() ?: return schema
+    return schema.withDescription(description)
+}
+
+private fun List<Annotation>.mcpDescription(): String? = filterIsInstance<McpDescription>().firstOrNull()?.value
+
+private fun JsonObject.withDescription(description: String): JsonObject = JsonObject(this + ("description" to JsonPrimitive(description)))
+
+private fun typeOnly(type: String): JsonObject = buildJsonObject { put("type", type) }

--- a/jetwhale-host-sdk/src/test/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchemaTest.kt
+++ b/jetwhale-host-sdk/src/test/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchemaTest.kt
@@ -1,0 +1,131 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.kitakkun.jetwhale.host.sdk
+
+import com.kitakkun.jetwhale.annotations.McpDescription
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.serializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+// Unit tests for the SerialDescriptor -> JSON Schema rules, over purpose-built types. The schema
+// the Network Inspector actually advertises is guarded separately by McpParameterDslTest.
+@Serializable
+private data class Primitives(val text: String, val letter: Char, val count: Int, val size: Long, val ratio: Double, val flag: Boolean)
+
+@Serializable
+private data class Optionality(val required: String?, val optional: String? = null)
+
+@Serializable
+private data class Node(val name: String, val children: List<Node> = emptyList())
+
+@Serializable
+@JvmInline
+private value class RuleId(val value: String)
+
+@Serializable
+private data class HasValueClass(val id: RuleId)
+
+@Serializable
+private data class Nested(val counts: Map<String, Int>, val rows: List<List<String>>)
+
+@Serializable
+@JsonClassDiscriminator("kind")
+private sealed interface Shape {
+    @Serializable
+    @SerialName("circle")
+    @McpDescription("A circle.")
+    data class Circle(val radius: Double) : Shape
+
+    @Serializable
+    @SerialName("nothing")
+    data object Nothing : Shape
+}
+
+@Serializable
+private abstract class OpenBase
+
+class McpJsonSchemaTest {
+    private inline fun <reified T> schemaOf(): JsonObject = serializer<T>().descriptor.toJsonSchema()
+
+    private fun JsonObject.obj(key: String): JsonObject = get(key) as JsonObject
+
+    private fun JsonObject.property(name: String): JsonObject = obj("properties").obj(name)
+
+    private fun JsonObject.string(key: String): String = (getValue(key) as JsonPrimitive).content
+
+    private fun JsonObject.strings(key: String): List<String> = (get(key) as JsonArray).map { (it as JsonPrimitive).content }
+
+    private fun JsonObject.variants(): List<JsonObject> = (getValue("oneOf") as JsonArray).map { it as JsonObject }
+
+    @Test
+    fun `primitive kinds map onto the JSON Schema types`() {
+        val schema = schemaOf<Primitives>()
+        assertEquals("string", schema.property("text").string("type"))
+        assertEquals("string", schema.property("letter").string("type"))
+        assertEquals("integer", schema.property("count").string("type"))
+        assertEquals("integer", schema.property("size").string("type"))
+        assertEquals("number", schema.property("ratio").string("type"))
+        assertEquals("boolean", schema.property("flag").string("type"))
+    }
+
+    @Test
+    fun `a nullable property without a default is still required`() {
+        assertEquals(listOf("required"), schemaOf<Optionality>().strings("required"))
+    }
+
+    @Test
+    fun `maps and nested lists keep their element schemas`() {
+        val schema = schemaOf<Nested>()
+        assertEquals("integer", schema.property("counts").obj("additionalProperties").string("type"))
+        // The recursion guard covers classes only, so List<List<String>> is not cut short.
+        assertEquals("string", schema.property("rows").obj("items").obj("items").string("type"))
+    }
+
+    @Test
+    fun `a value class is transparent, showing its underlying type`() {
+        assertEquals("string", schemaOf<HasValueClass>().property("id").string("type"))
+    }
+
+    @Test
+    fun `a self-referencing type stops recursing at the second visit`() {
+        val child = schemaOf<Node>().property("children").obj("items")
+        assertEquals("object", child.string("type"))
+        assertNull(child["properties"])
+    }
+
+    @Test
+    fun `a JsonClassDiscriminator overrides the discriminator key of every variant`() {
+        val variants = schemaOf<Shape>().variants()
+        assertEquals(listOf("circle", "nothing"), variants.map { it.property("kind").string("const") })
+        variants.forEach { assertEquals("kind", it.strings("required").first()) }
+    }
+
+    @Test
+    fun `a sealed variant with no properties still requires the discriminator`() {
+        val nothing = schemaOf<Shape>().variants().single { it.property("kind").string("const") == "nothing" }
+        assertEquals(listOf("kind"), nothing.strings("required"))
+        assertEquals(listOf("kind"), nothing.obj("properties").keys.toList())
+    }
+
+    @Test
+    fun `a class-level McpDescription describes its sealed variant`() {
+        val circle = schemaOf<Shape>().variants().single { it.property("kind").string("const") == "circle" }
+        assertEquals("A circle.", circle.string("description"))
+    }
+
+    @Test
+    fun `an open polymorphic type is advertised as an unconstrained object`() {
+        val schema = PolymorphicSerializer(OpenBase::class).descriptor.toJsonSchema()
+        assertEquals("object", schema.string("type"))
+        assertNull(schema["oneOf"])
+    }
+}

--- a/jetwhale-host-sdk/src/test/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchemaTest.kt
+++ b/jetwhale-host-sdk/src/test/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchemaTest.kt
@@ -7,8 +7,11 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.ClassDiscriminatorMode
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.serializer
@@ -22,7 +25,15 @@ import kotlin.test.assertNull
 private data class Primitives(val text: String, val letter: Char, val count: Int, val size: Long, val ratio: Double, val flag: Boolean)
 
 @Serializable
-private data class Optionality(val required: String?, val optional: String? = null)
+private data class Optionality(val requiredHere: String?, val optionalHere: String? = null)
+
+/** A sealed type that pins no discriminator of its own, so the format's is used. */
+@Serializable
+private sealed interface Payload {
+    @Serializable
+    @SerialName("text")
+    data class Text(val body: String) : Payload
+}
 
 @Serializable
 private data class Node(val name: String, val children: List<Node> = emptyList())
@@ -54,7 +65,7 @@ private sealed interface Shape {
 private abstract class OpenBase
 
 class McpJsonSchemaTest {
-    private inline fun <reified T> schemaOf(): JsonObject = serializer<T>().descriptor.toJsonSchema()
+    private inline fun <reified T> schemaOf(json: Json = DefaultArgumentJson): JsonObject = serializer<T>().descriptor.toJsonSchema(json)
 
     private fun JsonObject.obj(key: String): JsonObject = get(key) as JsonObject
 
@@ -79,7 +90,7 @@ class McpJsonSchemaTest {
 
     @Test
     fun `a nullable property without a default is still required`() {
-        assertEquals(listOf("required"), schemaOf<Optionality>().strings("required"))
+        assertEquals(listOf("requiredHere"), schemaOf<Optionality>().strings("required"))
     }
 
     @Test
@@ -124,8 +135,37 @@ class McpJsonSchemaTest {
 
     @Test
     fun `an open polymorphic type is advertised as an unconstrained object`() {
-        val schema = PolymorphicSerializer(OpenBase::class).descriptor.toJsonSchema()
+        val schema = PolymorphicSerializer(OpenBase::class).descriptor.toJsonSchema(DefaultArgumentJson)
         assertEquals("object", schema.string("type"))
         assertNull(schema["oneOf"])
+    }
+
+    @Test
+    fun `the format's class discriminator is used when the type does not pin one`() {
+        val json = Json(from = DefaultArgumentJson) { classDiscriminator = "@case" }
+        val variants = schemaOf<Payload>(json).variants()
+        assertEquals(listOf("text"), variants.map { it.property("@case").string("const") })
+    }
+
+    @Test
+    fun `a type-level JsonClassDiscriminator still wins over the format's`() {
+        val json = Json(from = DefaultArgumentJson) { classDiscriminator = "@case" }
+        val variants = schemaOf<Shape>(json).variants()
+        variants.forEach { assertEquals("kind", it.strings("required").first()) }
+    }
+
+    @Test
+    fun `ClassDiscriminatorMode NONE drops the discriminator from every variant`() {
+        val json = Json(from = DefaultArgumentJson) { classDiscriminatorMode = ClassDiscriminatorMode.NONE }
+        val variants = schemaOf<Payload>(json).variants()
+        assertEquals(listOf("body"), variants.single().obj("properties").keys.toList())
+    }
+
+    @Test
+    fun `the format's naming strategy renames properties and the required list`() {
+        val json = Json(from = DefaultArgumentJson) { namingStrategy = JsonNamingStrategy.SnakeCase }
+        val schema = schemaOf<Optionality>(json)
+        assertEquals(listOf("required_here", "optional_here"), schema.obj("properties").keys.toList())
+        assertEquals(listOf("required_here"), schema.strings("required"))
     }
 }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import java.util.concurrent.atomic.AtomicBoolean
@@ -183,6 +182,12 @@ class DefaultMcpServerService(
                 buildJsonObject {
                     put("type", param.type)
                     put("description", param.description)
+                    param.itemsType?.let { itemsType ->
+                        put("items", buildJsonObject { put("type", itemsType) })
+                    }
+                    param.valueType?.let { valueType ->
+                        put("additionalProperties", buildJsonObject { put("type", valueType) })
+                    }
                 }
             }
             val inputSchema = ToolSchema(
@@ -194,9 +199,9 @@ class DefaultMcpServerService(
                 description = descriptor.description,
                 inputSchema = inputSchema,
             ) { request ->
-                val arguments = request.arguments?.mapValues { (_, v) ->
-                    (v as? JsonPrimitive)?.content ?: v.toString()
-                } ?: emptyMap()
+                // Forward the arguments as raw JSON so structured (object/array) parameters keep
+                // their shape; the command's parameter DSL decodes each value by its declared type.
+                val arguments = request.arguments ?: emptyMap()
                 val result = toolRegistry.dispatch(toolName, arguments)
                 CallToolResult(content = listOf(TextContent(result ?: "null")))
             }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import java.util.concurrent.atomic.AtomicBoolean
@@ -178,17 +179,9 @@ class DefaultMcpServerService(
                 put("type", "string")
                 put("description", "Session ID of the target device (from jetwhale.listSessions)")
             }
+            // The parameter's schema describes its type; only the description has to be merged in.
             val pluginProperties = descriptor.parameters.mapValues { (_, param) ->
-                buildJsonObject {
-                    put("type", param.type)
-                    put("description", param.description)
-                    param.itemsType?.let { itemsType ->
-                        put("items", buildJsonObject { put("type", itemsType) })
-                    }
-                    param.valueType?.let { valueType ->
-                        put("additionalProperties", buildJsonObject { put("type", valueType) })
-                    }
-                }
+                JsonObject(param.schema + ("description" to JsonPrimitive(param.description)))
             }
             val inputSchema = ToolSchema(
                 properties = JsonObject(mapOf("sessionId" to sessionIdProperty) + pluginProperties),

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
@@ -6,6 +6,9 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import java.util.concurrent.ConcurrentHashMap
@@ -61,8 +64,8 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
      *
      * @return The result string, or null if not found or plugin returned null.
      */
-    suspend fun dispatch(toolName: String, arguments: Map<String, String>): String? {
-        val sessionId = arguments["sessionId"] ?: return null
+    suspend fun dispatch(toolName: String, arguments: Map<String, JsonElement>): String? {
+        val sessionId = (arguments["sessionId"] as? JsonPrimitive)?.content ?: return null
         val entry = registrations[toolName] ?: return null
         val pluginId = entry.sessionToPlugin[sessionId] ?: return null
         val plugin = pluginInstanceService.getPluginInstanceForSession(
@@ -71,7 +74,7 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
         ) as? JetWhaleMcpCapablePlugin ?: return null
         val command = plugin.mcpCommands.firstOrNull { it.name == toolName } ?: return null
         return try {
-            command.execute(JetWhaleMcpArguments(arguments - "sessionId"))
+            command.execute(JetWhaleMcpArguments(JsonObject(arguments - "sessionId")))
         } catch (e: JetWhaleMcpArgumentException) {
             // A caller mistake becomes a payload the AI agent can read and correct, instead of
             // an MCP-level failure.

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/AddMockRuleCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/AddMockRuleCommand.kt
@@ -32,6 +32,12 @@ internal class AddMockRuleCommand(
     private val ruleName by stringOrNull("Human-readable rule name shown in the UI.", name = "name")
     private val statusCode by intOrNull("Status code of the mocked response. Defaults to 200.")
     private val body by stringOrNull("Body of the mocked response. Defaults to empty.")
+    private val headers by stringMapOrNull(
+        "Response headers as a JSON object of string values, e.g. {\"Content-Type\":\"application/json\"}. Defaults to none.",
+    )
+    private val contentType by stringOrNull(
+        "Convenience for the Content-Type response header. Ignored if headers already sets Content-Type.",
+    )
     private val delayMs by longOrNull("Artificial delay before the mocked response is delivered, in milliseconds. Defaults to 0.")
 
     override suspend fun execute(arguments: JetWhaleMcpArguments): String {
@@ -46,6 +52,7 @@ internal class AddMockRuleCommand(
             ),
             response = MockResponseSpec(
                 statusCode = arguments[statusCode] ?: 200,
+                headers = resolveHeaders(arguments[headers], arguments[contentType]),
                 body = arguments[body] ?: "",
                 delayMs = arguments[delayMs] ?: 0L,
             ),
@@ -54,5 +61,12 @@ internal class AddMockRuleCommand(
             null -> Json.encodeToJsonElement(rule).toString()
             else -> syncErrorJson(failure)
         }
+    }
+
+    // The explicit headers map wins; contentType only fills in a Content-Type when absent.
+    private fun resolveHeaders(headers: Map<String, String>?, contentType: String?): Map<String, String> {
+        val base = headers ?: emptyMap()
+        if (contentType == null || base.keys.any { it.equals("Content-Type", ignoreCase = true) }) return base
+        return base + ("Content-Type" to contentType)
     }
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
@@ -157,5 +157,6 @@ private class NetworkHostPlugin :
         SetMockingEnabledCommand(syncMockingEnabled = ::syncMockingEnabled),
         AddMockRuleCommand(mockRules = { mockRules.toList() }, syncMockRules = ::syncMockRules),
         RemoveMockRuleCommand(mockRules = { mockRules.toList() }, syncMockRules = ::syncMockRules),
+        SetMockRulesCommand(syncMockRules = ::syncMockRules),
     )
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockRulesCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockRulesCommand.kt
@@ -1,0 +1,47 @@
+package com.kitakkun.jetwhale.plugins.network.host
+
+import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.put
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class SetMockRulesCommand(
+    private val syncMockRules: suspend (List<MockRule>) -> JetWhaleMessagingException?,
+) : JetWhaleMcpCommand() {
+    override val name = "$TOOL_PREFIX.setMockRules"
+    override val description =
+        "Replaces the entire set of mock rules with the given list, so an existing rule can be edited by " +
+            "sending back an edited copy of the `rules` array from getMockConfig. Each rule is an object: " +
+            "{id, name, enabled, matcher:{method, urlPattern, matchType}, response:{statusCode, headers, body, delayMs}}. " +
+            "Returns the applied rules."
+
+    private val rules by jsonArray("The full list of mock rules to apply, replacing the current set.")
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val newRules = try {
+            json.decodeFromJsonElement(rulesSerializer, arguments[rules])
+        } catch (e: SerializationException) {
+            throw JetWhaleMcpArgumentException("invalid rules: ${e.message}")
+        }
+        return when (val failure = syncMockRules(newRules)) {
+            null -> buildJsonObject { put("rules", json.encodeToJsonElement(newRules)) }.toString()
+            else -> syncErrorJson(failure)
+        }
+    }
+
+    private companion object {
+        // Tolerate extra fields so a rule object copied from getMockConfig round-trips even if the
+        // agent adds annotations of its own.
+        val json = Json { ignoreUnknownKeys = true }
+        val rulesSerializer = ListSerializer(MockRule.serializer())
+    }
+}

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockRulesCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockRulesCommand.kt
@@ -1,13 +1,10 @@
 package com.kitakkun.jetwhale.plugins.network.host
 
 import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
-import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
@@ -20,28 +17,15 @@ internal class SetMockRulesCommand(
     override val name = "$TOOL_PREFIX.setMockRules"
     override val description =
         "Replaces the entire set of mock rules with the given list, so an existing rule can be edited by " +
-            "sending back an edited copy of the `rules` array from getMockConfig. Each rule is an object: " +
-            "{id, name, enabled, matcher:{method, urlPattern, matchType}, response:{statusCode, headers, body, delayMs}}. " +
-            "Returns the applied rules."
+            "sending back an edited copy of the `rules` array from getMockConfig. Returns the applied rules."
 
-    private val rules by jsonArray("The full list of mock rules to apply, replacing the current set.")
+    private val rules by serializable<List<MockRule>>("The full list of mock rules to apply, replacing the current set.")
 
     override suspend fun execute(arguments: JetWhaleMcpArguments): String {
-        val newRules = try {
-            json.decodeFromJsonElement(rulesSerializer, arguments[rules])
-        } catch (e: SerializationException) {
-            throw JetWhaleMcpArgumentException("invalid rules: ${e.message}")
-        }
+        val newRules = arguments[rules]
         return when (val failure = syncMockRules(newRules)) {
-            null -> buildJsonObject { put("rules", json.encodeToJsonElement(newRules)) }.toString()
+            null -> buildJsonObject { put("rules", Json.encodeToJsonElement(newRules)) }.toString()
             else -> syncErrorJson(failure)
         }
-    }
-
-    private companion object {
-        // Tolerate extra fields so a rule object copied from getMockConfig round-trips even if the
-        // agent adds annotations of its own.
-        val json = Json { ignoreUnknownKeys = true }
-        val rulesSerializer = ListSerializer(MockRule.serializer())
     }
 }

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -1,0 +1,142 @@
+package com.kitakkun.jetwhale.plugins.network.host
+
+import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalJetWhaleApi::class)
+class McpParameterDslTest {
+    private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))) }
+
+    private class StringMapCommand : JetWhaleMcpCommand() {
+        override val name = "test.stringMap"
+        override val description = "echoes a string map"
+        val headers by stringMap("A string-to-string map.")
+        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[headers].entries.joinToString(",") { "${it.key}=${it.value}" }
+    }
+
+    private class OptionalStringMapCommand : JetWhaleMcpCommand() {
+        override val name = "test.optionalStringMap"
+        override val description = "echoes an optional string map"
+        val headers by stringMapOrNull("An optional string-to-string map.")
+        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[headers]?.size?.toString() ?: "absent"
+    }
+
+    private class StringListCommand : JetWhaleMcpCommand() {
+        override val name = "test.stringList"
+        override val description = "echoes a string list"
+        val items by stringList("A list of strings.")
+        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[items].joinToString(",")
+    }
+
+    private class JsonObjectCommand : JetWhaleMcpCommand() {
+        override val name = "test.jsonObject"
+        override val description = "echoes a raw json object"
+        val payload by jsonObject("A raw JSON object.")
+        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[payload].toString()
+    }
+
+    private class JsonArrayCommand : JetWhaleMcpCommand() {
+        override val name = "test.jsonArray"
+        override val description = "echoes a raw json array"
+        val payload by jsonArray("A raw JSON array.")
+        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[payload].size.toString()
+    }
+
+    @Test
+    fun `stringMap parses a JSON object into a string map`() {
+        val result = execute(
+            StringMapCommand(),
+            "headers" to buildJsonObject {
+                put("Content-Type", "application/json")
+                put("X-Trace", "abc")
+            },
+        )
+        assertEquals("Content-Type=application/json,X-Trace=abc", result)
+    }
+
+    @Test
+    fun `optional stringMap is null when omitted`() {
+        assertEquals("absent", execute(OptionalStringMapCommand()))
+    }
+
+    @Test
+    fun `stringList parses a JSON array into a list of strings`() {
+        val result = execute(
+            StringListCommand(),
+            "items" to buildJsonArray {
+                add(JsonPrimitive("a"))
+                add(JsonPrimitive("b"))
+            },
+        )
+        assertEquals("a,b", result)
+    }
+
+    @Test
+    fun `jsonObject and jsonArray hand back the raw element`() {
+        assertEquals(
+            """{"k":"v"}""",
+            execute(JsonObjectCommand(), "payload" to buildJsonObject { put("k", "v") }),
+        )
+        assertEquals(
+            "2",
+            execute(
+                JsonArrayCommand(),
+                "payload" to buildJsonArray {
+                    add(JsonPrimitive("x"))
+                    add(JsonPrimitive("y"))
+                },
+            ),
+        )
+    }
+
+    @Test
+    fun `a scalar passed where an object is expected throws a caller-facing exception`() {
+        val exception = assertFailsWith<JetWhaleMcpArgumentException> {
+            execute(StringMapCommand(), "headers" to JsonPrimitive("not-an-object"))
+        }
+        assertTrue("headers" in exception.message!!, exception.message!!)
+    }
+
+    @Test
+    fun `a missing required structured argument throws a caller-facing exception`() {
+        val exception = assertFailsWith<JetWhaleMcpArgumentException> {
+            execute(StringMapCommand())
+        }
+        assertTrue("missing required argument: headers" in exception.message!!, exception.message!!)
+    }
+
+    @Test
+    fun `the descriptor emits object and array types with element schemas`() {
+        val mapDescriptor = StringMapCommand().toDescriptor().parameters.getValue("headers")
+        assertEquals("object", mapDescriptor.type)
+        assertEquals("string", mapDescriptor.valueType)
+        assertNull(mapDescriptor.itemsType)
+
+        val listDescriptor = StringListCommand().toDescriptor().parameters.getValue("items")
+        assertEquals("array", listDescriptor.type)
+        assertEquals("string", listDescriptor.itemsType)
+        assertNull(listDescriptor.valueType)
+
+        val rawObject = JsonObjectCommand().toDescriptor().parameters.getValue("payload")
+        assertEquals("object", rawObject.type)
+        assertNull(rawObject.valueType)
+
+        val rawArray = JsonArrayCommand().toDescriptor().parameters.getValue("payload")
+        assertEquals("array", rawArray.type)
+        assertNull(rawArray.itemsType)
+    }
+}

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.plugins.network.host
 
+import com.kitakkun.jetwhale.host.sdk.DefaultArgumentJson
 import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
@@ -10,9 +11,11 @@ import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.PluginFrame
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
@@ -25,7 +28,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalJetWhaleApi::class)
+@OptIn(ExperimentalJetWhaleApi::class, ExperimentalSerializationApi::class)
 class McpParameterDslTest {
     private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))) }
 
@@ -84,6 +87,17 @@ class McpParameterDslTest {
         override val description = "echoes serializable mock rules"
         val rules by serializable<List<MockRule>>("The mock rules to apply.")
         override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[rules].joinToString(",") { "${it.id}:${it.matcher.matchType}" }
+    }
+
+    // Both the advertised schema and the decoder come from this format, so they cannot disagree.
+    private class SnakeCaseCommand :
+        JetWhaleMcpCommand(
+            Json(from = DefaultArgumentJson) { namingStrategy = JsonNamingStrategy.SnakeCase },
+        ) {
+        override val name = "test.snakeCase"
+        override val description = "echoes mock rules named in snake_case"
+        val rules by serializable<List<MockRule>>("The mock rules to apply.")
+        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[rules].single().matcher.urlPattern
     }
 
     // PluginFrame is a sealed interface whose subclasses (including those of the nested sealed
@@ -258,6 +272,44 @@ class McpParameterDslTest {
             "Notification:plugin-1",
             execute(SealedCommand(), "frame" to Json.encodeToJsonElement(PluginFrame.serializer(), frame)),
         )
+    }
+
+    @Test
+    fun `the default format accepts an enum entry written in the wrong case`() {
+        val payload = buildJsonArray {
+            add(
+                buildJsonObject {
+                    put("id", "rule-1")
+                    put(
+                        "matcher",
+                        buildJsonObject {
+                            put("urlPattern", "/api")
+                            put("matchType", "exact")
+                        },
+                    )
+                    put("response", buildJsonObject { })
+                },
+            )
+        }
+        assertEquals("rule-1:EXACT", execute(SerializableCommand(), "rules" to payload))
+    }
+
+    @Test
+    fun `a custom format drives both the advertised names and the decoding`() {
+        val command = SnakeCaseCommand()
+        val matcher = command.schemaOf("rules").obj("items").property("matcher")
+        assertEquals(listOf("method", "url_pattern", "match_type"), matcher.obj("properties").keys.toList())
+
+        val payload = buildJsonArray {
+            add(
+                buildJsonObject {
+                    put("id", "rule-1")
+                    put("matcher", buildJsonObject { put("url_pattern", "/api") })
+                    put("response", buildJsonObject { })
+                },
+            )
+        }
+        assertEquals("/api", execute(command, "rules" to payload))
     }
 
     @Test

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -4,12 +4,20 @@ import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType
+import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
+import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
+import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
+import com.kitakkun.jetwhale.protocol.messaging.PluginFrame
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,6 +28,14 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalJetWhaleApi::class)
 class McpParameterDslTest {
     private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))) }
+
+    private fun JetWhaleMcpCommand.schemaOf(parameter: String): JsonObject = toDescriptor().parameters.getValue(parameter).schema
+
+    private fun JsonObject.obj(key: String): JsonObject = get(key) as JsonObject
+
+    private fun JsonObject.property(name: String): JsonObject = obj("properties").obj(name)
+
+    private fun JsonObject.strings(key: String): List<String> = (get(key) as JsonArray).map { (it as JsonPrimitive).content }
 
     private class StringMapCommand : JetWhaleMcpCommand() {
         override val name = "test.stringMap"
@@ -54,6 +70,29 @@ class McpParameterDslTest {
         override val description = "echoes a raw json array"
         val payload by jsonArray("A raw JSON array.")
         override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[payload].size.toString()
+    }
+
+    private class EnumCommand : JetWhaleMcpCommand() {
+        override val name = "test.enum"
+        override val description = "echoes an enum"
+        val matchType by enum("How the pattern is compared.", MockMatchType.entries)
+        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[matchType].name
+    }
+
+    private class SerializableCommand : JetWhaleMcpCommand() {
+        override val name = "test.serializable"
+        override val description = "echoes serializable mock rules"
+        val rules by serializable<List<MockRule>>("The mock rules to apply.")
+        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[rules].joinToString(",") { "${it.id}:${it.matcher.matchType}" }
+    }
+
+    // PluginFrame is a sealed interface whose subclasses (including those of the nested sealed
+    // Reply) kotlinx flattens into one set of leaves.
+    private class SealedCommand : JetWhaleMcpCommand() {
+        override val name = "test.sealed"
+        override val description = "echoes a plugin frame"
+        val frame by serializable<PluginFrame>("A plugin frame.")
+        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[frame].let { "${it::class.simpleName}:${it.pluginId}" }
     }
 
     @Test
@@ -120,23 +159,112 @@ class McpParameterDslTest {
     }
 
     @Test
-    fun `the descriptor emits object and array types with element schemas`() {
-        val mapDescriptor = StringMapCommand().toDescriptor().parameters.getValue("headers")
-        assertEquals("object", mapDescriptor.type)
-        assertEquals("string", mapDescriptor.valueType)
-        assertNull(mapDescriptor.itemsType)
+    fun `the descriptor emits object and array schemas with element schemas`() {
+        assertEquals(
+            """{"type":"object","additionalProperties":{"type":"string"}}""",
+            StringMapCommand().schemaOf("headers").toString(),
+        )
+        assertEquals(
+            """{"type":"array","items":{"type":"string"}}""",
+            StringListCommand().schemaOf("items").toString(),
+        )
+        assertEquals("""{"type":"object"}""", JsonObjectCommand().schemaOf("payload").toString())
+        assertEquals("""{"type":"array"}""", JsonArrayCommand().schemaOf("payload").toString())
+    }
 
-        val listDescriptor = StringListCommand().toDescriptor().parameters.getValue("items")
-        assertEquals("array", listDescriptor.type)
-        assertEquals("string", listDescriptor.itemsType)
-        assertNull(listDescriptor.valueType)
+    @Test
+    fun `an enum parameter advertises its entry names`() {
+        assertEquals(
+            """{"type":"string","enum":["CONTAINS","EXACT","REGEX"]}""",
+            EnumCommand().schemaOf("matchType").toString(),
+        )
+    }
 
-        val rawObject = JsonObjectCommand().toDescriptor().parameters.getValue("payload")
-        assertEquals("object", rawObject.type)
-        assertNull(rawObject.valueType)
+    @Test
+    fun `serializable decodes a nested value`() {
+        val rule = MockRule(
+            id = "rule-1",
+            matcher = MockMatcher(urlPattern = "/api", matchType = MockMatchType.EXACT),
+            response = MockResponseSpec(),
+        )
+        val result = execute(SerializableCommand(), "rules" to Json.encodeToJsonElement(listOf(rule)))
+        assertEquals("rule-1:EXACT", result)
+    }
 
-        val rawArray = JsonArrayCommand().toDescriptor().parameters.getValue("payload")
-        assertEquals("array", rawArray.type)
-        assertNull(rawArray.itemsType)
+    @Test
+    fun `serializable tolerates unknown keys so a round-tripped value still decodes`() {
+        val payload = buildJsonArray {
+            add(
+                buildJsonObject {
+                    put("id", "rule-1")
+                    put("annotatedByTheAgent", "ignore me")
+                    put("matcher", buildJsonObject { put("urlPattern", "/api") })
+                    put("response", buildJsonObject { })
+                },
+            )
+        }
+        assertEquals("rule-1:CONTAINS", execute(SerializableCommand(), "rules" to payload))
+    }
+
+    @Test
+    fun `the derived schema advertises nested objects and enum entries`() {
+        val schema = SerializableCommand().schemaOf("rules")
+        assertEquals("array", (schema.getValue("type") as JsonPrimitive).content)
+
+        val rule = schema.obj("items")
+        assertEquals("object", (rule.getValue("type") as JsonPrimitive).content)
+        assertEquals("string", (rule.property("id").getValue("type") as JsonPrimitive).content)
+
+        val matchType = rule.property("matcher").property("matchType")
+        assertEquals(listOf("CONTAINS", "EXACT", "REGEX"), matchType.strings("enum"))
+    }
+
+    @Test
+    fun `the derived schema requires only properties without defaults`() {
+        val rule = SerializableCommand().schemaOf("rules").obj("items")
+        assertEquals(listOf("id", "matcher", "response"), rule.strings("required"))
+        assertEquals(listOf("urlPattern"), rule.property("matcher").strings("required"))
+        // Every property of MockResponseSpec has a default, so nothing is required.
+        assertNull(rule.property("response")["required"])
+    }
+
+    @Test
+    fun `the derived schema maps a Map property to additionalProperties`() {
+        val headers = SerializableCommand().schemaOf("rules").obj("items").property("response").property("headers")
+        assertEquals("object", (headers.getValue("type") as JsonPrimitive).content)
+        assertEquals("string", (headers.obj("additionalProperties").getValue("type") as JsonPrimitive).content)
+    }
+
+    @Test
+    fun `McpDescription surfaces as a property description in the derived schema`() {
+        val rule = SerializableCommand().schemaOf("rules").obj("items")
+        assertEquals(
+            "Human-readable rule name shown in the UI.",
+            (rule.property("name").getValue("description") as JsonPrimitive).content,
+        )
+        // A class-level annotation describes the nested object itself.
+        assertEquals(
+            "Which requests the rule applies to.",
+            (rule.property("matcher").getValue("description") as JsonPrimitive).content,
+        )
+    }
+
+    // The oneOf shape itself is covered by McpJsonSchemaTest; this checks that a value written in
+    // that shape actually decodes back through the DSL.
+    @Test
+    fun `serializable decodes a sealed value through its class discriminator`() {
+        val frame = PluginFrame.Notification(pluginId = "plugin-1", messageType = "m", payload = "{}")
+        assertEquals(
+            "Notification:plugin-1",
+            execute(SealedCommand(), "frame" to Json.encodeToJsonElement(PluginFrame.serializer(), frame)),
+        )
+    }
+
+    @Test
+    fun `a payload that does not fit the serializable type throws a caller-facing exception`() {
+        val exception = assertFailsWith<JetWhaleMcpArgumentException> {
+            execute(SerializableCommand(), "rules" to buildJsonArray { add(buildJsonObject { put("id", "rule-1") }) })
+        }
+        assertTrue("invalid rules" in exception.message!!, exception.message!!)
     }
 }

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommandsTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommandsTest.kt
@@ -5,14 +5,17 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
+import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -106,6 +109,57 @@ class NetworkMcpCommandsTest {
             execute(addMockRule, "urlPattern" to "/x", "matchType" to "GLOB")
         }
         assertTrue("invalid matchType" in badMatchType.message!!, badMatchType.message!!)
+    }
+
+    @Test
+    fun `addMockRule carries response headers through to the host`() {
+        var synced: List<MockRule>? = null
+        val command = AddMockRuleCommand(mockRules = { emptyList() }, syncMockRules = {
+            synced = it
+            null
+        })
+        val result = executeJson(
+            command,
+            "urlPattern" to JsonPrimitive("/x"),
+            "headers" to buildJsonObject {
+                put("Content-Type", "application/json")
+                put("X-Trace", "abc")
+            },
+        )
+        val rule = synced!!.single()
+        assertEquals(mapOf("Content-Type" to "application/json", "X-Trace" to "abc"), rule.response.headers)
+        assertTrue("application/json" in result, result)
+    }
+
+    @Test
+    fun `addMockRule contentType convenience fills in the Content-Type header`() {
+        var synced: List<MockRule>? = null
+        val command = AddMockRuleCommand(mockRules = { emptyList() }, syncMockRules = {
+            synced = it
+            null
+        })
+        executeJson(
+            command,
+            "urlPattern" to JsonPrimitive("/x"),
+            "contentType" to JsonPrimitive("application/json"),
+        )
+        assertEquals(mapOf("Content-Type" to "application/json"), synced!!.single().response.headers)
+    }
+
+    @Test
+    fun `addMockRule explicit headers win over the contentType convenience`() {
+        var synced: List<MockRule>? = null
+        val command = AddMockRuleCommand(mockRules = { emptyList() }, syncMockRules = {
+            synced = it
+            null
+        })
+        executeJson(
+            command,
+            "urlPattern" to JsonPrimitive("/x"),
+            "contentType" to JsonPrimitive("text/plain"),
+            "headers" to buildJsonObject { put("Content-Type", "application/json") },
+        )
+        assertEquals(mapOf("Content-Type" to "application/json"), synced!!.single().response.headers)
     }
 
     @Test

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommandsTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommandsTest.kt
@@ -7,6 +7,9 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -26,7 +29,9 @@ class NetworkMcpCommandsTest {
 
     private fun listCommand(data: List<HttpTransaction> = transactions) = ListTransactionsCommand(transactions = { data }, redactForMcp = { it })
 
-    private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, String>): String = runBlocking { command.execute(JetWhaleMcpArguments(args.toMap())) }
+    private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, String>): String = executeJson(command, *args.map { (key, value) -> key to JsonPrimitive(value) }.toTypedArray())
+
+    private fun executeJson(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))) }
 
     private fun txIdsOf(result: String): List<String> = Json.parseToJsonElement(result).jsonObject
         .getValue("transactions").jsonArray

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommandsTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommandsTest.kt
@@ -5,6 +5,9 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
+import com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType
+import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
+import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -12,6 +15,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -160,6 +164,39 @@ class NetworkMcpCommandsTest {
             "headers" to buildJsonObject { put("Content-Type", "application/json") },
         )
         assertEquals(mapOf("Content-Type" to "application/json"), synced!!.single().response.headers)
+    }
+
+    @Test
+    fun `setMockRules replaces the entire rule set`() {
+        var synced: List<MockRule>? = null
+        val command = SetMockRulesCommand(syncMockRules = {
+            synced = it
+            null
+        })
+        val edited = listOf(
+            MockRule(
+                id = "r1",
+                name = "edited",
+                enabled = false,
+                matcher = MockMatcher(urlPattern = "/a", matchType = MockMatchType.EXACT),
+                response = MockResponseSpec(statusCode = 201, headers = mapOf("Content-Type" to "application/json")),
+            ),
+        )
+        val result = executeJson(command, "rules" to Json.encodeToJsonElement(edited))
+        assertEquals(edited, synced)
+        assertTrue("edited" in result, result)
+    }
+
+    @Test
+    fun `setMockRules with a malformed rule throws a caller-facing argument exception`() {
+        val command = SetMockRulesCommand(syncMockRules = { null })
+        val exception = assertFailsWith<JetWhaleMcpArgumentException> {
+            executeJson(
+                command,
+                "rules" to Json.parseToJsonElement("""[{"name":"missing id and matcher"}]"""),
+            )
+        }
+        assertTrue("invalid rules" in exception.message!!, exception.message!!)
     }
 
     @Test

--- a/jetwhale-plugins/network/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/protocol/MockModels.kt
+++ b/jetwhale-plugins/network/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/protocol/MockModels.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.plugins.network.protocol
 
+import com.kitakkun.jetwhale.annotations.McpDescription
 import kotlinx.serialization.Serializable
 
 /** How a [MockMatcher.urlPattern] is compared against a request URL. */
@@ -14,18 +15,27 @@ enum class MockMatchType {
  * Matches a request. [method] is compared case-insensitively; null/blank means "any method".
  */
 @Serializable
+@McpDescription("Which requests the rule applies to.")
 data class MockMatcher(
+    @McpDescription("HTTP method to match (case-insensitive). Matches any method if omitted.")
     val method: String? = null,
+    @McpDescription("URL pattern to match, interpreted per matchType.")
     val urlPattern: String,
+    @McpDescription("How urlPattern is compared against the request URL. Defaults to CONTAINS.")
     val matchType: MockMatchType = MockMatchType.CONTAINS,
 )
 
 /** The canned response returned when a [MockRule] matches. */
 @Serializable
+@McpDescription("The canned response returned instead of hitting the network.")
 data class MockResponseSpec(
+    @McpDescription("Status code of the mocked response. Defaults to 200.")
     val statusCode: Int = 200,
+    @McpDescription("Response headers, e.g. {\"Content-Type\":\"application/json\"}. Defaults to none.")
     val headers: Map<String, String> = emptyMap(),
+    @McpDescription("Body of the mocked response. Defaults to empty.")
     val body: String = "",
+    @McpDescription("Artificial delay before the mocked response is delivered, in milliseconds. Defaults to 0.")
     val delayMs: Long = 0,
 )
 
@@ -35,8 +45,11 @@ data class MockResponseSpec(
  */
 @Serializable
 data class MockRule(
+    @McpDescription("Stable identifier of the rule. Reuse the id of an existing rule to edit it; use a fresh UUID for a new one.")
     val id: String,
+    @McpDescription("Human-readable rule name shown in the UI.")
     val name: String = "",
+    @McpDescription("Whether the rule takes effect. Defaults to true.")
     val enabled: Boolean = true,
     val matcher: MockMatcher,
     val response: MockResponseSpec,


### PR DESCRIPTION
## Summary

Adds structured (object/array) argument support to the MCP command parameter DSL, then builds two network mock features on top of it. Three commits, one per issue.

Closes #174
Closes #171
Closes #172

## #174 — structured arguments in the MCP parameter DSL (foundation)

The DSL and argument model were scalar-only. This widens them:

- `JetWhaleMcpArguments` now carries the raw `JsonObject` instead of a pre-flattened `Map<String, String>`; each parameter decodes its value by its declared type.
- New declarators (each with an `OrNull` optional variant):
  - `stringList` -> `List<String>`, schema `type: array`, `items: {type: string}`
  - `stringMap` -> `Map<String, String>`, schema `type: object`, `additionalProperties: {type: string}`
  - `jsonObject` -> raw `JsonObject`, schema `type: object`
  - `jsonArray` -> raw `JsonArray`, schema `type: array`
- `JetWhaleMcpParameterDescriptor` gains `itemsType` / `valueType`; `DefaultMcpServerService` emits the corresponding `items` / `additionalProperties` and forwards arguments as raw JSON end to end.

Scalar declarators (`string`/`int`/`long`/`boolean`/`enum`) keep the same public signatures and behaviour.

### Design fork (please confirm)

The issue allowed an interim path where a `jsonObject`-style declarator ships as `type: "string"` + parse. I took the **real `object`/`array` type** path instead: it advertises the true shape to MCP clients. Structured decoding of a full domain object (e.g. a `MockRule`) is done in the command via `jsonArray` + `kotlinx.serialization`, rather than exhaustively expanding every nested field into JSON Schema — the schema advertises `type: array` and the command's description documents the element shape. If you'd prefer a fully-expanded nested schema for `setMockRules`, that can be layered on later without touching call sites.

## #171 — `addMockRule` can set response headers

- Adds a `headers` argument (string->string map) plus a `contentType` scalar convenience that fills in `Content-Type` only when `headers` does not already set it.
- The created `MockRule` carries the headers through to the host via `onMockRulesChanged`, so an MCP-created mock can return a `Content-Type` and satisfy a `ContentNegotiation(json)` client.

## #172 — `setMockRules` to edit existing rules

- Adds a `setMockRules` MCP command that takes the full `rules` array (an edited copy of what `getMockConfig` returns) and replaces the whole set via the existing `onMockRulesChanged(List<MockRule>)`. Malformed input surfaces as a caller-facing `{"error": ...}` payload.

## Tests

New DSL tests in `McpParameterDslTest`:
- `stringMap parses a JSON object into a string map`
- `optional stringMap is null when omitted`
- `stringList parses a JSON array into a list of strings`
- `jsonObject and jsonArray hand back the raw element`
- `a scalar passed where an object is expected throws a caller-facing exception`
- `a missing required structured argument throws a caller-facing exception`
- `the descriptor emits object and array types with element schemas`

New network tests in `NetworkMcpCommandsTest`:
- `addMockRule carries response headers through to the host`
- `addMockRule contentType convenience fills in the Content-Type header`
- `addMockRule explicit headers win over the contentType convenience`
- `setMockRules replaces the entire rule set`
- `setMockRules with a malformed rule throws a caller-facing argument exception`

## Verification

- `./gradlew spotlessApply` + `./gradlew spotlessKotlinCheck` — clean
- Compiled and tested `:jetwhale-host-sdk`, `:jetwhale-host:core:mcp`, `:jetwhale-plugins:network:host` — all green
- Regenerated the `:jetwhale-host-sdk` ABI dump (`updateKotlinAbi`) for the new DSL surface