### PR TITLE
feat(network): add an HttpSend interceptor entry point for Ktor

### DIFF
--- a/docs/guide/network-inspector.md
+++ b/docs/guide/network-inspector.md
@@ -48,6 +48,26 @@ startJetWhale {
 }
 ```
 
+#### Attaching to a client you didn't build
+
+When the `HttpClient` comes from a DI container or a library, use the `HttpSend` interceptor
+instead — it attaches to an already-built client, so the construction site stays untouched:
+
+```kotlin
+import com.kitakkun.jetwhale.plugins.network.agent.ktor.ktorSendInterceptor
+import io.ktor.client.plugins.HttpSend
+import io.ktor.client.plugins.plugin
+
+val networkAgent = JetWhaleNetworkAgentPlugin()
+val client = HttpClient()
+
+client.plugin(HttpSend).intercept(networkAgent.ktorSendInterceptor(client))
+```
+
+Pass the same client the interceptor is registered on — it is used to synthesize mocked responses.
+Register it once per client at setup: `HttpSend` neither rejects duplicates nor offers a way to
+remove an interceptor, so registering twice records every transaction twice.
+
 ### OkHttp
 
 ```kotlin

--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPlugin.kt
@@ -1,35 +1,9 @@
 package com.kitakkun.jetwhale.plugins.network.agent.ktor
 
 import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
-import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
-import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse
-import com.kitakkun.jetwhale.plugins.network.protocol.HttpRequestFailure
-import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
-import io.ktor.client.HttpClient
-import io.ktor.client.call.HttpClientCall
-import io.ktor.client.call.save
 import io.ktor.client.plugins.api.ClientPlugin
 import io.ktor.client.plugins.api.Send
 import io.ktor.client.plugins.api.createClientPlugin
-import io.ktor.client.request.HttpRequestBuilder
-import io.ktor.client.request.HttpResponseData
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.ContentType
-import io.ktor.http.HeadersBuilder
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpProtocolVersion
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.content.OutgoingContent
-import io.ktor.util.StringValues
-import io.ktor.util.date.GMTDate
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.InternalAPI
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.TimeSource
 
 /**
  * Ktor [io.ktor.client.HttpClient] plugin that feeds request/response details to a
@@ -42,9 +16,12 @@ import kotlin.time.TimeSource
  * startJetWhale { plugins { register(agent) } }
  * ```
  *
+ * Use [ktorSendInterceptor] instead when the client is built somewhere you can't touch.
+ *
  * Known limitation: response bodies are buffered with `save()` before the caller sees them, so a
  * long-lived streaming response that isn't `text/event-stream` (which is skipped) is fully
- * buffered and delays the caller until the stream ends.
+ * buffered and delays the caller until the stream ends. Headers the engine injects
+ * (User-Agent, Accept-Encoding, Host) are not visible to a client plugin and are omitted.
  *
  * @param maxBodyChars request/response bodies longer than this are truncated for transport.
  */
@@ -52,156 +29,7 @@ fun JetWhaleNetworkAgentPlugin.ktorClientPlugin(maxBodyChars: Int = 100_000): Cl
     val agent = this
     return createClientPlugin("JetWhaleNetworkMonitor") {
         on(Send) { request ->
-            val txId = agent.newTransactionId()
-            val started = TimeSource.Monotonic.markNow()
-            val method = request.method.value
-            val url = request.url.buildString()
-
-            agent.recordRequest(request, txId, method, url, maxBodyChars)
-            val mock = agent.findMock(method, url)
-
-            val call = if (mock != null) {
-                serveMock(client, request, mock)
-            } else {
-                try {
-                    proceed(request)
-                } catch (e: Throwable) {
-                    agent.recordFailure(
-                        HttpRequestFailure(
-                            txId = txId,
-                            message = e.message ?: e.toString(),
-                            durationMs = started.elapsedNow().inWholeMilliseconds,
-                        ),
-                    )
-                    throw e
-                }
-            }
-
-            val (callToReturn, body) = captureResponseBodySafely(call, maxBodyChars)
-            agent.recordResponse(
-                CapturedHttpResponse(
-                    txId = txId,
-                    statusCode = callToReturn.response.status.value,
-                    statusDescription = callToReturn.response.status.description,
-                    headers = callToReturn.response.headers.toCapturedMap(),
-                    body = body.text,
-                    bodyTruncated = body.truncated,
-                    durationMs = started.elapsedNow().inWholeMilliseconds,
-                    fromMock = mock != null,
-                ),
-            )
-            callToReturn
+            agent.monitorSend(client, request, maxBodyChars) { proceed(it) }
         }
-    }
-}
-
-private fun JetWhaleNetworkAgentPlugin.recordRequest(request: HttpRequestBuilder, txId: String, method: String, url: String, maxBodyChars: Int) {
-    val body = captureRequestBodySafely(request.body, maxBodyChars)
-    recordRequest(
-        CapturedHttpRequest(
-            txId = txId,
-            method = method,
-            url = url,
-            headers = request.capturedRequestHeaders(),
-            body = body.text,
-            bodyTruncated = body.truncated,
-            timestampMs = GMTDate().timestamp,
-        ),
-    )
-}
-
-@OptIn(InternalAPI::class) // HttpClientCall's constructor is needed to synthesize mock responses.
-private suspend fun serveMock(client: HttpClient, request: HttpRequestBuilder, mock: MockResponseSpec): HttpClientCall {
-    if (mock.delayMs > 0) delay(mock.delayMs.milliseconds)
-    // Ktor completes the call context's Job when the response is done, so it must be a
-    // CompletableJob. The Send-pipeline coroutine's own Job is a StandaloneCoroutine, and handing
-    // that over crashes with "StandaloneCoroutine cannot be cast to CompletableJob" the moment the
-    // caller reads the mocked response — so give the call its own Job(parent), exactly as a real
-    // client engine builds its call context.
-    val parentContext = currentCoroutineContext()
-    val responseData = HttpResponseData(
-        statusCode = HttpStatusCode.fromValue(mock.statusCode),
-        requestTime = GMTDate(),
-        headers = HeadersBuilder().apply {
-            mock.headers.forEach { (key, value) -> append(key, value) }
-            // A mock without a Content-Type synthesizes a response whose header is null, which makes
-            // a client using ContentNegotiation reject the body. Default it so headerless JSON mocks
-            // stay usable, without overriding a Content-Type the mock already sets.
-            if (mock.headers.keys.none { it.equals(HttpHeaders.ContentType, ignoreCase = true) }) {
-                append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-            }
-        }.build(),
-        version = HttpProtocolVersion.HTTP_1_1,
-        body = ByteReadChannel(mock.body.encodeToByteArray()),
-        callContext = parentContext + Job(parentContext[Job]),
-    )
-    return HttpClientCall(client, request.build(), responseData)
-}
-
-private data class BodyCapture(val text: String?, val truncated: Boolean)
-
-private fun String.truncate(max: Int): BodyCapture = if (length <= max) BodyCapture(this, false) else BodyCapture(substring(0, max), true)
-
-/**
- * Reads the request body for capture without breaking the actual send: channel/stream bodies
- * that can't be read without consuming them are replaced with a placeholder instead.
- */
-private fun captureRequestBodySafely(content: Any?, maxChars: Int): BodyCapture = when (content) {
-    is OutgoingContent.ByteArrayContent -> content.bytes().decodeToString().truncate(maxChars)
-    is OutgoingContent -> BodyCapture(content.contentType?.let { "<$it>" }, false)
-    else -> BodyCapture(null, false)
-}
-
-/**
- * Reads the response body for capture without consuming or blocking the caller's response:
- * bodies that can't be buffered safely (WebSocket upgrades, endless streams) are replaced with a
- * placeholder instead. Returns the call the caller should receive — the original one when the
- * body was left untouched, or a saved copy whose body is still readable.
- */
-private suspend fun captureResponseBodySafely(call: HttpClientCall, maxChars: Int): Pair<HttpClientCall, BodyCapture> {
-    val response = call.response
-
-    // A WebSocket upgrade response (101) has no conventional body — by the time this plugin sees
-    // it, the connection has already switched to the raw frame stream, so save()/bodyAsText()
-    // would read live WebSocket frames as if they were an HTTP body, corrupting the frame stream
-    // for the caller.
-    if (response.isWebSocketUpgrade()) {
-        return call to BodyCapture("<websocket upgrade>", false)
-    }
-
-    // save() buffers the entire body before returning, so on a never-ending stream (SSE) the
-    // caller would wait forever for a response that has already started arriving.
-    val contentType = response.headers[HttpHeaders.ContentType]
-    if (contentType?.startsWith("text/event-stream", ignoreCase = true) == true) {
-        return call to BodyCapture("<streaming response body>", false)
-    }
-
-    // save() buffers the body so we can read it for inspection and still hand a fresh, readable
-    // response to the caller.
-    val saved = call.save()
-    return saved to saved.response.bodyAsText().truncate(maxChars)
-}
-
-private fun StringValues.toCapturedMap(): Map<String, List<String>> = entries().associate { it.key to it.value }
-
-/** True for a successful WebSocket upgrade response (101 Switching Protocols + `Upgrade: websocket`). */
-private fun HttpResponse.isWebSocketUpgrade(): Boolean = status == HttpStatusCode.SwitchingProtocols && headers[HttpHeaders.Upgrade]?.equals("websocket", ignoreCase = true) == true
-
-/**
- * Captures the request headers visible at the [Send] phase, enriched with the body's
- * Content-Type / Content-Length and any body-level headers. Headers injected later by the engine
- * (e.g. User-Agent, Accept-Encoding, Host) are not visible to a client plugin and are omitted.
- */
-private fun HttpRequestBuilder.capturedRequestHeaders(): Map<String, List<String>> = buildMap {
-    putAll(headers.build().toCapturedMap())
-    val content = body as? OutgoingContent ?: return@buildMap
-    content.contentType?.let { type ->
-        if (!containsKey("Content-Type")) put("Content-Type", listOf(type.toString()))
-    }
-    content.contentLength?.let { length ->
-        if (!containsKey("Content-Length")) put("Content-Length", listOf(length.toString()))
-    }
-    content.headers.entries().forEach { (key, value) ->
-        if (!containsKey(key)) put(key, value)
     }
 }

--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorSendInterceptor.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorSendInterceptor.kt
@@ -1,0 +1,42 @@
+package com.kitakkun.jetwhale.plugins.network.agent.ktor
+
+import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpSendInterceptor
+
+/**
+ * [io.ktor.client.plugins.HttpSend] interceptor that feeds request/response details to a
+ * [JetWhaleNetworkAgentPlugin] and serves mock responses configured from the host.
+ *
+ * Unlike [ktorClientPlugin] this attaches to an already-built client, so a client that comes from a
+ * DI container or a library can be inspected without touching where it is constructed:
+ * ```
+ * val agent = JetWhaleNetworkAgentPlugin()
+ * val client = HttpClient()
+ * client.plugin(HttpSend).intercept(agent.ktorSendInterceptor(client))
+ * startJetWhale { plugins { register(agent) } }
+ * ```
+ *
+ * `HttpSend` is installed in every `HttpClient`, so `client.plugin(HttpSend)` always resolves.
+ *
+ * Pass the same [client] the interceptor is registered on — it is used to synthesize the call that
+ * carries a mocked response, and `Sender` doesn't expose the client it is sending through.
+ *
+ * Register it once per client at setup: `HttpSend` neither rejects duplicates nor offers a way to
+ * remove an interceptor, so registering twice records every transaction twice. `HttpSend` runs
+ * interceptors outermost-first in registration order, so an interceptor added after the client was
+ * built sits closest to the network and records each redirect hop as its own transaction.
+ *
+ * Known limitation: response bodies are buffered with `save()` before the caller sees them, so a
+ * long-lived streaming response that isn't `text/event-stream` (which is skipped) is fully
+ * buffered and delays the caller until the stream ends. Headers the engine injects
+ * (User-Agent, Accept-Encoding, Host) are not visible here and are omitted.
+ *
+ * @param maxBodyChars request/response bodies longer than this are truncated for transport.
+ */
+fun JetWhaleNetworkAgentPlugin.ktorSendInterceptor(client: HttpClient, maxBodyChars: Int = 100_000): HttpSendInterceptor {
+    val agent = this
+    return { request ->
+        agent.monitorSend(client, request, maxBodyChars) { execute(it) }
+    }
+}

--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/NetworkMonitorSend.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/NetworkMonitorSend.kt
@@ -1,0 +1,195 @@
+package com.kitakkun.jetwhale.plugins.network.agent.ktor
+
+import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
+import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
+import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse
+import com.kitakkun.jetwhale.plugins.network.protocol.HttpRequestFailure
+import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
+import io.ktor.client.HttpClient
+import io.ktor.client.call.HttpClientCall
+import io.ktor.client.call.save
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.HttpResponseData
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HeadersBuilder
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpProtocolVersion
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.util.StringValues
+import io.ktor.util.date.GMTDate
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.InternalAPI
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
+
+/**
+ * Runs one request/response round trip through the agent: records the request, serves a matching
+ * mock instead of hitting the network, and records the response or failure.
+ *
+ * Shared by both entry points of this module. [proceed] is the caller's way to continue the send —
+ * `Send.Sender.proceed` for the client plugin, `Sender.execute` for the [io.ktor.client.plugins.HttpSend]
+ * interceptor. [client] is needed to synthesize a mocked [HttpClientCall] and must be the client the
+ * request is running on.
+ */
+internal suspend fun JetWhaleNetworkAgentPlugin.monitorSend(
+    client: HttpClient,
+    request: HttpRequestBuilder,
+    maxBodyChars: Int,
+    proceed: suspend (HttpRequestBuilder) -> HttpClientCall,
+): HttpClientCall {
+    val txId = newTransactionId()
+    val started = TimeSource.Monotonic.markNow()
+    val method = request.method.value
+    val url = request.url.buildString()
+
+    recordRequest(request, txId, method, url, maxBodyChars)
+    val mock = findMock(method, url)
+
+    val call = if (mock != null) {
+        serveMock(client, request, mock)
+    } else {
+        try {
+            proceed(request)
+        } catch (e: Throwable) {
+            recordFailure(
+                HttpRequestFailure(
+                    txId = txId,
+                    message = e.message ?: e.toString(),
+                    durationMs = started.elapsedNow().inWholeMilliseconds,
+                ),
+            )
+            throw e
+        }
+    }
+
+    val (callToReturn, body) = captureResponseBodySafely(call, maxBodyChars)
+    recordResponse(
+        CapturedHttpResponse(
+            txId = txId,
+            statusCode = callToReturn.response.status.value,
+            statusDescription = callToReturn.response.status.description,
+            headers = callToReturn.response.headers.toCapturedMap(),
+            body = body.text,
+            bodyTruncated = body.truncated,
+            durationMs = started.elapsedNow().inWholeMilliseconds,
+            fromMock = mock != null,
+        ),
+    )
+    return callToReturn
+}
+
+private fun JetWhaleNetworkAgentPlugin.recordRequest(request: HttpRequestBuilder, txId: String, method: String, url: String, maxBodyChars: Int) {
+    val body = captureRequestBodySafely(request.body, maxBodyChars)
+    recordRequest(
+        CapturedHttpRequest(
+            txId = txId,
+            method = method,
+            url = url,
+            headers = request.capturedRequestHeaders(),
+            body = body.text,
+            bodyTruncated = body.truncated,
+            timestampMs = GMTDate().timestamp,
+        ),
+    )
+}
+
+@OptIn(InternalAPI::class) // HttpClientCall's constructor is needed to synthesize mock responses.
+private suspend fun serveMock(client: HttpClient, request: HttpRequestBuilder, mock: MockResponseSpec): HttpClientCall {
+    if (mock.delayMs > 0) delay(mock.delayMs.milliseconds)
+    // Ktor completes the call context's Job when the response is done, so it must be a
+    // CompletableJob. The Send-pipeline coroutine's own Job is a StandaloneCoroutine, and handing
+    // that over crashes with "StandaloneCoroutine cannot be cast to CompletableJob" the moment the
+    // caller reads the mocked response — so give the call its own Job(parent), exactly as a real
+    // client engine builds its call context.
+    val parentContext = currentCoroutineContext()
+    val responseData = HttpResponseData(
+        statusCode = HttpStatusCode.fromValue(mock.statusCode),
+        requestTime = GMTDate(),
+        headers = HeadersBuilder().apply {
+            mock.headers.forEach { (key, value) -> append(key, value) }
+            // A mock without a Content-Type synthesizes a response whose header is null, which makes
+            // a client using ContentNegotiation reject the body. Default it so headerless JSON mocks
+            // stay usable, without overriding a Content-Type the mock already sets.
+            if (mock.headers.keys.none { it.equals(HttpHeaders.ContentType, ignoreCase = true) }) {
+                append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            }
+        }.build(),
+        version = HttpProtocolVersion.HTTP_1_1,
+        body = ByteReadChannel(mock.body.encodeToByteArray()),
+        callContext = parentContext + Job(parentContext[Job]),
+    )
+    return HttpClientCall(client, request.build(), responseData)
+}
+
+private data class BodyCapture(val text: String?, val truncated: Boolean)
+
+private fun String.truncate(max: Int): BodyCapture = if (length <= max) BodyCapture(this, false) else BodyCapture(substring(0, max), true)
+
+/**
+ * Reads the request body for capture without breaking the actual send: channel/stream bodies
+ * that can't be read without consuming them are replaced with a placeholder instead.
+ */
+private fun captureRequestBodySafely(content: Any?, maxChars: Int): BodyCapture = when (content) {
+    is OutgoingContent.ByteArrayContent -> content.bytes().decodeToString().truncate(maxChars)
+    is OutgoingContent -> BodyCapture(content.contentType?.let { "<$it>" }, false)
+    else -> BodyCapture(null, false)
+}
+
+/**
+ * Reads the response body for capture without consuming or blocking the caller's response:
+ * bodies that can't be buffered safely (WebSocket upgrades, endless streams) are replaced with a
+ * placeholder instead. Returns the call the caller should receive — the original one when the
+ * body was left untouched, or a saved copy whose body is still readable.
+ */
+private suspend fun captureResponseBodySafely(call: HttpClientCall, maxChars: Int): Pair<HttpClientCall, BodyCapture> {
+    val response = call.response
+
+    // A WebSocket upgrade response (101) has no conventional body — by the time this runs, the
+    // connection has already switched to the raw frame stream, so save()/bodyAsText() would read
+    // live WebSocket frames as if they were an HTTP body, corrupting the frame stream for the caller.
+    if (response.isWebSocketUpgrade()) {
+        return call to BodyCapture("<websocket upgrade>", false)
+    }
+
+    // save() buffers the entire body before returning, so on a never-ending stream (SSE) the
+    // caller would wait forever for a response that has already started arriving.
+    val contentType = response.headers[HttpHeaders.ContentType]
+    if (contentType?.startsWith("text/event-stream", ignoreCase = true) == true) {
+        return call to BodyCapture("<streaming response body>", false)
+    }
+
+    // save() buffers the body so we can read it for inspection and still hand a fresh, readable
+    // response to the caller.
+    val saved = call.save()
+    return saved to saved.response.bodyAsText().truncate(maxChars)
+}
+
+private fun StringValues.toCapturedMap(): Map<String, List<String>> = entries().associate { it.key to it.value }
+
+/** True for a successful WebSocket upgrade response (101 Switching Protocols + `Upgrade: websocket`). */
+private fun HttpResponse.isWebSocketUpgrade(): Boolean = status == HttpStatusCode.SwitchingProtocols && headers[HttpHeaders.Upgrade]?.equals("websocket", ignoreCase = true) == true
+
+/**
+ * Captures the request headers visible at the send phase, enriched with the body's
+ * Content-Type / Content-Length and any body-level headers. Headers injected later by the engine
+ * (e.g. User-Agent, Accept-Encoding, Host) are not visible here and are omitted.
+ */
+private fun HttpRequestBuilder.capturedRequestHeaders(): Map<String, List<String>> = buildMap {
+    putAll(headers.build().toCapturedMap())
+    val content = body as? OutgoingContent ?: return@buildMap
+    content.contentType?.let { type ->
+        if (!containsKey("Content-Type")) put("Content-Type", listOf(type.toString()))
+    }
+    content.contentLength?.let { length ->
+        if (!containsKey("Content-Length")) put("Content-Length", listOf(length.toString()))
+    }
+    content.headers.entries().forEach { (key, value) ->
+        if (!containsKey(key)) put(key, value)
+    }
+}

--- a/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/NetworkMonitorSend.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/NetworkMonitorSend.kt
@@ -183,13 +183,16 @@ private fun HttpResponse.isWebSocketUpgrade(): Boolean = status == HttpStatusCod
 private fun HttpRequestBuilder.capturedRequestHeaders(): Map<String, List<String>> = buildMap {
     putAll(headers.build().toCapturedMap())
     val content = body as? OutgoingContent ?: return@buildMap
-    content.contentType?.let { type ->
-        if (!containsKey("Content-Type")) put("Content-Type", listOf(type.toString()))
-    }
-    content.contentLength?.let { length ->
-        if (!containsKey("Content-Length")) put("Content-Length", listOf(length.toString()))
-    }
-    content.headers.entries().forEach { (key, value) ->
-        if (!containsKey(key)) put(key, value)
-    }
+    content.contentType?.let { putIfAbsentIgnoringCase("Content-Type", listOf(it.toString())) }
+    content.contentLength?.let { putIfAbsentIgnoringCase("Content-Length", listOf(it.toString())) }
+    content.headers.entries().forEach { (key, value) -> putIfAbsentIgnoringCase(key, value) }
+}
+
+/**
+ * Adds a body-derived header only when the request doesn't already carry it. The comparison ignores
+ * case because header names are case-insensitive but this map keeps whatever spelling the request
+ * used, so a case-sensitive check would let `content-length` and `Content-Length` both through.
+ */
+private fun MutableMap<String, List<String>>.putIfAbsentIgnoringCase(name: String, values: List<String>) {
+    if (keys.none { it.equals(name, ignoreCase = true) }) put(name, values)
 }

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
@@ -15,10 +15,16 @@ import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
 import io.ktor.client.request.prepareGet
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
 import io.ktor.http.headersOf
 import io.ktor.server.application.install
 import io.ktor.server.engine.embeddedServer
@@ -215,6 +221,27 @@ class JetWhaleNetworkKtorPluginTest {
     }
 
     @Test
+    fun `keeps a single entry when the request and the body spell a header differently`() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        val client = HttpClient(MockEngine { respond(content = "ok", status = HttpStatusCode.OK) }) {
+            install(agent.ktorClientPlugin())
+        }
+
+        client.post("http://example/echo") {
+            header("X-Trace", "from-request")
+            setBody(TracedContent("hi"))
+        }
+
+        // Header names are case-insensitive, so a body-level header must not be added again under
+        // the request's spelling — the inspector would show the same header twice.
+        val headers = (events.first() as RequestSent).request.headers
+        assertEquals(
+            listOf("X-Trace" to listOf("from-request")),
+            headers.entries.filter { it.key.equals("x-trace", ignoreCase = true) }.map { it.key to it.value },
+        )
+    }
+
+    @Test
     fun `a plugin installed before the monitor wraps it`() = runBlocking {
         val (agent, events) = agentWithEvents()
         val trace = mutableListOf<String>()
@@ -295,6 +322,13 @@ class JetWhaleNetworkKtorPluginTest {
         assertEquals(1, events.filterIsInstance<RequestSent>().size)
         assertEquals(1, events.filterIsInstance<ResponseReceived>().size)
     }
+}
+
+/** A body that carries its own header, spelled differently from the one the request sets. */
+private class TracedContent(private val text: String) : OutgoingContent.ByteArrayContent() {
+    override val contentType: ContentType = ContentType.Text.Plain
+    override val headers: Headers = headersOf("x-trace", "from-body")
+    override fun bytes(): ByteArray = text.encodeToByteArray()
 }
 
 /** A Send-hook plugin that appends the number of events recorded so far when it is entered and left. */

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
@@ -1,20 +1,17 @@
 package com.kitakkun.jetwhale.plugins.network.agent.ktor
 
-import com.kitakkun.jetwhale.agent.sdk.messaging.JetWhaleOfflineCapableMessenger
-import com.kitakkun.jetwhale.agent.sdk.messaging.OfflineSendPolicy
-import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
-import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
 import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
-import com.kitakkun.jetwhale.plugins.network.protocol.RequestFailed
 import com.kitakkun.jetwhale.plugins.network.protocol.RequestSent
 import com.kitakkun.jetwhale.plugins.network.protocol.ResponseReceived
-import com.kitakkun.jetwhale.protocol.messaging.DefaultJetWhaleMessagingFormat
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.api.ClientPlugin
+import io.ktor.client.plugins.api.Send
+import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.client.request.get
@@ -33,34 +30,13 @@ import io.ktor.utils.io.writeStringUtf8
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import kotlinx.serialization.StringFormat
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 class JetWhaleNetworkKtorPluginTest {
-
-    @OptIn(InternalJetWhaleApi::class)
-    private fun agentWithEvents(): Pair<JetWhaleNetworkAgentPlugin, MutableList<Any>> {
-        val agent = JetWhaleNetworkAgentPlugin()
-        val recorder = RecordingMessenger(java.util.Collections.synchronizedList(mutableListOf()))
-        agent.bindMessenger(recorder)
-        return agent to recorder.events
-    }
-
-    // The agent's mock rules are set by the host over messaging in production; a unit test can't
-    // drive that internal path, so seed the state directly for the mock-serving case.
-    @Suppress("UNCHECKED_CAST")
-    private fun JetWhaleNetworkAgentPlugin.seedMockRules(rules: List<MockRule>) {
-        val field = JetWhaleNetworkAgentPlugin::class.java.getDeclaredField("mockRules").apply { isAccessible = true }
-        (field.get(this) as MutableStateFlow<List<MockRule>>).value = rules
-    }
 
     @Test
     fun `serves a mock response whose body reads back without a coroutine-job cast crash`() = runBlocking {
@@ -237,21 +213,96 @@ class JetWhaleNetworkKtorPluginTest {
             server.stop()
         }
     }
-}
 
-/** Records every event the plugin sends, decoded back to its typed form. */
-private class RecordingMessenger(val events: MutableList<Any>) : JetWhaleOfflineCapableMessenger {
-    override val payloadFormat: StringFormat = DefaultJetWhaleMessagingFormat
-
-    override fun sendRaw(messageType: String, payload: String, policy: OfflineSendPolicy): Boolean {
-        events += when (messageType) {
-            "network/request_sent" -> payloadFormat.decodeFromString(RequestSent.serializer(), payload)
-            "network/response_received" -> payloadFormat.decodeFromString(ResponseReceived.serializer(), payload)
-            "network/request_failed" -> payloadFormat.decodeFromString(RequestFailed.serializer(), payload)
-            else -> error("Unexpected message type: $messageType")
+    @Test
+    fun `a plugin installed before the monitor wraps it`() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        val trace = mutableListOf<String>()
+        val client = HttpClient(MockEngine { respond(content = "hello", status = HttpStatusCode.OK) }) {
+            install(tracingPlugin(trace) { events.size })
+            install(agent.ktorClientPlugin())
         }
-        return true
+
+        client.get("http://example/plain").bodyAsText()
+
+        // HttpSend wraps interceptors in reverse registration order, so the plugin installed first
+        // is the outermost one: nothing is recorded when it starts, and by the time it regains
+        // control the monitor has already recorded both the request and the response.
+        assertEquals(listOf("enter@0", "exit@2"), trace)
     }
 
-    override suspend fun requestRaw(messageType: String, payload: String, timeout: Duration?): String = error("The network agent plugin never requests the host in these tests.")
+    @Test
+    fun `a plugin installed after the monitor runs inside it`() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        val trace = mutableListOf<String>()
+        val client = HttpClient(MockEngine { respond(content = "hello", status = HttpStatusCode.OK) }) {
+            install(agent.ktorClientPlugin())
+            install(tracingPlugin(trace) { events.size })
+        }
+
+        client.get("http://example/plain").bodyAsText()
+
+        // Installed second means innermost: the monitor has already recorded the request when the
+        // tracer starts, and records the response only after the tracer returns.
+        assertEquals(listOf("enter@1", "exit@1"), trace)
+    }
+
+    @Test
+    fun `records each redirect hop as its own transaction`() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        val client = HttpClient(
+            MockEngine { request ->
+                if (request.url.encodedPath == "/from") {
+                    respond(
+                        content = "",
+                        status = HttpStatusCode.Found,
+                        headers = headersOf(HttpHeaders.Location, "http://example/to"),
+                    )
+                } else {
+                    respond(content = "arrived", status = HttpStatusCode.OK)
+                }
+            },
+        ) {
+            install(agent.ktorClientPlugin())
+        }
+
+        assertEquals("arrived", client.get("http://example/from").bodyAsText())
+
+        // HttpRedirect is installed before any user plugin, so the monitor always sits inside it
+        // and sees every hop separately — install order in the config block can't change this.
+        assertEquals(
+            listOf("http://example/from", "http://example/to"),
+            events.filterIsInstance<RequestSent>().map { it.request.url },
+        )
+        assertEquals(
+            listOf(302, 200),
+            events.filterIsInstance<ResponseReceived>().map { it.response.statusCode },
+        )
+    }
+
+    @Test
+    fun `installing the plugin twice records the transaction once`() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        val client = HttpClient(MockEngine { respond(content = "hello", status = HttpStatusCode.OK) }) {
+            // createClientPlugin keys on the plugin name and AttributeKey is a data class, so both
+            // calls produce the same key and HttpClientConfig keeps only the first installation.
+            install(agent.ktorClientPlugin())
+            install(agent.ktorClientPlugin())
+        }
+
+        client.get("http://example/plain").bodyAsText()
+
+        assertEquals(1, events.filterIsInstance<RequestSent>().size)
+        assertEquals(1, events.filterIsInstance<ResponseReceived>().size)
+    }
+}
+
+/** A Send-hook plugin that appends the number of events recorded so far when it is entered and left. */
+private fun tracingPlugin(trace: MutableList<String>, recordedCount: () -> Int): ClientPlugin<Unit> = createClientPlugin("Tracer") {
+    on(Send) { request ->
+        trace += "enter@${recordedCount()}"
+        val call = proceed(request)
+        trace += "exit@${recordedCount()}"
+        call
+    }
 }

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorSendInterceptorTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorSendInterceptorTest.kt
@@ -1,0 +1,122 @@
+package com.kitakkun.jetwhale.plugins.network.agent.ktor
+
+import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
+import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
+import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
+import com.kitakkun.jetwhale.plugins.network.protocol.RequestSent
+import com.kitakkun.jetwhale.plugins.network.protocol.ResponseReceived
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpSend
+import io.ktor.client.plugins.plugin
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JetWhaleNetworkKtorSendInterceptorTest {
+
+    @Test
+    fun `records a round trip on a client that was built without installing the plugin`() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        // Built first, instrumented after — this is the whole point of the interceptor entry point.
+        val client = HttpClient(
+            MockEngine {
+                respond(
+                    content = "hello",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "text/plain"),
+                )
+            },
+        )
+        client.plugin(HttpSend).intercept(agent.ktorSendInterceptor(client))
+
+        val response = client.get("http://example/plain")
+
+        assertEquals("hello", response.bodyAsText())
+        val sent = events.first() as RequestSent
+        assertEquals("http://example/plain", sent.request.url)
+        val received = events.last() as ResponseReceived
+        assertEquals("hello", received.response.body)
+        assertEquals(sent.request.txId, received.response.txId)
+    }
+
+    @Test
+    fun `serves a mock through the interceptor without reaching the engine`() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        agent.seedMockRules(
+            listOf(
+                MockRule(
+                    id = "1",
+                    matcher = MockMatcher(urlPattern = "/todos/1"),
+                    response = MockResponseSpec(statusCode = 200, body = "{\"ok\":true}"),
+                ),
+            ),
+        )
+        val client = HttpClient(
+            // The real engine must never be hit — the mock is served before execute().
+            MockEngine { respond(content = "unmocked", status = HttpStatusCode.InternalServerError) },
+        )
+        client.plugin(HttpSend).intercept(agent.ktorSendInterceptor(client))
+
+        val response = client.get("http://example/todos/1")
+
+        // The mocked call is synthesized from the HttpClient handed to ktorSendInterceptor, since
+        // HttpSend's Sender doesn't expose the client it sends through.
+        assertEquals(200, response.status.value)
+        assertEquals("{\"ok\":true}", response.bodyAsText())
+        assertEquals(true, (events.last() as ResponseReceived).response.fromMock)
+    }
+
+    @Test
+    fun `registering the interceptor twice records the transaction twice`() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        val client = HttpClient(MockEngine { respond(content = "hello", status = HttpStatusCode.OK) })
+        // HttpSend rejects neither duplicates nor offers removal, so a double registration double
+        // records. Pinning the documented consequence of calling this more than once per client.
+        client.plugin(HttpSend).intercept(agent.ktorSendInterceptor(client))
+        client.plugin(HttpSend).intercept(agent.ktorSendInterceptor(client))
+
+        client.get("http://example/plain").bodyAsText()
+
+        assertEquals(2, events.filterIsInstance<RequestSent>().size)
+        assertEquals(2, events.filterIsInstance<ResponseReceived>().size)
+    }
+
+    @Test
+    fun `records each redirect hop as its own transaction`() = runBlocking {
+        val (agent, events) = agentWithEvents()
+        val client = HttpClient(
+            MockEngine { request ->
+                if (request.url.encodedPath == "/from") {
+                    respond(
+                        content = "",
+                        status = HttpStatusCode.Found,
+                        headers = headersOf(HttpHeaders.Location, "http://example/to"),
+                    )
+                } else {
+                    respond(content = "arrived", status = HttpStatusCode.OK)
+                }
+            },
+        )
+        client.plugin(HttpSend).intercept(agent.ktorSendInterceptor(client))
+
+        assertEquals("arrived", client.get("http://example/from").bodyAsText())
+
+        // HttpSend runs interceptors outermost-first in registration order, so one added after the
+        // client was built sits inside HttpRedirect and sees every hop separately.
+        assertEquals(
+            listOf("http://example/from", "http://example/to"),
+            events.filterIsInstance<RequestSent>().map { it.request.url },
+        )
+        assertEquals(
+            listOf(302, 200),
+            events.filterIsInstance<ResponseReceived>().map { it.response.statusCode },
+        )
+    }
+}

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/NetworkAgentTestSupport.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/NetworkAgentTestSupport.kt
@@ -1,0 +1,47 @@
+package com.kitakkun.jetwhale.plugins.network.agent.ktor
+
+import com.kitakkun.jetwhale.agent.sdk.messaging.JetWhaleOfflineCapableMessenger
+import com.kitakkun.jetwhale.agent.sdk.messaging.OfflineSendPolicy
+import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
+import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
+import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
+import com.kitakkun.jetwhale.plugins.network.protocol.RequestFailed
+import com.kitakkun.jetwhale.plugins.network.protocol.RequestSent
+import com.kitakkun.jetwhale.plugins.network.protocol.ResponseReceived
+import com.kitakkun.jetwhale.protocol.messaging.DefaultJetWhaleMessagingFormat
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.serialization.StringFormat
+import kotlin.time.Duration
+
+@OptIn(InternalJetWhaleApi::class)
+internal fun agentWithEvents(): Pair<JetWhaleNetworkAgentPlugin, MutableList<Any>> {
+    val agent = JetWhaleNetworkAgentPlugin()
+    val recorder = RecordingMessenger(java.util.Collections.synchronizedList(mutableListOf()))
+    agent.bindMessenger(recorder)
+    return agent to recorder.events
+}
+
+// The agent's mock rules are set by the host over messaging in production; a unit test can't
+// drive that internal path, so seed the state directly for the mock-serving case.
+@Suppress("UNCHECKED_CAST")
+internal fun JetWhaleNetworkAgentPlugin.seedMockRules(rules: List<MockRule>) {
+    val field = JetWhaleNetworkAgentPlugin::class.java.getDeclaredField("mockRules").apply { isAccessible = true }
+    (field.get(this) as MutableStateFlow<List<MockRule>>).value = rules
+}
+
+/** Records every event the agent sends, decoded back to its typed form. */
+private class RecordingMessenger(val events: MutableList<Any>) : JetWhaleOfflineCapableMessenger {
+    override val payloadFormat: StringFormat = DefaultJetWhaleMessagingFormat
+
+    override fun sendRaw(messageType: String, payload: String, policy: OfflineSendPolicy): Boolean {
+        events += when (messageType) {
+            "network/request_sent" -> payloadFormat.decodeFromString(RequestSent.serializer(), payload)
+            "network/response_received" -> payloadFormat.decodeFromString(ResponseReceived.serializer(), payload)
+            "network/request_failed" -> payloadFormat.decodeFromString(RequestFailed.serializer(), payload)
+            else -> error("Unexpected message type: $messageType")
+        }
+        return true
+    }
+
+    override suspend fun requestRaw(messageType: String, payload: String, timeout: Duration?): String = error("The network agent plugin never requests the host in these tests.")
+}


### PR DESCRIPTION
## Why

`ktorClientPlugin()` can only be applied inside an `HttpClient { }` config block, so a client built by a DI container or a library could not be inspected without changing its construction site.

## What

Adds `ktorSendInterceptor(client)`, which returns an `HttpSendInterceptor` the caller registers on an already-built client:

```kotlin
val networkAgent = JetWhaleNetworkAgentPlugin()
val client = HttpClient()

client.plugin(HttpSend).intercept(networkAgent.ktorSendInterceptor(client))
```

This mirrors the OkHttp adapter, which returns an `Interceptor` for the caller to pass to `addInterceptor`.

**Both Ktor entry points stay supported.** `install()` deduplicates by `AttributeKey` and reads declaratively, so it remains the better choice whenever the construction site is reachable; the interceptor is for when it isn't.

## How

The two are one mechanism — Ktor implements the `Send` hook as `client.plugin(HttpSend).intercept` (`ktor-client-core` 3.5.1, `plugins/api/CommonHooks.kt:50-54`), and `Send.Sender.proceed()` delegates to `Sender.execute()`. So the round-trip logic moves to a shared `monitorSend()`, parameterised only by how the send continues:

```kotlin
// ktorClientPlugin
on(Send) { request -> agent.monitorSend(client, request, maxBodyChars) { proceed(it) } }

// ktorSendInterceptor
{ request -> agent.monitorSend(client, request, maxBodyChars) { execute(it) } }
```

Behaviour is unchanged — the 6 existing tests are untouched and still pass.

`client` is a parameter because mocked responses synthesize an `HttpClientCall`, and `Sender` does not expose the client it sends through.

## Ordering, now pinned by tests

New tests fix the invariants both entry points rely on:

| Test | Invariant |
|---|---|
| `a plugin installed before the monitor wraps it` | `HttpSend` wraps interceptors in reverse registration order, so install order = nesting order |
| `a plugin installed after the monitor runs inside it` | ditto, other direction |
| `records each redirect hop as its own transaction` (×2) | `HttpRedirect` is installed before any user plugin (`HttpClient.kt:1389-1391`), so the monitor always sits inside it — for both entry points |
| `installing the plugin twice records the transaction once` | `createClientPlugin` keys on the plugin name and `AttributeKey` is a data class, so `install()` deduplicates |
| `registering the interceptor twice records the transaction twice` | `HttpSend` has no duplicate guard and no removal API — the documented cost of the interceptor form |

Test helpers (`RecordingMessenger`, `agentWithEvents`, `seedMockRules`) moved to `NetworkAgentTestSupport.kt` so both test classes share them.

## Verification

- `:jetwhale-plugins:network:agent-ktor:jvmTest` — 14 tests green (6 existing + 8 new)
- `compileKotlinJs` / `compileKotlinWasmJs` / `compileKotlinIosSimulatorArm64` / `compileKotlinMacosArm64` green
- `spotlessCheck` green

## Not in scope

`agent-okhttp`, `compat-test`, `settings.gradle.kts`, `libs.versions.toml` and the publish setup are untouched — no new module, no new dependency (`HttpSend` ships in `ktor-client-core`).