### PR TITLE
feat(network): resizable list/detail split pane in the Network Inspector

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ androidxDatastoreCoreOkio = { module = "androidx.datastore:datastore-core-okio",
 jetbrainsComposeRuntime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jetbrainsCompose" }
 jetbrainsComposePreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "jetbrainsCompose" }
 jetbrainsComposeResources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "jetbrainsCompose" }
+jetbrainsComposeSplitPane = { module = "org.jetbrains.compose.components:components-splitpane", version.ref = "jetbrainsCompose" }
 jetbrainsComposeMaterialIconsExtended = { module = "org.jetbrains.compose.material:material-icons-extended", version = "1.7.3" }
 material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
@@ -1,10 +1,12 @@
 package com.kitakkun.jetwhale.host.data.plugin
 
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.CanvasLayersComposeScene
@@ -85,6 +87,7 @@ class DefaultPluginComposeSceneService(
                 windowInfoUpdater = windowUpdatableContext,
                 semanticsOwners = windowUpdatableContext.semanticsOwners,
                 isScreenshotCapture = isScreenshotCapture,
+                pointerIcon = windowUpdatableContext.pointerIcon,
             )
             pluginScenes[sceneKey] = CachedScene(pluginInstance, scene)
             scene
@@ -135,6 +138,14 @@ private class DynamicWindowInfoPlatformContext(
 
         override fun onSemanticsChange(semanticsOwner: SemanticsOwner) = Unit
         override fun onLayoutChange(semanticsOwner: SemanticsOwner, semanticsNodeId: Int) = Unit
+    }
+
+    // A nested ComposeScene owns no window, and PlatformContext.setPointerIcon is a no-op by
+    // default, so Modifier.pointerHoverIcon inside a plugin would otherwise never reach a cursor.
+    // Publish the request instead; the renderer applies it to the window it does own.
+    val pointerIcon: MutableState<PointerIcon> = mutableStateOf(PointerIcon.Default)
+    override fun setPointerIcon(pointerIcon: PointerIcon) {
+        this.pointerIcon.value = pointerIcon
     }
 
     override val currentIntSize: IntSize get() = windowInfo.containerSize

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/PluginScenePointerIconTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/PluginScenePointerIconTest.kt
@@ -1,0 +1,63 @@
+package com.kitakkun.jetwhale.host.mcp.tools
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * A plugin renders into a nested, windowless [androidx.compose.ui.scene.ComposeScene], so its
+ * `Modifier.pointerHoverIcon` cannot touch a cursor by itself — the request only reaches the host
+ * through `PlatformContext.setPointerIcon`, whose default implementation is a no-op. These tests pin
+ * that routing, which is what a Compose upgrade could silently take away.
+ */
+@OptIn(InternalComposeUiApi::class)
+class PluginScenePointerIconTest {
+
+    @Test
+    fun `hovering a pointerHoverIcon region publishes the requested icon`() = runBlocking {
+        withContext(Dispatchers.Main) {
+            val scene = hoverIconScene()
+
+            scene.composeScene.sendPointerEvent(PointerEventType.Move, Offset(50f, 50f))
+
+            assertEquals(PointerIcon.Hand, scene.pointerIcon.value)
+        }
+    }
+
+    @Test
+    fun `a scene with no hovered region reports the default icon`() = runBlocking {
+        withContext(Dispatchers.Main) {
+            val scene = hoverIconScene()
+
+            assertEquals(PointerIcon.Default, scene.pointerIcon.value)
+        }
+    }
+
+    @Test
+    fun `leaving the region restores the default icon`() = runBlocking {
+        withContext(Dispatchers.Main) {
+            val scene = hoverIconScene()
+            scene.composeScene.sendPointerEvent(PointerEventType.Move, Offset(50f, 50f))
+
+            scene.composeScene.sendPointerEvent(PointerEventType.Move, Offset(400f, 400f))
+
+            assertEquals(PointerIcon.Default, scene.pointerIcon.value)
+        }
+    }
+
+    /** A rendered scene whose top-left 200x200 region asks for [PointerIcon.Hand]. */
+    private fun hoverIconScene() = createTestScene {
+        Box(Modifier.size(200.dp).pointerHoverIcon(PointerIcon.Hand))
+    }.also(::renderTestScene)
+}

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/TestSceneFactory.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/TestSceneFactory.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.semantics.SemanticsOwner
@@ -34,6 +35,7 @@ fun createTestScene(content: @Composable () -> Unit = {}): PluginComposeScene {
         windowInfoUpdater = platformContext,
         semanticsOwners = platformContext.semanticsOwners,
         isScreenshotCapture = isScreenshotCapture,
+        pointerIcon = platformContext.pointerIcon,
     )
 }
 
@@ -50,6 +52,11 @@ private class TestPlatformContext(
     WindowInfoUpdater {
 
     val semanticsOwners = mutableSetOf<SemanticsOwner>()
+
+    val pointerIcon = mutableStateOf(PointerIcon.Default)
+    override fun setPointerIcon(pointerIcon: PointerIcon) {
+        this.pointerIcon.value = pointerIcon
+    }
 
     override val semanticsOwnerListener = object : PlatformContext.SemanticsOwnerListener {
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeScene.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeScene.kt
@@ -1,7 +1,9 @@
 package com.kitakkun.jetwhale.host.model
 
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.unit.DpSize
@@ -15,6 +17,9 @@ data class PluginComposeScene(
     // Backs LocalIsScreenshotCapture inside the scene's composition; the screenshot tool flips
     // it around its off-screen render so plugins can hide sensitive values from captures.
     val isScreenshotCapture: MutableState<Boolean>,
+    // The cursor the plugin's composition currently asks for via Modifier.pointerHoverIcon. The
+    // nested scene owns no window, so whoever renders it must apply this to the real one.
+    val pointerIcon: State<PointerIcon>,
 )
 
 interface WindowInfoUpdater {

--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreen.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.layout.onSizeChanged
@@ -47,6 +48,9 @@ fun PluginScreen(pluginComposeScene: PluginComposeScene) {
 
     Canvas(
         modifier = Modifier.fillMaxSize()
+            // The plugin's scene is nested and windowless, so its Modifier.pointerHoverIcon requests
+            // surface here instead; this Canvas is the innermost node that sits in a real window.
+            .pointerHoverIcon(pluginComposeScene.pointerIcon.value)
             .onSizeChanged {
                 try {
                     pluginComposeScene.composeScene.density = density

--- a/jetwhale-plugins/network/host/build.gradle.kts
+++ b/jetwhale-plugins/network/host/build.gradle.kts
@@ -25,6 +25,10 @@ dependencies {
     compileOnly(compose.desktop.currentOs)
     compileOnly(libs.material3)
     compileOnly(libs.kotlinxSerializationJson)
+    // Not among the host-provided Compose artifacts, so this one ships with the plugin. Its own
+    // dependencies (compose runtime/foundation, kotlin-stdlib) *are* host-provided, hence
+    // isTransitive = false: only the split-pane jar itself reaches the fat jar and the manifest.
+    implementation(libs.jetbrainsComposeSplitPane) { isTransitive = false }
     api(projects.jetwhalePlugins.network.protocol)
     testImplementation(projects.jetwhaleHostSdk)
     testImplementation(libs.kotlinTest)

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkInspectorScreen.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkInspectorScreen.kt
@@ -28,6 +28,9 @@ fun NetworkInspectorScreen(
     onMockRulesChanged: (List<MockRule>) -> Unit,
 ) {
     var selectedTab by remember { mutableStateOf(0) }
+    // Hoisted out of TrafficTab so the selection survives a round trip through the Mocks tab, which
+    // swaps the tab content composable out of the composition entirely.
+    var selectedTxId by remember { mutableStateOf<String?>(null) }
     Column(Modifier.fillMaxSize()) {
         TabRow(selectedTabIndex = selectedTab) {
             Tab(
@@ -44,6 +47,8 @@ fun NetworkInspectorScreen(
         when (selectedTab) {
             0 -> TrafficTab(
                 transactions = transactions,
+                selectedTxId = selectedTxId,
+                onSelectTx = { selectedTxId = it },
                 onClear = onClearTransactions,
                 onCreateMock = { tx ->
                     tx.response?.let { response ->

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -30,11 +32,13 @@ import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -43,20 +47,35 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.host.sdk.rememberPersistent
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.splitpane.ExperimentalSplitPaneApi
+import org.jetbrains.compose.splitpane.HorizontalSplitPane
+import org.jetbrains.compose.splitpane.SplitPaneState
+import java.awt.Cursor
 import java.net.URLDecoder
 
+/** Storage key for the Traffic tab's list/detail split position. */
+private const val SPLIT_POSITION_KEY = "traffic.splitPosition"
+private const val DEFAULT_SPLIT_POSITION = 0.42f
+private val ListMinWidth = 240.dp
+private val DetailMinWidth = 280.dp
+
+@OptIn(ExperimentalSplitPaneApi::class)
 @Composable
 internal fun TrafficTab(
     transactions: List<HttpTransaction>,
+    selectedTxId: String?,
+    onSelectTx: (String) -> Unit,
     onClear: () -> Unit,
     onCreateMock: (HttpTransaction) -> Unit,
 ) {
-    var selectedTxId by remember { mutableStateOf<String?>(null) }
     var query by remember { mutableStateOf("") }
     val visible = remember(transactions, query) {
         val matched = if (query.isBlank()) {
@@ -77,8 +96,23 @@ internal fun TrafficTab(
         if (visible.isEmpty()) return
         val current = visible.indexOfFirst { it.txId == selectedTxId }
         val next = (if (current < 0) 0 else current + delta).coerceIn(0, visible.lastIndex)
-        selectedTxId = visible[next].txId
+        onSelectTx(visible[next].txId)
         scope.launch { listState.animateScrollToItem(next) }
+    }
+
+    var storedSplitPosition by rememberPersistent(SPLIT_POSITION_KEY, DEFAULT_SPLIT_POSITION)
+    val splitPaneState = remember { SplitPaneState(DEFAULT_SPLIT_POSITION, moveEnabled = true) }
+    // rememberPersistent hydrates from disk asynchronously, i.e. after SplitPaneState has already
+    // been constructed, so the two are mirrored in both directions rather than seeded once. Both are
+    // backed by mutableStateOf with structural equality, so echoing an unchanged value back does not
+    // re-emit and the mirroring settles immediately.
+    LaunchedEffect(splitPaneState) {
+        launch {
+            snapshotFlow { storedSplitPosition }
+                .collect { splitPaneState.positionPercentage = it }
+        }
+        snapshotFlow { splitPaneState.positionPercentage }
+            .collect { storedSplitPosition = it }
     }
 
     Column(Modifier.fillMaxSize()) {
@@ -105,64 +139,83 @@ internal fun TrafficTab(
             modifier = Modifier.padding(horizontal = 8.dp),
         )
         HorizontalDivider()
-        Row(Modifier.fillMaxSize()) {
-            LazyColumn(
-                state = listState,
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight()
-                    .focusable()
-                    .onPreviewKeyEvent { event ->
-                        if (event.type != KeyEventType.KeyDown) {
-                            false
-                        } else {
-                            when (event.key) {
-                                Key.DirectionDown -> {
-                                    moveSelection(1)
-                                    true
-                                }
+        HorizontalSplitPane(
+            modifier = Modifier.fillMaxSize(),
+            splitPaneState = splitPaneState,
+        ) {
+            first(minSize = ListMinWidth) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .focusable()
+                        .onPreviewKeyEvent { event ->
+                            if (event.type != KeyEventType.KeyDown) {
+                                false
+                            } else {
+                                when (event.key) {
+                                    Key.DirectionDown -> {
+                                        moveSelection(1)
+                                        true
+                                    }
 
-                                Key.DirectionUp -> {
-                                    moveSelection(-1)
-                                    true
-                                }
+                                    Key.DirectionUp -> {
+                                        moveSelection(-1)
+                                        true
+                                    }
 
-                                else -> false
+                                    else -> false
+                                }
                             }
+                        },
+                ) {
+                    items(visible, key = { it.txId }) { tx ->
+                        ContextMenuArea(items = { transactionContextMenuItems(tx) }) {
+                            TransactionRow(
+                                tx = tx,
+                                selected = tx.txId == selectedTxId,
+                                onClick = { onSelectTx(tx.txId) },
+                            )
                         }
-                    },
-            ) {
-                items(visible, key = { it.txId }) { tx ->
-                    ContextMenuArea(items = { transactionContextMenuItems(tx) }) {
-                        TransactionRow(
-                            tx = tx,
-                            selected = tx.txId == selectedTxId,
-                            onClick = { selectedTxId = tx.txId },
-                        )
+                        HorizontalDivider()
                     }
-                    HorizontalDivider()
                 }
             }
-            VerticalDivider()
-            Column(
-                modifier = Modifier
-                    .weight(1.4f)
-                    .fillMaxHeight()
-                    .verticalScroll(rememberScrollState())
-                    .padding(14.dp),
-            ) {
-                val tx = transactions.firstOrNull { it.txId == selectedTxId }
-                if (tx == null) {
-                    Text(
-                        text = "Select a request to see details",
-                        color = MaterialTheme.colorScheme.outline,
-                    )
-                } else {
-                    // Detail pane values (URL, headers, bodies) are read-only reference data
-                    // developers frequently copy, so make the whole pane text-selectable.
-                    SelectionContainer {
-                        TransactionDetail(tx = tx, onCreateMock = { onCreateMock(tx) })
+            second(minSize = DetailMinWidth) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(14.dp),
+                ) {
+                    val tx = transactions.firstOrNull { it.txId == selectedTxId }
+                    if (tx == null) {
+                        Text(
+                            text = "Select a request to see details",
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    } else {
+                        // Detail pane values (URL, headers, bodies) are read-only reference data
+                        // developers frequently copy, so make the whole pane text-selectable.
+                        SelectionContainer {
+                            TransactionDetail(tx = tx, onCreateMock = { onCreateMock(tx) })
+                        }
                     }
+                }
+            }
+            // Both parts must be declared: the DSL falls back to the default splitter — which draws
+            // nothing at all — unless visiblePart *and* handle are set. The handle is a wider,
+            // invisible hit area laid over the 1px divider so it stays comfortable to grab.
+            splitter {
+                visiblePart { VerticalDivider(Modifier.fillMaxHeight()) }
+                handle {
+                    Box(
+                        Modifier
+                            .markAsHandle()
+                            .pointerHoverIcon(PointerIcon(Cursor(Cursor.E_RESIZE_CURSOR)))
+                            .width(8.dp)
+                            .fillMaxHeight(),
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary

The Network Inspector's Traffic tab was a fixed `1 : 1.4` weighted `Row`, so a long URL or a deeply nested JSON body always left one pane cramped with no way to rebalance it. This makes the split draggable and persistent.

While wiring the drag handle's resize cursor, it turned out `Modifier.pointerHoverIcon` never worked inside *any* plugin — fixed here too, in its own commit.

## `fix(host)`: pointer icons from plugins reach the window

A plugin renders into a nested, windowless `ComposeScene` whose `PlatformContext` is built from `PlatformContext.Empty()`. `PlatformContext.setPointerIcon` has a no-op default body, so every `pointerHoverIcon` request inside a plugin was silently dropped — no resize cursor over a divider, no I-beam over a text field.

The scene's platform context now publishes the requested icon, and `PluginScreen` — the innermost node that does sit in a real window — applies it. Compose calls back with `PointerIcon.Default` when the pointer leaves a region, so the cursor restores itself with no extra bookkeeping.

## `feat(network)`: resizable split

- `HorizontalSplitPane` from `components-splitpane`, with minimum widths on both sides and the divider doubling as an 8dp drag handle.
- Split position persisted per plugin via `rememberPersistent`.
- `selectedTxId` hoisted to `NetworkInspectorScreen`: the tab content is swapped by a `when`, so the selection was previously lost on any round trip through the Mocks tab.

### On the new dependency

`components-splitpane` is not one of the host-provided Compose artifacts, so it ships with the plugin. Its own dependencies (compose runtime/foundation, kotlin-stdlib) *are* host-provided, hence `isTransitive = false`. Verified after the change:

- `dependencies.txt` gained exactly one line, `org.jetbrains.compose.components:components-splitpane-desktop:1.11.1`
- the fat jar gained only `org/jetbrains/compose/splitpane` (23 classes, ~50KB); no Compose core classes

I deliberately did **not** add it to the host as a provided dependency. It would join the host's compatibility contract permanently, and since the API is `@ExperimentalSplitPaneApi`, a later host Compose bump could then break already-installed plugins. Bundled per plugin, each carries the version it compiled against.

## Test plan

Automated:

- [x] `:jetwhale-plugins:network:host:build`, `:jetwhale-host:core:mcp:test`, `:jetwhale-host:app:compileKotlin`, `spotlessCheck` — all green
- [x] New `PluginScenePointerIconTest` (3 tests) covers hover / no-hover / leave. Mutation-checked: removing the `setPointerIcon` override makes it fail

Driven end-to-end against a running host with a live iOS session, via the host's own MCP tools (`jetwhale.drag` / `jetwhale.click` / `jetwhale.screenshot`), screenshots at 1280x720 px = 640x360 dp @ density 2:

- [x] Split pane renders with a visible divider; detail pane tracks the selected row
- [x] `jetwhale.drag` on the divider resizes both panes (divider x≈567 → 720; list URLs lengthen, detail URL wraps)
- [x] Dragging far left clamps at exactly x=480px — `ListMinWidth` (240dp) — instead of collapsing the list
- [x] Selection survives a Traffic → Mocks → Traffic round trip (the hoist)
- [x] Split position written to `plugin-data/com.kitakkun.jetwhale.network/store.json` as `traffic.splitPosition`
- [x] After a full host restart the divider returns to the persisted position, not the 0.42 default

Not verifiable here:

- [ ] The resize cursor's actual on-screen appearance — an AWT cursor is not part of the rendered scene, so it cannot be screenshotted. The routing it depends on is covered by `PluginScenePointerIconTest`.