### PR TITLE
fix(host): render plugin scenes at the host window's density

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.retain.retain
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalDensity
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.savedstate.serialization.SavedStateConfiguration
@@ -55,6 +56,13 @@ fun JetWhaleApp() {
         },
         EmptyPluginNavKey,
     )
+
+    // Scenes created for a caller that never displays them (the MCP screenshot tool, say) would
+    // otherwise lay out at density 1.0 and disagree with what this window shows.
+    val density = LocalDensity.current
+    LaunchedEffect(density) {
+        appGraph.pluginComposeSceneService.updateHostDensity(density)
+    }
 
     LaunchedEffect(Unit) {
         // dispose plugin scenes when the debug websocket server is stopped, as all plugin sessions will be closed

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import com.kitakkun.jetwhale.host.model.DynamicPluginBridgeProvider
@@ -46,6 +47,14 @@ class DefaultPluginComposeSceneService(
 
     private val pluginScenes = mutableMapOf<String, CachedScene>()
 
+    // Written from the host's composition and read when a scene is created; both happen on the main
+    // thread. Falls back to the ComposeScene default until the window has reported its density.
+    private var hostDensity: Density = Density(1f)
+
+    override fun updateHostDensity(density: Density) {
+        hostDensity = density
+    }
+
     override suspend fun getOrCreatePluginScene(
         pluginId: String,
         sessionId: String,
@@ -65,7 +74,10 @@ class DefaultPluginComposeSceneService(
             cached?.scene?.composeScene?.close()
 
             val windowUpdatableContext = DynamicWindowInfoPlatformContext()
-            val composeScene = CanvasLayersComposeScene(platformContext = windowUpdatableContext)
+            val composeScene = CanvasLayersComposeScene(
+                density = hostDensity,
+                platformContext = windowUpdatableContext,
+            )
             val isScreenshotCapture = mutableStateOf(false)
 
             composeScene.setContent {

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotTool.kt
@@ -5,10 +5,12 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asSkiaBitmap
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import com.kitakkun.jetwhale.host.mcp.JetWhaleMcpTool
 import com.kitakkun.jetwhale.host.mcp.errorResult
 import com.kitakkun.jetwhale.host.mcp.jsonContent
+import com.kitakkun.jetwhale.host.mcp.jsonFloat
 import com.kitakkun.jetwhale.host.mcp.jsonInt
 import com.kitakkun.jetwhale.host.mcp.numberProperty
 import com.kitakkun.jetwhale.host.mcp.stringProperty
@@ -47,6 +49,12 @@ class ScreenshotMcpTool(
                         "sessionId" to stringProperty("The session ID."),
                         "width" to numberProperty("Image width in pixels. Defaults to the current UI width (fallback: 1280)."),
                         "height" to numberProperty("Image height in pixels. Defaults to the current UI height (fallback: 720)."),
+                        "density" to numberProperty(
+                            "Pixel density to render at, e.g. 2 for HiDPI. Defaults to the scene's own density, " +
+                                "which follows the host window. Pin it to keep pixel geometry identical across " +
+                                "machines. Like width/height, this is applied to the live scene, so the host window " +
+                                "keeps rendering at it until the window next resizes.",
+                        ),
                     ),
                 ),
                 required = listOf("pluginId", "sessionId"),
@@ -61,10 +69,14 @@ class ScreenshotMcpTool(
             if ((requestedWidth == null) != (requestedHeight == null)) {
                 return@addTool errorResult("Both 'width' and 'height' must be provided together.")
             }
+            val requestedDensity = request.arguments?.get("density")?.jsonFloat
+            if (requestedDensity != null && requestedDensity <= 0f) {
+                return@addTool errorResult("'density' must be greater than 0.")
+            }
 
             val scene = pluginComposeSceneService.getOrCreatePluginScene(pluginId, sessionId)
             val (viewport, pngBytes) = withContext(Dispatchers.Main) {
-                val viewport = resolveViewport(scene, requestedWidth, requestedHeight)
+                val viewport = resolveViewport(scene, requestedWidth, requestedHeight, requestedDensity)
                 viewport to captureScreenshot(scene, viewport)
             }
             val base64 = Base64.getEncoder().encodeToString(pngBytes)
@@ -115,12 +127,13 @@ fun captureScreenshot(
 }
 
 @OptIn(InternalComposeUiApi::class)
-private fun resolveViewport(
+internal fun resolveViewport(
     scene: PluginComposeScene,
     requestedWidth: Int?,
     requestedHeight: Int?,
+    requestedDensity: Float?,
 ): McpViewport {
-    val density = scene.composeScene.density
+    val density = requestedDensity?.let { Density(it) } ?: scene.composeScene.density
     val requested = if (requestedWidth != null && requestedHeight != null) {
         IntSize(requestedWidth, requestedHeight)
     } else {

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotTool.kt
@@ -70,9 +70,7 @@ class ScreenshotMcpTool(
                 return@addTool errorResult("Both 'width' and 'height' must be provided together.")
             }
             val requestedDensity = request.arguments?.get("density")?.jsonFloat
-            if (requestedDensity != null && requestedDensity <= 0f) {
-                return@addTool errorResult("'density' must be greater than 0.")
-            }
+            invalidDensityMessage(requestedDensity)?.let { return@addTool errorResult(it) }
 
             val scene = pluginComposeSceneService.getOrCreatePluginScene(pluginId, sessionId)
             val (viewport, pngBytes) = withContext(Dispatchers.Main) {
@@ -126,6 +124,19 @@ fun captureScreenshot(
         ?: error("Failed to encode screenshot to PNG")
 }
 
+/**
+ * Why a caller-supplied density is rejected, or null when it is usable.
+ *
+ * A JSON number too large for a Float parses to `Infinity`, and `NaN` parses to `NaN`; neither is
+ * caught by a `<= 0` test (`NaN <= 0` is false), and both would reach Compose layout.
+ */
+internal fun invalidDensityMessage(requestedDensity: Float?): String? = when {
+    requestedDensity == null -> null
+    !requestedDensity.isFinite() -> "'density' must be a finite number."
+    requestedDensity <= 0f -> "'density' must be greater than 0."
+    else -> null
+}
+
 @OptIn(InternalComposeUiApi::class)
 internal fun resolveViewport(
     scene: PluginComposeScene,
@@ -133,7 +144,12 @@ internal fun resolveViewport(
     requestedHeight: Int?,
     requestedDensity: Float?,
 ): McpViewport {
-    val density = requestedDensity?.let { Density(it) } ?: scene.composeScene.density
+    val sceneDensity = scene.composeScene.density
+    // Override the density scalar only: fontScale is a separate, user-facing setting that the
+    // caller is not asking about, so carry the scene's through.
+    val density = requestedDensity
+        ?.let { Density(density = it, fontScale = sceneDensity.fontScale) }
+        ?: sceneDensity
     val requested = if (requestedWidth != null && requestedHeight != null) {
         IntSize(requestedWidth, requestedHeight)
     } else {

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotViewportTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotViewportTest.kt
@@ -1,0 +1,64 @@
+package com.kitakkun.jetwhale.host.mcp.tools
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.unit.IntSize
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The rendered density decides how many dp fit in a requested pixel size, so it changes what a
+ * screenshot actually shows. Callers need to be able to pin it — otherwise the same request renders
+ * differently on a HiDPI machine than on a plain one.
+ */
+@OptIn(InternalComposeUiApi::class)
+class ScreenshotViewportTest {
+
+    @Test
+    fun `an explicit density overrides the scene's own`() = runBlocking {
+        withContext(Dispatchers.Main) {
+            val scene = createTestScene().also(::renderTestScene)
+
+            val viewport = resolveViewport(scene, requestedWidth = null, requestedHeight = null, requestedDensity = 3f)
+
+            assertEquals(3f, viewport.density.density)
+        }
+    }
+
+    @Test
+    fun `omitting density keeps the scene's own`() = runBlocking {
+        withContext(Dispatchers.Main) {
+            val scene = createTestScene().also(::renderTestScene)
+            val sceneDensity = scene.composeScene.density.density
+
+            val viewport = resolveViewport(scene, requestedWidth = null, requestedHeight = null, requestedDensity = null)
+
+            assertEquals(sceneDensity, viewport.density.density)
+        }
+    }
+
+    @Test
+    fun `density and size are resolved independently`() = runBlocking {
+        withContext(Dispatchers.Main) {
+            val scene = createTestScene().also(::renderTestScene)
+
+            val viewport = resolveViewport(scene, requestedWidth = 800, requestedHeight = 600, requestedDensity = 2f)
+
+            assertEquals(IntSize(800, 600), viewport.size)
+            assertEquals(2f, viewport.density.density)
+        }
+    }
+
+    @Test
+    fun `omitting size falls back to the scene's current size`() = runBlocking {
+        withContext(Dispatchers.Main) {
+            val scene = createTestScene().also(::renderTestScene)
+
+            val viewport = resolveViewport(scene, requestedWidth = null, requestedHeight = null, requestedDensity = 2f)
+
+            assertEquals(IntSize(TEST_SCENE_WIDTH, TEST_SCENE_HEIGHT), viewport.size)
+        }
+    }
+}

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotViewportTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotViewportTest.kt
@@ -1,12 +1,15 @@
 package com.kitakkun.jetwhale.host.mcp.tools
 
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 /**
  * The rendered density decides how many dp fit in a requested pixel size, so it changes what a
@@ -60,5 +63,41 @@ class ScreenshotViewportTest {
 
             assertEquals(IntSize(TEST_SCENE_WIDTH, TEST_SCENE_HEIGHT), viewport.size)
         }
+    }
+
+    @Test
+    fun `overriding density keeps the scene's font scale`() = runBlocking {
+        withContext(Dispatchers.Main) {
+            val scene = createTestScene().also(::renderTestScene)
+            scene.composeScene.density = Density(density = 1f, fontScale = 1.5f)
+
+            val viewport = resolveViewport(scene, requestedWidth = null, requestedHeight = null, requestedDensity = 2f)
+
+            assertEquals(2f, viewport.density.density)
+            assertEquals(1.5f, viewport.density.fontScale)
+        }
+    }
+
+    @Test
+    fun `a usable density is accepted`() {
+        assertNull(invalidDensityMessage(null))
+        assertNull(invalidDensityMessage(1f))
+        assertNull(invalidDensityMessage(2.5f))
+    }
+
+    @Test
+    fun `a non-positive density is rejected`() {
+        assertNotNull(invalidDensityMessage(0f))
+        assertNotNull(invalidDensityMessage(-1f))
+    }
+
+    @Test
+    fun `a non-finite density is rejected`() {
+        // A JSON number too large for a Float parses to Infinity, and NaN parses to NaN. Neither is
+        // caught by a `<= 0` test, so both would otherwise reach Compose layout.
+        assertNotNull(invalidDensityMessage("1e400".toFloat()))
+        assertNotNull(invalidDensityMessage(Float.POSITIVE_INFINITY))
+        assertNotNull(invalidDensityMessage(Float.NEGATIVE_INFINITY))
+        assertNotNull(invalidDensityMessage(Float.NaN))
     }
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeSceneService.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeSceneService.kt
@@ -7,10 +7,11 @@ interface PluginComposeSceneService {
     /**
      * Records the density newly created scenes are seeded with.
      *
-     * A scene the host window renders is given the window's density on layout, but one created for
-     * a caller that never displays it — a screenshot, say — would otherwise sit at the ComposeScene
-     * default of 1.0 and lay out as if the display were non-HiDPI. Seeding it here keeps both paths
-     * showing the same thing.
+     * This is a starting value, not the authority: whichever window ends up rendering a scene
+     * assigns its own density, since a popped-out plugin gets its own window and can sit on a
+     * display with a different scale factor. The seed only decides how a scene lays out until then
+     * — without it, one created for a caller that never displays it (a screenshot, say) would sit
+     * at the ComposeScene default of 1.0 and lay out as if the display were non-HiDPI.
      */
     fun updateHostDensity(density: Density)
 

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeSceneService.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeSceneService.kt
@@ -1,8 +1,19 @@
 package com.kitakkun.jetwhale.host.model
 
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.unit.Density
 
 interface PluginComposeSceneService {
+    /**
+     * Records the density newly created scenes are seeded with.
+     *
+     * A scene the host window renders is given the window's density on layout, but one created for
+     * a caller that never displays it — a screenshot, say — would otherwise sit at the ComposeScene
+     * default of 1.0 and lay out as if the display were non-HiDPI. Seeding it here keeps both paths
+     * showing the same thing.
+     */
+    fun updateHostDensity(density: Density)
+
     @OptIn(InternalComposeUiApi::class)
     suspend fun getOrCreatePluginScene(
         pluginId: String,

--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreen.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreen.kt
@@ -53,6 +53,9 @@ fun PluginScreen(pluginComposeScene: PluginComposeScene) {
             .pointerHoverIcon(pluginComposeScene.pointerIcon.value)
             .onSizeChanged {
                 try {
+                    // The scene was seeded with a density when it was created, but only the window
+                    // actually showing it knows the right one: a popped-out plugin gets its own
+                    // Window, which can sit on a display with a different scale factor.
                     pluginComposeScene.composeScene.density = density
                     pluginComposeScene.composeScene.size = it
                 } catch (_: IllegalStateException) {


### PR DESCRIPTION
## Summary

A plugin scene the host window displays is given the window's density on layout (`PluginScreen.kt`), but `getOrCreatePluginScene` left one created for a caller that never displays it — an MCP screenshot, say — at the `CanvasLayersComposeScene` default of `Density(1f)`.

The same plugin therefore laid out two different ways:

| Scene | Density | A 1280x720 capture covers | A 240dp minimum width measures |
|---|---|---|---|
| displayed by the host window | 2.0 (Retina) | 640x360 dp | 480 px |
| created on demand for a screenshot | 1.0 | 1280x720 dp | 240 px |

So screenshots disagreed with what the user sees, and pixel landmarks were not comparable between the two paths — or between machines.

## Changes

**Seed new scenes with the host window's density.** `JetWhaleApp` reports `LocalDensity.current` to `PluginComposeSceneService`, which uses it when constructing a scene. It is the same value `PluginScreen` would later assign, so both paths agree by construction — no guessing from AWT's screen transform.

**Let `jetwhale.screenshot` override it.** A new optional `density` argument. This is the only answer where there is no window to inherit from, and it lets a caller pin density so pixel geometry is identical across machines. Values `<= 0` are rejected.

## Test plan

- [x] `:jetwhale-host:core:mcp:test`, `:jetwhale-host:app:compileKotlin`, `spotlessCheck` — green
- [x] New `ScreenshotViewportTest` (4 tests): explicit density wins, omitting it keeps the scene's, density and size resolve independently, size still falls back. Mutation-checked — dropping the override fails 2 of them
- [x] End-to-end against a running host with a live session, capturing a scene the window had never displayed:
  - before: rendered at density 1 (small text, 1280dp of UI)
  - after: renders at density 2, matching the window
  - `"density": 1` on the same request switches it back, confirming the override
  - `"density": 0` returns `'density' must be greater than 0.`

## Note for review

`density` is applied to the live scene, exactly as `width`/`height` already are, so the host window keeps rendering at an overridden density until it next resizes (`PluginScreen` only reassigns density in `onSizeChanged`). Documented in the argument description rather than fixed here — making capture fully side-effect-free would mean restoring the prior viewport for the size arguments too, which felt like a separate change.