### PR TITLE
feat(host): make the drawer plugin menu popout-state aware

### DIFF
--- a/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
@@ -20,7 +20,12 @@
     <string name="log_viewer_window_title">ログビューワー</string>
     <string name="plugins">プラグイン</string>
     <string name="no_plugins_installed">プラグインがインストールされていません。</string>
+    <string name="plugin_load_error_hint">一部のプラグインの読み込みに失敗しました。設定を確認してください。</string>
     <string name="enabled_plugins">有効なプラグイン</string>
     <string name="disabled_plugins">無効なプラグイン</string>
     <string name="unavailable_plugins">利用不可能なプラグイン</string>
+    <string name="popout">ポップアウト表示</string>
+    <string name="bring_back_from_popout">ポップアウトを戻す</string>
+    <string name="enable">有効化</string>
+    <string name="disable">無効化</string>
 </resources>

--- a/jetwhale-host/app/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="disabled_plugins">Disabled Plugins</string>
     <string name="unavailable_plugins">Unavailable Plugins</string>
     <string name="popout">Pop out</string>
+    <string name="bring_back_from_popout">Bring back</string>
     <string name="enable">Enable</string>
     <string name="disable">Disable</string>
 </resources>

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -31,7 +31,9 @@ import com.kitakkun.jetwhale.host.navigation.PluginNavKey
 import com.kitakkun.jetwhale.host.navigation.PluginPopoutNavKey
 import com.kitakkun.jetwhale.host.navigation.SettingsNavKey
 import com.kitakkun.jetwhale.host.navigation.addSingleTop
+import com.kitakkun.jetwhale.host.navigation.bringPluginBackToMainWindow
 import com.kitakkun.jetwhale.host.navigation.followPluginToSession
+import com.kitakkun.jetwhale.host.navigation.isPluginPoppedOut
 import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
 import com.kitakkun.jetwhale.host.ui.AppEnvironment
 import com.kitakkun.jetwhale.host.ui.JetWhaleTheme
@@ -138,6 +140,8 @@ fun JetWhaleApp() {
                                             ),
                                         )
                                     },
+                                    isPoppedOut = backStack::isPluginPoppedOut,
+                                    onClickBringBack = backStack::bringPluginBackToMainWindow,
                                     onSelectedSessionChange = { selectedSession ->
                                         // When the user switches the active session, make any plugin screen
                                         // currently on top follow the newly-selected session instead of

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/component/ToolingDrawer.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/component/ToolingDrawer.kt
@@ -24,6 +24,8 @@ fun ToolingDrawer(
     onClickPlugin: (String) -> Unit,
     onSelectSession: (DebugSession) -> Unit,
     onClickPopout: (DrawerPluginItemUiState) -> Unit,
+    isPoppedOut: (pluginId: String) -> Boolean,
+    onClickBringBack: (DrawerPluginItemUiState) -> Unit,
     onSetPluginEnabled: (pluginId: String, enabled: Boolean) -> Unit,
 ) {
     var expandMenu by remember { mutableStateOf(true) }
@@ -43,6 +45,8 @@ fun ToolingDrawer(
                 onClickPlugin = { onClickPlugin(it.id) },
                 onSelectSession = onSelectSession,
                 onClickPopout = onClickPopout,
+                isPoppedOut = isPoppedOut,
+                onClickBringBack = onClickBringBack,
                 onSetPluginEnabled = onSetPluginEnabled,
             )
         },

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ExpandedToolingDrawerView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ExpandedToolingDrawerView.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.ArrowOutward
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.RemoveCircle
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.SouthWest
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -34,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.Res
+import com.kitakkun.jetwhale.host.bring_back_from_popout
 import com.kitakkun.jetwhale.host.disable
 import com.kitakkun.jetwhale.host.disabled_plugins
 import com.kitakkun.jetwhale.host.enable
@@ -64,6 +66,8 @@ fun ExpandedToolingDrawerView(
     onClickPlugin: (DrawerPluginItemUiState) -> Unit,
     onSelectSession: (DebugSession) -> Unit,
     onClickPopout: (DrawerPluginItemUiState) -> Unit,
+    isPoppedOut: (pluginId: String) -> Boolean,
+    onClickBringBack: (DrawerPluginItemUiState) -> Unit,
     onSetPluginEnabled: (pluginId: String, enabled: Boolean) -> Unit,
 ) {
     ModalDrawerSheet {
@@ -177,19 +181,35 @@ fun ExpandedToolingDrawerView(
                                                     dismiss()
                                                 },
                                             )
-                                            DropdownMenuItem(
-                                                text = { Text(stringResource(Res.string.popout)) },
-                                                leadingIcon = {
-                                                    Icon(
-                                                        imageVector = Icons.Default.ArrowOutward,
-                                                        contentDescription = null,
-                                                    )
-                                                },
-                                                onClick = {
-                                                    onClickPopout(it)
-                                                    dismiss()
-                                                },
-                                            )
+                                            if (isPoppedOut(it.id)) {
+                                                DropdownMenuItem(
+                                                    text = { Text(stringResource(Res.string.bring_back_from_popout)) },
+                                                    leadingIcon = {
+                                                        Icon(
+                                                            imageVector = Icons.Default.SouthWest,
+                                                            contentDescription = null,
+                                                        )
+                                                    },
+                                                    onClick = {
+                                                        onClickBringBack(it)
+                                                        dismiss()
+                                                    },
+                                                )
+                                            } else {
+                                                DropdownMenuItem(
+                                                    text = { Text(stringResource(Res.string.popout)) },
+                                                    leadingIcon = {
+                                                        Icon(
+                                                            imageVector = Icons.Default.ArrowOutward,
+                                                            contentDescription = null,
+                                                        )
+                                                    },
+                                                    onClick = {
+                                                        onClickPopout(it)
+                                                        dismiss()
+                                                    },
+                                                )
+                                            }
                                         },
                                         modifier = Modifier.animateItem(),
                                     )

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/JetWhaleToolingScaffold.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/JetWhaleToolingScaffold.kt
@@ -20,6 +20,8 @@ fun ToolingScaffold(
     onClickInfo: () -> Unit,
     onClickPlugin: (String) -> Unit,
     onClickPopout: (DrawerPluginItemUiState) -> Unit,
+    isPoppedOut: (pluginId: String) -> Boolean,
+    onClickBringBack: (DrawerPluginItemUiState) -> Unit,
     onSelectSession: (DebugSession) -> Unit,
     onSetPluginEnabled: (pluginId: String, enabled: Boolean) -> Unit,
     modifier: Modifier = Modifier,
@@ -40,6 +42,8 @@ fun ToolingScaffold(
                     onClickPlugin = onClickPlugin,
                     onSelectSession = onSelectSession,
                     onClickPopout = onClickPopout,
+                    isPoppedOut = isPoppedOut,
+                    onClickBringBack = onClickBringBack,
                     onSetPluginEnabled = onSetPluginEnabled,
                 )
             },
@@ -68,6 +72,8 @@ private fun ToolingScaffoldPreview() {
         onClickPlugin = {},
         onSelectSession = {},
         onClickPopout = {},
+        isPoppedOut = { false },
+        onClickBringBack = {},
         onSetPluginEnabled = { _, _ -> },
     ) {
         Text("Hello, World!")

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -16,6 +16,8 @@ fun ToolingScaffoldRoot(
     onClickInfo: () -> Unit,
     onClickPlugin: (pluginId: String, sessionId: String) -> Unit,
     onClickPopout: (pluginId: String, pluginName: String, sessionId: String) -> Unit,
+    isPoppedOut: (pluginId: String, sessionId: String) -> Boolean,
+    onClickBringBack: (pluginId: String, sessionId: String) -> Unit,
     onSelectedSessionChange: (selectedSession: DebugSession) -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -65,6 +67,15 @@ fun ToolingScaffoldRoot(
             onClickPopout = {
                 val selectedSession = uiState.selectedSession ?: return@ToolingScaffold
                 onClickPopout(it.id, it.name, selectedSession.id)
+            },
+            isPoppedOut = { pluginId ->
+                val selectedSession = uiState.selectedSession ?: return@ToolingScaffold false
+                isPoppedOut(pluginId, selectedSession.id)
+            },
+            onClickBringBack = {
+                val selectedSession = uiState.selectedSession ?: return@ToolingScaffold
+                screenChannel.send(ToolingScaffoldScreenAction.UpdateSelectedPlugin(it.id))
+                onClickBringBack(it.id, selectedSession.id)
             },
             onSelectSession = { screenChannel.send(ToolingScaffoldScreenAction.SelectSession(it)) },
             onSetPluginEnabled = { pluginId, enabled ->

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavDisplay.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavDisplay.kt
@@ -63,26 +63,8 @@ fun JetWhaleNavDisplay(
             licensesEntry(onClickBack = backStack::removeLastOrNull)
             logViewerEntry()
             pluginEntries(
-                isOpenedOnPopout = { pluginId, sessionId ->
-                    backStack.any {
-                        it is PluginPopoutNavKey &&
-                            it.pluginId == pluginId &&
-                            it.sessionId == sessionId
-                    }
-                },
-                onBringbackToMainWindow = { pluginId, sessionId ->
-                    backStack.addSingleTop(
-                        PluginNavKey(
-                            pluginId = pluginId,
-                            sessionId = sessionId,
-                        ),
-                    )
-                    backStack.removeAll {
-                        it is PluginPopoutNavKey &&
-                            it.pluginId == pluginId &&
-                            it.sessionId == sessionId
-                    }
-                },
+                isOpenedOnPopout = backStack::isPluginPoppedOut,
+                onBringbackToMainWindow = backStack::bringPluginBackToMainWindow,
             )
             disabledPluginEntry()
         },

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
@@ -14,6 +14,32 @@ fun <T : NavKey> NavBackStack<T>.addSingleTop(index: Int, navKey: T) {
 }
 
 /**
+ * Whether the given plugin is currently shown in a separate popout window for [sessionId].
+ */
+fun NavBackStack<NavKey>.isPluginPoppedOut(pluginId: String, sessionId: String): Boolean = any {
+    it is PluginPopoutNavKey &&
+        it.pluginId == pluginId &&
+        it.sessionId == sessionId
+}
+
+/**
+ * Docks a popped-out plugin: shows it in the main window and closes its popout window.
+ */
+fun NavBackStack<NavKey>.bringPluginBackToMainWindow(pluginId: String, sessionId: String) {
+    addSingleTop(
+        PluginNavKey(
+            pluginId = pluginId,
+            sessionId = sessionId,
+        ),
+    )
+    removeAll {
+        it is PluginPopoutNavKey &&
+            it.pluginId == pluginId &&
+            it.sessionId == sessionId
+    }
+}
+
+/**
  * Makes the plugin screen currently on top of the back stack follow a session switch.
  *
  * If the top entry is a [PluginNavKey] targeting a different session, it is replaced with a


### PR DESCRIPTION
## Summary

The plugin drawer's overflow menu always showed **Pop out**, even for a plugin that was already displayed in its own window — where the item does nothing at all. Conversely, the only way to dock a popped-out plugin was the button on `PluginPoppedOutScreen`, which is only reachable by navigating to the plugin in the main window first.

The item now reflects the plugin's state for the currently selected session:

| State | Menu item |
|---|---|
| docked | **Pop out** (`ArrowOutward`) |
| popped out | **Bring back** (`SouthWest`) |

## Changes

**Popout state is shared, not duplicated.** It already lives in the back stack (`PluginPopoutNavKey`), and `JetWhaleNavDisplay` had both the "is it popped out" predicate and the docking routine inline. Those are lifted into `NavBackStackExtensions` as `isPluginPoppedOut` / `bringPluginBackToMainWindow` and reused by both the nav display and the drawer — no new state holder, and the presenter stays back-stack-agnostic.

**Session binding happens once.** `ToolingScaffoldRoot` binds the selected session to the two callbacks, so the drawer views take `(pluginId) -> Boolean` and keep the same shape as the existing `onClickPopout`. A plugin popped out for session A therefore still shows **Pop out** while session B is selected, which is what the popout action itself would do.

**Bringing back selects the plugin** (`UpdateSelectedPlugin`), mirroring `onClickPlugin`, so the drawer highlight follows the plugin into the main window.

**Japanese strings** (separate commit): `popout`, `enable`, `disable` and `plugin_load_error_hint` had no `values-ja` entry, so this menu rendered in English under a Japanese UI language. Filled in alongside the new `bring_back_from_popout`. `bring_back_to_main_window` (「メインウィンドウに戻す」) stays as-is for the `PluginPoppedOutScreen` button; the menu uses a shorter label.

## Test plan

- [x] `:jetwhale-host:app:compileKotlin`, `spotlessCheck` — green
- [ ] **Not yet verified in the GUI** — needs a live debug session. To check:
  - overflow menu on an enabled plugin → **Pop out** → separate window opens
  - reopen the menu → item is now **Bring back**; clicking it closes the window, shows the plugin in the main window, and moves the drawer selection
  - closing the popout window directly (× / Cmd+W) flips the item back to **Pop out**
  - switching sessions shows **Pop out** again for a session with no popout
  - Japanese UI language → 「ポップアウト表示」「ポップアウトを戻す」「有効化」「無効化」