### PR TITLE
Add MCP setup guidance to the Server settings

### DIFF
--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -56,6 +56,10 @@ The **Settings → Server** screen configures the debug WebSocket server and its
 The server status line shows the running ports, e.g. *Running on port 5080 (WSS: 5443)* when wss is
 active.
 
+The **MCP Server** section also offers copy-ready connection snippets — a `claude mcp add` command
+and a JSON config block, both carrying the port the MCP server is currently running on — plus a link
+to the [MCP Server](/guide/mcp-server) guide.
+
 ### SSL certificates
 
 To let agents connect over [wss](/guide/getting-started#secure-connections-wss), the host serves TLS

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -19,6 +19,10 @@ For example, to register it with Claude Code:
 claude mcp add --transport sse jetwhale http://localhost:7080/sse
 ```
 
+The host's **Settings → Server → MCP Server** section shows this command — and an equivalent JSON
+config block for other MCP clients — already filled in with the port the server is actually running
+on, ready to copy.
+
 ## Built-in tools
 
 | Tool | What it does |

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -62,6 +62,11 @@
     <string name="debug_server_port_apply_confirm_message">デバッグサーバーをポート %1$s で再起動しますか？</string>
     <string name="mcp_server_port_apply_confirm_title">MCPサーバーのポート変更を適用</string>
     <string name="mcp_server_port_apply_confirm_message">MCPサーバーをポート %1$s で再起動しますか？</string>
+    <string name="mcp_setup_note">以下の SSE エンドポイントを登録すると、AIエージェントからこのMCPサーバーに接続できます。</string>
+    <string name="mcp_setup_claude_code_label">Claude Code</string>
+    <string name="mcp_setup_json_label">JSON 設定</string>
+    <string name="mcp_setup_open_guide">セットアップガイドを開く</string>
+    <string name="copy_to_clipboard">コピー</string>
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">キャンセル</string>
     <string name="health_check">ヘルスチェック</string>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
@@ -62,6 +62,11 @@
     <string name="debug_server_port_apply_confirm_message">Restart Debug Server on port %1$s?</string>
     <string name="mcp_server_port_apply_confirm_title">Apply MCP Server Port Change</string>
     <string name="mcp_server_port_apply_confirm_message">Restart MCP Server on port %1$s?</string>
+    <string name="mcp_setup_note">Connect an AI agent to this MCP server by registering the SSE endpoint below.</string>
+    <string name="mcp_setup_claude_code_label">Claude Code</string>
+    <string name="mcp_setup_json_label">JSON config</string>
+    <string name="mcp_setup_open_guide">Open setup guide</string>
+    <string name="copy_to_clipboard">Copy</string>
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">Cancel</string>
     <string name="health_check">Health Check</string>

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreen.kt
@@ -2,16 +2,22 @@ package com.kitakkun.jetwhale.host.settings.server
 
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -19,11 +25,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.settings.Res
 import com.kitakkun.jetwhale.host.settings.SettingsScreenScaffoldPageContentPadding
 import com.kitakkun.jetwhale.host.settings.component.SettingOptionView
 import com.kitakkun.jetwhale.host.settings.component.TextFieldSettingsItemView
+import com.kitakkun.jetwhale.host.settings.copy_to_clipboard
 import com.kitakkun.jetwhale.host.settings.debug_server_label
 import com.kitakkun.jetwhale.host.settings.debug_server_port_apply_confirm_message
 import com.kitakkun.jetwhale.host.settings.debug_server_port_apply_confirm_title
@@ -34,6 +42,10 @@ import com.kitakkun.jetwhale.host.settings.mcp_server_label
 import com.kitakkun.jetwhale.host.settings.mcp_server_port_apply_confirm_message
 import com.kitakkun.jetwhale.host.settings.mcp_server_port_apply_confirm_title
 import com.kitakkun.jetwhale.host.settings.mcp_server_port_label
+import com.kitakkun.jetwhale.host.settings.mcp_setup_claude_code_label
+import com.kitakkun.jetwhale.host.settings.mcp_setup_json_label
+import com.kitakkun.jetwhale.host.settings.mcp_setup_note
+import com.kitakkun.jetwhale.host.settings.mcp_setup_open_guide
 import com.kitakkun.jetwhale.host.settings.server_configuration
 import com.kitakkun.jetwhale.host.settings.server_port_apply
 import com.kitakkun.jetwhale.host.settings.server_status_error
@@ -66,6 +78,7 @@ fun ServerSettingsScreen(
     onApplyMcpPortChange: () -> Unit,
     onConfirmApplyMcpPortChange: () -> Unit,
     onDismissApplyMcpPortDialog: () -> Unit,
+    onClickOpenMcpGuide: () -> Unit,
     onAddCertificate: () -> Unit,
     onSetActiveCertificate: (String) -> Unit,
     onDeleteCertificate: (String) -> Unit,
@@ -199,6 +212,23 @@ fun ServerSettingsScreen(
                         Text(stringResource(Res.string.server_port_apply))
                     }
                 }
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = stringResource(Res.string.mcp_setup_note),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                McpSnippetView(
+                    label = stringResource(Res.string.mcp_setup_claude_code_label),
+                    snippet = uiState.mcpClaudeCodeCommand,
+                )
+                McpSnippetView(
+                    label = stringResource(Res.string.mcp_setup_json_label),
+                    snippet = uiState.mcpJsonConfig,
+                )
+                OutlinedButton(onClick = onClickOpenMcpGuide) {
+                    Text(stringResource(Res.string.mcp_setup_open_guide))
+                }
             }
         }
         item {
@@ -247,6 +277,48 @@ fun ServerSettingsScreen(
                     Text(stringResource(Res.string.ssl_certificate_add))
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun McpSnippetView(
+    label: String,
+    snippet: String,
+) {
+    val clipboardManager = LocalClipboardManager.current
+    Spacer(Modifier.height(8.dp))
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = MaterialTheme.shapes.small,
+            ) {
+                SelectionContainer {
+                    Text(
+                        text = snippet,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .horizontalScroll(rememberScrollState()),
+                    )
+                }
+            }
+        }
+        TextButton(onClick = { clipboardManager.setText(AnnotatedString(snippet)) }) {
+            Text(stringResource(Res.string.copy_to_clipboard))
         }
     }
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenPresenter.kt
@@ -68,6 +68,18 @@ fun serverSettingsScreenPresenter(
     val isDebugPortValid by remember { derivedStateOf { parsedDebugPort != null && parsedDebugPort in 1..65535 } }
     val isMcpPortValid by remember { derivedStateOf { parsedMcpPort != null && parsedMcpPort in 1..65535 } }
 
+    // The snippets must describe the endpoint an agent can actually reach right now, so they follow
+    // the running server rather than the (possibly unapplied) port text field.
+    val runningMcpStatus by rememberUpdatedState(mcpServerStatus as? McpServerStatus.Running)
+    val savedMcpPort by rememberUpdatedState(debuggerSettings.mcpServerPort)
+    val mcpEndpointUrl by remember {
+        derivedStateOf {
+            val host = runningMcpStatus?.host ?: "localhost"
+            val port = runningMcpStatus?.port ?: savedMcpPort
+            "http://$host:$port/sse"
+        }
+    }
+
     LaunchedEffect(serverStatus) {
         if (serverStatus is DebugWebSocketServerStatus.Started) {
             editingDebugPortText = serverStatus.port.toString()
@@ -183,6 +195,17 @@ fun serverSettingsScreenPresenter(
         },
         editingDebugPortText = editingDebugPortText,
         editingMcpPortText = editingMcpPortText,
+        mcpClaudeCodeCommand = "claude mcp add --transport sse jetwhale $mcpEndpointUrl",
+        mcpJsonConfig = """
+            {
+              "mcpServers": {
+                "jetwhale": {
+                  "type": "sse",
+                  "url": "$mcpEndpointUrl"
+                }
+              }
+            }
+        """.trimIndent(),
         isDebugApplyVisible = isDebugDirty,
         isMcpApplyVisible = isMcpDirty,
         isDebugApplyEnabled = isDebugPortValid && isDebugDirty,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenRoot.kt
@@ -5,6 +5,9 @@ import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.settings.SettingsScreenContext
 import soil.query.compose.rememberSubscription
+import java.awt.Desktop
+
+private const val MCP_GUIDE_URL = "https://kitakkun.github.io/JetWhale/guide/mcp-server"
 
 @Composable
 context(screenContext: SettingsScreenContext)
@@ -51,6 +54,13 @@ fun ServerSettingsScreenRoot() {
             },
             onDismissApplyMcpPortDialog = {
                 screenChannel.send(ServerSettingsScreenAction.DismissApplyMcpPortDialog)
+            },
+            onClickOpenMcpGuide = {
+                try {
+                    Desktop.getDesktop().browse(java.net.URI(MCP_GUIDE_URL))
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
             },
             onAddCertificate = {
                 screenChannel.send(ServerSettingsScreenAction.AddCertificate)

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenUiState.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenUiState.kt
@@ -5,6 +5,8 @@ data class ServerSettingsScreenUiState(
     val mcpServerState: ServerState,
     val editingDebugPortText: String,
     val editingMcpPortText: String,
+    val mcpClaudeCodeCommand: String,
+    val mcpJsonConfig: String,
     val isDebugApplyVisible: Boolean,
     val isMcpApplyVisible: Boolean,
     val isDebugApplyEnabled: Boolean,


### PR DESCRIPTION
## Why

The **Settings → Server → MCP Server** section only showed a status line and a port field. Nothing in the app told you how to actually connect an AI agent — the `claude mcp add` command lived only in `docs/guide/mcp-server.md`, hardcoded to the default port `7080`, so anyone running on a different port had to hand-edit it.

## What

The MCP Server section now carries the setup guidance:

- **Copy-ready snippets** — a `claude mcp add --transport sse ...` command and an equivalent JSON config block for other MCP clients, both filled in with the port the MCP server is actually running on. Each has a Copy button, and the text is selectable so a URL or port can be picked out without copying the whole block.
- **Open setup guide** — opens https://kitakkun.github.io/JetWhale/guide/mcp-server in the browser, following the same `Desktop.getDesktop().browse` pattern as *Open Download Page* in the General settings.

The snippets are derived from `McpServerStatus.Running` and fall back to the saved setting when the server is not up, so they follow the running server rather than the (possibly unapplied) port text field — an endpoint that is not reachable yet is never advertised.

Strings were added to both `values/` and `values-ja/`. `docs/guide/mcp-server.md` and `docs/guide/host-settings.md` now mention that the snippets can be copied from the app.

## Out of scope

- An enable/disable toggle for the MCP server (it currently always starts with the host).
- Copy-completion feedback — the existing SSL certificate copy has none either, so this stays consistent.
- The SSL certificate PEM dialog, which has the same "copy button but unselectable text" shape.

## Verification

- `./gradlew :jetwhale-host:feature:settings:compileKotlin spotlessCheck` passes.
- **Not yet verified visually.** The host's own window is outside the reach of the built-in MCP tools (they take `sessionId` + `pluginId` and drive plugin scenes only), so the rendered layout — long command wrapping, ja string fit — still needs a human look.