### PR TITLE
Allow retrying a failed server start on the same port

### DIFF
--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -117,6 +117,12 @@ class DefaultMcpServerService(
         } catch (e: Exception) {
             server.stop(gracePeriodMillis = 0, timeoutMillis = 0)
             ktorServer = null
+            // stop() bails out early once running is false, so a failed start has to undo the
+            // observer job and the tool registrations itself or a later retry piles another
+            // collector on top of the one this attempt leaked.
+            lifecycleObserverJob?.cancel()
+            lifecycleObserverJob = null
+            toolRegistry.clear()
             running.set(false)
             _statusFlow.value = McpServerStatus.Error(e.message ?: "Unknown error")
         }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -27,6 +27,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -114,18 +115,30 @@ class DefaultMcpServerService(
         try {
             server.start(wait = false)
             _statusFlow.value = McpServerStatus.Running(host = host, port = port)
-        } catch (e: Exception) {
-            server.stop(gracePeriodMillis = 0, timeoutMillis = 0)
-            ktorServer = null
-            // stop() bails out early once running is false, so a failed start has to undo the
-            // observer job and the tool registrations itself or a later retry piles another
-            // collector on top of the one this attempt leaked.
-            lifecycleObserverJob?.cancel()
-            lifecycleObserverJob = null
-            toolRegistry.clear()
-            running.set(false)
+        } catch (e: CancellationException) {
+            // Never swallow cancellation: undo this attempt, then re-throw so the coroutine
+            // cancellation mechanism keeps working. The status stays untouched — the caller went
+            // away, the server did not fail.
+            rollbackFailedStart(server)
+            throw e
+        } catch (e: Throwable) {
+            rollbackFailedStart(server)
             _statusFlow.value = McpServerStatus.Error(e.message ?: "Unknown error")
         }
+    }
+
+    /**
+     * Undoes everything [start] set up before the bind attempt. [stop] bails out early once
+     * [running] is false, so a failed start has to release the observer job and the tool
+     * registrations itself or a later retry piles another collector on top of the leaked one.
+     */
+    private suspend fun rollbackFailedStart(server: EmbeddedServer<*, *>) {
+        server.stop(gracePeriodMillis = 0, timeoutMillis = 0)
+        ktorServer = null
+        lifecycleObserverJob?.cancel()
+        lifecycleObserverJob = null
+        toolRegistry.clear()
+        running.set(false)
     }
 
     override suspend fun stop() {

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.host.mcp
 
 import com.kitakkun.jetwhale.host.model.LoadedPluginInstance
+import com.kitakkun.jetwhale.host.model.McpServerStatus
 import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
@@ -42,6 +43,14 @@ class DefaultMcpServerServiceTest {
 
     private val host = "localhost"
     private val port = java.net.ServerSocket(0).use { it.localPort }
+
+    /**
+     * Holds [port] (0 picks a free one) on the loopback address specifically. A wildcard-bound
+     * `ServerSocket(0)` would not do: BSD-derived systems let a SO_REUSEADDR socket bind
+     * 127.0.0.1:p over an existing 0.0.0.0:p, so the server would start just fine and the test
+     * would silently stop testing the failure path.
+     */
+    private fun occupyPort(port: Int = 0): java.net.ServerSocket = java.net.ServerSocket(port, 50, java.net.InetAddress.getByName(host))
 
     @Test
     fun `listTools returns all registered built-in tools`() = runBlocking {
@@ -95,6 +104,66 @@ class DefaultMcpServerServiceTest {
         service.start(host, port) // second call should be no-op
         service.stop()
         service.stop() // second call should be no-op
+    }
+
+    @Test
+    fun `start on an occupied port reports Error`() = runBlocking {
+        occupyPort().use { occupied ->
+            service.start(host, occupied.localPort)
+            val status = service.statusFlow.value
+            assertTrue(status is McpServerStatus.Error, "Expected Error but was $status")
+        }
+    }
+
+    @Test
+    fun `a failed start can be retried on the same port once it frees up`() = runBlocking {
+        val contestedPort = occupyPort().use { it.localPort }
+
+        occupyPort(contestedPort).use {
+            service.start(host, contestedPort)
+            assertTrue(service.statusFlow.value is McpServerStatus.Error)
+        }
+
+        // The port is free again; retrying must not be blocked by the leftovers of the failed
+        // attempt (notably the `running` flag it had already flipped).
+        service.start(host, contestedPort)
+        try {
+            assertEquals(McpServerStatus.Running(host, contestedPort), service.statusFlow.value)
+        } finally {
+            service.stop()
+        }
+    }
+
+    @OptIn(ExperimentalJetWhaleApi::class)
+    @Test
+    fun `plugin tools registered by a failed start do not survive into the next start`() = runBlocking {
+        val testPluginId = "com.example.test"
+        val testSessionId = "test-session-failed-start"
+        every { pluginInstanceService.getLoadedPluginInstances() } returns listOf(
+            LoadedPluginInstance(testPluginId, testSessionId, FakeMcpCapablePlugin()),
+        )
+
+        occupyPort().use { occupied ->
+            service.start(host, occupied.localPort)
+            assertTrue(service.statusFlow.value is McpServerStatus.Error)
+        }
+
+        // No plugin instances remain loaded, so the tools the failed attempt registered must have
+        // been cleared rather than carried over.
+        every { pluginInstanceService.getLoadedPluginInstances() } returns emptyList()
+
+        service.start(host, port)
+        try {
+            val client = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$port/sse")
+            try {
+                val toolNames = client.listTools().tools.map { it.name }
+                assertFalse("com.example.test.greet" in toolNames, "Stale tool survived in $toolNames")
+            } finally {
+                client.close()
+            }
+        } finally {
+            service.stop()
+        }
     }
 
     @OptIn(ExperimentalJetWhaleApi::class)

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -56,6 +56,7 @@
     <string name="debug_server_port_label">デバッグサーバーポート</string>
     <string name="mcp_server_port_label">MCPサーバーポート</string>
     <string name="server_port_apply">適用</string>
+    <string name="server_start_retry">再試行</string>
     <string name="server_port_apply_confirm_title">ポート変更の適用</string>
     <string name="server_port_apply_confirm_message">ポート %1$s でサーバーを再起動しますか？</string>
     <string name="debug_server_port_apply_confirm_title">デバッグサーバーのポート変更を適用</string>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="debug_server_port_label">Debug Server Port</string>
     <string name="mcp_server_port_label">MCP Server Port</string>
     <string name="server_port_apply">Apply</string>
+    <string name="server_start_retry">Retry</string>
     <string name="server_port_apply_confirm_title">Apply Port Change</string>
     <string name="server_port_apply_confirm_message">Restart server on port %1$s?</string>
     <string name="debug_server_port_apply_confirm_title">Apply Debug Server Port Change</string>

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreen.kt
@@ -48,6 +48,7 @@ import com.kitakkun.jetwhale.host.settings.mcp_setup_note
 import com.kitakkun.jetwhale.host.settings.mcp_setup_open_guide
 import com.kitakkun.jetwhale.host.settings.server_configuration
 import com.kitakkun.jetwhale.host.settings.server_port_apply
+import com.kitakkun.jetwhale.host.settings.server_start_retry
 import com.kitakkun.jetwhale.host.settings.server_status_error
 import com.kitakkun.jetwhale.host.settings.server_status_running
 import com.kitakkun.jetwhale.host.settings.server_status_running_with_wss
@@ -187,7 +188,7 @@ fun ServerSettingsScreen(
                         onClick = onApplyDebugPortChange,
                         enabled = uiState.isDebugApplyEnabled,
                     ) {
-                        Text(stringResource(Res.string.server_port_apply))
+                        Text(applyButtonText(isRetry = uiState.isDebugRetry))
                     }
                 }
             }
@@ -209,7 +210,7 @@ fun ServerSettingsScreen(
                         onClick = onApplyMcpPortChange,
                         enabled = uiState.isMcpApplyEnabled,
                     ) {
-                        Text(stringResource(Res.string.server_port_apply))
+                        Text(applyButtonText(isRetry = uiState.isMcpRetry))
                     }
                 }
                 Spacer(Modifier.height(12.dp))
@@ -321,6 +322,13 @@ private fun McpSnippetView(
             Text(stringResource(Res.string.copy_to_clipboard))
         }
     }
+}
+
+@Composable
+private fun applyButtonText(isRetry: Boolean): String = if (isRetry) {
+    stringResource(Res.string.server_start_retry)
+} else {
+    stringResource(Res.string.server_port_apply)
 }
 
 @Composable

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenPresenter.kt
@@ -68,6 +68,11 @@ fun serverSettingsScreenPresenter(
     val isDebugPortValid by remember { derivedStateOf { parsedDebugPort != null && parsedDebugPort in 1..65535 } }
     val isMcpPortValid by remember { derivedStateOf { parsedMcpPort != null && parsedMcpPort in 1..65535 } }
 
+    // A failed start leaves the port setting untouched, so gating the button on dirtiness alone
+    // would make retrying the same port impossible without editing it away and back again.
+    val isDebugStartFailed by rememberUpdatedState(serverStatus is DebugWebSocketServerStatus.Error)
+    val isMcpStartFailed by rememberUpdatedState(mcpServerStatus is McpServerStatus.Error)
+
     // The snippets must describe the endpoint an agent can actually reach right now, so they follow
     // the running server rather than the (possibly unapplied) port text field.
     val runningMcpStatus by rememberUpdatedState(mcpServerStatus as? McpServerStatus.Running)
@@ -99,8 +104,13 @@ fun serverSettingsScreenPresenter(
             }
 
             ServerSettingsScreenAction.ApplyDebugPortChange -> {
-                if (isDebugPortValid && isDebugDirty) {
-                    showDebugApplyConfirmDialog = true
+                if (!isDebugPortValid) return@ActionEffect
+                when {
+                    isDebugDirty -> showDebugApplyConfirmDialog = true
+
+                    // Nothing is listening after a failed start, so there are no connected clients
+                    // a restart could disrupt — retry without asking.
+                    isDebugStartFailed -> debugPortMutation.mutateAsync(parsedDebugPort ?: return@ActionEffect)
                 }
             }
 
@@ -120,8 +130,10 @@ fun serverSettingsScreenPresenter(
             }
 
             ServerSettingsScreenAction.ApplyMcpPortChange -> {
-                if (isMcpPortValid && isMcpDirty) {
-                    showMcpApplyConfirmDialog = true
+                if (!isMcpPortValid) return@ActionEffect
+                when {
+                    isMcpDirty -> showMcpApplyConfirmDialog = true
+                    isMcpStartFailed -> mcpPortMutation.mutateAsync(parsedMcpPort ?: return@ActionEffect)
                 }
             }
 
@@ -206,10 +218,12 @@ fun serverSettingsScreenPresenter(
               }
             }
         """.trimIndent(),
-        isDebugApplyVisible = isDebugDirty,
-        isMcpApplyVisible = isMcpDirty,
-        isDebugApplyEnabled = isDebugPortValid && isDebugDirty,
-        isMcpApplyEnabled = isMcpPortValid && isMcpDirty,
+        isDebugApplyVisible = isDebugDirty || isDebugStartFailed,
+        isMcpApplyVisible = isMcpDirty || isMcpStartFailed,
+        isDebugApplyEnabled = isDebugPortValid && (isDebugDirty || isDebugStartFailed),
+        isMcpApplyEnabled = isMcpPortValid && (isMcpDirty || isMcpStartFailed),
+        isDebugRetry = isDebugStartFailed && !isDebugDirty,
+        isMcpRetry = isMcpStartFailed && !isMcpDirty,
         showDebugApplyConfirmDialog = showDebugApplyConfirmDialog,
         showMcpApplyConfirmDialog = showMcpApplyConfirmDialog,
         certificates = certificates,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenUiState.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenUiState.kt
@@ -11,6 +11,8 @@ data class ServerSettingsScreenUiState(
     val isMcpApplyVisible: Boolean,
     val isDebugApplyEnabled: Boolean,
     val isMcpApplyEnabled: Boolean,
+    val isDebugRetry: Boolean,
+    val isMcpRetry: Boolean,
     val showDebugApplyConfirmDialog: Boolean,
     val showMcpApplyConfirmDialog: Boolean,
     val certificates: List<CertificateUiEntry>,


### PR DESCRIPTION
Follows #183 (already merged), so the diff here is just the retry fix.

## The problem

The Apply button in **Settings → Server** was gated on the port text being dirty:

```kotlin
isMcpApplyVisible = isMcpDirty
```

A failed start leaves the port *setting* untouched, so an `Error` state never makes the field dirty and the button stays hidden. Retrying the same port meant typing a different port, starting, typing the original back, and starting again.

## The fix

- The button shows whenever the port changed **or** the last start failed, for both the debug server and the MCP server.
- When the port is unchanged it reads **Retry** and mutates straight away, with no confirmation dialog. The dialog exists to warn that a restart drops connected clients — after a failed start nothing is listening, so there is nothing to warn about.
- `isDebugStartFailed` / `isMcpStartFailed` go through `rememberUpdatedState`. `ActionEffect` is a `LaunchedEffect(screenChannel)`, so its block captures values once; a plain `val` would be read stale inside the action handler. This matches how `savedDebugPortText` is already handled.

## Also in here

`DefaultMcpServerService.start()` launched the plugin-lifecycle observer job and registered plugin tools before binding, but its `catch` only reset `running` and the status. `stop()` early-returns once `running` is false, so nobody ever cancelled that job — each failed start leaked a collector, and every retry stacked another one on top. The failure path now cancels the job and clears the tool registry itself.

This was easy to ignore while retrying was awkward; it is worth closing now that retry becomes a normal action.

## Verification

- `./gradlew :jetwhale-host:feature:settings:compileKotlin :jetwhale-host:core:mcp:test spotlessCheck` passes.
- Checked soil's `shouldMutate` in the 1.0.0-alpha15 sources: `isOneShot` and `isStrictMode` both default to false, leaving `!state.isPending`. Calling `mutateAsync` again with the same port is therefore not deduplicated — the whole fix depends on that, so it seemed worth confirming rather than assuming.
- **The failure path has not been exercised in the running app.** Occupying the port before launching the host is the quickest way to reproduce it if someone wants to check the rendered states by hand.