### PR TITLE
feat(tools): add a headless QA agent that can drive any host plugin

### DIFF
--- a/.claude/skills/plugin-qa/SKILL.md
+++ b/.claude/skills/plugin-qa/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: plugin-qa
+description: Drive a JetWhale host plugin's real UI from an agent — launch the host, then click/drag/type/screenshot the plugin through the host's own MCP server to verify layout, gestures, persisted state, and restart restore.
+---
+
+# Plugin QA
+
+How to verify a host plugin's UI **for real** instead of stopping at "it compiles and the unit
+tests pass". The host exposes an MCP server whose tools operate on a plugin's Compose scene, so an
+agent can drive the actual UI and look at the result.
+
+The key property: `PluginComposeSceneService.getOrCreatePluginScene(pluginId, sessionId)` creates
+the scene **on demand**, independent of what the host window is displaying. You never navigate the
+host UI, and you never steal the window from whoever is using it.
+
+## 1. Scope — what this can and cannot verify
+
+Can:
+
+- layout and rendering (screenshot), at a chosen viewport
+- gestures: click, drag, scroll, typing, and the state changes they cause
+- the Compose semantics tree (`getAccessibilityTree`) for locating elements
+- persisted plugin state, and whether it survives a host restart
+- the plugin's own contributed MCP tools
+
+Cannot:
+
+- **anything in the host shell** — settings, session switching, plugin install/enable, navigation,
+  popout windows. Every tool is scoped to `pluginId` + `sessionId`; no host-control tool exists.
+- the mouse cursor's appearance. An AWT cursor is not part of the rendered scene, so
+  `Modifier.pointerHoverIcon` results never show up in a screenshot. Cover that with a unit test
+  (see §6) and say plainly that the visual was not verified.
+- native window chrome, real DPI switching, multi-window behaviour.
+
+## 2. Launch the host
+
+```bash
+./gradlew :jetwhale-plugins:<plugin>:host:runJetWhaleLocal
+```
+
+- Run it in the **background, redirected to a file** (`> run.log 2>&1`). Do NOT pipe it through
+  `tail`/`grep`: the pipeline buffers and the log file stays empty until the process exits, so you
+  lose all live output.
+- Wait for it properly — Gradle configuration plus the app launch takes minutes on a cold build:
+  ```bash
+  until pgrep -f com.kitakkun.jetwhale.host.MainKt >/dev/null; do sleep 3; done
+  ```
+- App data lives in an isolated sandbox, `<module>/build/jetwhale-sandbox`, not the developer's
+  `~/.jetwhale`. **`clean` wipes it** — never clean between the save and restore halves of a
+  persistence check.
+- The plugin is staged to `<module>/build/jetwhale/devPlugins` and hot-reloaded from there.
+
+Every UI tool needs a `sessionId`, which means a connected debuggee. `./gradlew :demo:desktop:run`
+is the cheapest source; the Android / iOS / web demos under `demo/` work too. If
+`jetwhale.listSessions` comes back empty, nothing is connected — start a demo app first.
+
+## 3. Reaching the tools
+
+The host's MCP server is SSE on `http://localhost:7080/sse`, with **no authentication**. Register
+it and the tools arrive natively as `mcp__jetwhale__*` — no client script needed. `.mcp.json` is
+gitignored (`.gitignore:7`), so each developer creates their own:
+
+```json
+{
+  "mcpServers": {
+    "jetwhale": { "type": "sse", "url": "http://localhost:7080/sse" }
+  }
+}
+```
+
+The catch: MCP servers connect when the session starts, and this workflow **launches the host
+mid-session**. If the tools are missing or stale, reconnect with `/mcp` after the host is up. Tool
+lists are also per-session — a plugin's own tools only register once its instance is live, so
+reconnect after connecting a debuggee if you expect `<pluginId>.*` tools.
+
+If reconnecting is not an option (say, a headless run), the same server is reachable over plain
+HTTP: open `GET /sse`, take the `endpoint` event's path, and POST JSON-RPC to it.
+
+| Tool | Purpose |
+|---|---|
+| `jetwhale.listSessions` / `jetwhale.listPlugins` | discovery (read-only) |
+| `jetwhale.screenshot` | render the plugin scene to PNG |
+| `jetwhale.click` / `jetwhale.drag` / `jetwhale.scroll` | pointer input |
+| `jetwhale.type` | text and special keys |
+| `jetwhale.getAccessibilityTree` | semantics tree; use it to find coordinates |
+| `<pluginId>.*` | tools the plugin itself contributes |
+
+Always `Read` the screenshot afterwards. A screenshot you never open verifies nothing.
+
+## 4. Coordinates and density — the expensive gotcha
+
+- `click` / `drag` / `scroll` coordinates are in the **same pixel space as the screenshot**, so
+  read positions off the image you just captured.
+- `width` / `height` on `screenshot` are **pixels**, and `resolveViewport` keeps the scene's own
+  density (`ScreenshotTool.kt:123`). That density comes from the host window — **2.0 on a Retina
+  Mac, not 1.0**. So a 1280x720 request renders 640x360 **dp**, and a 240dp minimum width lands at
+  480px. Never assume 1 px = 1 dp.
+- Passing `width`/`height` **resizes the live scene** (`applyViewport` writes `composeScene.size`)
+  — the very scene the host window is showing. Omit both to capture at the current size unless a
+  fixed viewport is the point.
+- Prefer asserting **relationships** — "the left pane grew", "the divider stopped moving" — over
+  absolute pixel values, which depend on the machine's density.
+
+## 5. Verifying persisted state
+
+`rememberPersistent` writes to:
+
+```
+<module>/build/jetwhale-sandbox/plugin-data/<pluginId>/store.json
+```
+
+- Writes are **debounced 300 ms** (`RememberPersistent.kt`), so sleep 1–2 s after the interaction
+  before reading the file.
+- Restart restore is a real check and worth doing: kill the host, relaunch, screenshot, and
+  confirm the UI comes back at the persisted value rather than the coded default. **Wait for the
+  loading spinner to clear** — the first frames after restart are a spinner, not your UI.
+
+## 6. Prefer a regression test to a one-off check
+
+If the behaviour can be pinned in a unit test, add the test as well — a manual MCP pass proves it
+worked once, on one machine. Scene-level test infrastructure already exists:
+`jetwhale-host/core/mcp/src/test/kotlin/.../TestSceneFactory.kt` (`createTestScene`,
+`renderTestScene`) plus the `dispatchClick` / `dispatchDrag` / `dispatchScroll` helpers.
+
+Mutation-check every new test: break the production code, confirm the test fails, restore. A test
+that passes both ways is worse than no test.
+
+## 7. Reporting
+
+State separately what was **driven and observed**, what was covered by **tests**, and what was
+**not verified** (§1 lists the usual suspects). Do not let a green build imply the UI was seen.

--- a/.claude/skills/plugin-qa/SKILL.md
+++ b/.claude/skills/plugin-qa/SKILL.md
@@ -57,20 +57,47 @@ they only fire the handful of requests their buttons are wired to, and **a GUI a
 from an agent at all** — MCP reaches plugin scenes, never a debuggee.
 
 Use the headless QA agent instead. It connects as an ordinary session and exposes a control API, so
-any request can be injected on demand:
+messages can be injected on demand. Name the plugin ids it should impersonate:
 
 ```bash
-./gradlew :tools:qa-agent:run            # background it; keeps the session alive
+# in this repository
+./gradlew :tools:qa-agent:run --args="--plugin com.example.myplugin"
 
-curl -s 127.0.0.1:7100/fire -H 'Content-Type: application/json' \
-  -d '{"method":"GET","url":"https://example.com/items?page=2"}'
+# from a plugin's own repository (jetwhalePlugin.hostVersion decides the agent version)
+./gradlew runJetWhaleQaAgent -PjetwhaleQaAgentArgs="--plugin com.example.myplugin"
 ```
+
+Background it — it holds the session open for as long as it runs.
+
+**Driving the plugin.** `/send` and `/request` speak the messenger's raw layer, so the agent needs no
+compile-time knowledge of the plugin. `messageType` is the payload class's `serialName` (its
+fully-qualified name unless it carries `@SerialName`), and `payload` is that class as JSON:
+
+```bash
+curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' -d '{
+  "pluginId": "com.example.myplugin",
+  "messageType": "com.example.myplugin.protocol.ItemAdded",
+  "payload": {"id": 1, "label": "hello"}
+}'
+```
+
+`/request` takes the same shape plus an optional `timeoutMs` and returns the host's reply. Get the
+`serialName` wrong and the host reports no registered handler — check it against the plugin's
+protocol module rather than guessing.
+
+**This is send-only.** Inbound handlers resolve their serializer from a reified type parameter
+(`onEvent<E>` / `onRequest<REQ, R>`), so there is no raw shape to register a catch-all against: a
+plugin whose flow depends on the *host* requesting the agent (the Network Inspector's mock replies,
+for one) cannot be answered from here. Drive those from the plugin's own MCP tools instead.
 
 - Use **`127.0.0.1`, not `localhost`** — the control API binds loopback IPv4 only, and `localhost`
   can resolve to `::1` first and get connection-refused.
 - It shows up as `appName: qa-agent` / `QA Agent (headless)`, so it is never mistaken for a real
   device. Its `sessionId` is its own — mock rules and transactions are per session.
-- `POST /shutdown` stops it; `GET /health` is a readiness probe worth polling before firing.
+- `GET /plugins` lists what it is impersonating; `GET /health` is a readiness probe worth polling
+  before sending; `POST /shutdown` stops it.
+- `POST /fire` (`{"method":"GET","url":"…"}`) injects real HTTP traffic for the bundled Network
+  Inspector — the one plugin-specific shortcut, and it needs no `--plugin`.
 - On startup the agent logs a failed plain-HTTP CA fetch followed by a successful HTTPS one. That
   is the trust-on-first-use probe, not an error.
 

--- a/.claude/skills/plugin-qa/SKILL.md
+++ b/.claude/skills/plugin-qa/SKILL.md
@@ -60,14 +60,26 @@ Use the headless QA agent instead. It connects as an ordinary session and expose
 messages can be injected on demand. Name the plugin ids it should impersonate:
 
 ```bash
-# in this repository
-./gradlew :tools:qa-agent:run --args="--plugin com.example.myplugin"
+# in this repository, from the plugin module
+./gradlew :jetwhale-plugins:<plugin>:host:runJetWhaleQaAgentLocal \
+  -PjetwhaleQaAgentArgs="--plugin com.example.myplugin"
 
 # from a plugin's own repository (jetwhalePlugin.hostVersion decides the agent version)
 ./gradlew runJetWhaleQaAgent -PjetwhaleQaAgentArgs="--plugin com.example.myplugin"
 ```
 
-Background it — it holds the session open for as long as it runs.
+Background it — it holds the session open for as long as it runs. (`./gradlew :tools:qa-agent:run
+--args="…"` runs the same binary without going through a plugin module.)
+
+**Wait for readiness, and read it when a send fails.** The control API answers well before the debug
+session is up, so a send right after the port opens is dropped. Poll `GET /health` until
+`"ready": true`. When a send does come back `"sent": false`, its `hint` and `GET /plugins` separate
+the two situations:
+
+| `/plugins` | meaning |
+|---|---|
+| `"activated": false` | the host has **not enabled this plugin id** — waiting will not help; enable it in the host, or check the id |
+| `"activated": true, "ready": false` | connected, still preparing — keep polling |
 
 **Driving the plugin.** `/send` and `/request` speak the messenger's raw layer, so the agent needs no
 compile-time knowledge of the plugin. `messageType` is the payload class's `serialName` (its
@@ -94,8 +106,8 @@ for one) cannot be answered from here. Drive those from the plugin's own MCP too
   can resolve to `::1` first and get connection-refused.
 - It shows up as `appName: qa-agent` / `QA Agent (headless)`, so it is never mistaken for a real
   device. Its `sessionId` is its own — mock rules and transactions are per session.
-- `GET /plugins` lists what it is impersonating; `GET /health` is a readiness probe worth polling
-  before sending; `POST /shutdown` stops it.
+- `GET /plugins` lists what it is impersonating, with each one's `activated` / `ready` state;
+  `POST /shutdown` stops it.
 - `POST /fire` (`{"method":"GET","url":"…"}`) injects real HTTP traffic for the bundled Network
   Inspector — the one plugin-specific shortcut, and it needs no `--plugin`.
 - On startup the agent logs a failed plain-HTTP CA fetch followed by a successful HTTPS one. That

--- a/.claude/skills/plugin-qa/SKILL.md
+++ b/.claude/skills/plugin-qa/SKILL.md
@@ -29,7 +29,7 @@ Cannot:
   popout windows. Every tool is scoped to `pluginId` + `sessionId`; no host-control tool exists.
 - the mouse cursor's appearance. An AWT cursor is not part of the rendered scene, so
   `Modifier.pointerHoverIcon` results never show up in a screenshot. Cover that with a unit test
-  (see §6) and say plainly that the visual was not verified.
+  (see §7) and say plainly that the visual was not verified.
 - native window chrome, real DPI switching, multi-window behaviour.
 
 ## 2. Launch the host
@@ -50,11 +50,33 @@ Cannot:
   persistence check.
 - The plugin is staged to `<module>/build/jetwhale/devPlugins` and hot-reloaded from there.
 
-Every UI tool needs a `sessionId`, which means a connected debuggee. `./gradlew :demo:desktop:run`
-is the cheapest source; the Android / iOS / web demos under `demo/` work too. If
-`jetwhale.listSessions` comes back empty, nothing is connected — start a demo app first.
+## 3. Get a debuggee you can actually drive
 
-## 3. Reaching the tools
+Every UI tool needs a `sessionId`, which means a connected debuggee. The demo apps are a poor fit:
+they only fire the handful of requests their buttons are wired to, and **a GUI app cannot be driven
+from an agent at all** — MCP reaches plugin scenes, never a debuggee.
+
+Use the headless QA agent instead. It connects as an ordinary session and exposes a control API, so
+any request can be injected on demand:
+
+```bash
+./gradlew :tools:qa-agent:run            # background it; keeps the session alive
+
+curl -s 127.0.0.1:7100/fire -H 'Content-Type: application/json' \
+  -d '{"method":"GET","url":"https://example.com/items?page=2"}'
+```
+
+- Use **`127.0.0.1`, not `localhost`** — the control API binds loopback IPv4 only, and `localhost`
+  can resolve to `::1` first and get connection-refused.
+- It shows up as `appName: qa-agent` / `QA Agent (headless)`, so it is never mistaken for a real
+  device. Its `sessionId` is its own — mock rules and transactions are per session.
+- `POST /shutdown` stops it; `GET /health` is a readiness probe worth polling before firing.
+- On startup the agent logs a failed plain-HTTP CA fetch followed by a successful HTTPS one. That
+  is the trust-on-first-use probe, not an error.
+
+`./gradlew :demo:desktop:run` still works when you specifically want the demo's own fixed requests.
+
+## 4. Reaching the tools
 
 The host's MCP server is SSE on `http://localhost:7080/sse`, with **no authentication**. Register
 it and the tools arrive natively as `mcp__jetwhale__*` — no client script needed. `.mcp.json` is
@@ -87,21 +109,26 @@ HTTP: open `GET /sse`, take the `endpoint` event's path, and POST JSON-RPC to it
 
 Always `Read` the screenshot afterwards. A screenshot you never open verifies nothing.
 
-## 4. Coordinates and density — the expensive gotcha
+## 5. Coordinates and density — the expensive gotcha
 
 - `click` / `drag` / `scroll` coordinates are in the **same pixel space as the screenshot**, so
   read positions off the image you just captured.
-- `width` / `height` on `screenshot` are **pixels**, and `resolveViewport` keeps the scene's own
-  density (`ScreenshotTool.kt:123`). That density comes from the host window — **2.0 on a Retina
-  Mac, not 1.0**. So a 1280x720 request renders 640x360 **dp**, and a 240dp minimum width lands at
-  480px. Never assume 1 px = 1 dp.
-- Passing `width`/`height` **resizes the live scene** (`applyViewport` writes `composeScene.size`)
-  — the very scene the host window is showing. Omit both to capture at the current size unless a
-  fixed viewport is the point.
+- `width` / `height` on `screenshot` are **pixels**, and the scene renders at the host window's
+  density — 2.0 on a Retina Mac, so a 240dp minimum width measures 480px. That holds even for a
+  scene the tool created on demand and the window never displayed: it is seeded with the window's
+  density (`PluginComposeSceneService.updateHostDensity`). Never assume 1 px = 1 dp.
+- A pixel landmark is therefore only portable if you **pin the density**: `screenshot` takes a
+  `density` argument (`ScreenshotTool.kt:52`) — pass `2` and the geometry is identical on any
+  machine. Omit it to inherit whatever the window is at. Values that are not finite and > 0 are
+  rejected.
+- Passing `width`/`height`/`density` **mutates the live scene** — `applyViewport` writes
+  `composeScene.density` and `composeScene.size` (`McpViewportUtils.kt:37`) on the very scene the
+  host window is showing, and it keeps rendering that way until the window next resizes. Omit them
+  to capture as-is unless a fixed viewport is the point.
 - Prefer asserting **relationships** — "the left pane grew", "the divider stopped moving" — over
-  absolute pixel values, which depend on the machine's density.
+  absolute pixel values.
 
-## 5. Verifying persisted state
+## 6. Verifying persisted state
 
 `rememberPersistent` writes to:
 
@@ -115,17 +142,18 @@ Always `Read` the screenshot afterwards. A screenshot you never open verifies no
   confirm the UI comes back at the persisted value rather than the coded default. **Wait for the
   loading spinner to clear** — the first frames after restart are a spinner, not your UI.
 
-## 6. Prefer a regression test to a one-off check
+## 7. Prefer a regression test to a one-off check
 
 If the behaviour can be pinned in a unit test, add the test as well — a manual MCP pass proves it
 worked once, on one machine. Scene-level test infrastructure already exists:
 `jetwhale-host/core/mcp/src/test/kotlin/.../TestSceneFactory.kt` (`createTestScene`,
-`renderTestScene`) plus the `dispatchClick` / `dispatchDrag` / `dispatchScroll` helpers.
+`renderTestScene`), driven with the `dispatchClick` / `dispatchDrag` / `dispatchScroll` helpers the
+tools themselves expose (`ClickTool.kt`, `DragTool.kt`, `ScrollTool.kt`).
 
 Mutation-check every new test: break the production code, confirm the test fails, restore. A test
 that passes both ways is worse than no test.
 
-## 7. Reporting
+## 8. Reporting
 
 State separately what was **driven and observed**, what was covered by **tests**, and what was
 **not verified** (§1 lists the usual suspects). Do not let a green build imply the UI was seen.

--- a/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/jetwhale-host-launch.gradle.kts
@@ -4,9 +4,10 @@ import org.gradle.process.CommandLineArgumentProvider
  * In-repo-only companion to the published `com.kitakkun.jetwhale.host` plugin.
  *
  * Adds `runJetWhaleLocal`, which launches the locally built host project (`:jetwhale-host:app`) with
- * this plugin staged for hot reload. It lives here, and is NOT published, because it depends on the
- * JetWhale repository's own host project — which external plugin authors don't have. They use
- * `runJetWhale` from the published plugin instead.
+ * this plugin staged for hot reload, and `runJetWhaleQaAgentLocal`, which runs the locally built QA
+ * agent (`:tools:qa-agent`) against it. Both live here, and are NOT published, because they depend on
+ * this repository's own projects — which external plugin authors don't have. They use `runJetWhale`
+ * and `runJetWhaleQaAgent` from the published plugin instead, which resolve released artifacts.
  *
  * Apply this alongside `com.kitakkun.jetwhale.host`: it reuses that plugin's `stageDevPlugin` task and its
  * dev plugins directory.
@@ -61,6 +62,31 @@ tasks.register<JavaExec>("runJetWhaleLocal") {
                 // can only be set via -Xdock:name at launch — it is not settable at runtime.
                 if (osName.getOrElse("").contains("mac", ignoreCase = true)) add("-Xdock:name=JetWhale")
             }
+        },
+    )
+}
+
+// Resolve the QA agent from this build rather than from Maven, so a plugin can be driven against an
+// agent built from the working tree — the published `runJetWhaleQaAgent` can only run released ones.
+val jetwhaleQaAgentRuntime = configurations.create("jetwhaleQaAgentRuntime") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+dependencies.add("jetwhaleQaAgentRuntime", dependencies.project(":tools:qa-agent"))
+
+tasks.register<JavaExec>("runJetWhaleQaAgentLocal") {
+    group = "jetwhale"
+    description = "Runs the locally built JetWhale QA agent — a headless debuggee for this plugin, driven over HTTP."
+
+    classpath = jetwhaleQaAgentRuntime
+    mainClass.set("com.kitakkun.jetwhale.tools.qaagent.MainKt")
+
+    // Same property the published `runJetWhaleQaAgent` reads, so a command line moves between them
+    // unchanged: `-PjetwhaleQaAgentArgs="--plugin com.example.myplugin"`. See the agent's `--help`.
+    val extraArgs = providers.gradleProperty("jetwhaleQaAgentArgs")
+    argumentProviders.add(
+        CommandLineArgumentProvider {
+            extraArgs.getOrElse("").split(" ").filter { it.isNotBlank() }
         },
     )
 }

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -24,6 +24,9 @@ import util.JetWhalePluginExtension
  * - `runJetWhaleHot` — the same, but runs the host on the JetBrains Runtime (so structural code changes
  *   hot-reload in place too; requires a JBR toolchain) AND keeps the plugin re-staged in the background,
  *   so a single command is the whole hot-reload loop — no separate `stageDevPlugin -t` terminal needed.
+ * - `runJetWhaleQaAgent` — launches a headless debuggee that connects as an ordinary session, so the
+ *   plugin has a session to render for, and forwards messages POSTed to its local control API on to
+ *   the host plugin. Pass `-PjetwhaleQaAgentArgs="--plugin <your plugin id>"`.
  *
  * The in-repo host launcher (`runJetWhaleLocal`, which runs the local `:jetwhale-host:app` project)
  * lives in the separate, non-published `jetwhale-host-launch` convention.
@@ -371,6 +374,56 @@ registerRunTask(
         "place; requires a JBR toolchain) and auto re-stages the plugin in the background — the whole hot-reload loop in one command.",
     hot = true,
 )
+
+// ---------------------------------------------------------------------------
+// QA agent: a headless debuggee to drive this plugin against.
+// ---------------------------------------------------------------------------
+
+// A plugin's UI only renders for a connected session, and the usual source of one is a real app.
+// This launches a headless stand-in instead: it connects as an ordinary session and forwards
+// messages POSTed to its local control API on to the host plugin, so the UI can be driven from a
+// script with no debuggee app to build. It speaks the raw messaging layer, so nothing here depends
+// on this plugin's own protocol.
+val qaAgentClasspath = configurations.create("jetwhaleQaAgent") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    isVisible = false
+}
+
+// addProvider rather than a plain coordinate string: the version comes from the extension, whose
+// value is not yet known while this script is being configured.
+dependencies.addProvider(
+    qaAgentClasspath.name,
+    pluginExtension.qaAgentVersion.orElse(pluginExtension.hostVersion)
+        .map { version -> "com.kitakkun.jetwhale:jetwhale-qa-agent:$version" },
+)
+
+tasks.register<JavaExec>("runJetWhaleQaAgent") {
+    group = "jetwhale"
+    description = "Runs the headless JetWhale QA agent — a debuggee for this plugin that you drive over HTTP."
+
+    classpath = qaAgentClasspath
+    mainClass.set("com.kitakkun.jetwhale.tools.qaagent.MainKt")
+
+    // Arguments come from the command line so one run can target any plugin id, port or host without
+    // editing the build:
+    // `-PjetwhaleQaAgentArgs="--plugin com.example.myplugin --control-port 7101"`.
+    // The agent's `--help` lists them all.
+    val extraArgs = providers.gradleProperty("jetwhaleQaAgentArgs")
+    argumentProviders.add(
+        CommandLineArgumentProvider {
+            extraArgs.getOrElse("").split(" ").filter { it.isNotBlank() }
+        },
+    )
+
+    val agentVersion = pluginExtension.qaAgentVersion.orElse(pluginExtension.hostVersion)
+    doFirst {
+        check(agentVersion.isPresent) {
+            "Set jetwhalePlugin.hostVersion (or jetwhalePlugin.qaAgentVersion) so the matching " +
+                "JetWhale QA agent can be resolved."
+        }
+    }
+}
 
 // Make sure `packagePlugin` participates in the standard `assemble`/`build` lifecycle so authors get
 // the distributable artifact without invoking the task by name.

--- a/jetwhale-gradle-plugin/src/main/kotlin/util/JetWhalePluginExtension.kt
+++ b/jetwhale-gradle-plugin/src/main/kotlin/util/JetWhalePluginExtension.kt
@@ -23,4 +23,14 @@ interface JetWhalePluginExtension {
      * `-PjetwhaleHostJar=<path>` to launch a locally built host uber jar instead.
      */
     val hostVersion: Property<String>
+
+    /**
+     * Version of the JetWhale QA agent `runJetWhaleQaAgent` runs. Defaults to [hostVersion], so the
+     * agent and the host it connects to speak the same protocol version.
+     *
+     * The QA agent is a headless debuggee: it connects as an ordinary session — giving the plugin's
+     * UI a session to render for — and forwards messages you POST to its local control API on to the
+     * host plugin. Set this only to pin an agent version other than the host's.
+     */
+    val qaAgentVersion: Property<String>
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,8 @@ include(":jetwhale-plugins:network:host")
 
 include(":test-annotations")
 
+include(":tools:qa-agent")
+
 include(":demo:shared")
 include(":demo:android")
 include(":demo:desktop")

--- a/tools/qa-agent/build.gradle.kts
+++ b/tools/qa-agent/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.serialization)
+    alias(libs.plugins.publish)
     application
 }
 
@@ -12,6 +13,8 @@ dependencies {
     // Deliberately independent of :demo — this is development infrastructure, not a usage example,
     // and it must stay driveable without a UI toolkit on the classpath.
     implementation(projects.jetwhaleAgentRuntime)
+    // The one plugin compiled in: `/fire` injects traffic for the bundled Network Inspector. Every
+    // other plugin is reached over the raw messaging layer, so no dependency on it is needed.
     implementation(projects.jetwhalePlugins.network.agent)
     implementation(projects.jetwhalePlugins.network.agentKtor)
 
@@ -21,4 +24,12 @@ dependencies {
     implementation(libs.ktorServerNetty)
     implementation(libs.ktorServerContentNegotiation)
     implementation(libs.ktorSerializationKotlinxJson)
+}
+
+// Published so plugin authors outside this repository can run it — `runJetWhaleQaAgent` in the
+// Gradle plugin resolves exactly these coordinates.
+jetwhalePublish {
+    artifactId = "jetwhale-qa-agent"
+    name = "JetWhale QA Agent"
+    description = "Headless JetWhale debuggee that drives host plugins through a local control API."
 }

--- a/tools/qa-agent/build.gradle.kts
+++ b/tools/qa-agent/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    alias(libs.plugins.jvm)
+    alias(libs.plugins.serialization)
+    application
+}
+
+application {
+    mainClass = "com.kitakkun.jetwhale.tools.qaagent.MainKt"
+}
+
+dependencies {
+    // Deliberately independent of :demo — this is development infrastructure, not a usage example,
+    // and it must stay driveable without a UI toolkit on the classpath.
+    implementation(projects.jetwhaleAgentRuntime)
+    implementation(projects.jetwhalePlugins.network.agent)
+    implementation(projects.jetwhalePlugins.network.agentKtor)
+
+    // Outbound: the instrumented client whose traffic the Network Inspector captures.
+    implementation(libs.ktorClientCio)
+    // Inbound: the control API this agent is driven through.
+    implementation(libs.ktorServerNetty)
+    implementation(libs.ktorServerContentNegotiation)
+    implementation(libs.ktorSerializationKotlinxJson)
+}

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
@@ -89,8 +89,9 @@ private data class SendRequest(
     val policy: OfflineSendPolicy = OfflineSendPolicy.DROP,
 )
 
+/** @param hint why a `false` send was dropped, when the agent can tell. */
 @Serializable
-private data class SendResponse(val sent: Boolean)
+private data class SendResponse(val sent: Boolean, val hint: String? = null)
 
 @Serializable
 private data class RequestMessage(
@@ -108,6 +109,18 @@ private data class RequestResponse(
 
 @Serializable
 private data class ErrorResponse(val error: String)
+
+/** @param ready whether every impersonated plugin can reach the host right now. */
+@Serializable
+private data class HealthResponse(val status: String, val ready: Boolean)
+
+/**
+ * @param activated the host enabled this plugin id. False means it is disabled there, and waiting
+ *   will not help.
+ * @param ready a message sent now would reach the host.
+ */
+@Serializable
+private data class PluginStatus(val version: String, val activated: Boolean, val ready: Boolean)
 
 /**
  * What the agent impersonates and where it connects.
@@ -215,11 +228,26 @@ fun main(args: Array<String>) {
         install(ContentNegotiation) { json() }
         routing {
             get("/health") {
-                call.respond(mapOf("status" to "ok"))
+                // `ready` is what a caller must poll before sending: the control API answers long
+                // before the debug session is up, and a send in that window is silently dropped.
+                call.respond(
+                    HealthResponse(
+                        status = "ok",
+                        ready = wirePluginsById.values.all { it.isReady },
+                    ),
+                )
             }
 
             get("/plugins") {
-                call.respond(wirePluginsById.mapValues { (_, plugin) -> plugin.pluginVersion })
+                call.respond(
+                    wirePluginsById.mapValues { (_, plugin) ->
+                        PluginStatus(
+                            version = plugin.pluginVersion,
+                            activated = plugin.isActivated,
+                            ready = plugin.isReady,
+                        )
+                    },
+                )
             }
 
             post("/send") {
@@ -234,7 +262,8 @@ fun main(args: Array<String>) {
                     return@post
                 }
                 try {
-                    call.respond(SendResponse(plugin.send(spec.messageType, spec.payload.toString(), spec.policy)))
+                    val sent = plugin.send(spec.messageType, spec.payload.toString(), spec.policy)
+                    call.respond(SendResponse(sent = sent, hint = if (sent) null else dropHint(plugin)))
                 } catch (e: Exception) {
                     // FAIL policy while offline lands here; that is an answer about the connection,
                     // not a malformed call.
@@ -326,6 +355,20 @@ private fun unknownPluginError(pluginId: String, known: Set<String>) = ErrorResp
         "No plugin is registered under '$pluginId'. Registered: ${known.joinToString()}."
     },
 )
+
+/**
+ * Why a send was dropped. Both cases look identical from the caller's side — `sent: false` — but only
+ * one of them is worth waiting out.
+ */
+private fun dropHint(plugin: WireLevelQaPlugin): String = when {
+    !plugin.isActivated ->
+        "The host has not enabled '${plugin.pluginId}' for this session, so nothing is listening. " +
+            "Enable the plugin in the host, or check the id."
+
+    !plugin.isReady -> "Connected but not prepared yet — poll /health until \"ready\": true."
+
+    else -> "The connection was unavailable. Retry, or send with \"policy\": \"QUEUE\" to buffer it."
+}
 
 /** Replies are opaque here — hand back JSON as JSON, and anything else as a string. */
 private fun String.asJsonOrString(): JsonElement = runCatching { Json.parseToJsonElement(this) }.getOrElse { JsonPrimitive(this) }

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
@@ -1,0 +1,157 @@
+package com.kitakkun.jetwhale.tools.qaagent
+
+import com.kitakkun.jetwhale.agent.runtime.KtorLogLevel
+import com.kitakkun.jetwhale.agent.runtime.LogLevel
+import com.kitakkun.jetwhale.agent.runtime.startJetWhale
+import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
+import com.kitakkun.jetwhale.plugins.network.agent.ktor.ktorClientPlugin
+import io.ktor.client.HttpClient
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import kotlin.concurrent.thread
+import kotlin.system.exitProcess
+import kotlin.system.measureTimeMillis
+
+/**
+ * A headless JetWhale debuggee for QA.
+ *
+ * The demo apps can only fire the handful of requests their buttons are wired to, and a GUI app
+ * cannot be driven from an agent at all. This connects to the host as an ordinary debug session and
+ * exposes a small control API instead, so any request — arbitrary URL, method, headers, body — can
+ * be injected into the Network Inspector on demand.
+ *
+ * The control API binds loopback IPv4 only, so address it as `127.0.0.1`: `localhost` may resolve to
+ * `::1` first and be refused.
+ *
+ * ```
+ * ./gradlew :tools:qa-agent:run
+ * curl -s 127.0.0.1:7100/fire -H 'Content-Type: application/json' \
+ *   -d '{"method":"GET","url":"https://example.com/items?page=2"}'
+ * ```
+ */
+private const val DEFAULT_CONTROL_PORT = 7100
+private const val DEFAULT_HOST_PORT = 5443
+private const val BODY_PREVIEW_LIMIT = 2000
+
+@Serializable
+private data class FireRequest(
+    val url: String,
+    val method: String = "GET",
+    val headers: Map<String, String> = emptyMap(),
+    val body: String? = null,
+    val contentType: String? = null,
+)
+
+@Serializable
+private data class FireResponse(
+    val status: Int,
+    val durationMs: Long,
+    val bodyPreview: String,
+)
+
+@Serializable
+private data class ErrorResponse(val error: String)
+
+private fun intProperty(name: String, default: Int): Int = System.getProperty(name)?.toIntOrNull() ?: default
+
+fun main() {
+    val controlPort = intProperty("qa.controlPort", DEFAULT_CONTROL_PORT)
+    val hostPort = intProperty("qa.hostPort", DEFAULT_HOST_PORT)
+    val hostName = System.getProperty("qa.host") ?: "localhost"
+
+    val networkAgentPlugin = JetWhaleNetworkAgentPlugin()
+
+    startJetWhale {
+        app {
+            // Make this session obvious in jetwhale.listSessions so it is never mistaken for a
+            // real device someone is debugging.
+            appName = "qa-agent"
+            deviceName = "QA Agent (headless)"
+            deviceId = "jetwhale-qa-agent"
+        }
+        connection {
+            host = hostName
+            port = hostPort
+            ssl {
+                trustServerCertificate()
+            }
+        }
+        logging {
+            enabled = true
+            logLevel = LogLevel.INFO
+            ktorLogLevel = KtorLogLevel.NONE
+        }
+        plugins {
+            register(networkAgentPlugin)
+        }
+    }
+
+    val client = HttpClient {
+        install(networkAgentPlugin.ktorClientPlugin())
+    }
+
+    val server = embeddedServer(Netty, host = "127.0.0.1", port = controlPort) {
+        install(ContentNegotiation) { json() }
+        routing {
+            get("/health") {
+                call.respond(mapOf("status" to "ok"))
+            }
+
+            post("/fire") {
+                val spec = try {
+                    call.receive<FireRequest>()
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Malformed request: ${e.message}"))
+                    return@post
+                }
+                try {
+                    lateinit var status: HttpStatusCode
+                    lateinit var preview: String
+                    val elapsed = measureTimeMillis {
+                        val response = client.request(spec.url) {
+                            method = HttpMethod.parse(spec.method.uppercase())
+                            spec.contentType?.let { contentType(ContentType.parse(it)) }
+                            spec.headers.forEach { (name, value) -> headers.append(name, value) }
+                            spec.body?.let { setBody(it) }
+                        }
+                        status = response.status
+                        preview = response.bodyAsText().take(BODY_PREVIEW_LIMIT)
+                    }
+                    call.respond(FireResponse(status.value, elapsed, preview))
+                } catch (e: Exception) {
+                    // A failed request is a legitimate QA scenario (the inspector should show it as
+                    // a failure), so report it as data rather than a control-API error.
+                    call.respond(HttpStatusCode.OK, ErrorResponse("${e::class.simpleName}: ${e.message}"))
+                }
+            }
+
+            post("/shutdown") {
+                call.respond(mapOf("status" to "stopping"))
+                thread {
+                    Thread.sleep(200)
+                    exitProcess(0)
+                }
+            }
+        }
+    }
+
+    println("qa-agent: control API on http://127.0.0.1:$controlPort (host $hostName:$hostPort)")
+    runBlocking { server.start(wait = true) }
+}

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.tools.qaagent
 import com.kitakkun.jetwhale.agent.runtime.KtorLogLevel
 import com.kitakkun.jetwhale.agent.runtime.LogLevel
 import com.kitakkun.jetwhale.agent.runtime.startJetWhale
+import com.kitakkun.jetwhale.agent.sdk.messaging.OfflineSendPolicy
 import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
 import com.kitakkun.jetwhale.plugins.network.agent.ktor.ktorClientPlugin
 import io.ktor.client.HttpClient
@@ -25,25 +26,38 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.concurrent.thread
 import kotlin.system.exitProcess
 import kotlin.system.measureTimeMillis
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * A headless JetWhale debuggee for QA.
  *
- * The demo apps can only fire the handful of requests their buttons are wired to, and a GUI app
- * cannot be driven from an agent at all. This connects to the host as an ordinary debug session and
- * exposes a small control API instead, so any request — arbitrary URL, method, headers, body — can
- * be injected into the Network Inspector on demand.
+ * Driving a host plugin's UI needs a connected session, and the demo apps are a poor stand-in: they
+ * only fire the handful of requests their buttons are wired to, and a GUI app cannot be driven from
+ * an agent at all. This connects as an ordinary debug session and exposes a control API instead.
+ *
+ * It is **plugin-agnostic**. Name the plugin ids to impersonate, and `/send` and `/request` carry
+ * arbitrary messages to their host counterparts over the messenger's raw layer — no compile-time
+ * dependency on the plugin being tested, so it works for plugins living outside this repository.
+ * `/fire`, which injects HTTP traffic for the bundled Network Inspector, is the one plugin-specific
+ * convenience on top.
  *
  * The control API binds loopback IPv4 only, so address it as `127.0.0.1`: `localhost` may resolve to
  * `::1` first and be refused.
  *
  * ```
- * ./gradlew :tools:qa-agent:run
- * curl -s 127.0.0.1:7100/fire -H 'Content-Type: application/json' \
- *   -d '{"method":"GET","url":"https://example.com/items?page=2"}'
+ * ./gradlew :tools:qa-agent:run --args="--plugin com.example.myplugin"
+ *
+ * curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' -d '{
+ *   "pluginId": "com.example.myplugin",
+ *   "messageType": "com.example.myplugin.protocol.ItemAdded",
+ *   "payload": {"id": 1, "label": "hello"}
+ * }'
  * ```
  */
 private const val DEFAULT_CONTROL_PORT = 7100
@@ -67,16 +81,103 @@ private data class FireResponse(
 )
 
 @Serializable
+private data class SendRequest(
+    val pluginId: String,
+    val messageType: String,
+    val payload: JsonElement,
+    /** Offline behaviour: DROP (default), QUEUE or FAIL. */
+    val policy: OfflineSendPolicy = OfflineSendPolicy.DROP,
+)
+
+@Serializable
+private data class SendResponse(val sent: Boolean)
+
+@Serializable
+private data class RequestMessage(
+    val pluginId: String,
+    val messageType: String,
+    val payload: JsonElement,
+    val timeoutMs: Long? = null,
+)
+
+@Serializable
+private data class RequestResponse(
+    val durationMs: Long,
+    val reply: JsonElement,
+)
+
+@Serializable
 private data class ErrorResponse(val error: String)
 
-private fun intProperty(name: String, default: Int): Int = System.getProperty(name)?.toIntOrNull() ?: default
+/**
+ * What the agent impersonates and where it connects.
+ *
+ * @param plugins plugin ids to register a [WireLevelQaPlugin] for, each with the version to report.
+ */
+private data class QaAgentOptions(
+    val plugins: Map<String, String>,
+    val hostName: String,
+    val hostPort: Int,
+    val controlPort: Int,
+)
 
-fun main() {
-    val controlPort = intProperty("qa.controlPort", DEFAULT_CONTROL_PORT)
-    val hostPort = intProperty("qa.hostPort", DEFAULT_HOST_PORT)
-    val hostName = System.getProperty("qa.host") ?: "localhost"
+private const val DEFAULT_PLUGIN_VERSION = "1.0.0"
+
+private val usage = """
+    Usage: qa-agent [options]
+
+      --plugin <id>[@<version>]  Register a raw-messaging plugin under this id, so /send and
+                                 /request can drive its host counterpart. Repeatable.
+                                 Version defaults to $DEFAULT_PLUGIN_VERSION.
+      --host <name>              JetWhale host to connect to (default: localhost).
+      --port <n>                 Host debug port (default: $DEFAULT_HOST_PORT).
+      --control-port <n>         Port for this agent's own control API (default: $DEFAULT_CONTROL_PORT).
+""".trimIndent()
+
+private fun parseArgs(args: Array<String>): QaAgentOptions {
+    val plugins = mutableMapOf<String, String>()
+    var hostName = "localhost"
+    var hostPort = DEFAULT_HOST_PORT
+    var controlPort = DEFAULT_CONTROL_PORT
+
+    fun valueOf(index: Int, name: String): String = args.getOrNull(index) ?: error("$name requires a value.\n\n$usage")
+
+    fun intValueOf(index: Int, name: String): Int = valueOf(index, name).toIntOrNull() ?: error("$name requires a number.\n\n$usage")
+
+    var i = 0
+    while (i < args.size) {
+        when (val arg = args[i]) {
+            "--plugin" -> {
+                val (id, version) = valueOf(++i, arg).split("@", limit = 2).let {
+                    it[0] to (it.getOrNull(1) ?: DEFAULT_PLUGIN_VERSION)
+                }
+                plugins[id] = version
+            }
+
+            "--host" -> hostName = valueOf(++i, arg)
+
+            "--port" -> hostPort = intValueOf(++i, arg)
+
+            "--control-port" -> controlPort = intValueOf(++i, arg)
+
+            "--help", "-h" -> {
+                println(usage)
+                exitProcess(0)
+            }
+
+            else -> error("Unknown option: $arg\n\n$usage")
+        }
+        i++
+    }
+
+    return QaAgentOptions(plugins, hostName, hostPort, controlPort)
+}
+
+fun main(args: Array<String>) {
+    val options = parseArgs(args)
 
     val networkAgentPlugin = JetWhaleNetworkAgentPlugin()
+    val wirePlugins = options.plugins.map { (id, version) -> WireLevelQaPlugin(id, version) }
 
     startJetWhale {
         app {
@@ -87,8 +188,8 @@ fun main() {
             deviceId = "jetwhale-qa-agent"
         }
         connection {
-            host = hostName
-            port = hostPort
+            host = options.hostName
+            port = options.hostPort
             ssl {
                 trustServerCertificate()
             }
@@ -100,18 +201,73 @@ fun main() {
         }
         plugins {
             register(networkAgentPlugin)
+            wirePlugins.forEach { register(it) }
         }
     }
+
+    val wirePluginsById = wirePlugins.associateBy { it.pluginId }
 
     val client = HttpClient {
         install(networkAgentPlugin.ktorClientPlugin())
     }
 
-    val server = embeddedServer(Netty, host = "127.0.0.1", port = controlPort) {
+    val server = embeddedServer(Netty, host = "127.0.0.1", port = options.controlPort) {
         install(ContentNegotiation) { json() }
         routing {
             get("/health") {
                 call.respond(mapOf("status" to "ok"))
+            }
+
+            get("/plugins") {
+                call.respond(wirePluginsById.mapValues { (_, plugin) -> plugin.pluginVersion })
+            }
+
+            post("/send") {
+                val spec = try {
+                    call.receive<SendRequest>()
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Malformed request: ${e.message}"))
+                    return@post
+                }
+                val plugin = wirePluginsById[spec.pluginId] ?: run {
+                    call.respond(HttpStatusCode.BadRequest, unknownPluginError(spec.pluginId, wirePluginsById.keys))
+                    return@post
+                }
+                try {
+                    call.respond(SendResponse(plugin.send(spec.messageType, spec.payload.toString(), spec.policy)))
+                } catch (e: Exception) {
+                    // FAIL policy while offline lands here; that is an answer about the connection,
+                    // not a malformed call.
+                    call.respond(HttpStatusCode.OK, ErrorResponse("${e::class.simpleName}: ${e.message}"))
+                }
+            }
+
+            post("/request") {
+                val spec = try {
+                    call.receive<RequestMessage>()
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Malformed request: ${e.message}"))
+                    return@post
+                }
+                val plugin = wirePluginsById[spec.pluginId] ?: run {
+                    call.respond(HttpStatusCode.BadRequest, unknownPluginError(spec.pluginId, wirePluginsById.keys))
+                    return@post
+                }
+                try {
+                    lateinit var reply: String
+                    val elapsed = measureTimeMillis {
+                        reply = plugin.request(
+                            messageType = spec.messageType,
+                            payload = spec.payload.toString(),
+                            timeout = spec.timeoutMs?.milliseconds,
+                        )
+                    }
+                    call.respond(RequestResponse(elapsed, reply.asJsonOrString()))
+                } catch (e: Exception) {
+                    // A host handler that fails, times out or is not registered is a legitimate QA
+                    // finding, so report it as data rather than a control-API error.
+                    call.respond(HttpStatusCode.OK, ErrorResponse("${e::class.simpleName}: ${e.message}"))
+                }
             }
 
             post("/fire") {
@@ -152,6 +308,24 @@ fun main() {
         }
     }
 
-    println("qa-agent: control API on http://127.0.0.1:$controlPort (host $hostName:$hostPort)")
+    println("qa-agent: control API on http://127.0.0.1:${options.controlPort} (host ${options.hostName}:${options.hostPort})")
+    println(
+        if (wirePluginsById.isEmpty()) {
+            "qa-agent: no --plugin given; only /fire (Network Inspector) is available."
+        } else {
+            "qa-agent: impersonating ${wirePluginsById.keys.joinToString()}"
+        },
+    )
     runBlocking { server.start(wait = true) }
 }
+
+private fun unknownPluginError(pluginId: String, known: Set<String>) = ErrorResponse(
+    if (known.isEmpty()) {
+        "No plugin is registered under '$pluginId'. Start the agent with --plugin $pluginId."
+    } else {
+        "No plugin is registered under '$pluginId'. Registered: ${known.joinToString()}."
+    },
+)
+
+/** Replies are opaque here — hand back JSON as JSON, and anything else as a string. */
+private fun String.asJsonOrString(): JsonElement = runCatching { Json.parseToJsonElement(this) }.getOrElse { JsonPrimitive(this) }

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/WireLevelQaPlugin.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/WireLevelQaPlugin.kt
@@ -21,6 +21,44 @@ internal class WireLevelQaPlugin(
     override val pluginId: String,
     override val pluginVersion: String,
 ) : JetWhaleAgentPlugin() {
+    /**
+     * Whether the host has enabled this plugin id. False means the host is not listening for this
+     * plugin at all — usually because it is disabled there — and no send will ever arrive, however
+     * long you wait.
+     */
+    @Volatile
+    var isActivated: Boolean = false
+        private set
+
+    /**
+     * Whether a message sent right now would reach the host.
+     *
+     * The control API accepts connections well before the debug session is up, so "the port answers"
+     * is not readiness: a send in that window is dropped and only reports `false` afterwards. This
+     * tracks the activation/connection lifecycle instead, so a caller can poll for readiness and
+     * then send exactly once.
+     */
+    @Volatile
+    var isReady: Boolean = false
+        private set
+
+    override fun onActivate() {
+        isActivated = true
+    }
+
+    override suspend fun onPrepare() {
+        isReady = true
+    }
+
+    override suspend fun onDisconnected() {
+        isReady = false
+    }
+
+    override fun onDeactivate() {
+        isActivated = false
+        isReady = false
+    }
+
     fun send(messageType: String, payload: String, policy: OfflineSendPolicy): Boolean = messenger.sendRaw(messageType, payload, policy)
 
     suspend fun request(messageType: String, payload: String, timeout: Duration?): String = messenger.requestRaw(messageType, payload, timeout)

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/WireLevelQaPlugin.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/WireLevelQaPlugin.kt
@@ -1,0 +1,27 @@
+package com.kitakkun.jetwhale.tools.qaagent
+
+import com.kitakkun.jetwhale.agent.sdk.JetWhaleAgentPlugin
+import com.kitakkun.jetwhale.agent.sdk.messaging.OfflineSendPolicy
+import kotlin.time.Duration
+
+/**
+ * An agent plugin that carries no vocabulary of its own.
+ *
+ * A normal agent plugin speaks in typed messages, so driving one means compiling its protocol in.
+ * This plugin instead exposes the messenger's raw (string) layer, where a message is just a
+ * `messageType` — the `serialName` of the payload's `@Serializable` class — and a JSON string. Any
+ * host plugin can therefore be driven with no compile-time dependency on it at all: name the
+ * `pluginId` it is paired with, and the messages it already understands go straight through.
+ *
+ * Sending only. Inbound handlers (`onEvent<E>` / `onRequest<REQ, R>`) resolve their serializer from
+ * a reified type parameter, so there is no raw shape to register a catch-all against — a host plugin
+ * that *requests* the agent (rather than being driven by it) cannot be answered from here.
+ */
+internal class WireLevelQaPlugin(
+    override val pluginId: String,
+    override val pluginVersion: String,
+) : JetWhaleAgentPlugin() {
+    fun send(messageType: String, payload: String, policy: OfflineSendPolicy): Boolean = messenger.sendRaw(messageType, payload, policy)
+
+    suspend fun request(messageType: String, payload: String, timeout: Duration?): String = messenger.requestRaw(messageType, payload, timeout)
+}


### PR DESCRIPTION
## Summary

Verifying a host plugin's UI has been stopping at "it compiles and the unit tests pass", because the two things needed to go further were missing:

1. **Something to drive the plugin against.** Every MCP UI tool needs a `sessionId`, i.e. a connected debuggee. The demo apps only fire the handful of requests their buttons are wired to, and a GUI app cannot be driven from an agent at all — MCP reaches plugin scenes, never a debuggee.
2. **A written-down way to drive the UI.** The host's MCP server operates on a plugin's Compose scene, and `getOrCreatePluginScene` creates that scene on demand — so an agent can click, drag, type and screenshot a plugin without ever navigating the host window or stealing it from whoever is using it. None of this was documented.

This adds a headless debuggee that works for **any** plugin — including plugins developed outside this repository — and a skill describing the workflow around it.

## `tools/qa-agent` — a debuggee for any plugin

It connects as an ordinary session and exposes a local control API. Messages go over the messenger's **raw layer** (`sendRaw` / `requestRaw`), where a message is just a `messageType` — the payload class's `serialName` — and JSON. So a plugin is driven with **no compile-time knowledge of it**:

```bash
curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' -d '{
  "pluginId": "com.example.myplugin",
  "messageType": "com.example.myplugin.protocol.ItemAdded",
  "payload": {"id": 1, "label": "hello"}
}'
```

- `/request` adds `timeoutMs` and returns the host's reply; `POST /shutdown` stops it.
- `/fire` (`{"method":"GET","url":"…"}`) injects real HTTP traffic for the bundled Network Inspector — the one plugin-specific shortcut, and the only reason any plugin is compiled in at all.
- Identifies itself as `appName: qa-agent` / `QA Agent (headless)`, so it is never mistaken for a real device someone is debugging.
- Binds loopback IPv4 only — hence `127.0.0.1` rather than `localhost`, which may resolve to `::1` and be refused.
- Deliberately independent of `:demo`: this is development infrastructure, not a usage example, and it must stay driveable with no UI toolkit on the classpath.

### Readiness is reported, not guessed

The control API binds its HTTP port long before the debug session exists, so "the port answers" says nothing about whether a message will arrive — a send in that window is dropped. Worse, the same bare `"sent": false` covered a case that waiting can never fix: a plugin the host has **disabled** is never activated, so nothing is listening however long you poll.

The agent now tracks the lifecycle the SDK already hands it (`onActivate` / `onPrepare` / `onDisconnected` / `onDeactivate`) and reports it:

- `GET /health` carries `ready`, so polling before sending is meaningful
- `GET /plugins` reports `activated` and `ready` per plugin
- a dropped send carries a `hint` naming which of the two it hit

Found the hard way, by driving a plugin that turned out to be disabled on the host and having no way to tell why.

**Send-only, deliberately.** Inbound handlers (`onEvent<E>` / `onRequest<REQ, R>`) resolve their serializer from a reified type parameter, so there is no raw shape to register a catch-all against — the protocol is asymmetric here. A plugin whose flow depends on the *host* requesting the agent (the Network Inspector's mock replies) cannot be answered from this agent. Documented in the skill rather than papered over; making it symmetric means new public API on `jetwhale-protocol-core`, which is a separate decision.

## Running it

Two entry points, sharing the same `-PjetwhaleQaAgentArgs` property so a command line moves between them unchanged:

```bash
# in this repository — the agent built from the working tree
./gradlew :jetwhale-plugins:<plugin>:host:runJetWhaleQaAgentLocal \
  -PjetwhaleQaAgentArgs="--plugin com.example.myplugin"

# from a plugin's own repository — resolves the published agent
./gradlew runJetWhaleQaAgent -PjetwhaleQaAgentArgs="--plugin com.example.myplugin"
```

`runJetWhaleQaAgent` joins `runJetWhale` on the published `com.kitakkun.jetwhale.host` convention, so an outside author needs nothing beyond the plugin they already apply. Its version follows `jetwhalePlugin.hostVersion` — agent and host then speak the same protocol version — overridable with the new `jetwhalePlugin.qaAgentVersion`. The dependency is added through `dependencies.addProvider`, since that version is not known while the script is being configured.

`runJetWhaleQaAgentLocal` lives in the in-repo-only `jetwhale-host-launch` convention next to `runJetWhaleLocal`, for the same reason: it depends on this repository's own project, which outside authors don't have.

The module is published as `com.kitakkun.jetwhale:jetwhale-qa-agent` so the former can resolve it.

## `.claude/skills/plugin-qa/SKILL.md`

The workflow end to end: launching the host, registering the SSE MCP server, the tool inventory, readiness, and how to report results. Two sections are there specifically because they cost time to rediscover:

- **Scope.** What this genuinely cannot verify — anything in the host shell (every tool is scoped to `pluginId` + `sessionId`), and the mouse cursor's appearance, since an AWT cursor is not part of the rendered scene. Both belong in the report as "not verified" rather than being quietly implied by a green build.
- **Coordinates and density.** `width`/`height`/`density` are pixels applied to the *live* scene, and a scene renders at the host window's density — 2.0 on a Retina Mac — including one created on demand, which is seeded via `updateHostDensity`. So 1 px ≠ 1 dp, and a pixel landmark is only portable if `density` is pinned.

Also covered: `rememberPersistent`'s 300 ms debounce and sandbox path (for restart-restore checks), and a pointer to the existing scene-level test infrastructure, since a regression test beats a one-off MCP pass.

## Test plan

- [x] `:tools:qa-agent:build`, `:jetwhale-gradle-plugin:compileKotlin`, `spotlessCheck` — green, rebased onto current `main`
- [x] **End-to-end against a running host**, driving the Example plugin with zero compile-time dependency on its protocol:
  - `jetwhale.listSessions` shows the agent as `appName: qa-agent`, `installedPlugins: [network, example]` — the `--plugin` id reached the host
  - `POST /send` with `messageType: "example/button_clicked"` → the plugin's UI (captured via `jetwhale.screenshot`) lists `Event: ButtonClicked(count=12345)`
  - `POST /request` for `example/ping` comes back with `No request handler registered for 'example/ping'` — the round trip reaches the host and its reply reaches the caller. (No host plugin in this repo registers `onRequest`, so an *answered* request could not be exercised.)
  - unknown `pluginId` → HTTP 400 naming what is registered; `--control-port` honoured; `/fire` returns a real 200 from example.com
- [x] **Readiness, both ways round.** Against a plugin the host had disabled: `"activated": false, "ready": false`, and a send explaining itself — *"The host has not enabled '…' for this session, so nothing is listening."* Against the same plugin once enabled: `"activated": true, "ready": true` within a second, `"sent": true`, and the event reaching the UI. Enabling the plugin is the only thing that changed between the two runs, which is exactly what `activated` claims to report.
- [x] **`runJetWhaleQaAgent` resolves and runs the published artifact.** Verified by temporarily dropping `signAllPublications()` (no GPG key locally), `publishToMavenLocal`, adding `mavenLocal()` to `settings.gradle.kts` and pinning `qaAgentVersion` — the task then resolved `com.kitakkun.jetwhale:jetwhale-qa-agent` and ran it. All four edits reverted, the local artifact deleted. Its guard also fires without a version: *"Set jetwhalePlugin.hostVersion (or jetwhalePlugin.qaAgentVersion)…"*
- [x] `runJetWhaleQaAgentLocal` drives a plugin end to end from a plugin module
- [x] SKILL.md re-checked against `main`: MCP tool names, `.gitignore:7`, the `runJetWhaleLocal` / sandbox / `devPlugins` paths, the `store.json` path and the 300 ms debounce constant all still match the code it cites
- [ ] No automated tests for the Gradle tasks — this repo has no harness for them, matching the existing `runJetWhale` tasks
