### PR TITLE
test(host): deflake plugin tool registration lifecycle tests

### DIFF
--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -20,13 +20,18 @@ import io.modelcontextprotocol.kotlin.sdk.client.mcpSse
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class DefaultMcpServerServiceTest {
 
@@ -151,16 +156,9 @@ class DefaultMcpServerServiceTest {
             // Emit Ready event after server started (simulates Android device connecting later)
             eventFlow.emit(PluginInstanceEvent.Ready(testPluginId, testSessionId))
 
-            // Connect a new client after the event was processed to pick up the newly registered tool
-            val client = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$port/sse")
-            try {
-                val listResult = client.listTools()
-                assertNotNull(listResult)
-                val toolNames = listResult.tools.map { it.name }
-                assertTrue("com.example.test.greet" in toolNames, "Expected tool in $toolNames")
-            } finally {
-                client.close()
-            }
+            // The event is handled asynchronously by the service's collector, so the registration
+            // may not be visible the instant emit() returns. Poll until the tool appears.
+            awaitToolListed("com.example.test.greet")
         } finally {
             service.stop()
         }
@@ -181,29 +179,52 @@ class DefaultMcpServerServiceTest {
         try {
             eventFlow.emit(PluginInstanceEvent.Ready(testPluginId, testSessionId))
 
-            // Verify tool is registered
-            val clientBefore = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$port/sse")
-            try {
-                assertTrue("com.example.test.greet" in clientBefore.listTools().tools.map { it.name })
-            } finally {
-                clientBefore.close()
-            }
+            // Both events are handled asynchronously, so poll for each transition rather than
+            // reading the tool list the instant emit() returns.
+            awaitToolListed("com.example.test.greet")
 
-            // Emit Disposed event
             eventFlow.emit(PluginInstanceEvent.Disposed(testPluginId, testSessionId))
 
-            // Reconnect and verify tool is gone
-            val clientAfter = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$port/sse")
-            try {
-                assertFalse("com.example.test.greet" in clientAfter.listTools().tools.map { it.name })
-            } finally {
-                clientAfter.close()
-            }
+            awaitToolAbsent("com.example.test.greet")
         } finally {
             service.stop()
         }
     }
+
+    /**
+     * The service registers and unregisters plugin tools asynchronously in response to lifecycle
+     * events, so a tool list read immediately after emitting an event can observe the state from
+     * before the event was handled. These helpers reconnect and re-read until the tool list reaches
+     * the expected state, so the tests assert on the eventual result instead of racing the handler.
+     *
+     * A fresh connection is opened each poll because the tool list is computed at connection time.
+     */
+    private suspend fun awaitToolListed(toolName: String, timeout: Duration = 5.seconds) = awaitTools(timeout, "$toolName to be listed") { toolName in it }
+
+    private suspend fun awaitToolAbsent(toolName: String, timeout: Duration = 5.seconds) = awaitTools(timeout, "$toolName to be absent") { toolName !in it }
+
+    private suspend fun awaitTools(timeout: Duration, description: String, predicate: (List<String>) -> Boolean) {
+        var lastSeen: List<String> = emptyList()
+        try {
+            withTimeout(timeout) {
+                while (true) {
+                    val client = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$port/sse")
+                    lastSeen = try {
+                        client.listTools().tools.map { it.name }
+                    } finally {
+                        client.close()
+                    }
+                    if (predicate(lastSeen)) return@withTimeout
+                    delay(POLL_INTERVAL_MILLIS)
+                }
+            }
+        } catch (e: TimeoutCancellationException) {
+            throw AssertionError("Timed out waiting for $description; last saw $lastSeen", e)
+        }
+    }
 }
+
+private const val POLL_INTERVAL_MILLIS = 50L
 
 private class FakeMcpTool(
     private val name: String,


### PR DESCRIPTION
## What

`DefaultMcpServerServiceTest` has two event-driven tests that emit a `PluginInstanceEvent` and then read the MCP tool list on the next line:

- `plugin tools are registered via pluginInstanceEventFlow after server start`
- `plugin tools are unregistered when Disposed event is received`

Registration/unregistration is handled asynchronously in the service's event collector (`Dispatchers.IO`), so `emit()` returns before the handler has updated the registry. The immediate `listTools()` read can therefore observe the pre-event state and the assertion fails (`AssertionError: Expected value to be true.` at the "tool is registered" check).

## Fix

Replace the immediate reads with a poll that reconnects and re-lists until the tool list reaches the expected state — listed after `Ready`, absent after `Disposed` — with a 5s timeout that fails with the last-seen list. A fresh connection is opened per poll because the tool list is computed at connection time. No production code changes.

## Repro notes (honest scope)

The racy test code is identical on `main` and is inherently racy (emit-then-assert with no synchronization). In my runs I could **not** reproduce the failure on clean `main` in isolation (0/14 dedicated runs) — it surfaced under the extra concurrent load of additional tests in the same class. So this is a latent race that hardening removes deterministically, rather than a failure that reproduces reliably on `main` today. Opening it separately as requested so it can land independent of unrelated work.

After the fix: 8/8 full-class runs pass.