### PR TITLE
fix(host): make jetwhale.scroll deltaX/deltaY optional

### DIFF
--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScrollTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScrollTool.kt
@@ -40,11 +40,11 @@ class ScrollMcpTool(
                         "sessionId" to stringProperty("The session ID."),
                         "x" to numberProperty("X coordinate in pixels from the left edge of the plugin UI."),
                         "y" to numberProperty("Y coordinate in pixels from the top edge of the plugin UI."),
-                        "deltaX" to numberProperty("Horizontal scroll delta in pixels. Positive scrolls right, negative scrolls left."),
-                        "deltaY" to numberProperty("Vertical scroll delta in pixels. Positive scrolls down, negative scrolls up."),
+                        "deltaX" to numberProperty("Horizontal scroll delta in pixels. Positive scrolls right, negative scrolls left. Defaults to 0."),
+                        "deltaY" to numberProperty("Vertical scroll delta in pixels. Positive scrolls down, negative scrolls up. Defaults to 0."),
                     ),
                 ),
-                required = listOf("pluginId", "sessionId", "x", "y", "deltaX", "deltaY"),
+                required = listOf("pluginId", "sessionId", "x", "y"),
             ),
         ) { request ->
             val pluginId = request.arguments?.get("pluginId")?.jsonContent
@@ -55,10 +55,8 @@ class ScrollMcpTool(
                 ?: return@addTool errorResult("Missing required argument: x")
             val y = request.arguments?.get("y")?.jsonFloat
                 ?: return@addTool errorResult("Missing required argument: y")
-            val deltaX = request.arguments?.get("deltaX")?.jsonFloat
-                ?: return@addTool errorResult("Missing required argument: deltaX")
-            val deltaY = request.arguments?.get("deltaY")?.jsonFloat
-                ?: return@addTool errorResult("Missing required argument: deltaY")
+            val deltaX = request.arguments?.get("deltaX")?.jsonFloat ?: 0f
+            val deltaY = request.arguments?.get("deltaY")?.jsonFloat ?: 0f
 
             val scene = pluginComposeSceneService.getOrCreatePluginScene(pluginId, sessionId)
             withContext(Dispatchers.Main) { dispatchScroll(scene, x, y, deltaX, deltaY) }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScrollTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScrollTool.kt
@@ -55,8 +55,12 @@ class ScrollMcpTool(
                 ?: return@addTool errorResult("Missing required argument: x")
             val y = request.arguments?.get("y")?.jsonFloat
                 ?: return@addTool errorResult("Missing required argument: y")
-            val deltaX = request.arguments?.get("deltaX")?.jsonFloat ?: 0f
-            val deltaY = request.arguments?.get("deltaY")?.jsonFloat ?: 0f
+            val deltaX = request.arguments?.get("deltaX")?.let {
+                it.jsonFloat ?: return@addTool errorResult("deltaX must be a number")
+            } ?: 0f
+            val deltaY = request.arguments?.get("deltaY")?.let {
+                it.jsonFloat ?: return@addTool errorResult("deltaY must be a number")
+            } ?: 0f
 
             val scene = pluginComposeSceneService.getOrCreatePluginScene(pluginId, sessionId)
             withContext(Dispatchers.Main) { dispatchScroll(scene, x, y, deltaX, deltaY) }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScrollToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScrollToolTest.kt
@@ -166,6 +166,55 @@ class ScrollToolTest {
         assertTrue(receivedDeltas[0].y > 0, "Provided deltaY should be dispatched, but was ${receivedDeltas[0].y}")
     }
 
+    @Test
+    fun `scroll returns an error when a delta is present but not a number`() = runBlocking {
+        val receivedDeltas = mutableListOf<Offset>()
+        val scene = createTestScene {
+            Box(
+                modifier = Modifier
+                    .size(200.dp)
+                    .pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                if (event.type == PointerEventType.Scroll) {
+                                    event.changes.firstOrNull()?.scrollDelta?.let { receivedDeltas += it }
+                                }
+                            }
+                        }
+                    },
+            )
+        }
+        renderTestScene(scene)
+
+        val server = Server(
+            serverInfo = Implementation(name = "test", version = "1.0.0"),
+            options = ServerOptions(ServerCapabilities(tools = ServerCapabilities.Tools())),
+        )
+        ScrollMcpTool(FakePluginComposeSceneService(scene)).register(server)
+        val handler = server.tools.getValue("jetwhale.scroll").handler
+
+        // deltaX is present but non-numeric; it must be rejected instead of silently treated as 0.
+        val request = CallToolRequest(
+            CallToolRequestParams(
+                name = "jetwhale.scroll",
+                arguments = buildJsonObject {
+                    put("pluginId", "plugin")
+                    put("sessionId", "session")
+                    put("x", 100)
+                    put("y", 100)
+                    put("deltaX", "abc")
+                    put("deltaY", 50)
+                },
+            ),
+        )
+
+        val result = handler(noOpClientConnection(), request)
+
+        assertEquals(true, result.isError, "Expected an error result for a non-numeric deltaX")
+        assertTrue(receivedDeltas.isEmpty(), "No scroll event should be dispatched, but got $receivedDeltas")
+    }
+
     private class FakePluginComposeSceneService(
         private val scene: PluginComposeScene,
     ) : PluginComposeSceneService {

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScrollToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScrollToolTest.kt
@@ -11,10 +11,23 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.host.model.PluginComposeScene
+import com.kitakkun.jetwhale.host.model.PluginComposeSceneService
+import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.lang.reflect.Proxy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -102,4 +115,70 @@ class ScrollToolTest {
         assertTrue(receivedDeltas[0].y > 0, "First (down) scroll should have positive deltaY, but was ${receivedDeltas[0].y}")
         assertTrue(receivedDeltas[1].y < 0, "Second (up) scroll should have negative deltaY, but was ${receivedDeltas[1].y}")
     }
+
+    @Test
+    fun `scroll defaults the omitted axis to zero`() = runBlocking {
+        val receivedDeltas = mutableListOf<Offset>()
+        val scene = createTestScene {
+            Box(
+                modifier = Modifier
+                    .size(200.dp)
+                    .pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                if (event.type == PointerEventType.Scroll) {
+                                    event.changes.firstOrNull()?.scrollDelta?.let { receivedDeltas += it }
+                                }
+                            }
+                        }
+                    },
+            )
+        }
+        renderTestScene(scene)
+
+        val server = Server(
+            serverInfo = Implementation(name = "test", version = "1.0.0"),
+            options = ServerOptions(ServerCapabilities(tools = ServerCapabilities.Tools())),
+        )
+        ScrollMcpTool(FakePluginComposeSceneService(scene)).register(server)
+        val handler = server.tools.getValue("jetwhale.scroll").handler
+
+        // Only deltaY is provided; deltaX is omitted and must default to 0.
+        val request = CallToolRequest(
+            CallToolRequestParams(
+                name = "jetwhale.scroll",
+                arguments = buildJsonObject {
+                    put("pluginId", "plugin")
+                    put("sessionId", "session")
+                    put("x", 100)
+                    put("y", 100)
+                    put("deltaY", 50)
+                },
+            ),
+        )
+
+        val result = handler(noOpClientConnection(), request)
+
+        assertTrue(result.isError != true, "Expected a successful result, but was an error")
+        assertEquals(1, receivedDeltas.size, "Expected 1 scroll event to be received")
+        assertEquals(0f, receivedDeltas[0].x, "Omitted deltaX should default to 0, but was ${receivedDeltas[0].x}")
+        assertTrue(receivedDeltas[0].y > 0, "Provided deltaY should be dispatched, but was ${receivedDeltas[0].y}")
+    }
+
+    private class FakePluginComposeSceneService(
+        private val scene: PluginComposeScene,
+    ) : PluginComposeSceneService {
+        override fun updateHostDensity(density: Density) = Unit
+        override suspend fun getOrCreatePluginScene(pluginId: String, sessionId: String): PluginComposeScene = scene
+        override fun disposePluginSceneForSession(sessionId: String) = Unit
+        override fun disposePluginScenesForPlugin(pluginId: String) = Unit
+        override fun disposeAllPluginScenes() = Unit
+    }
+
+    // The scroll handler never touches the connection, so a proxy that rejects every call is enough.
+    private fun noOpClientConnection(): ClientConnection = Proxy.newProxyInstance(
+        ClientConnection::class.java.classLoader,
+        arrayOf(ClientConnection::class.java),
+    ) { _, method, _ -> throw UnsupportedOperationException(method.name) } as ClientConnection
 }


### PR DESCRIPTION
## Problem

The `jetwhale.scroll` MCP tool declared both `deltaX` and `deltaY` as required. A caller that only wants to scroll one axis (the common case) still had to pass the other axis explicitly, and omitting it failed with `Missing required argument: deltaX` / `deltaY`.

## Fix

- Removed `deltaX` and `deltaY` from the tool schema's `required` list, so each is now individually optional. `pluginId`, `sessionId`, `x`, and `y` remain required.
- In the handler, the omitted axis now defaults to `0f` (`?.jsonFloat ?: 0f`) instead of returning an error. `x` and `y` still error when missing.
- Updated the schema descriptions to note the `0` default.

## Tests

- Added `scroll defaults the omitted axis to zero`, which registers the tool on a `Server`, invokes the handler with only `deltaY` provided, and asserts the dispatched scroll event has `deltaX == 0` and the expected `deltaY`.
- Existing `ScrollToolTest` cases still pass.

`./gradlew spotlessApply :jetwhale-host:core:mcp:test` -> BUILD SUCCESSFUL (6 tests, 0 failures).