### PR TITLE
chore: bump version to 1.0.0-alpha11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jetwhale = "1.0.0-alpha10"
+jetwhale = "1.0.0-alpha11"
 mavenPublish = "0.37.0"
 
 # kotlin


### PR DESCRIPTION
Bump `jetwhale` in `gradle/libs.versions.toml` from `1.0.0-alpha10` to `1.0.0-alpha11` ahead of the next snapshot publish.