### PR TITLE
feat(tools): make the QA agent drive any plugin, from any repository

### DIFF
--- a/.claude/skills/plugin-qa/SKILL.md
+++ b/.claude/skills/plugin-qa/SKILL.md
@@ -57,20 +57,47 @@ they only fire the handful of requests their buttons are wired to, and **a GUI a
 from an agent at all** — MCP reaches plugin scenes, never a debuggee.
 
 Use the headless QA agent instead. It connects as an ordinary session and exposes a control API, so
-any request can be injected on demand:
+messages can be injected on demand. Name the plugin ids it should impersonate:
 
 ```bash
-./gradlew :tools:qa-agent:run            # background it; keeps the session alive
+# in this repository
+./gradlew :tools:qa-agent:run --args="--plugin com.example.myplugin"
 
-curl -s 127.0.0.1:7100/fire -H 'Content-Type: application/json' \
-  -d '{"method":"GET","url":"https://example.com/items?page=2"}'
+# from a plugin's own repository (jetwhalePlugin.hostVersion decides the agent version)
+./gradlew runJetWhaleQaAgent -PjetwhaleQaAgentArgs="--plugin com.example.myplugin"
 ```
+
+Background it — it holds the session open for as long as it runs.
+
+**Driving the plugin.** `/send` and `/request` speak the messenger's raw layer, so the agent needs no
+compile-time knowledge of the plugin. `messageType` is the payload class's `serialName` (its
+fully-qualified name unless it carries `@SerialName`), and `payload` is that class as JSON:
+
+```bash
+curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' -d '{
+  "pluginId": "com.example.myplugin",
+  "messageType": "com.example.myplugin.protocol.ItemAdded",
+  "payload": {"id": 1, "label": "hello"}
+}'
+```
+
+`/request` takes the same shape plus an optional `timeoutMs` and returns the host's reply. Get the
+`serialName` wrong and the host reports no registered handler — check it against the plugin's
+protocol module rather than guessing.
+
+**This is send-only.** Inbound handlers resolve their serializer from a reified type parameter
+(`onEvent<E>` / `onRequest<REQ, R>`), so there is no raw shape to register a catch-all against: a
+plugin whose flow depends on the *host* requesting the agent (the Network Inspector's mock replies,
+for one) cannot be answered from here. Drive those from the plugin's own MCP tools instead.
 
 - Use **`127.0.0.1`, not `localhost`** — the control API binds loopback IPv4 only, and `localhost`
   can resolve to `::1` first and get connection-refused.
 - It shows up as `appName: qa-agent` / `QA Agent (headless)`, so it is never mistaken for a real
   device. Its `sessionId` is its own — mock rules and transactions are per session.
-- `POST /shutdown` stops it; `GET /health` is a readiness probe worth polling before firing.
+- `GET /plugins` lists what it is impersonating; `GET /health` is a readiness probe worth polling
+  before sending; `POST /shutdown` stops it.
+- `POST /fire` (`{"method":"GET","url":"…"}`) injects real HTTP traffic for the bundled Network
+  Inspector — the one plugin-specific shortcut, and it needs no `--plugin`.
 - On startup the agent logs a failed plain-HTTP CA fetch followed by a successful HTTPS one. That
   is the trust-on-first-use probe, not an error.
 

--- a/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
+++ b/jetwhale-gradle-plugin/src/main/kotlin/com.kitakkun.jetwhale.host.gradle.kts
@@ -24,6 +24,9 @@ import util.JetWhalePluginExtension
  * - `runJetWhaleHot` — the same, but runs the host on the JetBrains Runtime (so structural code changes
  *   hot-reload in place too; requires a JBR toolchain) AND keeps the plugin re-staged in the background,
  *   so a single command is the whole hot-reload loop — no separate `stageDevPlugin -t` terminal needed.
+ * - `runJetWhaleQaAgent` — launches a headless debuggee that connects as an ordinary session, so the
+ *   plugin has a session to render for, and forwards messages POSTed to its local control API on to
+ *   the host plugin. Pass `-PjetwhaleQaAgentArgs="--plugin <your plugin id>"`.
  *
  * The in-repo host launcher (`runJetWhaleLocal`, which runs the local `:jetwhale-host:app` project)
  * lives in the separate, non-published `jetwhale-host-launch` convention.
@@ -371,6 +374,56 @@ registerRunTask(
         "place; requires a JBR toolchain) and auto re-stages the plugin in the background — the whole hot-reload loop in one command.",
     hot = true,
 )
+
+// ---------------------------------------------------------------------------
+// QA agent: a headless debuggee to drive this plugin against.
+// ---------------------------------------------------------------------------
+
+// A plugin's UI only renders for a connected session, and the usual source of one is a real app.
+// This launches a headless stand-in instead: it connects as an ordinary session and forwards
+// messages POSTed to its local control API on to the host plugin, so the UI can be driven from a
+// script with no debuggee app to build. It speaks the raw messaging layer, so nothing here depends
+// on this plugin's own protocol.
+val qaAgentClasspath = configurations.create("jetwhaleQaAgent") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    isVisible = false
+}
+
+// addProvider rather than a plain coordinate string: the version comes from the extension, whose
+// value is not yet known while this script is being configured.
+dependencies.addProvider(
+    qaAgentClasspath.name,
+    pluginExtension.qaAgentVersion.orElse(pluginExtension.hostVersion)
+        .map { version -> "com.kitakkun.jetwhale:jetwhale-qa-agent:$version" },
+)
+
+tasks.register<JavaExec>("runJetWhaleQaAgent") {
+    group = "jetwhale"
+    description = "Runs the headless JetWhale QA agent — a debuggee for this plugin that you drive over HTTP."
+
+    classpath = qaAgentClasspath
+    mainClass.set("com.kitakkun.jetwhale.tools.qaagent.MainKt")
+
+    // Arguments come from the command line so one run can target any plugin id, port or host without
+    // editing the build:
+    // `-PjetwhaleQaAgentArgs="--plugin com.example.myplugin --control-port 7101"`.
+    // The agent's `--help` lists them all.
+    val extraArgs = providers.gradleProperty("jetwhaleQaAgentArgs")
+    argumentProviders.add(
+        CommandLineArgumentProvider {
+            extraArgs.getOrElse("").split(" ").filter { it.isNotBlank() }
+        },
+    )
+
+    val agentVersion = pluginExtension.qaAgentVersion.orElse(pluginExtension.hostVersion)
+    doFirst {
+        check(agentVersion.isPresent) {
+            "Set jetwhalePlugin.hostVersion (or jetwhalePlugin.qaAgentVersion) so the matching " +
+                "JetWhale QA agent can be resolved."
+        }
+    }
+}
 
 // Make sure `packagePlugin` participates in the standard `assemble`/`build` lifecycle so authors get
 // the distributable artifact without invoking the task by name.

--- a/jetwhale-gradle-plugin/src/main/kotlin/util/JetWhalePluginExtension.kt
+++ b/jetwhale-gradle-plugin/src/main/kotlin/util/JetWhalePluginExtension.kt
@@ -23,4 +23,14 @@ interface JetWhalePluginExtension {
      * `-PjetwhaleHostJar=<path>` to launch a locally built host uber jar instead.
      */
     val hostVersion: Property<String>
+
+    /**
+     * Version of the JetWhale QA agent `runJetWhaleQaAgent` runs. Defaults to [hostVersion], so the
+     * agent and the host it connects to speak the same protocol version.
+     *
+     * The QA agent is a headless debuggee: it connects as an ordinary session — giving the plugin's
+     * UI a session to render for — and forwards messages you POST to its local control API on to the
+     * host plugin. Set this only to pin an agent version other than the host's.
+     */
+    val qaAgentVersion: Property<String>
 }

--- a/tools/qa-agent/build.gradle.kts
+++ b/tools/qa-agent/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.serialization)
+    alias(libs.plugins.publish)
     application
 }
 
@@ -12,6 +13,8 @@ dependencies {
     // Deliberately independent of :demo — this is development infrastructure, not a usage example,
     // and it must stay driveable without a UI toolkit on the classpath.
     implementation(projects.jetwhaleAgentRuntime)
+    // The one plugin compiled in: `/fire` injects traffic for the bundled Network Inspector. Every
+    // other plugin is reached over the raw messaging layer, so no dependency on it is needed.
     implementation(projects.jetwhalePlugins.network.agent)
     implementation(projects.jetwhalePlugins.network.agentKtor)
 
@@ -21,4 +24,12 @@ dependencies {
     implementation(libs.ktorServerNetty)
     implementation(libs.ktorServerContentNegotiation)
     implementation(libs.ktorSerializationKotlinxJson)
+}
+
+// Published so plugin authors outside this repository can run it — `runJetWhaleQaAgent` in the
+// Gradle plugin resolves exactly these coordinates.
+jetwhalePublish {
+    artifactId = "jetwhale-qa-agent"
+    name = "JetWhale QA Agent"
+    description = "Headless JetWhale debuggee that drives host plugins through a local control API."
 }

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.tools.qaagent
 import com.kitakkun.jetwhale.agent.runtime.KtorLogLevel
 import com.kitakkun.jetwhale.agent.runtime.LogLevel
 import com.kitakkun.jetwhale.agent.runtime.startJetWhale
+import com.kitakkun.jetwhale.agent.sdk.messaging.OfflineSendPolicy
 import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
 import com.kitakkun.jetwhale.plugins.network.agent.ktor.ktorClientPlugin
 import io.ktor.client.HttpClient
@@ -25,25 +26,38 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.concurrent.thread
 import kotlin.system.exitProcess
 import kotlin.system.measureTimeMillis
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * A headless JetWhale debuggee for QA.
  *
- * The demo apps can only fire the handful of requests their buttons are wired to, and a GUI app
- * cannot be driven from an agent at all. This connects to the host as an ordinary debug session and
- * exposes a small control API instead, so any request — arbitrary URL, method, headers, body — can
- * be injected into the Network Inspector on demand.
+ * Driving a host plugin's UI needs a connected session, and the demo apps are a poor stand-in: they
+ * only fire the handful of requests their buttons are wired to, and a GUI app cannot be driven from
+ * an agent at all. This connects as an ordinary debug session and exposes a control API instead.
+ *
+ * It is **plugin-agnostic**. Name the plugin ids to impersonate, and `/send` and `/request` carry
+ * arbitrary messages to their host counterparts over the messenger's raw layer — no compile-time
+ * dependency on the plugin being tested, so it works for plugins living outside this repository.
+ * `/fire`, which injects HTTP traffic for the bundled Network Inspector, is the one plugin-specific
+ * convenience on top.
  *
  * The control API binds loopback IPv4 only, so address it as `127.0.0.1`: `localhost` may resolve to
  * `::1` first and be refused.
  *
  * ```
- * ./gradlew :tools:qa-agent:run
- * curl -s 127.0.0.1:7100/fire -H 'Content-Type: application/json' \
- *   -d '{"method":"GET","url":"https://example.com/items?page=2"}'
+ * ./gradlew :tools:qa-agent:run --args="--plugin com.example.myplugin"
+ *
+ * curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' -d '{
+ *   "pluginId": "com.example.myplugin",
+ *   "messageType": "com.example.myplugin.protocol.ItemAdded",
+ *   "payload": {"id": 1, "label": "hello"}
+ * }'
  * ```
  */
 private const val DEFAULT_CONTROL_PORT = 7100
@@ -67,16 +81,103 @@ private data class FireResponse(
 )
 
 @Serializable
+private data class SendRequest(
+    val pluginId: String,
+    val messageType: String,
+    val payload: JsonElement,
+    /** Offline behaviour: DROP (default), QUEUE or FAIL. */
+    val policy: OfflineSendPolicy = OfflineSendPolicy.DROP,
+)
+
+@Serializable
+private data class SendResponse(val sent: Boolean)
+
+@Serializable
+private data class RequestMessage(
+    val pluginId: String,
+    val messageType: String,
+    val payload: JsonElement,
+    val timeoutMs: Long? = null,
+)
+
+@Serializable
+private data class RequestResponse(
+    val durationMs: Long,
+    val reply: JsonElement,
+)
+
+@Serializable
 private data class ErrorResponse(val error: String)
 
-private fun intProperty(name: String, default: Int): Int = System.getProperty(name)?.toIntOrNull() ?: default
+/**
+ * What the agent impersonates and where it connects.
+ *
+ * @param plugins plugin ids to register a [WireLevelQaPlugin] for, each with the version to report.
+ */
+private data class QaAgentOptions(
+    val plugins: Map<String, String>,
+    val hostName: String,
+    val hostPort: Int,
+    val controlPort: Int,
+)
 
-fun main() {
-    val controlPort = intProperty("qa.controlPort", DEFAULT_CONTROL_PORT)
-    val hostPort = intProperty("qa.hostPort", DEFAULT_HOST_PORT)
-    val hostName = System.getProperty("qa.host") ?: "localhost"
+private const val DEFAULT_PLUGIN_VERSION = "1.0.0"
+
+private val usage = """
+    Usage: qa-agent [options]
+
+      --plugin <id>[@<version>]  Register a raw-messaging plugin under this id, so /send and
+                                 /request can drive its host counterpart. Repeatable.
+                                 Version defaults to $DEFAULT_PLUGIN_VERSION.
+      --host <name>              JetWhale host to connect to (default: localhost).
+      --port <n>                 Host debug port (default: $DEFAULT_HOST_PORT).
+      --control-port <n>         Port for this agent's own control API (default: $DEFAULT_CONTROL_PORT).
+""".trimIndent()
+
+private fun parseArgs(args: Array<String>): QaAgentOptions {
+    val plugins = mutableMapOf<String, String>()
+    var hostName = "localhost"
+    var hostPort = DEFAULT_HOST_PORT
+    var controlPort = DEFAULT_CONTROL_PORT
+
+    fun valueOf(index: Int, name: String): String = args.getOrNull(index) ?: error("$name requires a value.\n\n$usage")
+
+    fun intValueOf(index: Int, name: String): Int = valueOf(index, name).toIntOrNull() ?: error("$name requires a number.\n\n$usage")
+
+    var i = 0
+    while (i < args.size) {
+        when (val arg = args[i]) {
+            "--plugin" -> {
+                val (id, version) = valueOf(++i, arg).split("@", limit = 2).let {
+                    it[0] to (it.getOrNull(1) ?: DEFAULT_PLUGIN_VERSION)
+                }
+                plugins[id] = version
+            }
+
+            "--host" -> hostName = valueOf(++i, arg)
+
+            "--port" -> hostPort = intValueOf(++i, arg)
+
+            "--control-port" -> controlPort = intValueOf(++i, arg)
+
+            "--help", "-h" -> {
+                println(usage)
+                exitProcess(0)
+            }
+
+            else -> error("Unknown option: $arg\n\n$usage")
+        }
+        i++
+    }
+
+    return QaAgentOptions(plugins, hostName, hostPort, controlPort)
+}
+
+fun main(args: Array<String>) {
+    val options = parseArgs(args)
 
     val networkAgentPlugin = JetWhaleNetworkAgentPlugin()
+    val wirePlugins = options.plugins.map { (id, version) -> WireLevelQaPlugin(id, version) }
 
     startJetWhale {
         app {
@@ -87,8 +188,8 @@ fun main() {
             deviceId = "jetwhale-qa-agent"
         }
         connection {
-            host = hostName
-            port = hostPort
+            host = options.hostName
+            port = options.hostPort
             ssl {
                 trustServerCertificate()
             }
@@ -100,18 +201,73 @@ fun main() {
         }
         plugins {
             register(networkAgentPlugin)
+            wirePlugins.forEach { register(it) }
         }
     }
+
+    val wirePluginsById = wirePlugins.associateBy { it.pluginId }
 
     val client = HttpClient {
         install(networkAgentPlugin.ktorClientPlugin())
     }
 
-    val server = embeddedServer(Netty, host = "127.0.0.1", port = controlPort) {
+    val server = embeddedServer(Netty, host = "127.0.0.1", port = options.controlPort) {
         install(ContentNegotiation) { json() }
         routing {
             get("/health") {
                 call.respond(mapOf("status" to "ok"))
+            }
+
+            get("/plugins") {
+                call.respond(wirePluginsById.mapValues { (_, plugin) -> plugin.pluginVersion })
+            }
+
+            post("/send") {
+                val spec = try {
+                    call.receive<SendRequest>()
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Malformed request: ${e.message}"))
+                    return@post
+                }
+                val plugin = wirePluginsById[spec.pluginId] ?: run {
+                    call.respond(HttpStatusCode.BadRequest, unknownPluginError(spec.pluginId, wirePluginsById.keys))
+                    return@post
+                }
+                try {
+                    call.respond(SendResponse(plugin.send(spec.messageType, spec.payload.toString(), spec.policy)))
+                } catch (e: Exception) {
+                    // FAIL policy while offline lands here; that is an answer about the connection,
+                    // not a malformed call.
+                    call.respond(HttpStatusCode.OK, ErrorResponse("${e::class.simpleName}: ${e.message}"))
+                }
+            }
+
+            post("/request") {
+                val spec = try {
+                    call.receive<RequestMessage>()
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Malformed request: ${e.message}"))
+                    return@post
+                }
+                val plugin = wirePluginsById[spec.pluginId] ?: run {
+                    call.respond(HttpStatusCode.BadRequest, unknownPluginError(spec.pluginId, wirePluginsById.keys))
+                    return@post
+                }
+                try {
+                    lateinit var reply: String
+                    val elapsed = measureTimeMillis {
+                        reply = plugin.request(
+                            messageType = spec.messageType,
+                            payload = spec.payload.toString(),
+                            timeout = spec.timeoutMs?.milliseconds,
+                        )
+                    }
+                    call.respond(RequestResponse(elapsed, reply.asJsonOrString()))
+                } catch (e: Exception) {
+                    // A host handler that fails, times out or is not registered is a legitimate QA
+                    // finding, so report it as data rather than a control-API error.
+                    call.respond(HttpStatusCode.OK, ErrorResponse("${e::class.simpleName}: ${e.message}"))
+                }
             }
 
             post("/fire") {
@@ -152,6 +308,24 @@ fun main() {
         }
     }
 
-    println("qa-agent: control API on http://127.0.0.1:$controlPort (host $hostName:$hostPort)")
+    println("qa-agent: control API on http://127.0.0.1:${options.controlPort} (host ${options.hostName}:${options.hostPort})")
+    println(
+        if (wirePluginsById.isEmpty()) {
+            "qa-agent: no --plugin given; only /fire (Network Inspector) is available."
+        } else {
+            "qa-agent: impersonating ${wirePluginsById.keys.joinToString()}"
+        },
+    )
     runBlocking { server.start(wait = true) }
 }
+
+private fun unknownPluginError(pluginId: String, known: Set<String>) = ErrorResponse(
+    if (known.isEmpty()) {
+        "No plugin is registered under '$pluginId'. Start the agent with --plugin $pluginId."
+    } else {
+        "No plugin is registered under '$pluginId'. Registered: ${known.joinToString()}."
+    },
+)
+
+/** Replies are opaque here — hand back JSON as JSON, and anything else as a string. */
+private fun String.asJsonOrString(): JsonElement = runCatching { Json.parseToJsonElement(this) }.getOrElse { JsonPrimitive(this) }

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/WireLevelQaPlugin.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/WireLevelQaPlugin.kt
@@ -1,0 +1,27 @@
+package com.kitakkun.jetwhale.tools.qaagent
+
+import com.kitakkun.jetwhale.agent.sdk.JetWhaleAgentPlugin
+import com.kitakkun.jetwhale.agent.sdk.messaging.OfflineSendPolicy
+import kotlin.time.Duration
+
+/**
+ * An agent plugin that carries no vocabulary of its own.
+ *
+ * A normal agent plugin speaks in typed messages, so driving one means compiling its protocol in.
+ * This plugin instead exposes the messenger's raw (string) layer, where a message is just a
+ * `messageType` — the `serialName` of the payload's `@Serializable` class — and a JSON string. Any
+ * host plugin can therefore be driven with no compile-time dependency on it at all: name the
+ * `pluginId` it is paired with, and the messages it already understands go straight through.
+ *
+ * Sending only. Inbound handlers (`onEvent<E>` / `onRequest<REQ, R>`) resolve their serializer from
+ * a reified type parameter, so there is no raw shape to register a catch-all against — a host plugin
+ * that *requests* the agent (rather than being driven by it) cannot be answered from here.
+ */
+internal class WireLevelQaPlugin(
+    override val pluginId: String,
+    override val pluginVersion: String,
+) : JetWhaleAgentPlugin() {
+    fun send(messageType: String, payload: String, policy: OfflineSendPolicy): Boolean = messenger.sendRaw(messageType, payload, policy)
+
+    suspend fun request(messageType: String, payload: String, timeout: Duration?): String = messenger.requestRaw(messageType, payload, timeout)
+}


### PR DESCRIPTION
Stacked on #185 — review that one first; this PR's diff is only the three commits on top.

## Summary

The QA agent #185 introduces compiles in the Network Inspector's agent plugin and injects HTTP traffic, so it QAs exactly one plugin. Every other plugin — including any plugin developed outside this repository — would need its own bespoke debuggee.

Two things had to change for one agent to serve them all: **what it can say**, and **where it can be run from**.

## What it can say: the raw messaging layer

`JetWhaleMessenger` already exposes `sendRaw(messageType, payload)` / `requestRaw(...)`, where `messageType` is the payload class's `serialName` and the payload is a JSON string. A plugin can therefore be driven with no compile-time knowledge of it whatsoever:

```bash
curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' -d '{
  "pluginId": "com.example.myplugin",
  "messageType": "com.example.myplugin.protocol.ItemAdded",
  "payload": {"id": 1, "label": "hello"}
}'
```

`WireLevelQaPlugin` is an agent plugin with no vocabulary of its own — it exists to expose that raw layer under whichever `pluginId` you name via `--plugin`. `/request` adds `timeoutMs` and returns the host's reply; `/plugins` lists what is being impersonated. `/fire` stays as the one plugin-specific shortcut, and still needs no `--plugin`.

**This is send-only, deliberately.** Inbound handlers (`onEvent<E>` / `onRequest<REQ, R>`) resolve their serializer from a reified type parameter, so there is no raw shape to register a catch-all against — the protocol is asymmetric here. A plugin whose flow depends on the *host* requesting the agent (the Network Inspector's mock replies) cannot be answered from this agent. Documented in the skill rather than papered over; making it symmetric means new public API on `jetwhale-protocol-core`, which is a separate decision.

## Where it can be run from: `runJetWhaleQaAgent`

`:tools:qa-agent:run` is an in-repo project path, useless to an outside author. The module is now published as `com.kitakkun.jetwhale:jetwhale-qa-agent`, and the `com.kitakkun.jetwhale.host` convention registers a task that resolves and runs it:

```bash
./gradlew runJetWhaleQaAgent -PjetwhaleQaAgentArgs="--plugin com.example.myplugin"
```

The version follows `jetwhalePlugin.hostVersion` (so agent and host always speak the same protocol version), overridable with the new `jetwhalePlugin.qaAgentVersion`. The dependency is added via `dependencies.addProvider` because that version is not known while the script is being configured.

Note this task only works for outside authors **once `jetwhale-qa-agent` is published**; in-repo, `:tools:qa-agent:run` remains the path.

## Test plan

- [x] `:tools:qa-agent:compileKotlin`, `:jetwhale-gradle-plugin:compileKotlin`, `spotlessCheck` — green
- [x] `runJetWhaleQaAgent` appears in `:jetwhale-plugins:network:host:tasks --group jetwhale`
- [x] **End-to-end against a running host**, driving the Example plugin with zero compile-time dependency on its protocol:
  - `jetwhale.listSessions` shows the agent as `appName: qa-agent`, `installedPlugins: [network, example]` — the `--plugin` id reached the host
  - `POST /send` with `messageType: "example/button_clicked"` → the plugin's UI (captured via `jetwhale.screenshot`) lists `Event: ButtonClicked(count=42)` / `(count=777)`
  - unknown `pluginId` → HTTP 400 naming what is registered; `/fire` still returns a real 200 from example.com
- [ ] Not covered by automated tests — the Gradle task has no test harness in this repo, matching the existing `runJetWhale` tasks