### PR TITLE
feat(mcp): expose host-wide MCP tools for AI agents

### DIFF
--- a/.claude/skills/plugin-qa/SKILL.md
+++ b/.claude/skills/plugin-qa/SKILL.md
@@ -10,8 +10,9 @@ tests pass". The host exposes an MCP server whose tools operate on a plugin's Co
 agent can drive the actual UI and look at the result.
 
 The key property: `PluginComposeSceneService.getOrCreatePluginScene(pluginId, sessionId)` creates
-the scene **on demand**, independent of what the host window is displaying. You never navigate the
-host UI, and you never steal the window from whoever is using it.
+the scene **on demand**, independent of what the host window is displaying. Driving a plugin never
+needs the host window, and never steals it from whoever is using it — `jetwhale.navigate` exists for
+the times you *want* the window moved, and is the only tool that touches it.
 
 ## 1. Scope — what this can and cannot verify
 
@@ -22,11 +23,17 @@ Can:
 - the Compose semantics tree (`getAccessibilityTree`) for locating elements
 - persisted plugin state, and whether it survives a host restart
 - the plugin's own contributed MCP tools
+- **the host shell itself** — enabling a plugin, changing settings, restarting the debug server, and
+  switching the main window to another screen, through the host tools in §4
 
 Cannot:
 
-- **anything in the host shell** — settings, session switching, plugin install/enable, navigation,
-  popout windows. Every tool is scoped to `pluginId` + `sessionId`; no host-control tool exists.
+- **popout windows** — a plugin can be sent to the main window, but nothing pops it out or docks it
+  back.
+- **anything that needs the user's consent.** Installing a plugin is off by default and the agent
+  cannot lift that gate itself: `jetwhale.updateSettings` deliberately does not expose
+  `mcpPluginInstallAllowed`, so a refusal means asking the user to flip it in
+  **Settings → Server → MCP Server**.
 - the mouse cursor's appearance. An AWT cursor is not part of the rendered scene, so
   `Modifier.pointerHoverIcon` results never show up in a screenshot. Cover that with a unit test
   (see §7) and say plainly that the visual was not verified.
@@ -78,7 +85,7 @@ the two situations:
 
 | `/plugins` | meaning |
 |---|---|
-| `"activated": false` | the host has **not enabled this plugin id** — waiting will not help; enable it in the host, or check the id |
+| `"activated": false` | the host has **not enabled this plugin id** — waiting will not help. Enable it with `jetwhale.setPluginEnabled` (§4), or check the id |
 | `"activated": true, "ready": false` | connected, still preparing — keep polling |
 
 **Driving the plugin.** `/send` and `/request` speak the messenger's raw layer, so the agent needs no
@@ -131,8 +138,9 @@ gitignored (`.gitignore:7`), so each developer creates their own:
 
 The catch: MCP servers connect when the session starts, and this workflow **launches the host
 mid-session**. If the tools are missing or stale, reconnect with `/mcp` after the host is up. Tool
-lists are also per-session — a plugin's own tools only register once its instance is live, so
-reconnect after connecting a debuggee if you expect `<pluginId>.*` tools.
+lists are fixed at connection time, so a plugin's own tools appear only on a connection opened after
+its instance went live — reconnect after connecting a debuggee, and again after
+`jetwhale.setPluginEnabled`, if you expect `<pluginId>.*` tools.
 
 If reconnecting is not an option (say, a headless run), the same server is reachable over plain
 HTTP: open `GET /sse`, take the `endpoint` event's path, and POST JSON-RPC to it.
@@ -145,6 +153,28 @@ HTTP: open `GET /sse`, take the `endpoint` event's path, and POST JSON-RPC to it
 | `jetwhale.type` | text and special keys |
 | `jetwhale.getAccessibilityTree` | semantics tree; use it to find coordinates |
 | `<pluginId>.*` | tools the plugin itself contributes |
+
+Host-scoped tools take neither `pluginId` nor `sessionId`, and cover the setup a QA run used to need
+a human for:
+
+| Tool | Purpose |
+|------|---------|
+| `jetwhale.getStatus` | version, both servers, session/plugin counts, settings, current screen — call it first |
+| `jetwhale.listInstalledPlugins` | what is installed and whether it is enabled |
+| `jetwhale.setPluginEnabled` | enable the plugin under test; reports which sessions got an instance |
+| `jetwhale.navigate` | move the main window (`HOME` / `PLUGIN` / `SETTINGS` / `INFO` / `LOG_VIEWER`) |
+| `jetwhale.getLogs` / `jetwhale.clearLogs` | the **host's** own log — clear, reproduce, read |
+| `jetwhale.updateSettings` / `jetwhale.restartDebugServer` | ports and server lifecycle |
+
+`getLogs` reads the host's log, not the debuggee's — it is how a plugin jar that failed to load
+explains itself.
+
+::: warning
+`restartDebugServer`, and `updateSettings` when it changes a ws/wss setting, drop **every** session:
+each `sessionId` you hold goes stale and each debuggee has to reconnect. Re-run `listSessions`
+afterwards. Changing `mcpServerPort` never restarts the MCP server — it would kill your own
+connection — so that one only takes effect on the next host start.
+:::
 
 Always `Read` the screenshot afterwards. A screenshot you never open verifies nothing.
 

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -52,6 +52,7 @@ The **Settings → Server** screen configures the debug WebSocket server and its
 | **Debug server port** | `5080` | The plain **ws** port debuggee apps connect to. Must match the `port` in your app's `startJetWhale { connection { ... } }` block. |
 | **wss port** | `5443` | The **secure WebSocket (wss)** port, served alongside plain ws when a certificate is active. Point the agent's `port` at this when it connects over `ssl { }`. |
 | **MCP server port** | `7080` | Port of the built-in [MCP server](/guide/mcp-server) for AI agents. |
+| **Allow AI agents to install official plugins** | off | Lets an agent on the MCP server install plugins from the official catalog, which loads new code into JetWhale. Plugins from arbitrary Maven coordinates can never be installed this way. |
 
 The server status line shows the running ports, e.g. *Running on port 5080 (WSS: 5443)* when wss is
 active.
@@ -59,6 +60,10 @@ active.
 The **MCP Server** section also offers copy-ready connection snippets — a `claude mcp add` command
 and a JSON config block, both carrying the port the MCP server is currently running on — plus a link
 to the [MCP Server](/guide/mcp-server) guide.
+
+Changing the MCP server port here restarts the MCP server immediately. An agent changing it through
+`jetwhale.updateSettings` only persists the value — restarting would drop the agent's own
+connection — so that change takes effect on the next host start.
 
 ### Overriding the ports at startup
 

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -1,9 +1,14 @@
 # MCP Server <Badge type="warning" text="experimental" />
 
 The JetWhale host embeds an **MCP (Model Context Protocol) server**, so AI agents such as Claude
-can inspect and drive your debugging sessions. The built-in tools operate on a **plugin's UI inside
-the host** — capture it, click, type, scroll, and read its semantics tree — so an agent can use any
-plugin the way you do (and, through a plugin's own capabilities, reach the debuggee app itself).
+can inspect and drive your debugging sessions. The built-in tools come in two families:
+
+- **Plugin UI tools** operate on a **plugin's UI inside the host** — capture it, click, type,
+  scroll, and read its semantics tree — so an agent can use any plugin the way you do (and, through
+  a plugin's own capabilities, reach the debuggee app itself).
+- **Host tools** operate on the **debug tool as a whole** — read its status and logs, install and
+  enable plugins, change settings, and switch the window to another screen — so an agent can set
+  JetWhale up rather than only using what you have already set up by hand.
 
 ## Connecting an AI agent
 
@@ -23,7 +28,7 @@ The host's **Settings → Server → MCP Server** section shows this command —
 config block for other MCP clients — already filled in with the port the server is actually running
 on, ready to copy.
 
-## Built-in tools
+## Plugin UI tools
 
 | Tool | What it does |
 |------|--------------|
@@ -39,6 +44,53 @@ on, ready to copy.
 Because a single host can debug multiple apps at once — each with several plugins — every tool that
 targets a plugin UI takes required `sessionId` **and** `pluginId` parameters: call
 `jetwhale.listSessions` first, then `jetwhale.listPlugins` to pick the plugin.
+
+## Host tools
+
+These target the debug tool itself, so they take neither `sessionId` nor `pluginId`.
+`jetwhale.getStatus` is the recommended first call: one parameter-free request tells an agent the
+host version, both servers' endpoints, how many sessions and plugins are live, the current settings,
+and what the window is showing.
+
+| Tool | What it does |
+|------|--------------|
+| `jetwhale.getStatus` | One snapshot of the host: version, servers, session and plugin counts, settings, current screen |
+| `jetwhale.getLogs` | Reads the host's own captured stdout/stderr, filterable by level and substring |
+| `jetwhale.clearLogs` | Discards every captured host log entry |
+| `jetwhale.listInstalledPlugins` | Lists installed plugins and their enabled state, official plugins still available, and any failed or untrusted jar |
+| `jetwhale.setPluginEnabled` | Enables or disables an installed plugin, like the drawer toggle |
+| `jetwhale.installOfficialPlugin` | Installs a plugin from the official catalog (see below) |
+| `jetwhale.updateSettings` | Changes host settings; only the arguments you supply are touched |
+| `jetwhale.restartDebugServer` | Restarts the debug WebSocket server |
+| `jetwhale.navigate` | Switches the main window to another screen, selecting the session and plugin as it goes |
+
+`jetwhale.getLogs` reads the **host's** log, not the debuggee app's — use it to diagnose JetWhale
+itself, for example a plugin jar that failed to load.
+
+::: warning Destructive host tools
+`jetwhale.restartDebugServer` — and `jetwhale.updateSettings` when it changes a ws/wss setting —
+stops the debug server, which disconnects **every** session. Each `sessionId` an agent is holding
+becomes invalid and each app has to reconnect. Pass `restartDebugServer: false` to `updateSettings`
+to persist a change and apply it later instead.
+
+Changing `mcpServerPort` never restarts the MCP server, because that would drop the agent's own
+connection. The new port takes effect the next time the host starts.
+:::
+
+## Installing plugins from an AI agent
+
+`jetwhale.installOfficialPlugin` is deliberately narrow. It accepts only a `pluginId` from the
+**official catalog** — there is no MCP tool that installs arbitrary Maven coordinates — and it is
+**off by default**. Turn it on in **Settings → Server → MCP Server → "Allow AI agents to install
+official plugins"**. While it is off the tool still appears in the tool list but refuses with a
+message naming that setting, so an agent can tell you what to enable.
+
+Installing does not enable: the sequence is
+
+1. `jetwhale.installOfficialPlugin`
+2. `jetwhale.setPluginEnabled`
+3. **reconnect the MCP client** — tool lists are computed when a client connects, so a newly enabled
+   plugin's own tools only appear on the next connection.
 
 ## Plugin-provided tools
 
@@ -57,6 +109,12 @@ Plugin UIs can hide sensitive content from `jetwhale.screenshot` captures via th
 `LocalIsScreenshotCapture` CompositionLocal, and the Network Inspector's
 [redaction rules](/guide/network-inspector#redacting-sensitive-values) support an `MCP_ONLY` scope
 that keeps values visible to you but hidden from AI agents.
+:::
+
+::: warning The MCP port is unauthenticated
+The SSE endpoint has no authentication, so **any process on the machine** can reach it — and it is
+no longer a read-only surface: the host tools change settings and can restart the debug server. Bear
+that in mind before exposing the port beyond localhost.
 :::
 
 ::: warning

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -47,7 +47,11 @@ targets a plugin UI takes required `sessionId` **and** `pluginId` parameters: ca
 
 ## Host tools
 
-These target the debug tool itself, so they take neither `sessionId` nor `pluginId`.
+These target the debug tool itself rather than one plugin instance, so none of them takes the
+required `sessionId` + `pluginId` pair the plugin UI tools route on. Some do take a `pluginId` or an
+optional `sessionId` as ordinary arguments — which plugin to enable, which session to open — but the
+tool is not scoped to them.
+
 `jetwhale.getStatus` is the recommended first call: one parameter-free request tells an agent the
 host version, both servers' endpoints, how many sessions and plugins are live, the current settings,
 and what the window is showing.

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.retain.retain
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalDensity
 import androidx.navigation3.runtime.NavKey
@@ -28,6 +29,7 @@ import com.kitakkun.jetwhale.host.navigation.EmptyPluginNavKey
 import com.kitakkun.jetwhale.host.navigation.InfoNavKey
 import com.kitakkun.jetwhale.host.navigation.JetWhaleNavDisplay
 import com.kitakkun.jetwhale.host.navigation.LicensesNavKey
+import com.kitakkun.jetwhale.host.navigation.LogViewerNavKey
 import com.kitakkun.jetwhale.host.navigation.PluginNavKey
 import com.kitakkun.jetwhale.host.navigation.PluginPopoutNavKey
 import com.kitakkun.jetwhale.host.navigation.SettingsNavKey
@@ -36,6 +38,7 @@ import com.kitakkun.jetwhale.host.navigation.bringPluginBackToMainWindow
 import com.kitakkun.jetwhale.host.navigation.followPluginToSession
 import com.kitakkun.jetwhale.host.navigation.isPluginPoppedOut
 import com.kitakkun.jetwhale.host.navigation.openMcpTools
+import com.kitakkun.jetwhale.host.navigation.toHostDestination
 import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
 import com.kitakkun.jetwhale.host.ui.AppEnvironment
 import com.kitakkun.jetwhale.host.ui.JetWhaleTheme
@@ -65,6 +68,14 @@ fun JetWhaleApp() {
     val density = LocalDensity.current
     LaunchedEffect(density) {
         appGraph.pluginComposeSceneService.updateHostDensity(density)
+    }
+
+    // Publish what the window shows so the MCP server can report it and confirm its own navigation
+    // requests were applied. ToolingScaffoldRoot publishes the drawer selection alongside it.
+    LaunchedEffect(backStack) {
+        snapshotFlow { backStack.toList() }.collect { keys ->
+            appGraph.hostNavigationService.updateDestination(keys.toHostDestination())
+        }
     }
 
     LaunchedEffect(Unit) {
@@ -154,6 +165,15 @@ fun JetWhaleApp() {
                                     },
                                     isPoppedOut = backStack::isPluginPoppedOut,
                                     onClickBringBack = backStack::bringPluginBackToMainWindow,
+                                    onNavigateHome = {
+                                        // Popouts live in their own windows; going home in the main
+                                        // window must not close them.
+                                        backStack.removeAll { it !is EmptyPluginNavKey && it !is PluginPopoutNavKey }
+                                    },
+                                    onNavigateSettings = { menu ->
+                                        backStack.addSingleTop(SettingsNavKey(initialMenu = menu))
+                                    },
+                                    onNavigateLogViewer = { backStack.addSingleTop(LogViewerNavKey) },
                                     onSelectedSessionChange = { selectedSession ->
                                         // When the user switches the active session, make any plugin screen
                                         // currently on top follow the newly-selected session instead of

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
@@ -10,6 +10,7 @@ import com.kitakkun.jetwhale.host.model.AppearanceSettingsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
 import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
 import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.HostNavigationService
 import com.kitakkun.jetwhale.host.model.HostVersionInfo
 import com.kitakkun.jetwhale.host.model.LogCaptureService
 import com.kitakkun.jetwhale.host.model.PluginComposeSceneService
@@ -48,6 +49,7 @@ interface JetWhaleAppGraph : ScreenContext {
     val themeSubscriptionKey: ThemeSubscriptionKey
     val appearanceSettingsSubscriptionKey: AppearanceSettingsSubscriptionKey
     val debugWebSocketServer: DebugWebSocketServer
+    val hostNavigationService: HostNavigationService
     val pluginComposeSceneService: PluginComposeSceneService
     val pluginInstanceService: PluginInstanceService
     val pluginHotReloadService: PluginHotReloadService

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -2,10 +2,15 @@ package com.kitakkun.jetwhale.host.drawer
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import com.kitakkun.jetwhale.host.architecture.ActionResultEffect
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.model.DebugSession
+import com.kitakkun.jetwhale.host.model.HostNavigationRequest
+import com.kitakkun.jetwhale.host.navigation.toSegmentedMenu
+import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
 import soil.query.compose.rememberSubscription
 
 @Composable
@@ -20,6 +25,9 @@ fun ToolingScaffoldRoot(
     isPoppedOut: (pluginId: String, sessionId: String) -> Boolean,
     onClickBringBack: (pluginId: String, sessionId: String) -> Unit,
     onSelectedSessionChange: (selectedSession: DebugSession) -> Unit,
+    onNavigateHome: () -> Unit,
+    onNavigateSettings: (SettingsScreenSegmentedMenu) -> Unit,
+    onNavigateLogViewer: () -> Unit,
     content: @Composable () -> Unit,
 ) {
     SoilDataBoundary(
@@ -57,6 +65,49 @@ fun ToolingScaffoldRoot(
         LaunchedEffect(uiState.selectedSessionId) {
             val selectedSession = uiState.selectedSession ?: return@LaunchedEffect
             onSelectedSessionChange(selectedSession)
+        }
+
+        // Publish the drawer's selection so a caller outside the composition (the MCP server) can
+        // read what the window is pointed at; the destination itself is published by JetWhaleApp.
+        LaunchedEffect(uiState.selectedSessionId, uiState.selectedPluginId) {
+            screenContext.hostNavigationService.updateSelection(
+                selectedSessionId = uiState.selectedSessionId.takeIf { it.isNotEmpty() },
+                selectedPluginId = uiState.selectedPluginId.takeIf { it.isNotEmpty() },
+            )
+        }
+
+        // The collector below outlives every recomposition, so it must not close over the sessions
+        // and ui state of the composition that started it.
+        val currentSessions by rememberUpdatedState(debugSessions)
+        val currentUiState by rememberUpdatedState(uiState)
+
+        // The single collector of navigation requests: only here are both the screen channel and
+        // the navigation callbacks in scope, and the request channel delivers each request once.
+        LaunchedEffect(screenChannel) {
+            screenContext.hostNavigationService.requests.collect { request ->
+                when (request) {
+                    HostNavigationRequest.Home -> onNavigateHome()
+
+                    HostNavigationRequest.Info -> onClickInfo()
+
+                    HostNavigationRequest.LogViewer -> onNavigateLogViewer()
+
+                    is HostNavigationRequest.Settings -> onNavigateSettings(request.section.toSegmentedMenu())
+
+                    is HostNavigationRequest.Plugin -> {
+                        val targetSession = currentSessions.firstOrNull { it.id == request.sessionId }
+                            ?: currentUiState.selectedSession
+                            ?: return@collect
+                        // Drive the same path a drawer click takes, so an MCP-driven navigation and a
+                        // click are indistinguishable downstream.
+                        if (targetSession.id != currentUiState.selectedSessionId) {
+                            screenChannel.send(ToolingScaffoldScreenAction.SelectSession(targetSession))
+                        }
+                        screenChannel.send(ToolingScaffoldScreenAction.UpdateSelectedPlugin(request.pluginId))
+                        onClickPlugin(request.pluginId, targetSession.id)
+                    }
+                }
+            }
         }
 
         ToolingScaffold(

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -95,9 +95,13 @@ fun ToolingScaffoldRoot(
                     is HostNavigationRequest.Settings -> onNavigateSettings(request.section.toSegmentedMenu())
 
                     is HostNavigationRequest.Plugin -> {
-                        val targetSession = currentSessions.firstOrNull { it.id == request.sessionId }
-                            ?: currentUiState.selectedSession
-                            ?: return@collect
+                        // Only a request that named no session falls back to the drawer's selection.
+                        // A named session that has gone away since the request was validated must
+                        // drop the request rather than navigate to some other app.
+                        val targetSession = when (val requestedSessionId = request.sessionId) {
+                            null -> currentUiState.selectedSession
+                            else -> currentSessions.firstOrNull { it.id == requestedSessionId }
+                        } ?: return@collect
                         // Drive the same path a drawer click takes, so an MCP-driven navigation and a
                         // click are indistinguishable downstream.
                         if (targetSession.id != currentUiState.selectedSessionId) {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldScreenContext.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldScreenContext.kt
@@ -5,6 +5,7 @@ import com.kitakkun.jetwhale.host.architecture.ScreenContext
 import com.kitakkun.jetwhale.host.model.DebugSessionsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.EnabledPluginsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.FailedPluginJarPathsSubscriptionKey
+import com.kitakkun.jetwhale.host.model.HostNavigationService
 import com.kitakkun.jetwhale.host.model.LoadedPluginsMetaDataSubscriptionKey
 import com.kitakkun.jetwhale.host.model.McpActivitySubscriptionKey
 import com.kitakkun.jetwhale.host.model.McpCapablePluginsSubscriptionKey
@@ -31,5 +32,6 @@ class ToolingScaffoldScreenContext(
     val failedPluginJarPathsSubscriptionKey: FailedPluginJarPathsSubscriptionKey,
     val mcpActivitySubscriptionKey: McpActivitySubscriptionKey,
     val mcpCapablePluginsSubscriptionKey: McpCapablePluginsSubscriptionKey,
+    val hostNavigationService: HostNavigationService,
     val presenterContext: ToolingScaffoldPresenterContext,
 ) : ScreenContext

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMapping.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMapping.kt
@@ -1,0 +1,63 @@
+package com.kitakkun.jetwhale.host.navigation
+
+import androidx.navigation3.runtime.NavKey
+import com.kitakkun.jetwhale.host.model.HostDestination
+import com.kitakkun.jetwhale.host.model.HostDestinationKind
+import com.kitakkun.jetwhale.host.model.HostSettingsSection
+import com.kitakkun.jetwhale.host.model.PoppedOutPlugin
+import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
+
+/**
+ * Translates the back stack into the destination model that [com.kitakkun.jetwhale.host.model.HostNavigationService]
+ * publishes. Nav keys and the settings menu are app-level types, so the mapping lives here rather
+ * than leaking into `core/model`.
+ *
+ * The top-most entry that is not a popout wins: popouts render in their own windows and are
+ * reported alongside whatever the main window shows.
+ */
+fun List<NavKey>.toHostDestination(): HostDestination {
+    val poppedOut = filterIsInstance<PluginPopoutNavKey>().map { PoppedOutPlugin(it.pluginId, it.sessionId) }
+    return when (val top = lastOrNull { it !is PluginPopoutNavKey }) {
+        is PluginNavKey -> HostDestination(
+            kind = HostDestinationKind.PLUGIN,
+            pluginId = top.pluginId,
+            sessionId = top.sessionId,
+            poppedOutPlugins = poppedOut,
+        )
+
+        is SettingsNavKey -> HostDestination(
+            kind = HostDestinationKind.SETTINGS,
+            settingsSection = top.initialMenu.toHostSettingsSection(),
+            poppedOutPlugins = poppedOut,
+        )
+
+        is McpToolsNavKey -> HostDestination(
+            kind = HostDestinationKind.MCP_TOOLS,
+            pluginId = top.pluginId,
+            sessionId = top.sessionId,
+            poppedOutPlugins = poppedOut,
+        )
+
+        InfoNavKey -> HostDestination(HostDestinationKind.INFO, poppedOutPlugins = poppedOut)
+
+        LicensesNavKey -> HostDestination(HostDestinationKind.LICENSES, poppedOutPlugins = poppedOut)
+
+        LogViewerNavKey -> HostDestination(HostDestinationKind.LOG_VIEWER, poppedOutPlugins = poppedOut)
+
+        DisabledPluginNavKey -> HostDestination(HostDestinationKind.DISABLED_PLUGIN, poppedOutPlugins = poppedOut)
+
+        else -> HostDestination(HostDestinationKind.HOME, poppedOutPlugins = poppedOut)
+    }
+}
+
+fun HostSettingsSection.toSegmentedMenu(): SettingsScreenSegmentedMenu = when (this) {
+    HostSettingsSection.GENERAL -> SettingsScreenSegmentedMenu.General
+    HostSettingsSection.SERVER -> SettingsScreenSegmentedMenu.Server
+    HostSettingsSection.PLUGINS -> SettingsScreenSegmentedMenu.Plugins
+}
+
+private fun SettingsScreenSegmentedMenu.toHostSettingsSection(): HostSettingsSection = when (this) {
+    SettingsScreenSegmentedMenu.General -> HostSettingsSection.GENERAL
+    SettingsScreenSegmentedMenu.Server -> HostSettingsSection.SERVER
+    SettingsScreenSegmentedMenu.Plugins -> HostSettingsSection.PLUGINS
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultHostNavigationService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultHostNavigationService.kt
@@ -1,0 +1,57 @@
+package com.kitakkun.jetwhale.host.data.navigation
+
+import com.kitakkun.jetwhale.host.model.HostDestination
+import com.kitakkun.jetwhale.host.model.HostNavigationRequest
+import com.kitakkun.jetwhale.host.model.HostNavigationService
+import com.kitakkun.jetwhale.host.model.HostViewState
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultHostNavigationService : HostNavigationService {
+    // A buffered channel rather than a SharedFlow: a request that arrives before the window has
+    // composed has to wait for the collector, not be dropped on the floor.
+    private val requestChannel = Channel<HostNavigationRequest>(Channel.BUFFERED)
+    override val requests: Flow<HostNavigationRequest> = requestChannel.receiveAsFlow()
+
+    private val destinationFlow = MutableStateFlow<HostDestination?>(null)
+    private val selectionFlow = MutableStateFlow(Selection(null, null))
+
+    override val currentView: StateFlow<HostViewState?>
+        field = MutableStateFlow<HostViewState?>(null)
+
+    override suspend fun navigate(request: HostNavigationRequest) {
+        requestChannel.send(request)
+    }
+
+    override fun updateDestination(destination: HostDestination) {
+        destinationFlow.value = destination
+        recomputeCurrentView()
+    }
+
+    override fun updateSelection(selectedSessionId: String?, selectedPluginId: String?) {
+        selectionFlow.value = Selection(selectedSessionId, selectedPluginId)
+        recomputeCurrentView()
+    }
+
+    private fun recomputeCurrentView() {
+        val destination = destinationFlow.value ?: return
+        val selection = selectionFlow.value
+        currentView.value = HostViewState(
+            destination = destination,
+            selectedSessionId = selection.sessionId,
+            selectedPluginId = selection.pluginId,
+        )
+    }
+
+    private data class Selection(val sessionId: String?, val pluginId: String?)
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultOfficialPluginInstallMutationKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultOfficialPluginInstallMutationKey.kt
@@ -1,8 +1,8 @@
 package com.kitakkun.jetwhale.host.data.plugin
 
-import com.kitakkun.jetwhale.host.model.HostVersionInfo
 import com.kitakkun.jetwhale.host.model.OfficialPlugin
 import com.kitakkun.jetwhale.host.model.OfficialPluginInstallMutationKey
+import com.kitakkun.jetwhale.host.model.OfficialPluginInstallService
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -12,11 +12,10 @@ import soil.query.buildMutationKey
 @Inject
 @ContributesBinding(AppScope::class)
 class DefaultOfficialPluginInstallMutationKey(
-    private val mavenPluginInstallService: MavenPluginInstallService,
-    private val hostVersionInfo: HostVersionInfo,
+    private val officialPluginInstallService: OfficialPluginInstallService,
 ) : OfficialPluginInstallMutationKey by buildMutationKey(
     id = MutationId("officialPluginInstall"),
     mutate = { plugin: OfficialPlugin ->
-        mavenPluginInstallService.installFirstAvailable(plugin.installCandidatesFor(hostVersionInfo))
+        officialPluginInstallService.install(plugin)
     },
 )

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultOfficialPluginInstallService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultOfficialPluginInstallService.kt
@@ -1,0 +1,21 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.model.HostVersionInfo
+import com.kitakkun.jetwhale.host.model.OfficialPlugin
+import com.kitakkun.jetwhale.host.model.OfficialPluginInstallService
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultOfficialPluginInstallService(
+    private val mavenPluginInstallService: MavenPluginInstallService,
+    private val hostVersionInfo: HostVersionInfo,
+) : OfficialPluginInstallService {
+    override suspend fun install(plugin: OfficialPlugin) {
+        mavenPluginInstallService.installFirstAvailable(plugin.installCandidatesFor(hostVersionInfo))
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultDebugWebSocketServer.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultDebugWebSocketServer.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @Inject
@@ -33,6 +34,7 @@ class DefaultDebugWebSocketServer(
     private val ktorWebSocketServer: KtorWebSocketServer,
 ) : DebugWebSocketServer {
     private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+    override val statusFlow: StateFlow<DebugWebSocketServerStatus> get() = ktorWebSocketServer.statusFlow
     override val sessionClosedFlow: Flow<String> get() = ktorWebSocketServer.sessionClosedFlow
     private val mutableServerStoppedFlow: MutableSharedFlow<Unit> = MutableSharedFlow()
     override val serverStoppedFlow: Flow<Unit> = mutableServerStoppedFlow

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultMcpPluginInstallAllowedMutationKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultMcpPluginInstallAllowedMutationKey.kt
@@ -1,0 +1,23 @@
+package com.kitakkun.jetwhale.host.data.server
+
+import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.McpPluginInstallAllowedMutationKey
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
+import soil.query.MutationId
+import soil.query.MutationKey
+import soil.query.buildMutationKey
+
+@ContributesBinding(AppScope::class, binding<McpPluginInstallAllowedMutationKey>())
+@Inject
+class DefaultMcpPluginInstallAllowedMutationKey(
+    private val settingsRepository: DebuggerSettingsRepository,
+) : McpPluginInstallAllowedMutationKey,
+    MutationKey<Unit, Boolean> by buildMutationKey(
+        id = MutationId("mcp_plugin_install_allowed"),
+        mutate = { isAllowed: Boolean ->
+            settingsRepository.updateMcpPluginInstallAllowed(enabled = isAllowed)
+        },
+    )

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultServerStatusSubscriptionKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultServerStatusSubscriptionKey.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.data.server
 
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
 import com.kitakkun.jetwhale.host.model.ServerStatusSubscriptionKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -10,8 +11,8 @@ import soil.query.buildSubscriptionKey
 @Inject
 @ContributesBinding(AppScope::class)
 class DefaultServerStatusSubscriptionKey(
-    private val ktorWebSocketServer: KtorWebSocketServer,
+    private val debugWebSocketServer: DebugWebSocketServer,
 ) : ServerStatusSubscriptionKey by buildSubscriptionKey(
     id = SubscriptionId("server_status"),
-    subscribe = { ktorWebSocketServer.statusFlow },
+    subscribe = { debugWebSocketServer.statusFlow },
 )

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
@@ -90,6 +90,13 @@ class DefaultDebuggerSettingsRepository(
             started = SharingStarted.Eagerly,
             initialValue = DEFAULT_WSS_ENABLED,
         )
+    override val mcpPluginInstallAllowedFlow = dataStore.data
+        .map { it[KEY_MCP_PLUGIN_INSTALL_ALLOWED] ?: DEFAULT_MCP_PLUGIN_INSTALL_ALLOWED }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.Eagerly,
+            initialValue = DEFAULT_MCP_PLUGIN_INSTALL_ALLOWED,
+        )
 
     override suspend fun updateAdbAutoPortMappingEnabled(enabled: Boolean) {
         dataStore.edit { prefs ->
@@ -144,6 +151,12 @@ class DefaultDebuggerSettingsRepository(
         }
     }
 
+    override suspend fun updateMcpPluginInstallAllowed(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_MCP_PLUGIN_INSTALL_ALLOWED] = enabled
+        }
+    }
+
     /** Lets a launch override win over the stored value this flow carries. */
     private fun Flow<Int>.overriddenBy(selectOverride: (ServerPortOverrides) -> Int?): Flow<Int> = combine(portOverrides) { storedPort, overrides -> selectOverride(overrides) ?: storedPort }
 
@@ -168,9 +181,11 @@ class DefaultDebuggerSettingsRepository(
         private val KEY_MCP_SERVER_PORT = intPreferencesKey("mcp_server_port")
         private val KEY_WSS_PORT = intPreferencesKey("wss_port")
         private val KEY_WSS_ENABLED = booleanPreferencesKey("wss_enabled")
+        private val KEY_MCP_PLUGIN_INSTALL_ALLOWED = booleanPreferencesKey("mcp_plugin_install_allowed")
         private const val DEFAULT_SERVER_PORT = 5080
         private const val DEFAULT_MCP_SERVER_PORT = 7080
         private const val DEFAULT_WSS_PORT = 5443
         private const val DEFAULT_WSS_ENABLED = true
+        private const val DEFAULT_MCP_PLUGIN_INSTALL_ALLOWED = false
     }
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultSettingsSubscriptionKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultSettingsSubscriptionKey.kt
@@ -27,7 +27,8 @@ class DefaultSettingsSubscriptionKey(
             defaultDebuggerSettingsRepository.mcpServerPortFlow,
             defaultDebuggerSettingsRepository.wssPortFlow,
             defaultDebuggerSettingsRepository.wssEnabledFlow,
-        ) { adbAutoPortMappingEnabled, checkForUpdatesOnStartup, persistData, serverPort, mcpServerPort, wssPort, wssEnabled ->
+            defaultDebuggerSettingsRepository.mcpPluginInstallAllowedFlow,
+        ) { adbAutoPortMappingEnabled, checkForUpdatesOnStartup, persistData, serverPort, mcpServerPort, wssPort, wssEnabled, mcpPluginInstallAllowed ->
             DebuggerBehaviorSettings(
                 adbAutoPortMappingEnabled = adbAutoPortMappingEnabled,
                 checkForUpdatesOnStartup = checkForUpdatesOnStartup,
@@ -36,14 +37,15 @@ class DefaultSettingsSubscriptionKey(
                 mcpServerPort = mcpServerPort,
                 wssPort = wssPort,
                 wssEnabled = wssEnabled,
+                mcpPluginInstallAllowed = mcpPluginInstallAllowed,
             )
         }
     },
 )
 
-/** Seven-flow overload of [combine], which kotlinx.coroutines only provides up to five flows. */
+/** Eight-flow overload of [combine], which kotlinx.coroutines only provides up to five flows. */
 @Suppress("UNCHECKED_CAST")
-private inline fun <reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, R> combine(
+private inline fun <reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, R> combine(
     flow1: Flow<T1>,
     flow2: Flow<T2>,
     flow3: Flow<T3>,
@@ -51,8 +53,9 @@ private inline fun <reified T1, reified T2, reified T3, reified T4, reified T5, 
     flow5: Flow<T5>,
     flow6: Flow<T6>,
     flow7: Flow<T7>,
-    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7) -> R,
-): Flow<R> = combine(flow1, flow2, flow3, flow4, flow5, flow6, flow7) { args: Array<*> ->
+    flow8: Flow<T8>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
+): Flow<R> = combine(flow1, flow2, flow3, flow4, flow5, flow6, flow7, flow8) { args: Array<*> ->
     transform(
         args[0] as T1,
         args[1] as T2,
@@ -61,5 +64,6 @@ private inline fun <reified T1, reified T2, reified T3, reified T4, reified T5, 
         args[4] as T5,
         args[5] as T6,
         args[6] as T7,
+        args[7] as T8,
     )
 }

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultHostNavigationServiceTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultHostNavigationServiceTest.kt
@@ -1,0 +1,73 @@
+package com.kitakkun.jetwhale.host.data.navigation
+
+import com.kitakkun.jetwhale.host.model.HostDestination
+import com.kitakkun.jetwhale.host.model.HostDestinationKind
+import com.kitakkun.jetwhale.host.model.HostNavigationRequest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DefaultHostNavigationServiceTest {
+
+    private val service = DefaultHostNavigationService()
+
+    @Test
+    fun `a request emitted before a collector arrives is still delivered`() = runBlocking {
+        service.navigate(HostNavigationRequest.Info)
+
+        assertEquals(HostNavigationRequest.Info, service.requests.first())
+    }
+
+    @Test
+    fun `each request is delivered once, in order`() = runBlocking {
+        val received = mutableListOf<HostNavigationRequest>()
+        val collector = launch { service.requests.take(2).toList(received) }
+
+        service.navigate(HostNavigationRequest.Info)
+        service.navigate(HostNavigationRequest.LogViewer)
+        collector.join()
+
+        assertEquals(listOf(HostNavigationRequest.Info, HostNavigationRequest.LogViewer), received)
+    }
+
+    @Test
+    fun `currentView stays null until a destination is reported`() = runBlocking {
+        service.updateSelection(selectedSessionId = "session-1", selectedPluginId = "plugin-1")
+
+        assertNull(service.currentView.value)
+    }
+
+    @Test
+    fun `currentView combines the destination with the drawer selection`() = runBlocking {
+        service.updateSelection(selectedSessionId = "session-1", selectedPluginId = "plugin-1")
+        service.updateDestination(
+            HostDestination(
+                kind = HostDestinationKind.PLUGIN,
+                pluginId = "plugin-1",
+                sessionId = "session-1",
+            ),
+        )
+
+        val view = requireNotNull(service.currentView.value)
+        assertEquals(HostDestinationKind.PLUGIN, view.destination.kind)
+        assertEquals("plugin-1", view.destination.pluginId)
+        assertEquals("session-1", view.selectedSessionId)
+        assertEquals("plugin-1", view.selectedPluginId)
+    }
+
+    @Test
+    fun `a later selection update keeps the reported destination`() = runBlocking {
+        service.updateDestination(HostDestination(kind = HostDestinationKind.SETTINGS))
+        service.updateSelection(selectedSessionId = "session-2", selectedPluginId = null)
+
+        val view = requireNotNull(service.currentView.value)
+        assertEquals(HostDestinationKind.SETTINGS, view.destination.kind)
+        assertEquals("session-2", view.selectedSessionId)
+        assertNull(view.selectedPluginId)
+    }
+}

--- a/jetwhale-host/core/mcp/build.gradle.kts
+++ b/jetwhale-host/core/mcp/build.gradle.kts
@@ -10,6 +10,9 @@ plugins {
 kotlin {
     compilerOptions {
         freeCompilerArgs.add("-opt-in=com.kitakkun.jetwhale.annotations.InternalJetWhaleApi")
+        // The MCP server is the consumer of the experimental plugin-facing MCP API, and host tools
+        // are written with its parameter DSL, so every file in this module opts in.
+        freeCompilerArgs.add("-opt-in=com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi")
     }
 }
 

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -5,7 +5,6 @@ import com.kitakkun.jetwhale.host.model.McpCapablePlugins
 import com.kitakkun.jetwhale.host.model.McpServerStatus
 import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
-import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -29,20 +28,13 @@ import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
-import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.seconds
 
@@ -52,7 +44,6 @@ import kotlin.time.Duration.Companion.seconds
  */
 private val CLIENT_LIVENESS_PROBE_PERIOD = 5.seconds
 
-@OptIn(ExperimentalJetWhaleApi::class)
 @Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
@@ -60,6 +51,7 @@ class DefaultMcpServerService(
     private val pluginInstanceService: PluginInstanceService,
     private val mcpActivityRepository: McpActivityRepository,
     private val builtInTools: Set<JetWhaleMcpTool>,
+    private val statusHolder: McpServerStatusHolder,
 ) : McpServerService {
 
     private val coroutineScope = CoroutineScope(Dispatchers.IO)
@@ -69,8 +61,7 @@ class DefaultMcpServerService(
     private var ktorServer: EmbeddedServer<*, *>? = null
     private val running = AtomicBoolean(false)
 
-    private val _statusFlow = MutableStateFlow<McpServerStatus>(McpServerStatus.Stopped)
-    override val statusFlow: StateFlow<McpServerStatus> = _statusFlow.asStateFlow()
+    override val statusFlow: StateFlow<McpServerStatus> get() = statusHolder.statusFlow
 
     override val mcpCapablePluginsFlow: StateFlow<McpCapablePlugins> = toolRegistry.mcpCapablePluginsFlow
 
@@ -93,7 +84,7 @@ class DefaultMcpServerService(
             }
         }
 
-        _statusFlow.value = McpServerStatus.Starting
+        statusHolder.update(McpServerStatus.Starting)
         val transports = java.util.concurrent.ConcurrentHashMap<String, SseServerTransport>()
         val server = embeddedServer(Netty, host = host, port = port) {
             install(SSE)
@@ -145,7 +136,7 @@ class DefaultMcpServerService(
         ktorServer = server
         try {
             server.start(wait = false)
-            _statusFlow.value = McpServerStatus.Running(host = host, port = port)
+            statusHolder.update(McpServerStatus.Running(host = host, port = port))
         } catch (e: CancellationException) {
             // Never swallow cancellation: undo this attempt, then re-throw so the coroutine
             // cancellation mechanism keeps working. The status stays untouched — the caller went
@@ -154,7 +145,7 @@ class DefaultMcpServerService(
             throw e
         } catch (e: Throwable) {
             rollbackFailedStart(server)
-            _statusFlow.value = McpServerStatus.Error(e.message ?: "Unknown error")
+            statusHolder.update(McpServerStatus.Error(e.message ?: "Unknown error"))
         }
     }
 
@@ -177,11 +168,11 @@ class DefaultMcpServerService(
         lifecycleObserverJob?.cancel()
         lifecycleObserverJob = null
         toolRegistry.clear()
-        _statusFlow.value = McpServerStatus.Stopping
+        statusHolder.update(McpServerStatus.Stopping)
         ktorServer?.stop(gracePeriodMillis = 500, timeoutMillis = 2000)
         ktorServer = null
         mcpActivityRepository.clear()
-        _statusFlow.value = McpServerStatus.Stopped
+        statusHolder.update(McpServerStatus.Stopped)
     }
 
     private fun onPluginInstanceReady(pluginId: String, sessionId: String) {
@@ -227,17 +218,10 @@ class DefaultMcpServerService(
      */
     private fun registerPluginTools(registrar: McpToolRegistrar) {
         for ((toolName, descriptor) in toolRegistry.allRegistrations()) {
-            val sessionIdProperty = buildJsonObject {
-                put("type", "string")
-                put("description", "Session ID of the target device (from jetwhale.listSessions)")
-            }
-            // The parameter's schema describes its type; only the description has to be merged in.
-            val pluginProperties = descriptor.parameters.mapValues { (_, param) ->
-                JsonObject(param.schema + ("description" to JsonPrimitive(param.description)))
-            }
-            val inputSchema = ToolSchema(
-                properties = JsonObject(mapOf("sessionId" to sessionIdProperty) + pluginProperties),
-                required = listOf("sessionId") + descriptor.parameters.filterValues { it.required }.keys,
+            val inputSchema = descriptor.toToolSchema(
+                leadingProperties = mapOf(
+                    "sessionId" to stringProperty("Session ID of the target device (from jetwhale.listSessions)"),
+                ),
             )
             registrar.addPluginTool(
                 name = toolName,

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommand.kt
@@ -1,0 +1,59 @@
+package com.kitakkun.jetwhale.host.mcp
+
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * A built-in MCP tool scoped to the debug tool itself, written with the same parameter DSL that
+ * plugins use for their own commands.
+ *
+ * Unlike a plugin command — which [McpToolRegistry] routes to one plugin instance and which
+ * therefore carries an injected `sessionId` — a host command targets the host as a whole, so its
+ * schema is exactly the parameters it declares.
+ *
+ * Implementations must be stateless beyond their injected dependencies: one instance serves every
+ * SSE connection, concurrently.
+ *
+ * Contribute one with an explicit binding, because the single declared supertype of a subclass is
+ * [HostMcpCommand], not [JetWhaleMcpTool]:
+ * ```kotlin
+ * @Inject
+ * @ContributesIntoSet(AppScope::class, binding = binding<JetWhaleMcpTool>())
+ * class MyHostCommand(...) : HostMcpCommand()
+ * ```
+ */
+abstract class HostMcpCommand :
+    JetWhaleMcpCommand(),
+    JetWhaleMcpTool {
+
+    // Lazy, never an eager property: base-class initializers run before the subclass declares its
+    // parameters, and reading the descriptor seals the parameter list. Producing it is idempotent,
+    // so caching it here only avoids rebuilding it once per SSE connection.
+    private val descriptor by lazy { toDescriptor() }
+
+    final override fun register(registrar: McpToolRegistrar) {
+        registrar.addTool(
+            name = descriptor.name,
+            description = descriptor.description,
+            inputSchema = descriptor.toToolSchema(),
+        ) { request ->
+            try {
+                val result = execute(JetWhaleMcpArguments(JsonObject(request.arguments ?: emptyMap())))
+                CallToolResult(content = listOf(TextContent(result)))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: JetWhaleMcpArgumentException) {
+                errorResult(e.message.orEmpty())
+            } catch (e: Exception) {
+                // Host tools do real I/O — downloads, socket binds, plugin loading. A failure has to
+                // reach the agent as a readable result rather than tearing down the MCP connection.
+                errorResult("${e::class.simpleName}: ${e.message.orEmpty()}")
+            }
+        }
+    }
+}

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpServerStatusHolder.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpServerStatusHolder.kt
@@ -1,0 +1,26 @@
+package com.kitakkun.jetwhale.host.mcp
+
+import com.kitakkun.jetwhale.host.model.McpServerStatus
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Holds the MCP server's own status, separately from the server that writes it.
+ *
+ * A host tool that wants to report the status cannot inject [McpServerService] itself: the server
+ * is constructed from the set of tools, so the tool would close a dependency cycle. Both sides
+ * depend on this holder instead.
+ */
+@Inject
+@SingleIn(AppScope::class)
+class McpServerStatusHolder {
+    val statusFlow: StateFlow<McpServerStatus>
+        field = MutableStateFlow<McpServerStatus>(McpServerStatus.Stopped)
+
+    fun update(status: McpServerStatus) {
+        statusFlow.value = status
+    }
+}

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolExtensions.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolExtensions.kt
@@ -1,11 +1,32 @@
 package com.kitakkun.jetwhale.host.mcp
 
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+
+/**
+ * Assembles the MCP input schema of a tool declared with the parameter DSL.
+ *
+ * [leadingProperties] are properties the host adds on top of the command's own parameters and are
+ * always required — the plugin path uses it to prepend the `sessionId` that routes a call to the
+ * right plugin instance, while host-scoped tools pass nothing.
+ */
+fun JetWhaleMcpToolDescriptor.toToolSchema(
+    leadingProperties: Map<String, JsonObject> = emptyMap(),
+): ToolSchema = ToolSchema(
+    // The parameter's schema describes its type; only the description has to be merged in.
+    properties = JsonObject(
+        leadingProperties + parameters.mapValues { (_, parameter) ->
+            JsonObject(parameter.schema + ("description" to JsonPrimitive(parameter.description)))
+        },
+    ),
+    required = leadingProperties.keys.toList() + parameters.filterValues { it.required }.keys,
+)
 
 fun errorResult(message: String): CallToolResult = CallToolResult(
     content = listOf(TextContent(buildJsonObject { put("error", message) }.toString())),

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
@@ -4,7 +4,6 @@ import com.kitakkun.jetwhale.host.model.McpCapablePlugins
 import com.kitakkun.jetwhale.host.model.McpToolParameterSummary
 import com.kitakkun.jetwhale.host.model.McpToolSummary
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
-import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
@@ -26,7 +25,6 @@ import java.util.concurrent.ConcurrentHashMap
  * invoked, the caller must supply a `sessionId` argument so the registry can route the
  * call to the correct plugin instance.
  */
-@OptIn(ExperimentalJetWhaleApi::class)
 class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) {
 
     /**
@@ -142,7 +140,6 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
         .map { (name, entry) -> name to entry.descriptor }
 }
 
-@OptIn(ExperimentalJetWhaleApi::class)
 data class PluginToolEntry(
     val descriptor: JetWhaleMcpToolDescriptor,
     val sessionToPlugin: ConcurrentHashMap<String, String>,

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/SessionTools.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/SessionTools.kt
@@ -8,7 +8,6 @@ import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.DebugSessionRepository
 import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
-import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
@@ -34,7 +33,6 @@ suspend fun listSessions(debugSessionRepository: DebugSessionRepository): String
  * Returns a JSON string listing plugins installed in the given session.
  * Each entry includes whether the plugin implements [JetWhaleMcpCapablePlugin].
  */
-@OptIn(ExperimentalJetWhaleApi::class)
 suspend fun listPlugins(
     sessionId: String,
     debugSessionRepository: DebugSessionRepository,

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommands.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommands.kt
@@ -1,0 +1,96 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.mcp.HostMcpCommand
+import com.kitakkun.jetwhale.host.mcp.JetWhaleMcpTool
+import com.kitakkun.jetwhale.host.model.LogCaptureService
+import com.kitakkun.jetwhale.host.model.LogEntry
+import com.kitakkun.jetwhale.host.model.LogLevel
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Keeps a full log dump from blowing up a tool result; the host retains up to 10,000 entries. */
+private const val DEFAULT_LIMIT = 200
+private const val MAX_LIMIT = 1000
+private const val MAX_MESSAGE_LENGTH = 2000
+
+@Inject
+@ContributesIntoSet(AppScope::class, binding = binding<JetWhaleMcpTool>())
+class GetLogsCommand(
+    private val logCaptureService: LogCaptureService,
+) : HostMcpCommand() {
+    override val name: String = "jetwhale.getLogs"
+    override val description: String =
+        "Host-wide: reads the debug tool's own captured stdout/stderr, oldest first. Use it to diagnose JetWhale itself — plugin load failures, server errors — not the debugged app's logs."
+
+    private val limit by intOrNull("How many of the most recent matching entries to return. Default $DEFAULT_LIMIT, maximum $MAX_LIMIT.")
+    private val level by enumOrNull("Only return entries logged at this level.", LogLevel.entries)
+    private val contains by stringOrNull("Only return entries whose message contains this substring, case-insensitively.")
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val requestedLimit = arguments[limit] ?: DEFAULT_LIMIT
+        if (requestedLimit !in 1..MAX_LIMIT) {
+            throw JetWhaleMcpArgumentException("invalid limit: expected 1..$MAX_LIMIT but was $requestedLimit")
+        }
+        val requestedLevel = arguments[level]
+        val requestedSubstring = arguments[contains]
+
+        val matching = logCaptureService.logs.value.filter { entry ->
+            (requestedLevel == null || entry.level == requestedLevel) &&
+                (requestedSubstring == null || entry.message.contains(requestedSubstring, ignoreCase = true))
+        }
+        val returned = matching.takeLast(requestedLimit)
+
+        return Json.encodeToString(
+            GetLogsResult(
+                logs = returned.map { it.toJson() },
+                returned = returned.size,
+                total = matching.size,
+            ),
+        )
+    }
+}
+
+@Inject
+@ContributesIntoSet(AppScope::class, binding = binding<JetWhaleMcpTool>())
+class ClearLogsCommand(
+    private val logCaptureService: LogCaptureService,
+) : HostMcpCommand() {
+    override val name: String = "jetwhale.clearLogs"
+    override val description: String =
+        "Host-wide: discards every captured host log entry. Clear before reproducing an issue so that jetwhale.getLogs afterwards shows only what the reproduction produced."
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val cleared = logCaptureService.logs.value.size
+        logCaptureService.clearLogs()
+        return Json.encodeToString(ClearLogsResult(cleared = cleared))
+    }
+}
+
+private fun LogEntry.toJson() = LogEntryJson(
+    timestamp = timestamp.toString(),
+    level = level.name,
+    message = if (message.length > MAX_MESSAGE_LENGTH) message.take(MAX_MESSAGE_LENGTH) + "…(truncated)" else message,
+)
+
+@Serializable
+data class GetLogsResult(
+    val logs: List<LogEntryJson>,
+    val returned: Int,
+    val total: Int,
+)
+
+@Serializable
+data class LogEntryJson(
+    val timestamp: String,
+    val level: String,
+    val message: String,
+)
+
+@Serializable
+data class ClearLogsResult(val cleared: Int)

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommand.kt
@@ -1,0 +1,138 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.mcp.HostMcpCommand
+import com.kitakkun.jetwhale.host.mcp.JetWhaleMcpTool
+import com.kitakkun.jetwhale.host.model.DebugSessionRepository
+import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.HostDestination
+import com.kitakkun.jetwhale.host.model.HostDestinationKind
+import com.kitakkun.jetwhale.host.model.HostNavigationRequest
+import com.kitakkun.jetwhale.host.model.HostNavigationService
+import com.kitakkun.jetwhale.host.model.HostSettingsSection
+import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.PluginSessionReconciliationService
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** How long to wait for the window to report that it applied the request before giving up on confirming it. */
+private const val CONFIRMATION_TIMEOUT_MILLIS = 2_000L
+
+enum class NavigationDestination { HOME, PLUGIN, SETTINGS, INFO, LOG_VIEWER }
+
+@Inject
+@ContributesIntoSet(AppScope::class, binding = binding<JetWhaleMcpTool>())
+class HostNavigationCommand(
+    private val hostNavigationService: HostNavigationService,
+    private val debugSessionRepository: DebugSessionRepository,
+    private val pluginFactoryRepository: PluginFactoryRepository,
+    private val enabledPluginsRepository: EnabledPluginsRepository,
+    private val reconciliationService: PluginSessionReconciliationService,
+) : HostMcpCommand() {
+    override val name: String = "jetwhale.navigate"
+    override val description: String =
+        "Host-wide: switches the main JetWhale window to another screen. Navigating to PLUGIN also selects that session in the drawer, which is what jetwhale.screenshot of the same plugin will then show."
+
+    private val destination by enum("Which screen to show.", NavigationDestination.entries)
+    private val pluginId by stringOrNull("Required when destination is PLUGIN; from jetwhale.listInstalledPlugins.")
+    private val sessionId by stringOrNull("Only for PLUGIN. Defaults to the session already selected in the drawer.")
+    private val settingsSection by enumOrNull("Only for SETTINGS. Defaults to GENERAL.", HostSettingsSection.entries)
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val request = arguments.toRequest()
+        hostNavigationService.navigate(request)
+
+        // Report what the window actually shows rather than assuming the request landed: the drawer
+        // resets its selection when the selected session goes inactive, and the window may not have
+        // composed yet.
+        val applied = withTimeoutOrNull(CONFIRMATION_TIMEOUT_MILLIS) {
+            hostNavigationService.currentView.filterNotNull().first { request.matches(it.destination) }
+        }?.destination
+            ?: return Json.encodeToString(
+                NavigateResult(
+                    applied = false,
+                    reason = "The host window did not report the requested destination within $CONFIRMATION_TIMEOUT_MILLIS ms. It may still be starting up.",
+                ),
+            )
+
+        return Json.encodeToString(
+            NavigateResult(
+                applied = true,
+                destination = applied.kind.name,
+                pluginId = applied.pluginId,
+                sessionId = applied.sessionId,
+                settingsSection = applied.settingsSection?.name,
+                poppedOut = applied.poppedOutPlugins.any { it.pluginId == applied.pluginId && it.sessionId == applied.sessionId },
+            ),
+        )
+    }
+
+    private suspend fun JetWhaleMcpArguments.toRequest(): HostNavigationRequest = when (this[destination]) {
+        NavigationDestination.HOME -> HostNavigationRequest.Home
+
+        NavigationDestination.INFO -> HostNavigationRequest.Info
+
+        NavigationDestination.LOG_VIEWER -> HostNavigationRequest.LogViewer
+
+        NavigationDestination.SETTINGS -> HostNavigationRequest.Settings(this[settingsSection] ?: HostSettingsSection.GENERAL)
+
+        NavigationDestination.PLUGIN -> {
+            val targetPluginId = this[pluginId]
+                ?: throw JetWhaleMcpArgumentException("missing required argument: pluginId is required when destination is PLUGIN")
+            validatePlugin(targetPluginId, this[sessionId])
+            HostNavigationRequest.Plugin(targetPluginId, this[sessionId])
+        }
+    }
+
+    /** Turns the three ways a plugin screen can silently fail to open into three distinct errors. */
+    private suspend fun validatePlugin(targetPluginId: String, targetSessionId: String?) {
+        if (targetPluginId !in pluginFactoryRepository.loadedPlugins) {
+            throw JetWhaleMcpArgumentException("invalid pluginId: '$targetPluginId' is not installed. See jetwhale.listInstalledPlugins.")
+        }
+        if (targetPluginId !in enabledPluginsRepository.enabledPluginIdsFlow.first()) {
+            throw JetWhaleMcpArgumentException("invalid pluginId: '$targetPluginId' is installed but disabled. Enable it with jetwhale.setPluginEnabled.")
+        }
+        if (targetSessionId == null) return
+
+        val session = debugSessionRepository.debugSessionsFlow.firstOrNull()?.find { it.id == targetSessionId }
+            ?: throw JetWhaleMcpArgumentException("invalid sessionId: no session '$targetSessionId'. See jetwhale.listSessions.")
+        if (reconciliationService.requiresAgent(targetPluginId) && session.installedPlugins.none { it.pluginId == targetPluginId }) {
+            throw JetWhaleMcpArgumentException("invalid sessionId: session '$targetSessionId' does not have '$targetPluginId' installed on its agent.")
+        }
+    }
+}
+
+private fun HostNavigationRequest.matches(destination: HostDestination): Boolean = when (this) {
+    HostNavigationRequest.Home -> destination.kind == HostDestinationKind.HOME
+
+    HostNavigationRequest.Info -> destination.kind == HostDestinationKind.INFO
+
+    HostNavigationRequest.LogViewer -> destination.kind == HostDestinationKind.LOG_VIEWER
+
+    is HostNavigationRequest.Settings -> destination.kind == HostDestinationKind.SETTINGS && destination.settingsSection == section
+
+    is HostNavigationRequest.Plugin ->
+        destination.kind == HostDestinationKind.PLUGIN &&
+            destination.pluginId == pluginId &&
+            (sessionId == null || destination.sessionId == sessionId)
+}
+
+@Serializable
+data class NavigateResult(
+    val applied: Boolean,
+    val destination: String? = null,
+    val pluginId: String? = null,
+    val sessionId: String? = null,
+    val settingsSection: String? = null,
+    val poppedOut: Boolean = false,
+    val reason: String? = null,
+)

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommands.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommands.kt
@@ -1,0 +1,232 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.mcp.HostMcpCommand
+import com.kitakkun.jetwhale.host.mcp.JetWhaleMcpTool
+import com.kitakkun.jetwhale.host.model.DebugSessionRepository
+import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.OfficialPluginCatalog
+import com.kitakkun.jetwhale.host.model.OfficialPluginInstallService
+import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
+import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
+import com.kitakkun.jetwhale.host.model.PluginInstanceService
+import com.kitakkun.jetwhale.host.model.PluginTrustService
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Inject
+@ContributesIntoSet(AppScope::class, binding = binding<JetWhaleMcpTool>())
+class ListInstalledPluginsCommand(
+    private val pluginFactoryRepository: PluginFactoryRepository,
+    private val enabledPluginsRepository: EnabledPluginsRepository,
+    private val pluginTrustService: PluginTrustService,
+) : HostMcpCommand() {
+    override val name: String = "jetwhale.listInstalledPlugins"
+    override val description: String =
+        "Host-wide: lists every plugin installed into the debug tool and whether it is enabled, plus the official plugins that could still be installed and any jar that failed to load or is awaiting trust. Use jetwhale.listPlugins instead to see what a particular debug session advertises."
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val loaded = pluginFactoryRepository.loadedPlugins
+        val enabledPluginIds = enabledPluginsRepository.enabledPluginIdsFlow.first()
+
+        val installed = loaded.values.map { plugin ->
+            InstalledPluginJson(
+                pluginId = plugin.manifest.pluginId,
+                name = plugin.manifest.pluginName,
+                version = plugin.manifest.version,
+                requiresAgent = plugin.manifest.requiresAgent,
+                enabled = plugin.manifest.pluginId in enabledPluginIds,
+            )
+        }.sortedBy { it.pluginId }
+
+        return Json.encodeToString(
+            ListInstalledPluginsResult(
+                installed = installed,
+                availableOfficial = OfficialPluginCatalog.plugins.map { official ->
+                    OfficialPluginJson(
+                        pluginId = official.pluginId,
+                        displayName = official.displayName,
+                        description = official.description,
+                        installed = official.pluginId in loaded,
+                    )
+                },
+                failedJars = pluginFactoryRepository.failedJarsFlow.first().map { FailedJarJson(it.jarPath, it.reason) },
+                untrustedJars = pluginTrustService.untrustedJarPathsFlow.first(),
+            ),
+        )
+    }
+}
+
+/** How long to wait for reconciliation to instantiate a freshly enabled plugin before reporting what happened. */
+private const val INSTANTIATION_TIMEOUT_MILLIS = 2_000L
+
+@Inject
+@ContributesIntoSet(AppScope::class, binding = binding<JetWhaleMcpTool>())
+class SetPluginEnabledCommand(
+    private val pluginFactoryRepository: PluginFactoryRepository,
+    private val enabledPluginsRepository: EnabledPluginsRepository,
+    private val pluginInstanceService: PluginInstanceService,
+    private val debugSessionRepository: DebugSessionRepository,
+) : HostMcpCommand() {
+    override val name: String = "jetwhale.setPluginEnabled"
+    override val description: String =
+        "Host-wide: enables or disables an installed plugin across the whole debug tool, exactly like the toggle in the plugin drawer. A newly enabled plugin's own MCP tools only become visible after you reconnect to this MCP server."
+
+    private val pluginId by string("The plugin to toggle; from jetwhale.listInstalledPlugins.")
+    private val enabled by boolean("True to enable the plugin, false to disable it.")
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val targetPluginId = arguments[pluginId]
+        if (targetPluginId !in pluginFactoryRepository.loadedPlugins) {
+            throw JetWhaleMcpArgumentException("invalid pluginId: '$targetPluginId' is not installed. See jetwhale.listInstalledPlugins.")
+        }
+        val shouldEnable = arguments[enabled]
+
+        // Reconciliation runs asynchronously, so collect the Ready events before flipping the flag —
+        // otherwise "ok" would be reported before any instance actually exists. With nothing
+        // connected there is nothing to instantiate, so skip the wait entirely.
+        val hasActiveSession = debugSessionRepository.debugSessionsFlow.firstOrNull().orEmpty().any { it.isActive }
+        val instantiatedSessions = mutableSetOf<String>()
+        coroutineScope {
+            val collector = launch {
+                pluginInstanceService.pluginInstanceEventFlow
+                    .filterIsInstance<PluginInstanceEvent.Ready>()
+                    .filter { it.pluginId == targetPluginId }
+                    .collect { instantiatedSessions += it.sessionId }
+            }
+            enabledPluginsRepository.setPluginEnabled(targetPluginId, shouldEnable)
+            if (shouldEnable && hasActiveSession) delay(INSTANTIATION_TIMEOUT_MILLIS)
+            collector.cancel()
+        }
+
+        return Json.encodeToString(
+            SetPluginEnabledResult(
+                pluginId = targetPluginId,
+                enabled = shouldEnable,
+                instantiatedForSessions = instantiatedSessions.sorted(),
+                reconnectRequiredForNewTools = shouldEnable,
+            ),
+        )
+    }
+}
+
+@Inject
+@ContributesIntoSet(AppScope::class, binding = binding<JetWhaleMcpTool>())
+class InstallOfficialPluginCommand(
+    private val officialPluginInstallService: OfficialPluginInstallService,
+    private val pluginFactoryRepository: PluginFactoryRepository,
+    private val pluginInstallProgressRepository: PluginInstallProgressRepository,
+    private val settingsRepository: DebuggerSettingsRepository,
+) : HostMcpCommand() {
+    override val name: String = "jetwhale.installOfficialPlugin"
+    override val description: String =
+        "Host-wide: downloads and installs a plugin from JetWhale's official catalog, then enable it with jetwhale.setPluginEnabled. Only catalog plugins can be installed this way, and only when the user has allowed it in Settings → Server → MCP Server."
+
+    private val pluginId by string("The official plugin to install; from the availableOfficial list of jetwhale.listInstalledPlugins.")
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        if (!settingsRepository.mcpPluginInstallAllowedFlow.value) {
+            // Listed but refused on purpose: an agent that can read the reason can tell the user
+            // which switch to flip, where a hidden tool would only produce confusion.
+            throw JetWhaleMcpArgumentException(
+                "plugin installation over MCP is disabled. Ask the user to enable it in Settings → Server → MCP Server.",
+            )
+        }
+
+        val targetPluginId = arguments[pluginId]
+        val plugin = OfficialPluginCatalog.plugins.find { it.pluginId == targetPluginId }
+            ?: throw JetWhaleMcpArgumentException(
+                "invalid pluginId: '$targetPluginId' is not an official plugin. Only ${OfficialPluginCatalog.plugins.joinToString { it.pluginId }} can be installed over MCP.",
+            )
+        if (targetPluginId in pluginFactoryRepository.loadedPlugins) {
+            return Json.encodeToString(
+                InstallOfficialPluginResult(
+                    pluginId = targetPluginId,
+                    installed = true,
+                    alreadyInstalled = true,
+                    nextStep = "jetwhale.setPluginEnabled",
+                ),
+            )
+        }
+        // A single in-flight slot is shared with the settings screen's install flow.
+        if (pluginInstallProgressRepository.progressFlow.first() != null) {
+            throw JetWhaleMcpArgumentException("another plugin installation is already in progress; try again once it finishes")
+        }
+
+        withContext(Dispatchers.IO) { officialPluginInstallService.install(plugin) }
+
+        return Json.encodeToString(
+            InstallOfficialPluginResult(
+                pluginId = targetPluginId,
+                installed = true,
+                alreadyInstalled = false,
+                nextStep = "jetwhale.setPluginEnabled",
+            ),
+        )
+    }
+}
+
+@Serializable
+data class SetPluginEnabledResult(
+    val pluginId: String,
+    val enabled: Boolean,
+    val instantiatedForSessions: List<String>,
+    val reconnectRequiredForNewTools: Boolean,
+)
+
+@Serializable
+data class InstallOfficialPluginResult(
+    val pluginId: String,
+    val installed: Boolean,
+    val alreadyInstalled: Boolean,
+    val nextStep: String,
+    val enabled: Boolean = false,
+    val reconnectRequiredForNewTools: Boolean = true,
+)
+
+@Serializable
+data class ListInstalledPluginsResult(
+    val installed: List<InstalledPluginJson>,
+    val availableOfficial: List<OfficialPluginJson>,
+    val failedJars: List<FailedJarJson>,
+    val untrustedJars: List<String>,
+)
+
+@Serializable
+data class InstalledPluginJson(
+    val pluginId: String,
+    val name: String,
+    val version: String,
+    val requiresAgent: Boolean,
+    val enabled: Boolean,
+)
+
+@Serializable
+data class OfficialPluginJson(
+    val pluginId: String,
+    val displayName: String,
+    val description: String,
+    val installed: Boolean,
+)
+
+@Serializable
+data class FailedJarJson(
+    val jarPath: String,
+    val reason: String,
+)

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommands.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommands.kt
@@ -1,0 +1,167 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.mcp.HostMcpCommand
+import com.kitakkun.jetwhale.host.mcp.JetWhaleMcpTool
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
+import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+private const val SERVER_RESTART_NOTE = "Every agent session was dropped; call jetwhale.listSessions again before using any sessionId you were holding."
+
+@Inject
+@ContributesIntoSet(AppScope::class, binding = binding<JetWhaleMcpTool>())
+class UpdateSettingsCommand(
+    private val settingsRepository: DebuggerSettingsRepository,
+    private val debugWebSocketServer: DebugWebSocketServer,
+) : HostMcpCommand() {
+    override val name: String = "jetwhale.updateSettings"
+    override val description: String =
+        "Host-wide: changes the debug tool's settings. Only the arguments you supply are touched. Changing a ws/wss setting restarts the debug server, which drops every agent session — pass restartDebugServer=false to persist the change and apply it later instead."
+
+    private val serverPort by intOrNull("Port the debug WebSocket server listens on.")
+    private val wssPort by intOrNull("Port the secure (wss) connector listens on.")
+    private val wssEnabled by booleanOrNull("Whether the secure (wss) connector is exposed at all.")
+    private val mcpServerPort by intOrNull("Port this MCP server listens on. Persisted only — see the note in the result.")
+    private val adbAutoPortMappingEnabled by booleanOrNull("Whether the host runs `adb reverse` automatically for connected Android devices.")
+    private val checkForUpdatesOnStartup by booleanOrNull("Whether the host checks for a newer release when it starts.")
+    private val persistData by booleanOrNull("Whether captured debug data survives a host restart.")
+    private val restartDebugServer by booleanOrNull("Whether to restart the debug server so ws/wss changes take effect now. Defaults to true when a ws/wss setting changed.")
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        // Validate every port before writing any of them, so a bad argument late in the list cannot
+        // leave the settings half-applied.
+        val newServerPort = arguments[serverPort]?.requireValidPort("serverPort")
+        val newWssPort = arguments[wssPort]?.requireValidPort("wssPort")
+        val newMcpServerPort = arguments[mcpServerPort]?.requireValidPort("mcpServerPort")
+
+        val applied = mutableMapOf<String, String>()
+        val notes = mutableListOf<String>()
+
+        newServerPort?.let { port ->
+            settingsRepository.updateServerPort(port)
+            applied["serverPort"] = port.toString()
+        }
+        newWssPort?.let { port ->
+            settingsRepository.updateWssPort(port)
+            applied["wssPort"] = port.toString()
+        }
+        arguments[wssEnabled]?.let { enabled ->
+            settingsRepository.updateWssEnabled(enabled)
+            applied["wssEnabled"] = enabled.toString()
+        }
+        newMcpServerPort?.let { port ->
+            settingsRepository.updateMcpServerPort(port)
+            applied["mcpServerPort"] = port.toString()
+            // Restarting the MCP server here would tear down the very connection carrying this call.
+            notes += "mcpServerPort was saved but this MCP server is still listening on its old port; the change takes effect the next time the host starts."
+        }
+        arguments[adbAutoPortMappingEnabled]?.let { enabled ->
+            settingsRepository.updateAdbAutoPortMappingEnabled(enabled)
+            applied["adbAutoPortMappingEnabled"] = enabled.toString()
+            notes += "adbAutoPortMappingEnabled is read when the debug server starts, so it takes effect on the next debug server start."
+        }
+        arguments[checkForUpdatesOnStartup]?.let { enabled ->
+            settingsRepository.updateCheckForUpdatesOnStartup(enabled)
+            applied["checkForUpdatesOnStartup"] = enabled.toString()
+        }
+        arguments[persistData]?.let { enabled ->
+            settingsRepository.updatePersistData(enabled)
+            applied["persistData"] = enabled.toString()
+        }
+
+        if (applied.isEmpty()) {
+            throw JetWhaleMcpArgumentException("no settings given: supply at least one setting to change")
+        }
+
+        val debugServerAffected = applied.keys.any { it in DEBUG_SERVER_SETTINGS }
+        val shouldRestart = arguments[restartDebugServer] ?: debugServerAffected
+        if (shouldRestart) {
+            restartDebugServer(settingsRepository, debugWebSocketServer)
+            notes += SERVER_RESTART_NOTE
+        } else if (debugServerAffected) {
+            notes += "The debug server is still running with its previous ports; restart it with jetwhale.restartDebugServer to apply the change."
+        }
+
+        return Json.encodeToString(
+            UpdateSettingsResult(
+                applied = applied,
+                debugServerRestarted = shouldRestart,
+                mcpServerRestarted = false,
+                notes = notes,
+            ),
+        )
+    }
+
+    private fun Int.requireValidPort(parameterName: String): Int {
+        if (this !in 1..65535) throw JetWhaleMcpArgumentException("invalid $parameterName: expected 1..65535 but was $this")
+        return this
+    }
+
+    private companion object {
+        val DEBUG_SERVER_SETTINGS = setOf("serverPort", "wssPort", "wssEnabled", "adbAutoPortMappingEnabled")
+    }
+}
+
+@Inject
+@ContributesIntoSet(AppScope::class, binding = binding<JetWhaleMcpTool>())
+class RestartDebugServerCommand(
+    private val settingsRepository: DebuggerSettingsRepository,
+    private val debugWebSocketServer: DebugWebSocketServer,
+) : HostMcpCommand() {
+    override val name: String = "jetwhale.restartDebugServer"
+    override val description: String =
+        "Host-wide: stops and restarts the debug WebSocket server that agents connect to. This disconnects every session — every sessionId you hold becomes invalid and each app has to reconnect."
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        restartDebugServer(settingsRepository, debugWebSocketServer)
+        val status = debugWebSocketServer.statusFlow.value.toJson()
+        return Json.encodeToString(
+            RestartDebugServerResult(
+                state = status.state,
+                host = status.host,
+                port = status.port,
+                wssPort = status.wssPort,
+                note = SERVER_RESTART_NOTE,
+            ),
+        )
+    }
+}
+
+/** Mirrors the settings-screen restart path: stop, then start with whatever the wss settings now say. */
+private suspend fun restartDebugServer(
+    settingsRepository: DebuggerSettingsRepository,
+    debugWebSocketServer: DebugWebSocketServer,
+) = withContext(Dispatchers.IO) {
+    debugWebSocketServer.stop()
+    debugWebSocketServer.start(
+        host = "localhost",
+        port = settingsRepository.serverPortFlow.value,
+        wssPort = settingsRepository.wssPortFlow.value.takeIf { settingsRepository.wssEnabledFlow.value },
+    )
+}
+
+@Serializable
+data class UpdateSettingsResult(
+    val applied: Map<String, String>,
+    val debugServerRestarted: Boolean,
+    val mcpServerRestarted: Boolean,
+    val notes: List<String>,
+)
+
+@Serializable
+data class RestartDebugServerResult(
+    val state: String,
+    val host: String? = null,
+    val port: Int? = null,
+    val wssPort: Int? = null,
+    val note: String,
+)

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommands.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommands.kt
@@ -67,7 +67,6 @@ class UpdateSettingsCommand(
         arguments[adbAutoPortMappingEnabled]?.let { enabled ->
             settingsRepository.updateAdbAutoPortMappingEnabled(enabled)
             applied["adbAutoPortMappingEnabled"] = enabled.toString()
-            notes += "adbAutoPortMappingEnabled is read when the debug server starts, so it takes effect on the next debug server start."
         }
         arguments[checkForUpdatesOnStartup]?.let { enabled ->
             settingsRepository.updateCheckForUpdatesOnStartup(enabled)
@@ -88,7 +87,8 @@ class UpdateSettingsCommand(
             restartDebugServer(settingsRepository, debugWebSocketServer)
             notes += SERVER_RESTART_NOTE
         } else if (debugServerAffected) {
-            notes += "The debug server is still running with its previous ports; restart it with jetwhale.restartDebugServer to apply the change."
+            // Both the ports and adbAutoPortMappingEnabled are only read when the server starts.
+            notes += "The debug server is still running with its previous configuration; restart it with jetwhale.restartDebugServer to apply the change."
         }
 
         return Json.encodeToString(

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommand.kt
@@ -75,6 +75,7 @@ class HostStatusCommand(
                     adbAutoPortMappingEnabled = settingsRepository.adbAutoPortMappingEnabledFlow.value,
                     checkForUpdatesOnStartup = settingsRepository.checkForUpdatesOnStartupFlow.value,
                     persistData = settingsRepository.persistDataFlow.value,
+                    mcpPluginInstallAllowed = settingsRepository.mcpPluginInstallAllowedFlow.value,
                 ),
                 ui = hostNavigationService.currentView.value?.toJson(),
             ),
@@ -177,4 +178,6 @@ data class SettingsJson(
     val adbAutoPortMappingEnabled: Boolean,
     val checkForUpdatesOnStartup: Boolean,
     val persistData: Boolean,
+    /** Whether jetwhale.installOfficialPlugin is permitted; see Settings → Server → MCP Server. */
+    val mcpPluginInstallAllowed: Boolean,
 )

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommand.kt
@@ -1,0 +1,180 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.mcp.HostMcpCommand
+import com.kitakkun.jetwhale.host.mcp.JetWhaleMcpTool
+import com.kitakkun.jetwhale.host.mcp.McpServerStatusHolder
+import com.kitakkun.jetwhale.host.model.DebugSessionRepository
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
+import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.HostNavigationService
+import com.kitakkun.jetwhale.host.model.HostOs
+import com.kitakkun.jetwhale.host.model.HostVersionInfo
+import com.kitakkun.jetwhale.host.model.HostViewState
+import com.kitakkun.jetwhale.host.model.McpServerStatus
+import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
+import com.kitakkun.jetwhale.host.model.PluginTrustService
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Inject
+@ContributesIntoSet(AppScope::class, binding = binding<JetWhaleMcpTool>())
+class HostStatusCommand(
+    private val hostVersionInfo: HostVersionInfo,
+    private val debugWebSocketServer: DebugWebSocketServer,
+    private val mcpServerStatusHolder: McpServerStatusHolder,
+    private val debugSessionRepository: DebugSessionRepository,
+    private val pluginFactoryRepository: PluginFactoryRepository,
+    private val enabledPluginsRepository: EnabledPluginsRepository,
+    private val pluginTrustService: PluginTrustService,
+    private val pluginInstallProgressRepository: PluginInstallProgressRepository,
+    private val settingsRepository: DebuggerSettingsRepository,
+    private val hostNavigationService: HostNavigationService,
+) : HostMcpCommand() {
+    override val name: String = "jetwhale.getStatus"
+    override val description: String =
+        "Host-wide: one snapshot of the debug tool — its version, both servers, how many sessions and plugins are live, and the current settings. Call this first to orient yourself before any other jetwhale tool."
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val sessions = debugSessionRepository.debugSessionsFlow.firstOrNull().orEmpty()
+
+        return Json.encodeToString(
+            HostStatusResult(
+                host = HostInfoJson(
+                    version = hostVersionInfo.version,
+                    isSnapshot = hostVersionInfo.isSnapshot,
+                    os = HostOs.current.name,
+                ),
+                debugServer = debugWebSocketServer.statusFlow.value.toJson(),
+                mcpServer = mcpServerStatusHolder.statusFlow.value.toJson(),
+                sessions = SessionCountsJson(
+                    total = sessions.size,
+                    active = sessions.count { it.isActive },
+                ),
+                plugins = PluginCountsJson(
+                    loaded = pluginFactoryRepository.loadedPlugins.size,
+                    enabled = enabledPluginsRepository.enabledPluginIdsFlow.first().size,
+                    failedJars = pluginFactoryRepository.failedJarsFlow.first().size,
+                    untrustedJars = pluginTrustService.untrustedJarPathsFlow.first().size,
+                    installInProgress = pluginInstallProgressRepository.progressFlow.first() != null,
+                ),
+                settings = SettingsJson(
+                    serverPort = settingsRepository.serverPortFlow.value,
+                    wssPort = settingsRepository.wssPortFlow.value,
+                    wssEnabled = settingsRepository.wssEnabledFlow.value,
+                    mcpServerPort = settingsRepository.mcpServerPortFlow.value,
+                    adbAutoPortMappingEnabled = settingsRepository.adbAutoPortMappingEnabledFlow.value,
+                    checkForUpdatesOnStartup = settingsRepository.checkForUpdatesOnStartupFlow.value,
+                    persistData = settingsRepository.persistDataFlow.value,
+                ),
+                ui = hostNavigationService.currentView.value?.toJson(),
+            ),
+        )
+    }
+}
+
+private fun HostViewState.toJson() = UiStateJson(
+    destination = destination.kind.name,
+    pluginId = destination.pluginId,
+    sessionId = destination.sessionId,
+    settingsSection = destination.settingsSection?.name,
+    poppedOutPlugins = destination.poppedOutPlugins.map { PoppedOutPluginJson(it.pluginId, it.sessionId) },
+    selectedSessionId = selectedSessionId,
+    selectedPluginId = selectedPluginId,
+)
+
+internal fun DebugWebSocketServerStatus.toJson(): ServerStateJson = when (this) {
+    is DebugWebSocketServerStatus.Started -> ServerStateJson("Started", host = host, port = port, wssPort = wssPort)
+    is DebugWebSocketServerStatus.Error -> ServerStateJson("Error", message = message)
+    DebugWebSocketServerStatus.Starting -> ServerStateJson("Starting")
+    DebugWebSocketServerStatus.Stopping -> ServerStateJson("Stopping")
+    DebugWebSocketServerStatus.Stopped -> ServerStateJson("Stopped")
+}
+
+private fun McpServerStatus.toJson(): ServerStateJson = when (this) {
+    is McpServerStatus.Running -> ServerStateJson("Running", host = host, port = port)
+    is McpServerStatus.Error -> ServerStateJson("Error", message = message)
+    McpServerStatus.Starting -> ServerStateJson("Starting")
+    McpServerStatus.Stopping -> ServerStateJson("Stopping")
+    McpServerStatus.Stopped -> ServerStateJson("Stopped")
+}
+
+@Serializable
+data class HostStatusResult(
+    val host: HostInfoJson,
+    val debugServer: ServerStateJson,
+    val mcpServer: ServerStateJson,
+    val sessions: SessionCountsJson,
+    val plugins: PluginCountsJson,
+    val settings: SettingsJson,
+    /** Null until the host window has composed. */
+    val ui: UiStateJson? = null,
+)
+
+@Serializable
+data class UiStateJson(
+    val destination: String,
+    val pluginId: String? = null,
+    val sessionId: String? = null,
+    val settingsSection: String? = null,
+    val poppedOutPlugins: List<PoppedOutPluginJson> = emptyList(),
+    val selectedSessionId: String? = null,
+    val selectedPluginId: String? = null,
+)
+
+@Serializable
+data class PoppedOutPluginJson(
+    val pluginId: String,
+    val sessionId: String,
+)
+
+@Serializable
+data class HostInfoJson(
+    val version: String,
+    val isSnapshot: Boolean,
+    val os: String,
+)
+
+@Serializable
+data class ServerStateJson(
+    val state: String,
+    val host: String? = null,
+    val port: Int? = null,
+    val wssPort: Int? = null,
+    val message: String? = null,
+)
+
+@Serializable
+data class SessionCountsJson(
+    val total: Int,
+    val active: Int,
+)
+
+@Serializable
+data class PluginCountsJson(
+    val loaded: Int,
+    val enabled: Int,
+    val failedJars: Int,
+    val untrustedJars: Int,
+    val installInProgress: Boolean,
+)
+
+@Serializable
+data class SettingsJson(
+    val serverPort: Int,
+    val wssPort: Int,
+    val wssEnabled: Boolean,
+    val mcpServerPort: Int,
+    val adbAutoPortMappingEnabled: Boolean,
+    val checkForUpdatesOnStartup: Boolean,
+    val persistData: Boolean,
+)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -4,7 +4,6 @@ import com.kitakkun.jetwhale.host.model.LoadedPluginInstance
 import com.kitakkun.jetwhale.host.model.McpServerStatus
 import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
-import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
@@ -51,6 +50,7 @@ class DefaultMcpServerServiceTest {
         pluginInstanceService = pluginInstanceService,
         mcpActivityRepository = mcpActivityRepository,
         builtInTools = emptySet(),
+        statusHolder = McpServerStatusHolder(),
     )
 
     private val host = "localhost"
@@ -74,6 +74,7 @@ class DefaultMcpServerServiceTest {
                 FakeMcpTool("fake.toolB"),
                 FakeMcpTool("fake.toolC"),
             ),
+            statusHolder = McpServerStatusHolder(),
         )
         val toolsPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTools.start(host, toolsPort)
@@ -95,6 +96,7 @@ class DefaultMcpServerServiceTest {
             pluginInstanceService = pluginInstanceService,
             mcpActivityRepository = mcpActivityRepository,
             builtInTools = setOf(FakeMcpTool("fake.echo", response = "pong")),
+            statusHolder = McpServerStatusHolder(),
         )
         val echoPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTool.start(host, echoPort)
@@ -148,7 +150,6 @@ class DefaultMcpServerServiceTest {
         }
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `plugin tools registered by a failed start do not survive into the next start`() = runBlocking {
         val testPluginId = "com.example.test"
@@ -180,7 +181,6 @@ class DefaultMcpServerServiceTest {
         }
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `plugin tools are registered when McpCapablePlugin instance exists at server start`() = runBlocking {
         val testPluginId = "com.example.test"
@@ -218,7 +218,6 @@ class DefaultMcpServerServiceTest {
         }
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `plugin tools are registered via pluginInstanceEventFlow after server start`() = runBlocking {
         val testPluginId = "com.example.test"
@@ -242,7 +241,6 @@ class DefaultMcpServerServiceTest {
         }
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `plugin tools are unregistered when Disposed event is received`() = runBlocking {
         val testPluginId = "com.example.test"
@@ -301,7 +299,6 @@ class DefaultMcpServerServiceTest {
         }
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `every MCP-capable plugin in a session is reported as capable`() = runBlocking {
         // Regression guard: the drawer's "exposes MCP tools" badge reads mcpCapablePluginsFlow, and
@@ -344,6 +341,7 @@ class DefaultMcpServerServiceTest {
                     runningDuringCall = mcpActivityRepository.activityFlow.value.runningInvocations.map { it.toolName }
                 },
             ),
+            statusHolder = McpServerStatusHolder(),
         )
         val observedPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTool.start(host, observedPort)
@@ -368,6 +366,7 @@ class DefaultMcpServerServiceTest {
             pluginInstanceService = pluginInstanceService,
             mcpActivityRepository = mcpActivityRepository,
             builtInTools = setOf(FakeMcpTool("fake.targeted")),
+            statusHolder = McpServerStatusHolder(),
         )
         val targetedPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTool.start(host, targetedPort)
@@ -397,6 +396,7 @@ class DefaultMcpServerServiceTest {
             pluginInstanceService = pluginInstanceService,
             mcpActivityRepository = mcpActivityRepository,
             builtInTools = setOf(FailingMcpTool("fake.failing")),
+            statusHolder = McpServerStatusHolder(),
         )
         val failingPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTool.start(host, failingPort)
@@ -420,6 +420,7 @@ class DefaultMcpServerServiceTest {
             pluginInstanceService = pluginInstanceService,
             mcpActivityRepository = mcpActivityRepository,
             builtInTools = setOf(FakeMcpTool("fake.recorded")),
+            statusHolder = McpServerStatusHolder(),
         )
         val recordedPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTool.start(host, recordedPort)
@@ -452,6 +453,7 @@ class DefaultMcpServerServiceTest {
             pluginInstanceService = pluginInstanceService,
             mcpActivityRepository = mcpActivityRepository,
             builtInTools = setOf(MediaMcpTool("fake.captured")),
+            statusHolder = McpServerStatusHolder(),
         )
         val capturedPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTool.start(host, capturedPort)
@@ -477,6 +479,7 @@ class DefaultMcpServerServiceTest {
             pluginInstanceService = pluginInstanceService,
             mcpActivityRepository = mcpActivityRepository,
             builtInTools = setOf(ErrorResultMcpTool("fake.rejected")),
+            statusHolder = McpServerStatusHolder(),
         )
         val rejectedPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTool.start(host, rejectedPort)
@@ -506,6 +509,7 @@ class DefaultMcpServerServiceTest {
             pluginInstanceService = pluginInstanceService,
             mcpActivityRepository = mcpActivityRepository,
             builtInTools = setOf(StructuredMcpTool("fake.structured")),
+            statusHolder = McpServerStatusHolder(),
         )
         val structuredPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTool.start(host, structuredPort)
@@ -533,6 +537,7 @@ class DefaultMcpServerServiceTest {
             pluginInstanceService = pluginInstanceService,
             mcpActivityRepository = mcpActivityRepository,
             builtInTools = setOf(FailingMcpTool("fake.failing")),
+            statusHolder = McpServerStatusHolder(),
         )
         val failingPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTool.start(host, failingPort)
@@ -554,7 +559,6 @@ class DefaultMcpServerServiceTest {
         assertEquals("boom", record.response)
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `a plugin tool call is attributed to the plugin that owns it`() = runBlocking {
         val testPluginId = "com.example.test"
@@ -674,7 +678,6 @@ private class FailingMcpTool(private val name: String) : JetWhaleMcpTool {
     }
 }
 
-@OptIn(ExperimentalJetWhaleApi::class)
 private class FakeMcpCapablePlugin(private val toolName: String = "com.example.test.greet") :
     JetWhaleHostPlugin(),
     JetWhaleMcpCapablePlugin {

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommandTest.kt
@@ -1,0 +1,131 @@
+package com.kitakkun.jetwhale.host.mcp
+
+import com.kitakkun.jetwhale.host.model.PluginInstanceService
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.sse.SSE
+import io.modelcontextprotocol.kotlin.sdk.client.Client
+import io.modelcontextprotocol.kotlin.sdk.client.mcpSse
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HostMcpCommandTest {
+
+    private val pluginInstanceService = mock<PluginInstanceService> {
+        every { getLoadedPluginInstances() } returns emptyList()
+        every { pluginInstanceEventFlow } returns MutableSharedFlow()
+    }
+
+    @Test
+    fun `a host command's declared parameters appear in its input schema`() = withHostCommand(EchoHostCommand()) { client ->
+        val properties = client.echoTool().inputSchema.properties
+        assertEquals(setOf("text", "times"), properties?.keys)
+        assertEquals("string", properties?.getValue("text")?.jsonObject?.getValue("type")?.jsonPrimitive?.content)
+        assertEquals("Text to echo back.", properties?.getValue("text")?.jsonObject?.getValue("description")?.jsonPrimitive?.content)
+        assertEquals(listOf("text"), client.echoTool().inputSchema.required)
+    }
+
+    @Test
+    fun `a host command's schema carries no sessionId`() = withHostCommand(EchoHostCommand()) { client ->
+        val tool = client.echoTool()
+        assertFalse("sessionId" in tool.inputSchema.properties?.keys.orEmpty())
+        assertFalse("sessionId" in tool.inputSchema.required.orEmpty())
+    }
+
+    @Test
+    fun `a host command returns the string its execute produced`() = withHostCommand(EchoHostCommand()) { client ->
+        val result = client.callTool("jetwhale.test.echo", mapOf("text" to "hi", "times" to 3))
+        assertEquals("hihihi", result.firstText())
+    }
+
+    @Test
+    fun `an invalid argument is returned as an error result instead of failing the tool call`() = withHostCommand(EchoHostCommand()) { client ->
+        val result = client.callTool("jetwhale.test.echo", emptyMap())
+        assertEquals(true, result.isError)
+        assertContains(result.firstText(), "missing required argument: text")
+    }
+
+    @Test
+    fun `an exception thrown by execute becomes an error result`() = withHostCommand(ExplodingHostCommand()) { client ->
+        val result = client.callTool("jetwhale.test.explode", emptyMap())
+        assertEquals(true, result.isError)
+        assertContains(result.firstText(), "boom")
+    }
+
+    @Test
+    fun `registering the same host command for a second connection does not reseal its parameters`() {
+        val command = EchoHostCommand()
+        withServer(command) { port ->
+            repeat(2) {
+                val client = connect(port)
+                try {
+                    assertTrue("text" in client.echoTool().inputSchema.properties?.keys.orEmpty())
+                } finally {
+                    client.close()
+                }
+            }
+        }
+    }
+
+    private fun withHostCommand(command: HostMcpCommand, block: suspend (Client) -> Unit) = withServer(command) { port ->
+        val client = connect(port)
+        try {
+            block(client)
+        } finally {
+            client.close()
+        }
+    }
+
+    private fun withServer(command: HostMcpCommand, block: suspend (port: Int) -> Unit) = runBlocking {
+        val service = DefaultMcpServerService(
+            pluginInstanceService = pluginInstanceService,
+            mcpActivityRepository = FakeMcpActivityRepository(),
+            builtInTools = setOf(command),
+            statusHolder = McpServerStatusHolder(),
+        )
+        val port = java.net.ServerSocket(0).use { it.localPort }
+        service.start("localhost", port)
+        try {
+            block(port)
+        } finally {
+            service.stop()
+        }
+    }
+
+    private suspend fun connect(port: Int): Client = HttpClient(CIO) { install(SSE) }.mcpSse("http://localhost:$port/sse")
+}
+
+private suspend fun Client.echoTool(): Tool = listTools().tools.first { it.name.startsWith("jetwhale.test.") }
+
+private fun CallToolResult.firstText(): String = content.filterIsInstance<TextContent>().first().text
+
+private class EchoHostCommand : HostMcpCommand() {
+    override val name: String = "jetwhale.test.echo"
+    override val description: String = "Echoes text back."
+
+    private val text by string("Text to echo back.")
+    private val times by intOrNull("How many times to repeat it.")
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[text].repeat(arguments[times] ?: 1)
+}
+
+private class ExplodingHostCommand : HostMcpCommand() {
+    override val name: String = "jetwhale.test.explode"
+    override val description: String = "Always fails."
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String = throw IllegalStateException("boom")
+}

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolSchemaTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolSchemaTest.kt
@@ -1,0 +1,53 @@
+package com.kitakkun.jetwhale.host.mcp
+
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpParameterDescriptor
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class McpToolSchemaTest {
+
+    private val descriptor = JetWhaleMcpToolDescriptor(
+        name = "example.tool",
+        description = "An example.",
+        parameters = mapOf(
+            "required1" to JetWhaleMcpParameterDescriptor(
+                schema = buildJsonObject { put("type", "string") },
+                description = "A required parameter.",
+            ),
+            "optional1" to JetWhaleMcpParameterDescriptor(
+                schema = buildJsonObject { put("type", "integer") },
+                description = "An optional parameter.",
+                required = false,
+            ),
+        ),
+    )
+
+    @Test
+    fun `toToolSchema merges each parameter's description into its schema`() {
+        val properties = requireNotNull(descriptor.toToolSchema().properties)
+
+        assertEquals("string", properties.getValue("required1").jsonObject.getValue("type").jsonPrimitive.content)
+        assertEquals("A required parameter.", properties.getValue("required1").jsonObject.getValue("description").jsonPrimitive.content)
+        assertEquals("An optional parameter.", properties.getValue("optional1").jsonObject.getValue("description").jsonPrimitive.content)
+    }
+
+    @Test
+    fun `toToolSchema requires only the parameters that are declared required`() {
+        assertEquals(listOf("required1"), descriptor.toToolSchema().required)
+    }
+
+    @Test
+    fun `toToolSchema lists leading properties first and marks them required`() {
+        val schema = descriptor.toToolSchema(
+            leadingProperties = mapOf("sessionId" to stringProperty("The session.")),
+        )
+
+        assertEquals(listOf("sessionId", "required1", "optional1"), requireNotNull(schema.properties).keys.toList())
+        assertEquals(listOf("sessionId", "required1"), schema.required)
+    }
+}

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommandsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommandsTest.kt
@@ -1,0 +1,104 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.model.LogCaptureService
+import com.kitakkun.jetwhale.host.model.LogEntry
+import com.kitakkun.jetwhale.host.model.LogLevel
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class HostLogCommandsTest {
+
+    private val logs = MutableStateFlow(
+        listOf(
+            logEntry("first info", LogLevel.INFO),
+            logEntry("second boom", LogLevel.ERROR),
+            logEntry("third info", LogLevel.INFO),
+        ),
+    )
+    private val logCaptureService = mock<LogCaptureService> {
+        every { this@mock.logs } returns this@HostLogCommandsTest.logs
+        every { clearLogs() } returns Unit
+    }
+
+    @Test
+    fun `getLogs returns the newest entries last`() = runBlocking {
+        val result = GetLogsCommand(logCaptureService).execute(arguments()).decodeLogs()
+
+        assertEquals(listOf("first info", "second boom", "third info"), result.logs.map { it.message })
+        assertEquals(3, result.returned)
+        assertEquals(3, result.total)
+    }
+
+    @Test
+    fun `getLogs keeps only the most recent entries when a limit is given`() = runBlocking {
+        val result = GetLogsCommand(logCaptureService).execute(arguments("limit" to JsonPrimitive(2))).decodeLogs()
+
+        assertEquals(listOf("second boom", "third info"), result.logs.map { it.message })
+        assertEquals(2, result.returned)
+        assertEquals(3, result.total)
+    }
+
+    @Test
+    fun `getLogs filters by level`() = runBlocking {
+        val result = GetLogsCommand(logCaptureService).execute(arguments("level" to JsonPrimitive("ERROR"))).decodeLogs()
+
+        assertEquals(listOf("second boom"), result.logs.map { it.message })
+        assertEquals(1, result.total)
+    }
+
+    @Test
+    fun `getLogs filters by substring case-insensitively`() = runBlocking {
+        val result = GetLogsCommand(logCaptureService).execute(arguments("contains" to JsonPrimitive("BOOM"))).decodeLogs()
+
+        assertEquals(listOf("second boom"), result.logs.map { it.message })
+    }
+
+    @Test
+    fun `getLogs rejects a limit above the hard cap`(): Unit = runBlocking {
+        assertFailsWith<JetWhaleMcpArgumentException> {
+            GetLogsCommand(logCaptureService).execute(arguments("limit" to JsonPrimitive(1001)))
+        }
+    }
+
+    @Test
+    fun `getLogs truncates an oversized message`() = runBlocking {
+        logs.value = listOf(logEntry("x".repeat(3000), LogLevel.INFO))
+
+        val message = GetLogsCommand(logCaptureService).execute(arguments()).decodeLogs().logs.single().message
+
+        assertEquals(2000 + "…(truncated)".length, message.length)
+        assertTrue(message.endsWith("…(truncated)"))
+    }
+
+    @Test
+    fun `clearLogs reports how many entries were dropped`() = runBlocking {
+        val json = ClearLogsCommand(logCaptureService).execute(arguments())
+
+        assertEquals(3, Json.decodeFromString<ClearLogsResult>(json).cleared)
+        verify { logCaptureService.clearLogs() }
+    }
+}
+
+private fun logEntry(message: String, level: LogLevel) = LogEntry(
+    timestamp = Instant.fromEpochMilliseconds(0),
+    message = message,
+    level = level,
+)
+
+private fun arguments(vararg entries: Pair<String, JsonPrimitive>) = JetWhaleMcpArguments(JsonObject(entries.toMap()))
+
+private fun String.decodeLogs() = Json.decodeFromString<GetLogsResult>(this)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommandTest.kt
@@ -1,0 +1,216 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.model.DebugSession
+import com.kitakkun.jetwhale.host.model.DebugSessionRepository
+import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.HostDestination
+import com.kitakkun.jetwhale.host.model.HostDestinationKind
+import com.kitakkun.jetwhale.host.model.HostNavigationService
+import com.kitakkun.jetwhale.host.model.HostSettingsSection
+import com.kitakkun.jetwhale.host.model.HostViewState
+import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
+import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.PluginSessionReconciliationService
+import com.kitakkun.jetwhale.host.model.PoppedOutPlugin
+import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifest
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.protocol.negotiation.JetWhalePluginInfo
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HostNavigationCommandTest {
+
+    private val session = DebugSession(
+        id = "session-1",
+        name = "Pixel",
+        isActive = true,
+        transportSecurity = SessionTransportSecurity.LOOPBACK,
+        installedPlugins = persistentListOf(JetWhalePluginInfo("com.example.agent", "1.0.0")),
+    )
+
+    private val currentView = MutableStateFlow<HostViewState?>(null)
+    private val enabledPluginIds = MutableStateFlow(setOf("com.example.agent", "com.example.hostonly"))
+
+    private val hostNavigationService = mock<HostNavigationService>(MockMode.autoUnit) {
+        every { this@mock.currentView } returns this@HostNavigationCommandTest.currentView
+    }
+    private val debugSessionRepository = mock<DebugSessionRepository> {
+        every { debugSessionsFlow } returns flowOf(persistentListOf(session))
+    }
+    private val pluginFactoryRepository = mock<PluginFactoryRepository> {
+        every { loadedPlugins } returns mapOf(
+            "com.example.agent" to loadedPlugin("com.example.agent"),
+            "com.example.hostonly" to loadedPlugin("com.example.hostonly"),
+            "com.example.disabled" to loadedPlugin("com.example.disabled"),
+        )
+    }
+    private val enabledPluginsRepository = mock<EnabledPluginsRepository> {
+        every { enabledPluginIdsFlow } returns enabledPluginIds
+    }
+    private val reconciliationService = mock<PluginSessionReconciliationService> {
+        every { requiresAgent("com.example.agent") } returns true
+        every { requiresAgent("com.example.hostonly") } returns false
+    }
+
+    private val command = HostNavigationCommand(
+        hostNavigationService,
+        debugSessionRepository,
+        pluginFactoryRepository,
+        enabledPluginsRepository,
+        reconciliationService,
+    )
+
+    @Test
+    fun `navigate reports the destination the host switched to`() = runBlocking {
+        currentView.value = viewState(
+            HostDestination(kind = HostDestinationKind.SETTINGS, settingsSection = HostSettingsSection.SERVER),
+        )
+
+        val result = command
+            .execute(arguments("destination" to JsonPrimitive("SETTINGS"), "settingsSection" to JsonPrimitive("SERVER")))
+            .decode()
+
+        assertTrue(result.applied)
+        assertEquals("SETTINGS", result.destination)
+        assertEquals("SERVER", result.settingsSection)
+    }
+
+    @Test
+    fun `navigate does not confirm a settings section other than the one requested`() = runBlocking {
+        currentView.value = viewState(
+            HostDestination(kind = HostDestinationKind.SETTINGS, settingsSection = HostSettingsSection.GENERAL),
+        )
+
+        val result = command
+            .execute(arguments("destination" to JsonPrimitive("SETTINGS"), "settingsSection" to JsonPrimitive("PLUGINS")))
+            .decode()
+
+        assertFalse(result.applied)
+    }
+
+    @Test
+    fun `navigate reports not-applied when the host window never confirms`() = runBlocking {
+        val result = command.execute(arguments("destination" to JsonPrimitive("INFO"))).decode()
+
+        assertFalse(result.applied)
+        assertContains(result.reason.orEmpty(), "did not report")
+    }
+
+    @Test
+    fun `navigate reports that the target plugin is popped out`() = runBlocking {
+        currentView.value = viewState(
+            HostDestination(
+                kind = HostDestinationKind.PLUGIN,
+                pluginId = "com.example.agent",
+                sessionId = "session-1",
+                poppedOutPlugins = listOf(PoppedOutPlugin("com.example.agent", "session-1")),
+            ),
+        )
+
+        val result = command
+            .execute(arguments("destination" to JsonPrimitive("PLUGIN"), "pluginId" to JsonPrimitive("com.example.agent")))
+            .decode()
+
+        assertTrue(result.applied)
+        assertTrue(result.poppedOut)
+    }
+
+    @Test
+    fun `navigate requires a pluginId when the destination is PLUGIN`(): Unit = runBlocking {
+        val error = assertFailsWithArgumentException { command.execute(arguments("destination" to JsonPrimitive("PLUGIN"))) }
+        assertContains(error, "pluginId is required")
+    }
+
+    @Test
+    fun `navigate rejects a pluginId that is not installed`(): Unit = runBlocking {
+        val error = assertFailsWithArgumentException {
+            command.execute(arguments("destination" to JsonPrimitive("PLUGIN"), "pluginId" to JsonPrimitive("com.example.missing")))
+        }
+        assertContains(error, "is not installed")
+    }
+
+    @Test
+    fun `navigate rejects a plugin that is installed but disabled`(): Unit = runBlocking {
+        val error = assertFailsWithArgumentException {
+            command.execute(arguments("destination" to JsonPrimitive("PLUGIN"), "pluginId" to JsonPrimitive("com.example.disabled")))
+        }
+        assertContains(error, "disabled")
+    }
+
+    @Test
+    fun `navigate rejects a session that does not exist`(): Unit = runBlocking {
+        val error = assertFailsWithArgumentException {
+            command.execute(
+                arguments(
+                    "destination" to JsonPrimitive("PLUGIN"),
+                    "pluginId" to JsonPrimitive("com.example.agent"),
+                    "sessionId" to JsonPrimitive("session-missing"),
+                ),
+            )
+        }
+        assertContains(error, "no session")
+    }
+
+    @Test
+    fun `navigate rejects an agent-backed plugin the session does not advertise`(): Unit = runBlocking {
+        every { reconciliationService.requiresAgent("com.example.hostonly") } returns true
+
+        val error = assertFailsWithArgumentException {
+            command.execute(
+                arguments(
+                    "destination" to JsonPrimitive("PLUGIN"),
+                    "pluginId" to JsonPrimitive("com.example.hostonly"),
+                    "sessionId" to JsonPrimitive("session-1"),
+                ),
+            )
+        }
+        assertContains(error, "does not have")
+    }
+}
+
+private inline fun assertFailsWithArgumentException(block: () -> Unit): String = try {
+    block()
+    error("expected a JetWhaleMcpArgumentException")
+} catch (e: JetWhaleMcpArgumentException) {
+    e.message.orEmpty()
+}
+
+private fun viewState(destination: HostDestination) = HostViewState(
+    destination = destination,
+    selectedSessionId = "session-1",
+    selectedPluginId = destination.pluginId,
+)
+
+private fun loadedPlugin(pluginId: String) = LoadedHostPlugin(
+    manifest = JetWhaleHostPluginManifest(
+        pluginId = pluginId,
+        pluginName = pluginId,
+        version = "1.0.0",
+        factoryClass = "$pluginId.Factory",
+    ),
+    factory = object : JetWhaleHostPluginFactory {
+        override fun createPlugin(): JetWhaleHostPlugin = throw UnsupportedOperationException()
+    },
+)
+
+private fun arguments(vararg entries: Pair<String, JsonPrimitive>) = JetWhaleMcpArguments(JsonObject(entries.toMap()))
+
+private fun String.decode() = Json.decodeFromString<NavigateResult>(this)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommandsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommandsTest.kt
@@ -1,0 +1,216 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.model.DebugSessionRepository
+import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.FailedPluginJar
+import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
+import com.kitakkun.jetwhale.host.model.OfficialPluginCatalog
+import com.kitakkun.jetwhale.host.model.OfficialPluginInstallService
+import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.PluginInstallProgress
+import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
+import com.kitakkun.jetwhale.host.model.PluginInstanceService
+import com.kitakkun.jetwhale.host.model.PluginTrustService
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifest
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HostPluginCommandsTest {
+
+    private val officialPluginId = OfficialPluginCatalog.plugins.first().pluginId
+
+    private val loadedPlugins = mutableMapOf(
+        "com.example.local" to loadedPlugin("com.example.local", "Local Plugin", requiresAgent = false),
+    )
+    private val failedJars = MutableStateFlow(listOf(FailedPluginJar("/plugins/broken.jar", "bad manifest")))
+    private val untrustedJars = MutableStateFlow(listOf("/plugins/unknown.jar"))
+    private val enabledPluginIds = MutableStateFlow(setOf("com.example.local"))
+    private val installProgress = MutableStateFlow<PluginInstallProgress?>(null)
+    private val installAllowed = MutableStateFlow(false)
+
+    private val pluginFactoryRepository = mock<PluginFactoryRepository> {
+        every { this@mock.loadedPlugins } returns this@HostPluginCommandsTest.loadedPlugins
+        every { failedJarsFlow } returns failedJars
+    }
+    private val enabledPluginsRepository = mock<EnabledPluginsRepository>(MockMode.autoUnit) {
+        every { enabledPluginIdsFlow } returns enabledPluginIds
+    }
+    private val pluginTrustService = mock<PluginTrustService> {
+        every { untrustedJarPathsFlow } returns untrustedJars
+    }
+    private val pluginInstanceService = mock<PluginInstanceService> {
+        every { pluginInstanceEventFlow } returns MutableSharedFlow()
+    }
+    private val pluginInstallProgressRepository = mock<PluginInstallProgressRepository> {
+        every { progressFlow } returns installProgress
+    }
+    private val settingsRepository = mock<DebuggerSettingsRepository> {
+        every { mcpPluginInstallAllowedFlow } returns installAllowed
+    }
+    private val officialPluginInstallService = mock<OfficialPluginInstallService>(MockMode.autoUnit)
+
+    private val listInstalledPlugins = ListInstalledPluginsCommand(pluginFactoryRepository, enabledPluginsRepository, pluginTrustService)
+    private val setPluginEnabled = SetPluginEnabledCommand(
+        pluginFactoryRepository,
+        enabledPluginsRepository,
+        pluginInstanceService,
+        mock<DebugSessionRepository> { every { debugSessionsFlow } returns flowOf(persistentListOf()) },
+    )
+    private val installOfficialPlugin = InstallOfficialPluginCommand(
+        officialPluginInstallService,
+        pluginFactoryRepository,
+        pluginInstallProgressRepository,
+        settingsRepository,
+    )
+
+    @Test
+    fun `listInstalledPlugins reports each plugin's enabled state`() = runBlocking {
+        val result = listInstalledPlugins.execute(arguments()).decodeList()
+
+        val plugin = result.installed.single()
+        assertEquals("com.example.local", plugin.pluginId)
+        assertEquals("Local Plugin", plugin.name)
+        assertFalse(plugin.requiresAgent)
+        assertTrue(plugin.enabled)
+    }
+
+    @Test
+    fun `listInstalledPlugins marks an official plugin that is not installed`() = runBlocking {
+        val official = listInstalledPlugins.execute(arguments()).decodeList().availableOfficial.single { it.pluginId == officialPluginId }
+
+        assertFalse(official.installed)
+    }
+
+    @Test
+    fun `listInstalledPlugins marks an official plugin that is already installed`() = runBlocking {
+        loadedPlugins[officialPluginId] = loadedPlugin(officialPluginId, "Network Inspector", requiresAgent = true)
+
+        val official = listInstalledPlugins.execute(arguments()).decodeList().availableOfficial.single { it.pluginId == officialPluginId }
+
+        assertTrue(official.installed)
+    }
+
+    @Test
+    fun `listInstalledPlugins reports failed and untrusted jars`() = runBlocking {
+        val result = listInstalledPlugins.execute(arguments()).decodeList()
+
+        assertEquals("/plugins/broken.jar", result.failedJars.single().jarPath)
+        assertEquals("/plugins/unknown.jar", result.untrustedJars.single())
+    }
+
+    @Test
+    fun `setPluginEnabled rejects a pluginId that is not installed`(): Unit = runBlocking {
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            setPluginEnabled.execute(arguments("pluginId" to JsonPrimitive("com.example.missing"), "enabled" to JsonPrimitive(true)))
+        }
+        assertContains(error.message.orEmpty(), "is not installed")
+    }
+
+    @Test
+    fun `setPluginEnabled disables a plugin without waiting for instantiation`() = runBlocking {
+        val result = setPluginEnabled
+            .execute(arguments("pluginId" to JsonPrimitive("com.example.local"), "enabled" to JsonPrimitive(false)))
+            .let { Json.decodeFromString<SetPluginEnabledResult>(it) }
+
+        assertFalse(result.enabled)
+        assertFalse(result.reconnectRequiredForNewTools)
+        assertTrue(result.instantiatedForSessions.isEmpty())
+        verifySuspend { enabledPluginsRepository.setPluginEnabled("com.example.local", false) }
+    }
+
+    @Test
+    fun `installOfficialPlugin is refused when the setting is disabled`(): Unit = runBlocking {
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            installOfficialPlugin.execute(arguments("pluginId" to JsonPrimitive(officialPluginId)))
+        }
+        assertContains(error.message.orEmpty(), "Settings → Server → MCP Server")
+    }
+
+    @Test
+    fun `installOfficialPlugin rejects a pluginId that is not in the official catalog`(): Unit = runBlocking {
+        installAllowed.value = true
+
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            installOfficialPlugin.execute(arguments("pluginId" to JsonPrimitive("com.evil.backdoor")))
+        }
+        assertContains(error.message.orEmpty(), "is not an official plugin")
+    }
+
+    @Test
+    fun `installOfficialPlugin is refused while another installation is in flight`(): Unit = runBlocking {
+        installAllowed.value = true
+        installProgress.value = PluginInstallProgress.DownloadingPlugin
+
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            installOfficialPlugin.execute(arguments("pluginId" to JsonPrimitive(officialPluginId)))
+        }
+        assertContains(error.message.orEmpty(), "already in progress")
+    }
+
+    @Test
+    fun `installOfficialPlugin installs the catalog entry and points at the next step`() = runBlocking {
+        installAllowed.value = true
+
+        val result = installOfficialPlugin
+            .execute(arguments("pluginId" to JsonPrimitive(officialPluginId)))
+            .let { Json.decodeFromString<InstallOfficialPluginResult>(it) }
+
+        assertTrue(result.installed)
+        assertFalse(result.alreadyInstalled)
+        assertFalse(result.enabled)
+        assertEquals("jetwhale.setPluginEnabled", result.nextStep)
+        assertTrue(result.reconnectRequiredForNewTools)
+        verifySuspend { officialPluginInstallService.install(OfficialPluginCatalog.plugins.first()) }
+    }
+
+    @Test
+    fun `installOfficialPlugin reports an already installed plugin without reinstalling it`() = runBlocking {
+        installAllowed.value = true
+        loadedPlugins[officialPluginId] = loadedPlugin(officialPluginId, "Network Inspector", requiresAgent = true)
+
+        val result = installOfficialPlugin
+            .execute(arguments("pluginId" to JsonPrimitive(officialPluginId)))
+            .let { Json.decodeFromString<InstallOfficialPluginResult>(it) }
+
+        assertTrue(result.alreadyInstalled)
+    }
+}
+
+private fun loadedPlugin(pluginId: String, name: String, requiresAgent: Boolean) = LoadedHostPlugin(
+    manifest = JetWhaleHostPluginManifest(
+        pluginId = pluginId,
+        pluginName = name,
+        version = "1.0.0",
+        factoryClass = "$pluginId.Factory",
+        requiresAgent = requiresAgent,
+    ),
+    factory = object : JetWhaleHostPluginFactory {
+        override fun createPlugin(): JetWhaleHostPlugin = throw UnsupportedOperationException()
+    },
+)
+
+private fun arguments(vararg entries: Pair<String, JsonPrimitive>) = JetWhaleMcpArguments(JsonObject(entries.toMap()))
+
+private fun String.decodeList() = Json.decodeFromString<ListInstalledPluginsResult>(this)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommandsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommandsTest.kt
@@ -1,0 +1,140 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
+import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HostSettingsCommandsTest {
+
+    private val serverPortFlow = MutableStateFlow(5080)
+    private val wssPortFlow = MutableStateFlow(5443)
+    private val wssEnabledFlow = MutableStateFlow(true)
+
+    private val settingsRepository = mock<DebuggerSettingsRepository>(MockMode.autoUnit) {
+        every { this@mock.serverPortFlow } returns this@HostSettingsCommandsTest.serverPortFlow
+        every { this@mock.wssPortFlow } returns this@HostSettingsCommandsTest.wssPortFlow
+        every { this@mock.wssEnabledFlow } returns this@HostSettingsCommandsTest.wssEnabledFlow
+    }
+
+    private val debugWebSocketServer = mock<DebugWebSocketServer>(MockMode.autoUnit) {
+        every { statusFlow } returns MutableStateFlow(DebugWebSocketServerStatus.Started("localhost", 5080, 5443))
+    }
+
+    private val updateSettings = UpdateSettingsCommand(settingsRepository, debugWebSocketServer)
+
+    @Test
+    fun `updateSettings applies only the arguments that were supplied`() = runBlocking {
+        val result = updateSettings.execute(arguments("persistData" to JsonPrimitive(true))).decodeSettings()
+
+        assertEquals(mapOf("persistData" to "true"), result.applied)
+        verifySuspend { settingsRepository.updatePersistData(true) }
+        verifySuspend(VerifyMode.not) { settingsRepository.updateServerPort(any()) }
+    }
+
+    @Test
+    fun `updateSettings persists the mcp port without restarting the mcp server`() = runBlocking {
+        val result = updateSettings.execute(arguments("mcpServerPort" to JsonPrimitive(7100))).decodeSettings()
+
+        assertFalse(result.mcpServerRestarted)
+        assertFalse(result.debugServerRestarted)
+        assertTrue(result.notes.any { "next time the host starts" in it })
+        verifySuspend { settingsRepository.updateMcpServerPort(7100) }
+        verifySuspend(VerifyMode.not) { debugWebSocketServer.stop() }
+    }
+
+    @Test
+    fun `updateSettings restarts the debug server when the ws port changed`() = runBlocking {
+        serverPortFlow.value = 5090
+        val result = updateSettings.execute(arguments("serverPort" to JsonPrimitive(5090))).decodeSettings()
+
+        assertTrue(result.debugServerRestarted)
+        verifySuspend { debugWebSocketServer.stop() }
+        verifySuspend { debugWebSocketServer.start("localhost", 5090, 5443) }
+    }
+
+    @Test
+    fun `updateSettings can persist a ws change without restarting when asked`() = runBlocking {
+        val result = updateSettings.execute(
+            arguments(
+                "serverPort" to JsonPrimitive(5090),
+                "restartDebugServer" to JsonPrimitive(false),
+            ),
+        ).decodeSettings()
+
+        assertFalse(result.debugServerRestarted)
+        assertTrue(result.notes.any { "jetwhale.restartDebugServer" in it })
+        verifySuspend(VerifyMode.not) { debugWebSocketServer.stop() }
+    }
+
+    @Test
+    fun `updateSettings rejects an out-of-range port before writing anything`(): Unit = runBlocking {
+        assertFailsWith<JetWhaleMcpArgumentException> {
+            updateSettings.execute(
+                arguments(
+                    "persistData" to JsonPrimitive(true),
+                    "serverPort" to JsonPrimitive(70000),
+                ),
+            )
+        }
+        verifySuspend(VerifyMode.not) { settingsRepository.updatePersistData(any()) }
+    }
+
+    @Test
+    fun `updateSettings rejects a call that changes nothing`(): Unit = runBlocking {
+        assertFailsWith<JetWhaleMcpArgumentException> { updateSettings.execute(arguments()) }
+    }
+
+    @Test
+    fun `restartDebugServer starts with the configured wss port when wss is enabled`() = runBlocking {
+        RestartDebugServerCommand(settingsRepository, debugWebSocketServer).execute(arguments())
+
+        verifySuspend { debugWebSocketServer.stop() }
+        verifySuspend { debugWebSocketServer.start("localhost", 5080, 5443) }
+    }
+
+    @Test
+    fun `restartDebugServer omits the wss port when wss is disabled`() = runBlocking {
+        wssEnabledFlow.value = false
+
+        val result = RestartDebugServerCommand(settingsRepository, debugWebSocketServer)
+            .execute(arguments())
+            .let { Json.decodeFromString<RestartDebugServerResult>(it) }
+
+        verifySuspend { debugWebSocketServer.start("localhost", 5080, null) }
+        assertTrue("dropped" in result.note)
+    }
+
+    @Test
+    fun `restartDebugServer reports the state the server ended up in`() = runBlocking {
+        val result = RestartDebugServerCommand(settingsRepository, debugWebSocketServer)
+            .execute(arguments())
+            .let { Json.decodeFromString<RestartDebugServerResult>(it) }
+
+        assertEquals("Started", result.state)
+        assertEquals(5080, result.port)
+        assertEquals(5443, result.wssPort)
+    }
+}
+
+private fun arguments(vararg entries: Pair<String, JsonPrimitive>) = JetWhaleMcpArguments(JsonObject(entries.toMap()))
+
+private fun String.decodeSettings() = Json.decodeFromString<UpdateSettingsResult>(this)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommandsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommandsTest.kt
@@ -72,6 +72,22 @@ class HostSettingsCommandsTest {
     }
 
     @Test
+    fun `updateSettings restarts the debug server when adb auto port mapping changed`() = runBlocking {
+        // The setting is read when the server starts, so it is inert until the server restarts.
+        val result = updateSettings.execute(arguments("adbAutoPortMappingEnabled" to JsonPrimitive(true))).decodeSettings()
+
+        assertTrue(result.debugServerRestarted)
+        verifySuspend { debugWebSocketServer.stop() }
+    }
+
+    @Test
+    fun `updateSettings does not claim a change is pending once it has restarted the server`() = runBlocking {
+        val result = updateSettings.execute(arguments("adbAutoPortMappingEnabled" to JsonPrimitive(true))).decodeSettings()
+
+        assertFalse(result.notes.any { "still running" in it })
+    }
+
+    @Test
     fun `updateSettings can persist a ws change without restarting when asked`() = runBlocking {
         val result = updateSettings.execute(
             arguments(

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommandTest.kt
@@ -70,6 +70,7 @@ class HostStatusCommandTest {
             every { adbAutoPortMappingEnabledFlow } returns MutableStateFlow(true)
             every { checkForUpdatesOnStartupFlow } returns MutableStateFlow(true)
             every { persistDataFlow } returns MutableStateFlow(false)
+            every { mcpPluginInstallAllowedFlow } returns MutableStateFlow(false)
         },
         hostNavigationService = mock<HostNavigationService> {
             every { this@mock.currentView } returns this@HostStatusCommandTest.currentView
@@ -125,6 +126,12 @@ class HostStatusCommandTest {
     @Test
     fun `getStatus reports that no install is in flight`() = runBlocking {
         assertFalse(command.execute(arguments()).decode().plugins.installInProgress)
+    }
+
+    @Test
+    fun `getStatus reports whether installing plugins over MCP is allowed`() = runBlocking {
+        // Without this an agent could only discover the gate by attempting an install and being refused.
+        assertFalse(command.execute(arguments()).decode().settings.mcpPluginInstallAllowed)
     }
 }
 

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommandTest.kt
@@ -1,0 +1,141 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.mcp.McpServerStatusHolder
+import com.kitakkun.jetwhale.host.model.DebugSession
+import com.kitakkun.jetwhale.host.model.DebugSessionRepository
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
+import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.HostDestination
+import com.kitakkun.jetwhale.host.model.HostDestinationKind
+import com.kitakkun.jetwhale.host.model.HostNavigationService
+import com.kitakkun.jetwhale.host.model.HostVersionInfo
+import com.kitakkun.jetwhale.host.model.HostViewState
+import com.kitakkun.jetwhale.host.model.McpServerStatus
+import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
+import com.kitakkun.jetwhale.host.model.PluginTrustService
+import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HostStatusCommandTest {
+
+    private val currentView = MutableStateFlow<HostViewState?>(null)
+    private val mcpServerStatusHolder = McpServerStatusHolder().apply {
+        update(McpServerStatus.Running(host = "localhost", port = 7080))
+    }
+
+    private val command = HostStatusCommand(
+        hostVersionInfo = HostVersionInfo("1.2.3-SNAPSHOT"),
+        debugWebSocketServer = mock<DebugWebSocketServer> {
+            every { statusFlow } returns MutableStateFlow(DebugWebSocketServerStatus.Started("localhost", 5080, 5443))
+        },
+        mcpServerStatusHolder = mcpServerStatusHolder,
+        debugSessionRepository = mock<DebugSessionRepository> {
+            every { debugSessionsFlow } returns flowOf(persistentListOf(session("s1", isActive = true), session("s2", isActive = false)))
+        },
+        pluginFactoryRepository = mock<PluginFactoryRepository> {
+            every { loadedPlugins } returns emptyMap()
+            every { failedJarsFlow } returns MutableStateFlow(emptyList())
+        },
+        enabledPluginsRepository = mock<EnabledPluginsRepository> {
+            every { enabledPluginIdsFlow } returns MutableStateFlow(emptySet())
+        },
+        pluginTrustService = mock<PluginTrustService> {
+            every { untrustedJarPathsFlow } returns MutableStateFlow(emptyList())
+        },
+        pluginInstallProgressRepository = mock<PluginInstallProgressRepository> {
+            every { progressFlow } returns MutableStateFlow(null)
+        },
+        settingsRepository = mock<DebuggerSettingsRepository> {
+            every { serverPortFlow } returns MutableStateFlow(5080)
+            every { wssPortFlow } returns MutableStateFlow(5443)
+            every { wssEnabledFlow } returns MutableStateFlow(true)
+            every { mcpServerPortFlow } returns MutableStateFlow(7080)
+            every { adbAutoPortMappingEnabledFlow } returns MutableStateFlow(true)
+            every { checkForUpdatesOnStartupFlow } returns MutableStateFlow(true)
+            every { persistDataFlow } returns MutableStateFlow(false)
+        },
+        hostNavigationService = mock<HostNavigationService> {
+            every { this@mock.currentView } returns this@HostStatusCommandTest.currentView
+        },
+    )
+
+    @Test
+    fun `getStatus reports the debug server and mcp server endpoints`() = runBlocking {
+        val status = command.execute(arguments()).decode()
+
+        assertEquals("Started", status.debugServer.state)
+        assertEquals(5080, status.debugServer.port)
+        assertEquals(5443, status.debugServer.wssPort)
+        assertEquals("Running", status.mcpServer.state)
+        assertEquals(7080, status.mcpServer.port)
+    }
+
+    @Test
+    fun `getStatus reports the host version and whether it is a snapshot`() = runBlocking {
+        val status = command.execute(arguments()).decode()
+
+        assertEquals("1.2.3-SNAPSHOT", status.host.version)
+        assertTrue(status.host.isSnapshot)
+    }
+
+    @Test
+    fun `getStatus counts sessions by whether they are still connected`() = runBlocking {
+        val status = command.execute(arguments()).decode()
+
+        assertEquals(2, status.sessions.total)
+        assertEquals(1, status.sessions.active)
+    }
+
+    @Test
+    fun `getStatus reports a null ui block before the host window has composed`() = runBlocking {
+        assertNull(command.execute(arguments()).decode().ui)
+    }
+
+    @Test
+    fun `getStatus reports what the host window shows once it has composed`() = runBlocking {
+        currentView.value = HostViewState(
+            destination = HostDestination(kind = HostDestinationKind.PLUGIN, pluginId = "com.example", sessionId = "s1"),
+            selectedSessionId = "s1",
+            selectedPluginId = "com.example",
+        )
+
+        val ui = requireNotNull(command.execute(arguments()).decode().ui)
+        assertEquals("PLUGIN", ui.destination)
+        assertEquals("com.example", ui.pluginId)
+        assertEquals("s1", ui.selectedSessionId)
+    }
+
+    @Test
+    fun `getStatus reports that no install is in flight`() = runBlocking {
+        assertFalse(command.execute(arguments()).decode().plugins.installInProgress)
+    }
+}
+
+private fun session(id: String, isActive: Boolean) = DebugSession(
+    id = id,
+    name = id,
+    isActive = isActive,
+    transportSecurity = SessionTransportSecurity.LOOPBACK,
+    installedPlugins = persistentListOf(),
+)
+
+private fun arguments() = JetWhaleMcpArguments(JsonObject(emptyMap()))
+
+private fun String.decode() = Json.decodeFromString<HostStatusResult>(this)

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugWebSocketServer.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugWebSocketServer.kt
@@ -1,8 +1,10 @@
 package com.kitakkun.jetwhale.host.model
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 interface DebugWebSocketServer {
+    val statusFlow: StateFlow<DebugWebSocketServerStatus>
     val sessionClosedFlow: Flow<String>
     val serverStoppedFlow: Flow<Unit>
 

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerBehaviorSettings.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerBehaviorSettings.kt
@@ -8,4 +8,5 @@ data class DebuggerBehaviorSettings(
     val mcpServerPort: Int,
     val wssPort: Int,
     val wssEnabled: Boolean,
+    val mcpPluginInstallAllowed: Boolean,
 )

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerSettingsRepository.kt
@@ -10,6 +10,12 @@ interface DebuggerSettingsRepository {
     val mcpServerPortFlow: StateFlow<Int>
     val wssPortFlow: StateFlow<Int>
     val wssEnabledFlow: StateFlow<Boolean>
+
+    /**
+     * Whether an AI agent connected to the MCP server may install official plugins. Off by default:
+     * installing a plugin loads new code into the host process, so it stays an opt-in.
+     */
+    val mcpPluginInstallAllowedFlow: StateFlow<Boolean>
     suspend fun readServerPort(): Int
     suspend fun readMcpServerPort(): Int
     suspend fun readWssPort(): Int
@@ -21,4 +27,5 @@ interface DebuggerSettingsRepository {
     suspend fun updateMcpServerPort(port: Int)
     suspend fun updateWssPort(port: Int)
     suspend fun updateWssEnabled(enabled: Boolean)
+    suspend fun updateMcpPluginInstallAllowed(enabled: Boolean)
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/HostNavigationService.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/HostNavigationService.kt
@@ -1,0 +1,61 @@
+package com.kitakkun.jetwhale.host.model
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+
+/** A screen of the main host window a caller outside the composition can ask for. */
+sealed interface HostNavigationRequest {
+    data object Home : HostNavigationRequest
+
+    /** Opens [pluginId]; a null [sessionId] means "whichever session the drawer already has selected". */
+    data class Plugin(val pluginId: String, val sessionId: String?) : HostNavigationRequest
+
+    data class Settings(val section: HostSettingsSection) : HostNavigationRequest
+    data object Info : HostNavigationRequest
+    data object LogViewer : HostNavigationRequest
+}
+
+enum class HostSettingsSection { GENERAL, SERVER, PLUGINS }
+
+/**
+ * MCP_TOOLS is reported but cannot be requested: the tool browser exists so a person can watch what
+ * an agent is doing, so an agent has no reason to send itself there.
+ */
+enum class HostDestinationKind { HOME, PLUGIN, DISABLED_PLUGIN, SETTINGS, INFO, LICENSES, LOG_VIEWER, MCP_TOOLS }
+
+data class PoppedOutPlugin(val pluginId: String, val sessionId: String)
+
+/** What the main host window currently shows. Popped-out plugins live in their own windows and are listed separately. */
+data class HostDestination(
+    val kind: HostDestinationKind,
+    val pluginId: String? = null,
+    val sessionId: String? = null,
+    val settingsSection: HostSettingsSection? = null,
+    val poppedOutPlugins: List<PoppedOutPlugin> = emptyList(),
+)
+
+data class HostViewState(
+    val destination: HostDestination,
+    val selectedSessionId: String?,
+    val selectedPluginId: String?,
+)
+
+/**
+ * Lets a caller outside the composition — the MCP server — drive the main window's navigation and
+ * read back what is on screen.
+ *
+ * The back stack and the drawer's selection stay owned by the UI; this is only the channel between
+ * the two. [requests] is delivered exactly once, so it must have a single collector.
+ */
+interface HostNavigationService {
+    val requests: Flow<HostNavigationRequest>
+
+    /** Null until the host window has composed and reported its first destination. */
+    val currentView: StateFlow<HostViewState?>
+
+    suspend fun navigate(request: HostNavigationRequest)
+
+    fun updateDestination(destination: HostDestination)
+
+    fun updateSelection(selectedSessionId: String?, selectedPluginId: String?)
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/McpPluginInstallAllowedMutationKey.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/McpPluginInstallAllowedMutationKey.kt
@@ -1,0 +1,9 @@
+package com.kitakkun.jetwhale.host.model
+
+import soil.query.MutationKey
+
+/**
+ * Persists whether an AI agent on the MCP server may install official plugins. Off by default:
+ * installing a plugin loads new code into the host process, and the MCP port is unauthenticated.
+ */
+interface McpPluginInstallAllowedMutationKey : MutationKey<Unit, Boolean>

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/OfficialPluginInstallService.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/OfficialPluginInstallService.kt
@@ -1,0 +1,12 @@
+package com.kitakkun.jetwhale.host.model
+
+/**
+ * Installs a plugin from the [OfficialPluginCatalog].
+ *
+ * Deliberately narrower than the install-by-coordinates path: callers name a catalog entry, never
+ * arbitrary [MavenCoordinates]. Installing a plugin loads code into the host process, so the MCP
+ * server — which anything on the machine can talk to — is only given this narrow door.
+ */
+interface OfficialPluginInstallService {
+    suspend fun install(plugin: OfficialPlugin)
+}

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -67,6 +67,8 @@
     <string name="mcp_setup_claude_code_label">Claude Code</string>
     <string name="mcp_setup_json_label">JSON 設定</string>
     <string name="mcp_setup_open_guide">セットアップガイドを開く</string>
+    <string name="mcp_plugin_install_allowed_label">AIエージェントによる公式プラグインのインストールを許可</string>
+    <string name="mcp_plugin_install_allowed_note">既定ではオフです。オンにすると、MCPサーバーに接続したAIエージェントが公式カタログのプラグインをインストールできます（JetWhale に新しいコードが読み込まれます）。任意の Maven coordinates からのインストールはこの経路では行えません。</string>
     <string name="copy_to_clipboard">コピー</string>
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">キャンセル</string>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
@@ -67,6 +67,8 @@
     <string name="mcp_setup_claude_code_label">Claude Code</string>
     <string name="mcp_setup_json_label">JSON config</string>
     <string name="mcp_setup_open_guide">Open setup guide</string>
+    <string name="mcp_plugin_install_allowed_label">Allow AI agents to install official plugins</string>
+    <string name="mcp_plugin_install_allowed_note">Off by default. When on, an AI agent on the MCP server can install plugins from the official catalog, which loads new code into JetWhale. Plugins from arbitrary Maven coordinates can never be installed this way.</string>
     <string name="copy_to_clipboard">Copy</string>
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">Cancel</string>

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenContext.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenContext.kt
@@ -15,6 +15,7 @@ import com.kitakkun.jetwhale.host.model.GenerateSslCertificateMutationKey
 import com.kitakkun.jetwhale.host.model.HostVersionInfo
 import com.kitakkun.jetwhale.host.model.LoadedPluginsMetaDataSubscriptionKey
 import com.kitakkun.jetwhale.host.model.LogCaptureService
+import com.kitakkun.jetwhale.host.model.McpPluginInstallAllowedMutationKey
 import com.kitakkun.jetwhale.host.model.McpServerPortMutationKey
 import com.kitakkun.jetwhale.host.model.McpServerStatusSubscriptionKey
 import com.kitakkun.jetwhale.host.model.OfficialPluginInstallMutationKey
@@ -45,6 +46,7 @@ class SettingsPresenterContext(
     val adbAutoPortMappingMutationKey: AdbAutoPortMappingMutationKey,
     val serverPortMutationKey: ServerPortMutationKey,
     val mcpServerPortMutationKey: McpServerPortMutationKey,
+    val mcpPluginInstallAllowedMutationKey: McpPluginInstallAllowedMutationKey,
     val pluginInstallMutationKey: PluginInstallMutationKey,
     val pluginInstallFromMavenMutationKey: PluginInstallFromMavenMutationKey,
     val trustPluginMutationKey: TrustPluginMutationKey,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.settings.Res
 import com.kitakkun.jetwhale.host.settings.SettingsScreenScaffoldPageContentPadding
 import com.kitakkun.jetwhale.host.settings.component.SettingOptionView
+import com.kitakkun.jetwhale.host.settings.component.SwitchSettingsItemView
 import com.kitakkun.jetwhale.host.settings.component.TextFieldSettingsItemView
 import com.kitakkun.jetwhale.host.settings.copy_to_clipboard
 import com.kitakkun.jetwhale.host.settings.debug_server_label
@@ -38,6 +39,8 @@ import com.kitakkun.jetwhale.host.settings.debug_server_port_apply_confirm_title
 import com.kitakkun.jetwhale.host.settings.debug_server_port_label
 import com.kitakkun.jetwhale.host.settings.dialog_cancel
 import com.kitakkun.jetwhale.host.settings.dialog_ok
+import com.kitakkun.jetwhale.host.settings.mcp_plugin_install_allowed_label
+import com.kitakkun.jetwhale.host.settings.mcp_plugin_install_allowed_note
 import com.kitakkun.jetwhale.host.settings.mcp_server_label
 import com.kitakkun.jetwhale.host.settings.mcp_server_port_apply_confirm_message
 import com.kitakkun.jetwhale.host.settings.mcp_server_port_apply_confirm_title
@@ -80,6 +83,7 @@ fun ServerSettingsScreen(
     onConfirmApplyMcpPortChange: () -> Unit,
     onDismissApplyMcpPortDialog: () -> Unit,
     onClickOpenMcpGuide: () -> Unit,
+    onMcpPluginInstallAllowedChange: (Boolean) -> Unit,
     onAddCertificate: () -> Unit,
     onSetActiveCertificate: (String) -> Unit,
     onDeleteCertificate: (String) -> Unit,
@@ -230,6 +234,17 @@ fun ServerSettingsScreen(
                 OutlinedButton(onClick = onClickOpenMcpGuide) {
                     Text(stringResource(Res.string.mcp_setup_open_guide))
                 }
+                Spacer(Modifier.height(12.dp))
+                SwitchSettingsItemView(
+                    label = stringResource(Res.string.mcp_plugin_install_allowed_label),
+                    isChecked = uiState.mcpPluginInstallAllowed,
+                    onCheckedChange = onMcpPluginInstallAllowedChange,
+                )
+                Text(
+                    text = stringResource(Res.string.mcp_plugin_install_allowed_note),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
         }
         item {

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenAction.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenAction.kt
@@ -10,6 +10,7 @@ sealed interface ServerSettingsScreenAction {
     data object ApplyMcpPortChange : ServerSettingsScreenAction
     data object ConfirmApplyMcpPortChange : ServerSettingsScreenAction
     data object DismissApplyMcpPortDialog : ServerSettingsScreenAction
+    data class SetMcpPluginInstallAllowed(val allowed: Boolean) : ServerSettingsScreenAction
 
     data object AddCertificate : ServerSettingsScreenAction
     data class SetActiveCertificate(val id: String) : ServerSettingsScreenAction

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenPresenter.kt
@@ -55,6 +55,7 @@ fun serverSettingsScreenPresenter(
     val generateCertificateMutation = rememberMutation(presenterContext.generateSslCertificateMutationKey)
     val activateCertificateMutation = rememberMutation(presenterContext.activateSslCertificateMutationKey)
     val deleteCertificateMutation = rememberMutation(presenterContext.deleteSslCertificateMutationKey)
+    val mcpPluginInstallAllowedMutation = rememberMutation(presenterContext.mcpPluginInstallAllowedMutationKey)
 
     val savedDebugPortText by rememberUpdatedState(debuggerSettings.serverPort.toString())
     val savedMcpPortText by rememberUpdatedState(debuggerSettings.mcpServerPort.toString())
@@ -148,6 +149,10 @@ fun serverSettingsScreenPresenter(
                 showMcpApplyConfirmDialog = false
             }
 
+            is ServerSettingsScreenAction.SetMcpPluginInstallAllowed -> {
+                mcpPluginInstallAllowedMutation.mutateAsync(action.allowed)
+            }
+
             ServerSettingsScreenAction.AddCertificate -> {
                 // A newly generated certificate becomes the active one; the running TLS server
                 // hot-swaps to it automatically.
@@ -218,6 +223,7 @@ fun serverSettingsScreenPresenter(
               }
             }
         """.trimIndent(),
+        mcpPluginInstallAllowed = debuggerSettings.mcpPluginInstallAllowed,
         isDebugApplyVisible = isDebugDirty || isDebugStartFailed,
         isMcpApplyVisible = isMcpDirty || isMcpStartFailed,
         isDebugApplyEnabled = isDebugPortValid && (isDebugDirty || isDebugStartFailed),

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenRoot.kt
@@ -62,6 +62,9 @@ fun ServerSettingsScreenRoot() {
                     e.printStackTrace()
                 }
             },
+            onMcpPluginInstallAllowedChange = {
+                screenChannel.send(ServerSettingsScreenAction.SetMcpPluginInstallAllowed(it))
+            },
             onAddCertificate = {
                 screenChannel.send(ServerSettingsScreenAction.AddCertificate)
             },

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenUiState.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenUiState.kt
@@ -7,6 +7,7 @@ data class ServerSettingsScreenUiState(
     val editingMcpPortText: String,
     val mcpClaudeCodeCommand: String,
     val mcpJsonConfig: String,
+    val mcpPluginInstallAllowed: Boolean,
     val isDebugApplyVisible: Boolean,
     val isMcpApplyVisible: Boolean,
     val isDebugApplyEnabled: Boolean,


### PR DESCRIPTION
## What

Adds nine MCP tools scoped to **the debug tool as a whole**, so an AI agent can operate JetWhale end to end instead of only using what a human has already set up by hand.

Every MCP tool so far has been scoped to one session and one plugin. An agent could look at the Network Inspector's UI, but it could not install the Network Inspector, enable it, read the host's own log, change a port, or switch the window to the screen it wanted to look at.

| Group | Tools |
|---|---|
| Observation | `jetwhale.getStatus` / `getLogs` / `clearLogs` |
| Plugins | `jetwhale.listInstalledPlugins` / `setPluginEnabled` / `installOfficialPlugin` |
| Settings & server | `jetwhale.updateSettings` / `restartDebugServer` |
| Host UI | `jetwhale.navigate` |

`jetwhale.getStatus` is the intended first call: one parameter-free request returns the host version, both servers' endpoints, session and plugin counts, the current settings, and what the window is showing.

Naming stays flat `jetwhale.*` — `listSessions` and `listPlugins` are already host-level, and a `jetwhale.host.*` prefix would either strand those two or force a breaking rename of names already published in the docs. The two families are distinguished by a `Host-wide:` description prefix and by separate tables in the guide.

## How

**DSL reuse.** New tools are written with the host SDK's by-delegate parameter DSL rather than a hand-written `ToolSchema`. `HostMcpCommand` bridges a `JetWhaleMcpCommand` onto `JetWhaleMcpTool`; unlike the plugin path it injects no `sessionId`, which is what makes a tool host-scoped. The descriptor→`ToolSchema` conversion is extracted to `toToolSchema()` so `registerPluginTools` shares it. The existing eight tools are untouched.

> [!NOTE]
> Review point: a `HostMcpCommand` subclass **must** contribute with an explicit `binding<JetWhaleMcpTool>()`. Its single declared supertype is `HostMcpCommand`, so a plain `@ContributesIntoSet(AppScope::class)` compiles fine and silently lands in the wrong multibinding — the tool just disappears. `HostMcpCommandTest` covers the bridge; there is no compile-time guard for this.

**Navigation.** The back stack is local to `JetWhaleApp` and the drawer selection is retained state inside the presenter, so neither is reachable from the MCP server. `HostNavigationService` (core/model) carries requests one way and the resulting view state back. `ToolingScaffoldRoot` is the single collector — a `Channel` delivers each request once, so splitting the collector would make the two halves steal each other's requests — and it drives the same callbacks a drawer click does, so an MCP-driven navigation and a click are indistinguishable downstream. `navigate` reads the view back rather than reporting success optimistically, because the drawer resets its selection when the selected session goes inactive.

## Security

Installing a plugin loads new code into the host process, `MavenPluginInstallService` auto-trusts by design, and the MCP port is unauthenticated — any local process can reach it. An agent also routinely reads attacker-influenced bytes (HTTP response bodies via the Network Inspector), so prompt injection reaching an install API is a real path to unsandboxed code execution.

Two layers:

1. **Catalog-only, enforced by the type system.** `installOfficialPlugin` takes a catalog `pluginId` and calls the new `OfficialPluginInstallService`. There is no MCP-reachable API that accepts `MavenCoordinates`. Worst case narrows from "arbitrary jar from arbitrary repo" to "a first-party `com.kitakkun.jetwhale` artifact at the host's own version".
2. **Off by default.** New setting under **Settings → Server → MCP Server → "Allow AI agents to install official plugins"**. While off the tool still lists but refuses, naming the setting so an agent can tell the user what to enable — a hidden tool would just produce flailing.

Routing MCP installs into the untrusted-jar review queue was considered and rejected: it writes attacker-chosen jars onto an unattended host and trains the user to approve jars they never asked for. With layer 1 there is nothing left for it to gate. If third-party MCP installs are ever wanted, that is the right shape for *that* feature.

`setPluginEnabled` is deliberately **not** gated — enabling loads no new code, it instantiates an already-trusted, already-loaded factory. Same privilege as the drawer toggle.

## Destructive behaviour, and one thing deliberately not done

`restartDebugServer` — and `updateSettings` when a ws/wss setting changes — stops the debug server, which drops **every** session and invalidates every `sessionId` the agent holds. Both say so in their result; `updateSettings` accepts `restartDebugServer: false` to persist and apply later.

`updateSettings` **never** restarts the MCP server, even when `mcpServerPort` changes — that would tear down the calling agent's own connection. It persists the value and reports that it applies on the next host start. There is intentionally no `jetwhale.restartMcpServer`.

## Supporting changes

- `DebugWebSocketServer` gains `statusFlow`; the status was previously reachable only from core/data, so core/mcp could not name the type. `DefaultServerStatusSubscriptionKey` now subscribes through the interface.
- `McpServerStatusHolder` breaks a DI cycle: a tool reporting the MCP server's status cannot inject `McpServerService`, because the server is built from the set of tools. Both sides depend on the holder instead.
- `OfficialPluginInstallService` promoted to core/model (core/mcp cannot depend on core/data); `DefaultOfficialPluginInstallMutationKey` now delegates to it, removing duplicated candidate derivation.
- `McpPluginInstallAllowedMutationKey` is declared as an interface, not a typealias — `MutationKey<Unit, Boolean>` typealiases are the same type to Metro, matching the existing `CheckForUpdatesOnStartupMutationKey` convention.

## Testing

56 new tests, all green:

| Suite | Tests |
|---|---|
| `HostMcpCommandTest` | 6 |
| `McpToolSchemaTest` | 3 |
| `HostStatusCommandTest` | 6 |
| `HostLogCommandsTest` | 7 |
| `HostPluginCommandsTest` | 11 |
| `HostSettingsCommandsTest` | 9 |
| `HostNavigationCommandTest` | 9 |
| `DefaultHostNavigationServiceTest` | 5 |

`./gradlew :jetwhale-host:app:build :jetwhale-host:core:mcp:build :jetwhale-host:core:data:build spotlessCheck` passes. The full `./gradlew build` was not run locally — this machine has no Android SDK.

> [!IMPORTANT]
> **The Compose wiring in `JetWhaleApp` and `ToolingScaffoldRoot` is not covered by unit tests** — the host modules have no Compose UI test infrastructure. It needs manual verification:
>
> 1. `./gradlew :jetwhale-host:app:run`
> 2. `claude mcp add --transport sse jetwhale http://localhost:7080/sse`
> 3. `getStatus` → `installOfficialPlugin` (refused with the setting off; enable it in Settings, then succeeds) → reconnect → `setPluginEnabled` → `navigate(PLUGIN)` → `screenshot` shows the expected screen
> 4. `getLogs` / `clearLogs` / `restartDebugServer` (sessions drop)

## Out of scope

- ADB/device tools (`listDevices`, port forwarding) — `ADBAutoWiringService` exposes neither today.
- Authentication for the MCP port. Worth a follow-up issue now that the port is a mutation surface.
- `docs/guide/network-inspector.md` is missing `com.kitakkun.jetwhale.network.setMockRules` from its tool table (it exists in `SetMockRulesCommand.kt`). Pre-existing; worth a separate one-line docs PR.
