### PR TITLE
feat(network): make list-row URLs horizontally scrollable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ jetbrainsComposePreview = { module = "org.jetbrains.compose.ui:ui-tooling-previe
 jetbrainsComposeResources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "jetbrainsCompose" }
 jetbrainsComposeSplitPane = { module = "org.jetbrains.compose.components:components-splitpane", version.ref = "jetbrainsCompose" }
 jetbrainsComposeMaterialIconsExtended = { module = "org.jetbrains.compose.material:material-icons-extended", version = "1.7.3" }
+jetbrainsComposeUiTestJUnit4 = { module = "org.jetbrains.compose.ui:ui-test-junit4", version.ref = "jetbrainsCompose" }
 material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 
 # navigation3

--- a/jetwhale-plugins/network/host/build.gradle.kts
+++ b/jetwhale-plugins/network/host/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     testImplementation(libs.kotlinTest)
     testImplementation(libs.kotlinxSerializationJson)
     testImplementation(compose.desktop.currentOs)
+    testImplementation(compose.desktop.uiTestJUnit4)
     testImplementation(libs.material3)
 }
 

--- a/jetwhale-plugins/network/host/build.gradle.kts
+++ b/jetwhale-plugins/network/host/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     testImplementation(libs.kotlinTest)
     testImplementation(libs.kotlinxSerializationJson)
     testImplementation(compose.desktop.currentOs)
-    testImplementation(compose.desktop.uiTestJUnit4)
+    testImplementation(libs.jetbrainsComposeUiTestJUnit4)
     testImplementation(libs.material3)
 }
 

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -51,7 +52,6 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.sdk.rememberPersistent
 import kotlinx.coroutines.launch
@@ -254,13 +254,15 @@ private fun TransactionRow(tx: HttpTransaction, selected: Boolean, onClick: () -
         Text(
             text = tx.request.url,
             style = MaterialTheme.typography.bodySmall,
+            // The list pane is narrow, so long URLs are read by scrolling the text sideways rather
+            // than by selecting the row. maxLines = 1 plus softWrap = false keeps the URL on a
+            // single line; weight(1f) fixes the viewport before horizontalScroll measures the text
+            // against the unbounded width it hands down.
             maxLines = 1,
-            // softWrap = false keeps the URL on one line so a narrow column truncates it with an
-            // ellipsis at the edge; with the default softWrap the text wraps at the "//" first and
-            // maxLines = 1 then leaves only the "https://" scheme visible.
             softWrap = false,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .horizontalScroll(rememberScrollState()),
         )
         if (tx.response?.fromMock == true) {
             MockChip()

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficRowUrlScrollTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficRowUrlScrollTest.kt
@@ -113,8 +113,8 @@ private fun txId(index: Int) = "tx-$index"
  * Long enough to overflow the list pane at any plausible split position, and index-tagged so each
  * row is individually addressable.
  */
-private fun url(index: Int) = "https://api.example.com/v1/organizations/acme-corp/projects/atlas/" +
-    "deployments/$index?environment=production&include=metrics%2Ctraces&page=3"
+private fun url(index: Int) = "https://example.com/a/deliberately/long/path/that/no/list/pane/" +
+    "is/wide/enough/to/show/items/$index?first=1&second=2&third=3"
 
 /** Built newest-first so that [TOP_ROW] is index 0 once [TrafficTab] reverses the list. */
 private fun transaction(index: Int, rows: Int) = HttpTransaction(

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficRowUrlScrollTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficRowUrlScrollTest.kt
@@ -1,0 +1,178 @@
+package com.kitakkun.jetwhale.plugins.network.host
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.ScrollAxisRange
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.ScrollWheel
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasScrollToIndexAction
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.host.sdk.JetWhalePluginStorage
+import com.kitakkun.jetwhale.host.sdk.LocalJetWhalePluginStorage
+import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
+import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.serialization.KSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the horizontally scrollable URL in [TrafficTab]'s list rows: the list pane is too narrow
+ * for a real URL, so the text scrolls sideways instead of being truncated. The row is a scrollable
+ * inside a scrollable inside a clickable, so the gestures that must keep working (vertical wheel to
+ * scroll the list, click to select the row) are asserted alongside the horizontal scroll itself.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TrafficRowUrlScrollTest {
+
+    @Test
+    fun `a long url in a list row is horizontally scrollable`() = runTrafficTab { _ ->
+        val range = urlNode(newestIndex).horizontalScrollRange()
+        assertEquals(0f, range.value(), "starts unscrolled")
+        assertTrue(range.maxValue() > 0f, "content is wider than the row's viewport, maxValue=${range.maxValue()}")
+    }
+
+    @Test
+    fun `a horizontal wheel over the url scrolls the url`() = runTrafficTab { _ ->
+        val url = urlNode(newestIndex)
+        url.performMouseInput {
+            moveTo(center)
+            repeat(WHEEL_NOTCHES) { scroll(1f, ScrollWheel.Horizontal) }
+        }
+        waitUntil("the url scrolls right") { url.horizontalScrollRange().value() > 0f }
+    }
+
+    @Test
+    fun `a vertical wheel over the url scrolls the list and leaves the url alone`() = runTrafficTab { _ ->
+        // Aim at a row well down the viewport and send a single notch, so the row the wheel lands on
+        // is still composed afterwards and its horizontal offset can be re-read.
+        val index = newestIndex - 10
+        val list = onNode(hasScrollToIndexAction())
+        assertEquals(0f, list.verticalScrollRange().value(), "list starts at the top")
+
+        urlNode(index).performMouseInput {
+            moveTo(center)
+            scroll(1f, ScrollWheel.Vertical)
+        }
+
+        waitUntil("the list scrolls down") { list.verticalScrollRange().value() > 0f }
+        assertEquals(0f, urlNode(index).horizontalScrollRange().value(), "the url did not move sideways")
+    }
+
+    @Test
+    fun `clicking the url selects its row`() = runTrafficTab { selected ->
+        urlNode(newestIndex).performClick()
+        waitForIdle()
+        assertEquals(txId(newestIndex), selected())
+    }
+}
+
+/** Enough rows that the list can scroll vertically well past the viewport. */
+private const val TRANSACTION_COUNT = 60
+
+/** Mouse wheel notches to send; one notch alone is a sub-pixel move under smooth scrolling. */
+private const val WHEEL_NOTCHES = 10
+
+/** [TrafficTab] renders newest-first, so the newest transaction owns the topmost row. */
+private val newestIndex = TRANSACTION_COUNT - 1
+
+private fun txId(index: Int) = "tx-$index"
+
+/**
+ * Long enough to overflow the list pane at any plausible split position, and index-tagged so each
+ * row is individually addressable.
+ */
+private fun url(index: Int) =
+    "https://api.example.com/v1/organizations/acme-corp/projects/atlas/deployments/$index" +
+        "?environment=production&include=metrics%2Ctraces&page=3"
+
+private fun transaction(index: Int) = HttpTransaction(
+    request = CapturedHttpRequest(
+        txId = txId(index),
+        method = "GET",
+        url = url(index),
+        timestampMs = index.toLong(),
+    ),
+    response = CapturedHttpResponse(
+        txId = txId(index),
+        statusCode = 200,
+        statusDescription = "OK",
+        durationMs = 12L,
+    ),
+)
+
+/**
+ * Renders [TrafficTab] at a fixed size and runs [block] against it. The lambda receives a getter for
+ * the most recently selected transaction id.
+ */
+@OptIn(ExperimentalTestApi::class)
+private fun runTrafficTab(block: ComposeUiTest.(selected: () -> String?) -> Unit) = runComposeUiTest {
+    var selected: String? = null
+    setContent {
+        CompositionLocalProvider(LocalJetWhalePluginStorage provides InMemoryPluginStorage()) {
+            MaterialTheme {
+                // Wide enough to clear ListMinWidth + DetailMinWidth, tall enough that the list has
+                // far more rows than fit.
+                Box(Modifier.requiredSize(width = 900.dp, height = 600.dp)) {
+                    TrafficTab(
+                        transactions = List(TRANSACTION_COUNT) { transaction(it) },
+                        selectedTxId = null,
+                        onSelectTx = { selected = it },
+                        onClear = {},
+                        onCreateMock = {},
+                    )
+                }
+            }
+        }
+    }
+    block { selected }
+}
+
+@OptIn(ExperimentalTestApi::class)
+private fun ComposeUiTest.urlNode(index: Int): SemanticsNodeInteraction = onNodeWithText(url(index))
+
+private fun SemanticsNodeInteraction.horizontalScrollRange(): ScrollAxisRange =
+    fetchSemanticsNode().config[SemanticsProperties.HorizontalScrollAxisRange]
+
+private fun SemanticsNodeInteraction.verticalScrollRange(): ScrollAxisRange =
+    fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange]
+
+/** Minimal in-memory [JetWhalePluginStorage] so `rememberPersistent` has something to bind to. */
+@Suppress("UNCHECKED_CAST")
+private class InMemoryPluginStorage : JetWhalePluginStorage {
+    private val values = MutableStateFlow<Map<String, Any?>>(emptyMap())
+
+    override suspend fun <T> put(key: String, value: T, serializer: KSerializer<T>) {
+        values.update { it + (key to value) }
+    }
+
+    override suspend fun <T> get(key: String, serializer: KSerializer<T>): T? = values.value[key] as T?
+
+    override fun <T> getFlow(key: String, serializer: KSerializer<T>): Flow<T?> = values.map { it[key] as T? }
+
+    override suspend fun contains(key: String): Boolean = values.value.containsKey(key)
+
+    override suspend fun remove(key: String) {
+        values.update { it - key }
+    }
+
+    override suspend fun clear() {
+        values.value = emptyMap()
+    }
+
+    override val keysFlow: Flow<Set<String>> get() = values.map { it.keys }
+}

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficRowUrlScrollTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/TrafficRowUrlScrollTest.kt
@@ -41,14 +41,14 @@ class TrafficRowUrlScrollTest {
 
     @Test
     fun `a long url in a list row is horizontally scrollable`() = runTrafficTab { _ ->
-        val range = urlNode(newestIndex).horizontalScrollRange()
+        val range = urlNode(TOP_ROW).horizontalScrollRange()
         assertEquals(0f, range.value(), "starts unscrolled")
         assertTrue(range.maxValue() > 0f, "content is wider than the row's viewport, maxValue=${range.maxValue()}")
     }
 
     @Test
     fun `a horizontal wheel over the url scrolls the url`() = runTrafficTab { _ ->
-        val url = urlNode(newestIndex)
+        val url = urlNode(TOP_ROW)
         url.performMouseInput {
             moveTo(center)
             repeat(WHEEL_NOTCHES) { scroll(1f, ScrollWheel.Horizontal) }
@@ -57,38 +57,55 @@ class TrafficRowUrlScrollTest {
     }
 
     @Test
-    fun `a vertical wheel over the url scrolls the list and leaves the url alone`() = runTrafficTab { _ ->
-        // Aim at a row well down the viewport and send a single notch, so the row the wheel lands on
-        // is still composed afterwards and its horizontal offset can be re-read.
-        val index = newestIndex - 10
+    fun `a vertical wheel over the url scrolls the list`() = runTrafficTab(rows = LONG_LIST) { _ ->
         val list = onNode(hasScrollToIndexAction())
         assertEquals(0f, list.verticalScrollRange().value(), "list starts at the top")
 
-        urlNode(index).performMouseInput {
+        urlNode(TOP_ROW).performMouseInput {
             moveTo(center)
-            scroll(1f, ScrollWheel.Vertical)
+            repeat(WHEEL_NOTCHES) { scroll(1f, ScrollWheel.Vertical) }
         }
 
+        // Asserted on the list rather than on the row: how far one notch travels is platform
+        // specific, and the row the wheel landed on may itself have scrolled out of the viewport.
         waitUntil("the list scrolls down") { list.verticalScrollRange().value() > 0f }
-        assertEquals(0f, urlNode(index).horizontalScrollRange().value(), "the url did not move sideways")
+    }
+
+    @Test
+    fun `a vertical wheel does not scroll the url sideways`() = runTrafficTab(rows = SHORT_LIST) { _ ->
+        // A list short enough to need no vertical scrolling keeps the row in place, so the same URL
+        // node can be re-read after the wheel regardless of how far a notch would have travelled.
+        val url = urlNode(TOP_ROW)
+        url.performMouseInput {
+            moveTo(center)
+            repeat(WHEEL_NOTCHES) { scroll(1f, ScrollWheel.Vertical) }
+        }
+        waitForIdle()
+        assertEquals(0f, url.horizontalScrollRange().value())
     }
 
     @Test
     fun `clicking the url selects its row`() = runTrafficTab { selected ->
-        urlNode(newestIndex).performClick()
+        urlNode(TOP_ROW).performClick()
         waitForIdle()
-        assertEquals(txId(newestIndex), selected())
+        assertEquals(txId(TOP_ROW), selected())
     }
 }
 
 /** Enough rows that the list can scroll vertically well past the viewport. */
-private const val TRANSACTION_COUNT = 60
+private const val LONG_LIST = 60
+
+/** Few enough rows that the list fits the viewport and cannot scroll at all. */
+private const val SHORT_LIST = 3
 
 /** Mouse wheel notches to send; one notch alone is a sub-pixel move under smooth scrolling. */
 private const val WHEEL_NOTCHES = 10
 
-/** [TrafficTab] renders newest-first, so the newest transaction owns the topmost row. */
-private val newestIndex = TRANSACTION_COUNT - 1
+/**
+ * [TrafficTab] renders newest-first, and the fixtures are built newest-last, so index 0 owns the
+ * topmost row.
+ */
+private const val TOP_ROW = 0
 
 private fun txId(index: Int) = "tx-$index"
 
@@ -96,16 +113,16 @@ private fun txId(index: Int) = "tx-$index"
  * Long enough to overflow the list pane at any plausible split position, and index-tagged so each
  * row is individually addressable.
  */
-private fun url(index: Int) =
-    "https://api.example.com/v1/organizations/acme-corp/projects/atlas/deployments/$index" +
-        "?environment=production&include=metrics%2Ctraces&page=3"
+private fun url(index: Int) = "https://api.example.com/v1/organizations/acme-corp/projects/atlas/" +
+    "deployments/$index?environment=production&include=metrics%2Ctraces&page=3"
 
-private fun transaction(index: Int) = HttpTransaction(
+/** Built newest-first so that [TOP_ROW] is index 0 once [TrafficTab] reverses the list. */
+private fun transaction(index: Int, rows: Int) = HttpTransaction(
     request = CapturedHttpRequest(
         txId = txId(index),
         method = "GET",
         url = url(index),
-        timestampMs = index.toLong(),
+        timestampMs = (rows - index).toLong(),
     ),
     response = CapturedHttpResponse(
         txId = txId(index),
@@ -116,20 +133,23 @@ private fun transaction(index: Int) = HttpTransaction(
 )
 
 /**
- * Renders [TrafficTab] at a fixed size and runs [block] against it. The lambda receives a getter for
- * the most recently selected transaction id.
+ * Renders [TrafficTab] with [rows] transactions at a fixed size and runs [block] against it. The
+ * lambda receives a getter for the most recently selected transaction id.
  */
 @OptIn(ExperimentalTestApi::class)
-private fun runTrafficTab(block: ComposeUiTest.(selected: () -> String?) -> Unit) = runComposeUiTest {
+private fun runTrafficTab(
+    rows: Int = LONG_LIST,
+    block: suspend ComposeUiTest.(selected: () -> String?) -> Unit,
+) = runComposeUiTest {
     var selected: String? = null
     setContent {
         CompositionLocalProvider(LocalJetWhalePluginStorage provides InMemoryPluginStorage()) {
             MaterialTheme {
-                // Wide enough to clear ListMinWidth + DetailMinWidth, tall enough that the list has
-                // far more rows than fit.
+                // Wide enough to clear ListMinWidth + DetailMinWidth, and tall enough that LONG_LIST
+                // overflows the viewport while SHORT_LIST does not.
                 Box(Modifier.requiredSize(width = 900.dp, height = 600.dp)) {
                     TrafficTab(
-                        transactions = List(TRANSACTION_COUNT) { transaction(it) },
+                        transactions = List(rows) { transaction(index = rows - 1 - it, rows = rows) },
                         selectedTxId = null,
                         onSelectTx = { selected = it },
                         onClear = {},
@@ -145,11 +165,11 @@ private fun runTrafficTab(block: ComposeUiTest.(selected: () -> String?) -> Unit
 @OptIn(ExperimentalTestApi::class)
 private fun ComposeUiTest.urlNode(index: Int): SemanticsNodeInteraction = onNodeWithText(url(index))
 
-private fun SemanticsNodeInteraction.horizontalScrollRange(): ScrollAxisRange =
-    fetchSemanticsNode().config[SemanticsProperties.HorizontalScrollAxisRange]
+private fun SemanticsNodeInteraction.horizontalScrollRange(): ScrollAxisRange = fetchSemanticsNode()
+    .config[SemanticsProperties.HorizontalScrollAxisRange]
 
-private fun SemanticsNodeInteraction.verticalScrollRange(): ScrollAxisRange =
-    fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange]
+private fun SemanticsNodeInteraction.verticalScrollRange(): ScrollAxisRange = fetchSemanticsNode()
+    .config[SemanticsProperties.VerticalScrollAxisRange]
 
 /** Minimal in-memory [JetWhalePluginStorage] so `rememberPersistent` has something to bind to. */
 @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
## What

List-row URLs in the Traffic tab now scroll horizontally instead of being cut off with an ellipsis. Each row keeps its own `ScrollState`, so rows scroll independently.

- Scoped to the list row (`TransactionRow`); the detail pane's URL still soft-wraps and is unchanged.
- No scrollbar is drawn, matching how `McpSnippetView` in `ServerSettingsScreen` handles its scrollable snippet.
- No new dependency: `horizontalScroll` / `rememberScrollState` come from host-provided compose-foundation, so the packaged plugin jar and its dependency manifest are unchanged.

## Why

The list pane is narrow, so a real URL's path and query were never visible. Telling two requests apart meant selecting the row to read the detail pane, or reaching for "Copy URL" in the context menu.

## Tested

Added `TrafficRowUrlScrollTest`, the module's first Compose UI test (4 tests, all green):

- The URL exposes a horizontal scroll range wider than its viewport.
- A horizontal wheel over the URL scrolls it.
- **A vertical wheel over the URL scrolls the list, not the URL.**
- Clicking the URL still selects its row.

The third is the one most likely to break silently. A horizontal scrollable resolves a vertically-angled delta to zero and leaves the event unconsumed, so it propagates to the enclosing `LazyColumn` (CMP 1.11.1 `ScrollingLogic.toSingleAxisDeltaFromAngle` / `MouseWheelScrollingLogic.canConsumeDelta`).

Reverting the implementation and re-running the suite fails the three scroll tests and passes the click test, confirming the tests actually pin down this change.

Before/after screenshots captured via `captureToImage()` inside the test confirm that after a horizontal scroll only the top row moves while the others stay put.

## Note

With the ellipsis gone, there is no longer a visual cue distinguishing "clipped" from "scrollable". Omitting the scrollbar was a deliberate choice to match existing conventions, but it may be worth revisiting after using it on real traffic.
