### PR TITLE
Let an MCP tool answer with more than a string

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -371,6 +371,51 @@ class DescribeWidgetCommand(private val widgets: WidgetStore) : JetWhaleMcpTextC
 }
 ```
 
+### Declaring what a tool returns
+
+A tool whose answer has a known shape declares it with `serializableOutput<T>()`, the mirror image of
+the `serializable<T>()` parameter declarator. The declaration hands back the handle that builds the
+result:
+
+```kotlin
+@Serializable
+data class WidgetDescription(val id: String, val label: String, val visible: Boolean = true)
+
+class InspectWidgetCommand(private val widgets: WidgetStore) : JetWhaleMcpCommand() {
+    override val name = "com.example.myplugin.inspectWidget"
+    override val description = "Inspect the selected widget"
+
+    private val widgetId by string("The widget ID")
+    private val widget = serializableOutput<WidgetDescription>()
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
+        val found = widgets.find(arguments[widgetId])
+            ?: return JetWhaleMcpResult.error("no widget with id: ${arguments[widgetId]}")
+        return widget.result(WidgetDescription(id = found.id, label = found.label))
+    }
+}
+```
+
+The tool's `outputSchema` is derived from `T`'s serializer — the same rules as for a parameter,
+including `@McpDescription` and "required means no default value" — and `result(...)` encodes with
+the same format. The AI agent therefore knows the shape of the answer *before* it calls the tool,
+instead of calling it once to find out, and what it is promised cannot drift from what it receives.
+
+Things to know:
+
+- **Declaring nothing is the default and stays valid.** A tool that declares no output advertises no
+  `outputSchema`, which is how it says its answer is prose for a human-like reader. Only declare an
+  output when the tool really does answer with one fixed structure.
+- **MCP requires the output schema to describe an object**, so `T` must serialize to a JSON object. A
+  list or a sealed hierarchy has to be wrapped in a `@Serializable` class holding it; declaring one
+  directly fails at construction time rather than advertising a schema MCP rejects.
+- **A failure is not the tool's answer.** A command that declares an output can still return
+  `JetWhaleMcpResult.error(...)` or throw `JetWhaleMcpArgumentException` — a failed call carries a
+  message, and the output schema does not apply to it.
+- **Declare it as a property**, next to the parameters. Like a parameter, an output declared after
+  the schema was read (inside `execute`, say) throws rather than silently diverging from the schema
+  the agent was already shown, and a command has a single output.
+
 ### Structured parameters
 
 Beyond scalars (`string`, `int`, `long`, `boolean`, `enum`), a parameter can take structured input.

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -414,6 +414,10 @@ Things to know:
 - **MCP requires the output schema to describe an object**, so `T` must serialize to a JSON object. A
   list or a sealed hierarchy has to be wrapped in a `@Serializable` class holding it; declaring one
   directly fails at construction time rather than advertising a schema MCP rejects.
+- **The declaration is enforced.** Once a command declares an output, a successful answer has to come
+  from that declaration's `result(...)`; one built with `JetWhaleMcpResult.json(...)` or `text(...)`
+  would be delivered under a schema nothing checked it against, so the host refuses it as a
+  programming error.
 - **A failure is not the tool's answer.** A command that declares an output can still return
   `JetWhaleMcpResult.error(...)` or throw `JetWhaleMcpException` — a failed call carries a message,
   and the output schema does not apply to it.

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -311,8 +311,10 @@ class InspectWidgetCommand(private val widgets: WidgetStore) : JetWhaleMcpComman
     private val widgetId by string("The widget ID")
     private val verbose by booleanOrNull("Include layout details.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
-        return widgets.describeAsJson(id = arguments[widgetId], verbose = arguments[verbose] ?: false)
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
+        val widget = widgets.find(arguments[widgetId])
+            ?: return JetWhaleMcpResult.error("no widget with id: ${arguments[widgetId]}")
+        return JetWhaleMcpResult.json(widget.describe(verbose = arguments[verbose] ?: false))
     }
 }
 
@@ -327,8 +329,6 @@ Things to know:
 - **`sessionId` is injected for you.** JetWhale adds a required `sessionId` parameter to every
   plugin tool's schema and routes the call to the right plugin instance, so your command runs
   against the correct session without handling it yourself.
-- **`execute` returns a string** (plain text or JSON). Throw `JetWhaleMcpArgumentException` for
-  caller mistakes — it is rendered as an `{"error": ...}` payload instead of failing the server.
 - **Messaging works from tool handlers.** `messenger` is valid for the whole instance lifetime, so
   a command can `request` the agent directly.
 - **Declare parameters as properties, never inside `execute`.** The list is read once, and declaring
@@ -337,6 +337,39 @@ Things to know:
 - Every declarator takes an optional `name` to override the wire name, for when the property cannot
   be called what the parameter should be called (`by stringOrNull("…", name = "name")`).
 - The MCP APIs are marked `@ExperimentalJetWhaleApi` and may change between releases.
+
+### What a tool answers with
+
+`execute` returns a `JetWhaleMcpResult`, built with one of four factories:
+
+| Factory                            | What the AI agent gets                                                        |
+|------------------------------------|-------------------------------------------------------------------------------|
+| `JetWhaleMcpResult.text(s)`        | Plain text — prose, or JSON you serialized yourself.                           |
+| `JetWhaleMcpResult.json(obj)`      | A `JsonObject` as structured content, repeated as text for agents that ignore it. |
+| `JetWhaleMcpResult.image(b64, mime)` | An image the agent can look at, Base64-encoded.                              |
+| `JetWhaleMcpResult.error(message)` | A **failure**: the call is flagged so the agent corrects and retries it.       |
+
+Report failures with `error(...)` rather than returning text that merely mentions the problem —
+without the flag, the agent reads "the widget does not exist" as the tool's answer and carries on.
+Throwing `JetWhaleMcpArgumentException` produces the same failed result and is the shorter path when
+the mistake is spotted deep inside the command; it never fails the MCP server.
+
+JetWhale deliberately owns this type instead of exposing the MCP library's own result types, so your
+plugin does not have to track that library's versions.
+
+A command that only ever answers with text can extend `JetWhaleMcpTextCommand` and return the string
+directly:
+
+```kotlin
+class DescribeWidgetCommand(private val widgets: WidgetStore) : JetWhaleMcpTextCommand() {
+    override val name = "com.example.myplugin.describeWidget"
+    override val description = "Describe the selected widget"
+
+    private val widgetId by string("The widget ID")
+
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String = widgets.describe(arguments[widgetId])
+}
+```
 
 ### Structured parameters
 

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -351,8 +351,10 @@ Things to know:
 
 Report failures with `error(...)` rather than returning text that merely mentions the problem —
 without the flag, the agent reads "the widget does not exist" as the tool's answer and carries on.
-Throwing `JetWhaleMcpArgumentException` produces the same failed result and is the shorter path when
-the mistake is spotted deep inside the command; it never fails the MCP server.
+Throwing `JetWhaleMcpException` produces the same failed result and is the shorter path when the
+failure is spotted deep inside the command; it never fails the MCP server. Throw its narrower
+subclass `JetWhaleMcpArgumentException` when the arguments are what went wrong — the argument
+accessors already do.
 
 JetWhale deliberately owns this type instead of exposing the MCP library's own result types, so your
 plugin does not have to track that library's versions.
@@ -370,6 +372,9 @@ class DescribeWidgetCommand(private val widgets: WidgetStore) : JetWhaleMcpTextC
     override suspend fun executeText(arguments: JetWhaleMcpArguments): String = widgets.describe(arguments[widgetId])
 }
 ```
+
+Whatever `executeText` returns is reported as a success, so it has no way to say "this failed" —
+throw `JetWhaleMcpException` for that.
 
 ### Declaring what a tool returns
 
@@ -410,8 +415,8 @@ Things to know:
   list or a sealed hierarchy has to be wrapped in a `@Serializable` class holding it; declaring one
   directly fails at construction time rather than advertising a schema MCP rejects.
 - **A failure is not the tool's answer.** A command that declares an output can still return
-  `JetWhaleMcpResult.error(...)` or throw `JetWhaleMcpArgumentException` — a failed call carries a
-  message, and the output schema does not apply to it.
+  `JetWhaleMcpResult.error(...)` or throw `JetWhaleMcpException` — a failed call carries a message,
+  and the output schema does not apply to it.
 - **Declare it as a property**, next to the parameters. Like a parameter, an output declared after
   the schema was read (inside `execute`, say) throws rather than silently diverging from the schema
   the agent was already shown, and a command has a single output.

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -409,8 +409,9 @@ instead of calling it once to find out, and what it is promised cannot drift fro
 Things to know:
 
 - **Declaring nothing is the default and stays valid.** A tool that declares no output advertises no
-  `outputSchema`, which is how it says its answer is prose for a human-like reader. Only declare an
-  output when the tool really does answer with one fixed structure.
+  `outputSchema`; it may still answer with `JetWhaleMcpResult.json(...)`, the agent is just not told
+  the shape in advance. Only declare an output when the tool really does answer with one fixed
+  structure.
 - **MCP requires the output schema to describe an object with named properties**, so `T` must
   serialize to one. A list, a map or a sealed hierarchy has to be wrapped in a `@Serializable` class
   holding it; declaring one directly fails at construction time rather than advertising a schema

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -411,9 +411,10 @@ Things to know:
 - **Declaring nothing is the default and stays valid.** A tool that declares no output advertises no
   `outputSchema`, which is how it says its answer is prose for a human-like reader. Only declare an
   output when the tool really does answer with one fixed structure.
-- **MCP requires the output schema to describe an object**, so `T` must serialize to a JSON object. A
-  list or a sealed hierarchy has to be wrapped in a `@Serializable` class holding it; declaring one
-  directly fails at construction time rather than advertising a schema MCP rejects.
+- **MCP requires the output schema to describe an object with named properties**, so `T` must
+  serialize to one. A list, a map or a sealed hierarchy has to be wrapped in a `@Serializable` class
+  holding it; declaring one directly fails at construction time rather than advertising a schema
+  MCP rejects or cannot carry.
 - **The declaration is enforced.** Once a command declares an output, a successful answer has to come
   from that declaration's `result(...)`; one built with `JetWhaleMcpResult.json(...)` or `text(...)`
   would be delivered under a schema nothing checked it against, so the host refuses it as a

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -237,6 +237,35 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
 	public final fun toDescriptor ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor;
 }
 
+public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent {
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Image : com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Image;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Image;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Image;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBase64Data ()Ljava/lang/String;
+	public final fun getMimeType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Text : com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Text;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Text;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Text;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameter {
 	public static final field $stable I
 	public final fun getDescription ()Ljava/lang/String;
@@ -266,6 +295,33 @@ public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor
 	public final fun getSchema ()Lkotlinx/serialization/json/JsonObject;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult {
+	public static final field $stable I
+	public static final field Companion Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult$Companion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/util/List;
+	public final fun getStructuredContent ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public final fun isError ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult$Companion {
+	public final fun error (Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult;
+	public final fun image (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult;
+	public final fun json (Lkotlinx/serialization/json/JsonObject;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult;
+	public final fun text (Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult;
+}
+
+public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpTextCommand : com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun execute (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpArguments;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected abstract fun executeText (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpArguments;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor {

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -218,6 +218,7 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
 	public static synthetic fun long$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun longOrNull (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun longOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	public final fun run (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpArguments;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun serializable (Lkotlinx/serialization/KSerializer;Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun serializable$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun serializableOrNull (Lkotlinx/serialization/KSerializer;Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -170,7 +170,7 @@ public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugi
 	public abstract fun Content (Landroidx/compose/runtime/Composer;I)V
 }
 
-public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpArgumentException : java/lang/Exception {
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpArgumentException : com/kitakkun/jetwhale/host/sdk/JetWhaleMcpException {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;)V
 }
@@ -265,6 +265,11 @@ public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Text : com/
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpException : java/lang/Exception {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
 }
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpOutput {

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -222,6 +222,7 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
 	public static synthetic fun serializable$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun serializableOrNull (Lkotlinx/serialization/KSerializer;Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun serializableOrNull$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
+	protected final fun serializableOutput (Lkotlinx/serialization/KSerializer;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpOutput;
 	protected final fun string (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	public static synthetic fun string$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
 	protected final fun stringList (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDeclaration;
@@ -264,6 +265,12 @@ public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Text : com/
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpOutput {
+	public static final field $stable I
+	public final fun getSchema ()Lkotlinx/serialization/json/JsonObject;
+	public final fun result (Ljava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult;
 }
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameter {
@@ -326,16 +333,18 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpTextCommand : co
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlinx/serialization/json/JsonObject;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/Map;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor;
-	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlinx/serialization/json/JsonObject;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
+	public final fun getOutputSchema ()Lkotlinx/serialization/json/JsonObject;
 	public final fun getParameters ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
@@ -35,15 +35,20 @@ public interface JetWhaleMcpCapablePlugin {
 /**
  * Describes a single MCP tool contributed by a plugin.
  *
- * @param name        Unique tool name (no spaces; use dots as separators).
- * @param description Human-readable description shown to the AI agent.
- * @param parameters  Parameter descriptors keyed by parameter name.
+ * @param name         Unique tool name (no spaces; use dots as separators).
+ * @param description  Human-readable description shown to the AI agent.
+ * @param parameters   Parameter descriptors keyed by parameter name.
+ * @param outputSchema JSON Schema of the structured content the tool answers with, always an
+ *                     `object` schema as MCP requires. Null when the command declares no output,
+ *                     which is how a tool says it answers with unstructured text; both defaults
+ *                     describe the tool that declares nothing beyond its name and description.
  */
 @ExperimentalJetWhaleApi
 public data class JetWhaleMcpToolDescriptor(
     val name: String,
     val description: String,
     val parameters: Map<String, JetWhaleMcpParameterDescriptor> = emptyMap(),
+    val outputSchema: JsonObject? = null,
 )
 
 /**

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
@@ -9,8 +9,9 @@ import kotlinx.serialization.json.JsonObject
  *
  * The MCP server queries all active plugin instances for this interface as sessions come up,
  * registers each command's descriptor, and dispatches invocations to the matching command on the
- * correct plugin instance (keyed by pluginId + sessionId). A [JetWhaleMcpArgumentException]
- * thrown by a command becomes a failed [JetWhaleMcpResult] instead of failing the server.
+ * correct plugin instance (keyed by pluginId + sessionId). A [JetWhaleMcpException] thrown by a
+ * command — or its narrower [JetWhaleMcpArgumentException], which the argument accessors raise —
+ * becomes a failed [JetWhaleMcpResult] instead of failing the server.
  *
  * Usage:
  * ```kotlin

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.JsonObject
  * The MCP server queries all active plugin instances for this interface as sessions come up,
  * registers each command's descriptor, and dispatches invocations to the matching command on the
  * correct plugin instance (keyed by pluginId + sessionId). A [JetWhaleMcpArgumentException]
- * thrown by a command is rendered as an `{"error": ...}` payload instead of failing the server.
+ * thrown by a command becomes a failed [JetWhaleMcpResult] instead of failing the server.
  *
  * Usage:
  * ```kotlin

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
@@ -39,9 +39,10 @@ public interface JetWhaleMcpCapablePlugin {
  * @param description  Human-readable description shown to the AI agent.
  * @param parameters   Parameter descriptors keyed by parameter name.
  * @param outputSchema JSON Schema of the structured content the tool answers with, always an
- *                     `object` schema as MCP requires. Null when the command declares no output,
- *                     which is how a tool says it answers with unstructured text; both defaults
- *                     describe the tool that declares nothing beyond its name and description.
+ *                     `object` schema as MCP requires. Null when the command declares no output:
+ *                     the tool advertises no shape for its answer, which may still be structured
+ *                     JSON; both defaults describe the tool that declares nothing beyond its name
+ *                     and description.
  */
 @ExperimentalJetWhaleApi
 public data class JetWhaleMcpToolDescriptor(

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -284,6 +284,11 @@ public abstract class JetWhaleMcpCommand(
     }
 
     private fun <T : Any> declareOutput(output: JetWhaleMcpOutput<T>): JetWhaleMcpOutput<T> {
+        // A text command's execute is final and never goes through the declaration, so every
+        // successful call of such a tool would be refused by run().
+        check(this !is JetWhaleMcpTextCommand) {
+            "'$name' is a JetWhaleMcpTextCommand, whose answer is always plain text, so it cannot declare an output. Extend JetWhaleMcpCommand instead."
+        }
         check(!declarationsSealed) {
             "The output of '$name' was declared after its schema was read. Declare the output only as a property declaration on the command, never inside execute()."
         }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -218,8 +218,8 @@ public abstract class JetWhaleMcpCommand(
      * parameter's, and [JetWhaleMcpOutput.result] encodes with the same [json] — so what the agent is
      * promised and what it receives come from one declaration and cannot drift.
      *
-     * MCP requires a tool's output schema to describe an object, so [T] must serialize to a JSON
-     * object; a list or a sealed hierarchy has to be wrapped in a class holding it.
+     * MCP requires a tool's output schema to describe an object with named properties, so [T] must
+     * serialize to one; a list, a map or a sealed hierarchy has to be wrapped in a class holding it.
      *
      * Declare this only as a property of the command, next to its parameters. Leave it out entirely
      * when the tool answers with unstructured text — a tool that declares no output advertises no
@@ -230,8 +230,10 @@ public abstract class JetWhaleMcpCommand(
     /** Explicit-serializer form of [serializableOutput], for types whose serializer cannot be resolved from the type argument. */
     protected fun <T : Any> serializableOutput(serializer: KSerializer<T>): JetWhaleMcpOutput<T> {
         val schema = serializer.descriptor.toJsonSchema(json)
-        check((schema["type"] as? JsonPrimitive)?.content == "object") {
-            "Output type ${serializer.descriptor.serialName} of '$name' does not serialize to a JSON object, which MCP requires of a tool's output schema. Wrap it in a @Serializable class."
+        // MCP's output schema names the object's properties, so a map — an object with none — has no
+        // more of a place at the root than a list does.
+        check((schema["type"] as? JsonPrimitive)?.content == "object" && "properties" in schema) {
+            "Output type ${serializer.descriptor.serialName} of '$name' does not serialize to a JSON object with named properties, which MCP requires of a tool's output schema. Wrap it in a @Serializable class."
         }
         return declareOutput(JetWhaleMcpOutput(schema = schema, json = json, serializer = serializer))
     }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -51,7 +51,7 @@ import kotlin.reflect.KProperty
  *
  * A command whose answer has a known shape declares it once with [serializableOutput], which derives
  * the tool's output schema from the type and hands back the [JetWhaleMcpOutput] that builds the
- * matching result. Declaring nothing means the tool answers with unstructured text and advertises no
+ * matching result; the host refuses a successful answer built any other way. Declaring nothing means the tool answers with unstructured text and advertises no
  * output schema.
  *
  * Expose commands through [JetWhaleMcpCapablePlugin]. A [JetWhaleMcpException] (thrown by [execute]
@@ -94,6 +94,21 @@ public abstract class JetWhaleMcpCommand(
      *   [JetWhaleMcpOutput.result] when the command declares an output.
      */
     public abstract suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult
+
+    /**
+     * Runs the tool the way the host does: [execute], then a check that a command which declared an
+     * output built its successful answer through it. An answer built any other way — `text(...)`,
+     * or `json(...)` around a hand-assembled object — would reach the agent under a schema nothing
+     * checked it against, so it is refused as a programming error rather than delivered.
+     */
+    public suspend fun run(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
+        val result = execute(arguments)
+        val output = declaredOutput ?: return result
+        check(result.isError || result.output === output) {
+            "'$name' declares an output but answered without it. Build a successful result with the JetWhaleMcpOutput handed back by serializableOutput(), or report a failure with JetWhaleMcpResult.error()."
+        }
+        return result
+    }
 
     public fun toDescriptor(): JetWhaleMcpToolDescriptor {
         declarationsSealed = true
@@ -437,7 +452,15 @@ public class JetWhaleMcpOutput<T : Any> internal constructor(
      * a [JetWhaleMcpException]: a failed call carries a message, not the tool's answer, so the
      * output schema does not apply to it.
      */
-    public fun result(value: T): JetWhaleMcpResult = JetWhaleMcpResult.json(json.encodeToJsonElement(serializer, value) as JsonObject)
+    public fun result(value: T): JetWhaleMcpResult {
+        val payload = json.encodeToJsonElement(serializer, value) as JsonObject
+        return JetWhaleMcpResult(
+            content = listOf(JetWhaleMcpContent.Text(payload.toString())),
+            structuredContent = payload,
+            isError = false,
+            output = this,
+        )
+    }
 }
 
 /**

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -33,8 +33,8 @@ import kotlin.reflect.KProperty
  *     private val widgetId by string("The widget ID")
  *     private val verbose by booleanOrNull("Include layout details.")
  *
- *     override suspend fun execute(arguments: JetWhaleMcpArguments): String {
- *         return widgets.describeAsJson(id = arguments[widgetId], verbose = arguments[verbose] ?: false)
+ *     override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
+ *         return JetWhaleMcpResult.json(widgets.describe(id = arguments[widgetId], verbose = arguments[verbose] ?: false))
  *     }
  * }
  * ```
@@ -44,9 +44,13 @@ import kotlin.reflect.KProperty
  * [stringList] / [stringMap] cover the common flat containers, and [jsonObject] / [jsonArray] hand
  * back the raw [JsonElement] for payloads whose shape is not known ahead of time.
  *
+ * [execute] answers with a [JetWhaleMcpResult] — text, structured JSON, an image, or a failure.
+ * A command that only ever answers with text can extend [JetWhaleMcpTextCommand] instead and
+ * return the string directly.
+ *
  * Expose commands through [JetWhaleMcpCapablePlugin]. A [JetWhaleMcpArgumentException] (thrown
- * by the argument accessors, or by [execute] directly for domain-level caller mistakes) is
- * rendered as an `{"error": ...}` payload instead of failing the MCP server.
+ * by the argument accessors, or by [execute] directly for domain-level caller mistakes) becomes a
+ * failed [JetWhaleMcpResult] the agent can read and correct, instead of failing the MCP server.
  *
  * @param json Format used to decode [serializable] arguments and to derive their schema; also
  *   available to [execute] for encoding results. Defaults to [DefaultArgumentJson]. Pass a custom
@@ -77,9 +81,9 @@ public abstract class JetWhaleMcpCommand(
     /**
      * Executes the tool.
      *
-     * @return A result string (plain text or JSON).
+     * @return What the AI agent receives — build it with the [JetWhaleMcpResult] factories.
      */
-    public abstract suspend fun execute(arguments: JetWhaleMcpArguments): String
+    public abstract suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult
 
     public fun toDescriptor(): JetWhaleMcpToolDescriptor {
         parametersSealed = true
@@ -280,6 +284,35 @@ public abstract class JetWhaleMcpCommand(
             putJsonArray("enum") { entries.forEach { add(it.name) } }
         }
     }
+}
+
+/**
+ * A [JetWhaleMcpCommand] whose answer is always plain text, so it returns the string itself:
+ * ```kotlin
+ * class DescribeWidgetCommand(private val widgets: WidgetStore) : JetWhaleMcpTextCommand() {
+ *     override val name = "com.example.myplugin.describeWidget"
+ *     override val description = "Describe the selected widget"
+ *
+ *     private val widgetId by string("The widget ID")
+ *
+ *     override suspend fun executeText(arguments: JetWhaleMcpArguments): String = widgets.describe(arguments[widgetId])
+ * }
+ * ```
+ * Extend [JetWhaleMcpCommand] directly to report a failure, structured JSON, or an image.
+ *
+ * @param json Same meaning as on [JetWhaleMcpCommand], and defaulted the same way.
+ */
+@ExperimentalJetWhaleApi
+public abstract class JetWhaleMcpTextCommand(json: Json = DefaultArgumentJson) : JetWhaleMcpCommand(json) {
+    final override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(executeText(arguments))
+
+    /**
+     * Executes the tool.
+     *
+     * @return The text handed to the AI agent. Throw [JetWhaleMcpArgumentException] to report a
+     *   caller mistake.
+     */
+    protected abstract suspend fun executeText(arguments: JetWhaleMcpArguments): String
 }
 
 /**

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -229,7 +229,15 @@ public abstract class JetWhaleMcpCommand(
      */
     protected inline fun <reified T : Any> serializableOutput(): JetWhaleMcpOutput<T> = serializableOutput(serializer<T>())
 
-    /** Explicit-serializer form of [serializableOutput], for types whose serializer cannot be resolved from the type argument. */
+    /**
+     * Explicit-serializer form of [serializableOutput], for types whose serializer cannot be resolved
+     * from the type argument.
+     *
+     * The schema is derived from [serializer]'s descriptor and the payload from what it writes, so
+     * the two agree exactly when the serializer honors kotlinx.serialization's own contract that a
+     * descriptor describes its encoding. A hand-written serializer that breaks it advertises a shape
+     * it does not produce; that is checked no further than the payload being a JSON object.
+     */
     protected fun <T : Any> serializableOutput(serializer: KSerializer<T>): JetWhaleMcpOutput<T> {
         val schema = serializer.descriptor.toJsonSchema(json)
         // MCP's output schema names the object's properties, so a map — an object with none — has no

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -32,9 +32,10 @@ import kotlin.reflect.KProperty
  *
  *     private val widgetId by string("The widget ID")
  *     private val verbose by booleanOrNull("Include layout details.")
+ *     private val widget = serializableOutput<WidgetDescription>()
  *
  *     override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
- *         return JetWhaleMcpResult.json(widgets.describe(id = arguments[widgetId], verbose = arguments[verbose] ?: false))
+ *         return widget.result(widgets.describe(id = arguments[widgetId], verbose = arguments[verbose] ?: false))
  *     }
  * }
  * ```
@@ -47,6 +48,11 @@ import kotlin.reflect.KProperty
  * [execute] answers with a [JetWhaleMcpResult] — text, structured JSON, an image, or a failure.
  * A command that only ever answers with text can extend [JetWhaleMcpTextCommand] instead and
  * return the string directly.
+ *
+ * A command whose answer has a known shape declares it once with [serializableOutput], which derives
+ * the tool's output schema from the type and hands back the [JetWhaleMcpOutput] that builds the
+ * matching result. Declaring nothing means the tool answers with unstructured text and advertises no
+ * output schema.
  *
  * Expose commands through [JetWhaleMcpCapablePlugin]. A [JetWhaleMcpArgumentException] (thrown
  * by the argument accessors, or by [execute] directly for domain-level caller mistakes) becomes a
@@ -72,21 +78,24 @@ public abstract class JetWhaleMcpCommand(
 
     private val declaredParameters = mutableListOf<JetWhaleMcpParameter<*>>()
 
+    private var declaredOutput: JetWhaleMcpOutput<*>? = null
+
     // Set once the schema has been produced (and may have been shown to a caller); late
     // declarations would silently diverge from it, so they throw instead. The declarations are
     // deliberately not readable any other way: an accidental read during construction would
     // observe a half-built list.
-    private var parametersSealed = false
+    private var declarationsSealed = false
 
     /**
      * Executes the tool.
      *
-     * @return What the AI agent receives — build it with the [JetWhaleMcpResult] factories.
+     * @return What the AI agent receives — build it with the [JetWhaleMcpResult] factories, or with
+     *   [JetWhaleMcpOutput.result] when the command declares an output.
      */
     public abstract suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult
 
     public fun toDescriptor(): JetWhaleMcpToolDescriptor {
-        parametersSealed = true
+        declarationsSealed = true
         return JetWhaleMcpToolDescriptor(
             name = name,
             description = description,
@@ -97,6 +106,7 @@ public abstract class JetWhaleMcpCommand(
                     required = parameter.required,
                 )
             },
+            outputSchema = declaredOutput?.schema,
         )
     }
 
@@ -177,6 +187,39 @@ public abstract class JetWhaleMcpCommand(
     /** @see jsonArray */
     protected fun jsonArrayOrNull(description: String, name: String? = null): JetWhaleMcpParameterDeclaration<JsonArray?> = optionalStructured(name, ARRAY_SCHEMA, description, parse = ::parseJsonArray)
 
+    // -- Output declaration -------------------------------------------------------------------
+
+    /**
+     * Declares that this command answers with the `@Serializable` type [T], and hands back the
+     * handle that turns a [T] into the tool's result:
+     * ```kotlin
+     * private val mockConfig = serializableOutput<MockConfig>()
+     *
+     * override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult =
+     *     mockConfig.result(MockConfig(enabled = true, rules = rules))
+     * ```
+     * The tool's output schema is derived from [T]'s serializer exactly as [serializable] derives a
+     * parameter's, and [JetWhaleMcpOutput.result] encodes with the same [json] — so what the agent is
+     * promised and what it receives come from one declaration and cannot drift.
+     *
+     * MCP requires a tool's output schema to describe an object, so [T] must serialize to a JSON
+     * object; a list or a sealed hierarchy has to be wrapped in a class holding it.
+     *
+     * Declare this only as a property of the command, next to its parameters. Leave it out entirely
+     * when the tool answers with unstructured text — a tool that declares no output advertises no
+     * output schema, which is what an agent reading prose expects.
+     */
+    protected inline fun <reified T : Any> serializableOutput(): JetWhaleMcpOutput<T> = serializableOutput(serializer<T>())
+
+    /** Explicit-serializer form of [serializableOutput], for types whose serializer cannot be resolved from the type argument. */
+    protected fun <T : Any> serializableOutput(serializer: KSerializer<T>): JetWhaleMcpOutput<T> {
+        val schema = serializer.descriptor.toJsonSchema(json)
+        check((schema["type"] as? JsonPrimitive)?.content == "object") {
+            "Output type ${serializer.descriptor.serialName} of '$name' does not serialize to a JSON object, which MCP requires of a tool's output schema. Wrap it in a @Serializable class."
+        }
+        return declareOutput(JetWhaleMcpOutput(schema = schema, json = json, serializer = serializer))
+    }
+
     // -- Declaration builders -----------------------------------------------------------------
 
     private fun <T : Any> requiredScalar(name: String?, schema: JsonObject, description: String, parse: (String, String) -> T): JetWhaleMcpParameterDeclaration<T> = requiredStructured(name, schema, description) { paramName, element ->
@@ -210,7 +253,7 @@ public abstract class JetWhaleMcpCommand(
     }
 
     internal fun <T> declare(parameter: JetWhaleMcpParameter<T>): JetWhaleMcpParameter<T> {
-        check(!parametersSealed) {
+        check(!declarationsSealed) {
             "Parameter '${parameter.name}' was declared after the parameter list of '$name' was read. Declare parameters only as property declarations on the command, never inside execute()."
         }
         check(declaredParameters.none { it.name == parameter.name }) {
@@ -218,6 +261,17 @@ public abstract class JetWhaleMcpCommand(
         }
         declaredParameters.add(parameter)
         return parameter
+    }
+
+    private fun <T : Any> declareOutput(output: JetWhaleMcpOutput<T>): JetWhaleMcpOutput<T> {
+        check(!declarationsSealed) {
+            "The output of '$name' was declared after its schema was read. Declare the output only as a property declaration on the command, never inside execute()."
+        }
+        check(declaredOutput == null) {
+            "'$name' declares more than one output; a tool has a single output schema."
+        }
+        declaredOutput = output
+        return output
     }
 
     private fun scalarContent(name: String, element: JsonElement): String = (element as? JsonPrimitive)?.content
@@ -358,6 +412,29 @@ public class JetWhaleMcpParameter<T> internal constructor(
     private val extract: (JsonObject) -> T,
 ) {
     internal fun extractFrom(raw: JsonObject): T = extract(raw)
+}
+
+/**
+ * The declared output of a [JetWhaleMcpCommand]: the JSON Schema the tool advertises, and the only
+ * way to build a result that satisfies it. Obtained from
+ * [JetWhaleMcpCommand.serializableOutput].
+ */
+@ExperimentalJetWhaleApi
+public class JetWhaleMcpOutput<T : Any> internal constructor(
+    // JSON Schema of the tool's structured content; an object schema, as MCP requires.
+    public val schema: JsonObject,
+    private val json: Json,
+    private val serializer: KSerializer<T>,
+) {
+    /**
+     * A successful result carrying [value], encoded with the command's format and delivered as the
+     * call's structured content.
+     *
+     * A command that declares an output can still report a failure with [JetWhaleMcpResult.error] or
+     * a [JetWhaleMcpArgumentException]: a failed call carries a message, not the tool's answer, so
+     * the output schema does not apply to it.
+     */
+    public fun result(value: T): JetWhaleMcpResult = JetWhaleMcpResult.json(json.encodeToJsonElement(serializer, value) as JsonObject)
 }
 
 /** A caller mistake in a tool invocation (missing/invalid argument, unknown id, ...). */

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -54,9 +54,10 @@ import kotlin.reflect.KProperty
  * matching result. Declaring nothing means the tool answers with unstructured text and advertises no
  * output schema.
  *
- * Expose commands through [JetWhaleMcpCapablePlugin]. A [JetWhaleMcpArgumentException] (thrown
- * by the argument accessors, or by [execute] directly for domain-level caller mistakes) becomes a
- * failed [JetWhaleMcpResult] the agent can read and correct, instead of failing the MCP server.
+ * Expose commands through [JetWhaleMcpCapablePlugin]. A [JetWhaleMcpException] (thrown by [execute]
+ * for a failure of any kind, or by the argument accessors as the narrower
+ * [JetWhaleMcpArgumentException]) becomes a failed [JetWhaleMcpResult] the agent can read and
+ * correct, instead of failing the MCP server.
  *
  * @param json Format used to decode [serializable] arguments and to derive their schema; also
  *   available to [execute] for encoding results. Defaults to [DefaultArgumentJson]. Pass a custom
@@ -363,8 +364,10 @@ public abstract class JetWhaleMcpTextCommand(json: Json = DefaultArgumentJson) :
     /**
      * Executes the tool.
      *
-     * @return The text handed to the AI agent. Throw [JetWhaleMcpArgumentException] to report a
-     *   caller mistake.
+     * @return The text handed to the AI agent — always the tool's answer, never a failure. Whatever
+     *   is returned is reported as a success, so an agent reading `"error: no such widget"` sees a
+     *   tool that worked and answered that. Throw [JetWhaleMcpException] instead: the flag is what
+     *   tells the agent to correct itself, not the wording.
      */
     protected abstract suspend fun executeText(arguments: JetWhaleMcpArguments): String
 }
@@ -431,15 +434,31 @@ public class JetWhaleMcpOutput<T : Any> internal constructor(
      * call's structured content.
      *
      * A command that declares an output can still report a failure with [JetWhaleMcpResult.error] or
-     * a [JetWhaleMcpArgumentException]: a failed call carries a message, not the tool's answer, so
-     * the output schema does not apply to it.
+     * a [JetWhaleMcpException]: a failed call carries a message, not the tool's answer, so the
+     * output schema does not apply to it.
      */
     public fun result(value: T): JetWhaleMcpResult = JetWhaleMcpResult.json(json.encodeToJsonElement(serializer, value) as JsonObject)
 }
 
-/** A caller mistake in a tool invocation (missing/invalid argument, unknown id, ...). */
+/**
+ * A tool call that failed: the device went away, the target no longer exists, the plugin cannot
+ * answer right now. [message] is handed to the AI agent as the failed call's text, so write it as
+ * something the agent can act on — what was wrong, and what would be right.
+ *
+ * This is the throwing counterpart of [JetWhaleMcpResult.error], and produces exactly that result.
+ * Throw when the failure is discovered deep inside the command; return when reporting it is the
+ * command's plain answer.
+ */
 @ExperimentalJetWhaleApi
-public class JetWhaleMcpArgumentException(message: String) : Exception(message)
+public open class JetWhaleMcpException(message: String) : Exception(message)
+
+/**
+ * A tool call that failed because of the arguments it was given: one is missing, unparseable, or
+ * names something that does not exist. Thrown by the argument accessors, and worth throwing
+ * directly when a command's own lookup of an argument's value comes up empty.
+ */
+@ExperimentalJetWhaleApi
+public class JetWhaleMcpArgumentException(message: String) : JetWhaleMcpException(message)
 
 /**
  * The raw arguments of an MCP tool call, read through the command's declared

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -462,7 +462,11 @@ public class JetWhaleMcpOutput<T : Any> internal constructor(
      * output schema does not apply to it.
      */
     public fun result(value: T): JetWhaleMcpResult {
-        val payload = json.encodeToJsonElement(serializer, value) as JsonObject
+        // The declaration was checked against the serializer's descriptor; a custom serializer can
+        // still write something else at run time, which would break the promise the schema made.
+        val payload = checkNotNull(json.encodeToJsonElement(serializer, value) as? JsonObject) {
+            "The serializer of ${serializer.descriptor.serialName} describes a JSON object but encoded something else, so the answer does not fit the output schema it was declared with."
+        }
         return JetWhaleMcpResult(
             content = listOf(JetWhaleMcpContent.Text(payload.toString())),
             structuredContent = payload,

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -51,8 +51,9 @@ import kotlin.reflect.KProperty
  *
  * A command whose answer has a known shape declares it once with [serializableOutput], which derives
  * the tool's output schema from the type and hands back the [JetWhaleMcpOutput] that builds the
- * matching result; the host refuses a successful answer built any other way. Declaring nothing means the tool answers with unstructured text and advertises no
- * output schema.
+ * matching result; the host refuses a successful answer built any other way. Declaring nothing means
+ * the tool advertises no output schema — its answer may still be JSON, built with
+ * [JetWhaleMcpResult.json], the agent is just not told its shape in advance.
  *
  * Expose commands through [JetWhaleMcpCapablePlugin]. A [JetWhaleMcpException] (thrown by [execute]
  * for a failure of any kind, or by the argument accessors as the narrower
@@ -221,9 +222,10 @@ public abstract class JetWhaleMcpCommand(
      * MCP requires a tool's output schema to describe an object with named properties, so [T] must
      * serialize to one; a list, a map or a sealed hierarchy has to be wrapped in a class holding it.
      *
-     * Declare this only as a property of the command, next to its parameters. Leave it out entirely
-     * when the tool answers with unstructured text — a tool that declares no output advertises no
-     * output schema, which is what an agent reading prose expects.
+     * Declare this only as a property of the command, next to its parameters. Leave it out when the
+     * answer's shape is not worth advertising — prose, or JSON whose shape varies from call to call,
+     * as the Network Inspector's transaction tools answer with. A tool that declares no output
+     * advertises no output schema and may still answer with [JetWhaleMcpResult.json].
      */
     protected inline fun <reified T : Any> serializableOutput(): JetWhaleMcpOutput<T> = serializableOutput(serializer<T>())
 

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult.kt
@@ -1,0 +1,107 @@
+package com.kitakkun.jetwhale.host.sdk
+
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * One block of a tool result, in the order the AI agent reads them.
+ *
+ * JetWhale owns this hierarchy instead of handing plugins the MCP library's own content types, so a
+ * plugin keeps compiling and loading when the host updates that library.
+ */
+@ExperimentalJetWhaleApi
+public sealed interface JetWhaleMcpContent {
+    /** Text the agent reads verbatim: prose, or a JSON document that is already serialized. */
+    public data class Text(val text: String) : JetWhaleMcpContent
+
+    /**
+     * An image the agent can look at.
+     *
+     * @param base64Data The image bytes, Base64-encoded, with no `data:` URI prefix.
+     * @param mimeType   The image's MIME type, e.g. `image/png`.
+     */
+    public data class Image(val base64Data: String, val mimeType: String) : JetWhaleMcpContent
+}
+
+/**
+ * What a [JetWhaleMcpCommand] hands back to the AI agent.
+ *
+ * Build one through the companion's factories rather than the constructor — that is what keeps a
+ * command source-compatible when the result gains a way to say something new:
+ * ```kotlin
+ * JetWhaleMcpResult.text("3 widgets are selected")
+ * JetWhaleMcpResult.json(buildJsonObject { put("selectedCount", 3) })
+ * JetWhaleMcpResult.image(base64Data = png, mimeType = "image/png")
+ * JetWhaleMcpResult.error("no widget with id: $id")
+ * ```
+ * A command whose result is always plain text can extend [JetWhaleMcpTextCommand] and skip the
+ * wrapping entirely.
+ *
+ * @property content          The blocks the agent reads, in order.
+ * @property structuredContent A machine-readable payload delivered next to [content]. Agents that
+ *   understand it read it instead of parsing the text.
+ * @property isError          Whether the call failed. A failed call is one the agent should correct
+ *   and retry, not an answer — so it must be reported here rather than as text that happens to
+ *   mention a problem.
+ */
+@ExperimentalJetWhaleApi
+public class JetWhaleMcpResult internal constructor(
+    public val content: List<JetWhaleMcpContent>,
+    public val structuredContent: JsonObject?,
+    public val isError: Boolean,
+) {
+    override fun equals(other: Any?): Boolean = this === other ||
+        (
+            other is JetWhaleMcpResult &&
+                content == other.content &&
+                structuredContent == other.structuredContent &&
+                isError == other.isError
+            )
+
+    override fun hashCode(): Int {
+        var result = content.hashCode()
+        result = 31 * result + structuredContent.hashCode()
+        result = 31 * result + isError.hashCode()
+        return result
+    }
+
+    override fun toString(): String = "JetWhaleMcpResult(content=$content, structuredContent=$structuredContent, isError=$isError)"
+
+    public companion object {
+        /** A successful result carrying [text] — prose, or JSON the command serialized itself. */
+        public fun text(text: String): JetWhaleMcpResult = JetWhaleMcpResult(
+            content = listOf(JetWhaleMcpContent.Text(text)),
+            structuredContent = null,
+            isError = false,
+        )
+
+        /**
+         * A successful structured result. [json] is delivered as the call's structured content and
+         * repeated as a text block, so an agent that reads only text still gets the whole answer.
+         */
+        public fun json(json: JsonObject): JetWhaleMcpResult = JetWhaleMcpResult(
+            content = listOf(JetWhaleMcpContent.Text(json.toString())),
+            structuredContent = json,
+            isError = false,
+        )
+
+        /** A successful result carrying a single image. @see JetWhaleMcpContent.Image */
+        public fun image(base64Data: String, mimeType: String): JetWhaleMcpResult = JetWhaleMcpResult(
+            content = listOf(JetWhaleMcpContent.Image(base64Data = base64Data, mimeType = mimeType)),
+            structuredContent = null,
+            isError = false,
+        )
+
+        /**
+         * A failed call. [message] says what went wrong, and the result is flagged so the agent
+         * treats it as a failure to correct rather than as the tool's answer.
+         *
+         * Throwing [JetWhaleMcpArgumentException] produces the same thing, and is the shorter path
+         * when the mistake is detected deep inside the command.
+         */
+        public fun error(message: String): JetWhaleMcpResult = JetWhaleMcpResult(
+            content = listOf(JetWhaleMcpContent.Text(message)),
+            structuredContent = null,
+            isError = true,
+        )
+    }
+}

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult.kt
@@ -51,6 +51,9 @@ public class JetWhaleMcpResult internal constructor(
     public val content: List<JetWhaleMcpContent>,
     public val structuredContent: JsonObject?,
     public val isError: Boolean,
+    // The declaration that encoded [structuredContent], so the host can tell an answer that
+    // honors the tool's declared output from one assembled by hand under the same schema.
+    internal val output: JetWhaleMcpOutput<*>?,
 ) {
     override fun equals(other: Any?): Boolean = this === other ||
         (
@@ -75,6 +78,7 @@ public class JetWhaleMcpResult internal constructor(
             content = listOf(JetWhaleMcpContent.Text(text)),
             structuredContent = null,
             isError = false,
+            output = null,
         )
 
         /**
@@ -85,6 +89,7 @@ public class JetWhaleMcpResult internal constructor(
             content = listOf(JetWhaleMcpContent.Text(json.toString())),
             structuredContent = json,
             isError = false,
+            output = null,
         )
 
         /** A successful result carrying a single image. @see JetWhaleMcpContent.Image */
@@ -92,6 +97,7 @@ public class JetWhaleMcpResult internal constructor(
             content = listOf(JetWhaleMcpContent.Image(base64Data = base64Data, mimeType = mimeType)),
             structuredContent = null,
             isError = false,
+            output = null,
         )
 
         /**
@@ -105,6 +111,7 @@ public class JetWhaleMcpResult internal constructor(
             content = listOf(JetWhaleMcpContent.Text(message)),
             structuredContent = null,
             isError = true,
+            output = null,
         )
     }
 }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.sdk
 
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -44,6 +45,8 @@ public sealed interface JetWhaleMcpContent {
  *   mention a problem.
  */
 @ExperimentalJetWhaleApi
+// Not a data class: the generated copy() and componentN would be public even though the constructor
+// is internal, which would hand plugins the very bypass the factories exist to prevent.
 public class JetWhaleMcpResult internal constructor(
     public val content: List<JetWhaleMcpContent>,
     public val structuredContent: JsonObject?,
@@ -95,8 +98,8 @@ public class JetWhaleMcpResult internal constructor(
          * A failed call. [message] says what went wrong, and the result is flagged so the agent
          * treats it as a failure to correct rather than as the tool's answer.
          *
-         * Throwing [JetWhaleMcpArgumentException] produces the same thing, and is the shorter path
-         * when the mistake is detected deep inside the command.
+         * Throwing [JetWhaleMcpException] produces the same thing, and is the shorter path when the
+         * failure is discovered deep inside the command.
          */
         public fun error(message: String): JetWhaleMcpResult = JetWhaleMcpResult(
             content = listOf(JetWhaleMcpContent.Text(message)),

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.json.JsonNamingStrategy
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
@@ -31,7 +32,8 @@ import kotlinx.serialization.json.putJsonObject
  * default is therefore required (it must be present, and may be `null`), which matches how
  * kotlinx.serialization decodes it. A format with `explicitNulls = false` is the exception: it reads
  * a missing nullable property as `null` and leaves a `null` one out when writing, so there a nullable
- * property is never required. A sealed hierarchy becomes a `oneOf` over its subclasses, each
+ * property is never required. A nullable property's schema admits JSON `null` next to its type, since
+ * that is what the format writes for it. A sealed hierarchy becomes a `oneOf` over its subclasses, each
  * carrying the class discriminator as a `const`. Open polymorphic types are advertised as an
  * unconstrained `object`, since their subclasses are only known at runtime.
  *
@@ -56,6 +58,11 @@ private class SchemaContext(
 )
 
 private fun SerialDescriptor.buildSchema(context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
+    val schema = nonNullSchema(context, enclosingTypes)
+    return if (isNullable) schema.allowingNull() else schema
+}
+
+private fun SerialDescriptor.nonNullSchema(context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
     // A value class is transparent on the wire: it encodes as its single underlying element.
     if (isInline) return getElementDescriptor(0).buildSchema(context, enclosingTypes)
 
@@ -182,5 +189,47 @@ private fun SchemaContext.jsonNameOf(descriptor: SerialDescriptor, index: Int): 
 private fun List<Annotation>.mcpDescription(): String? = filterIsInstance<McpDescription>().firstOrNull()?.value
 
 private fun JsonObject.withDescription(description: String): JsonObject = JsonObject(this + ("description" to JsonPrimitive(description)))
+
+/**
+ * Widens a schema so that JSON `null` validates against it, in the form each shape supports: `type`
+ * gains `"null"`, an `enum` gains the `null` entry, and a `oneOf` gains a null variant.
+ */
+private fun JsonObject.allowingNull(): JsonObject {
+    val type = this["type"]
+    return when {
+        type is JsonPrimitive -> buildJsonObject {
+            for ((key, value) in this@allowingNull) {
+                when (key) {
+                    "type" -> putJsonArray("type") {
+                        add(type)
+                        add("null")
+                    }
+
+                    "enum" -> putJsonArray("enum") {
+                        (value as JsonArray).forEach { add(it) }
+                        add(JsonNull)
+                    }
+
+                    else -> put(key, value)
+                }
+            }
+        }
+
+        "oneOf" in this -> buildJsonObject {
+            for ((key, value) in this@allowingNull) {
+                if (key == "oneOf") {
+                    putJsonArray("oneOf") {
+                        (value as JsonArray).forEach { add(it) }
+                        add(typeOnly("null"))
+                    }
+                } else {
+                    put(key, value)
+                }
+            }
+        }
+
+        else -> this
+    }
+}
 
 private fun typeOnly(type: String): JsonObject = buildJsonObject { put("type", type) }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
@@ -29,7 +29,9 @@ import kotlinx.serialization.json.putJsonObject
  *
  * A property is listed in `required` when it has no default value; a nullable property without a
  * default is therefore required (it must be present, and may be `null`), which matches how
- * kotlinx.serialization decodes it. A sealed hierarchy becomes a `oneOf` over its subclasses, each
+ * kotlinx.serialization decodes it. A format with `explicitNulls = false` is the exception: it reads
+ * a missing nullable property as `null` and leaves a `null` one out when writing, so there a nullable
+ * property is never required. A sealed hierarchy becomes a `oneOf` over its subclasses, each
  * carrying the class discriminator as a `const`. Open polymorphic types are advertised as an
  * unconstrained `object`, since their subclasses are only known at runtime.
  *
@@ -41,6 +43,7 @@ internal fun SerialDescriptor.toJsonSchema(json: Json): JsonObject = buildSchema
         classDiscriminator = json.configuration.classDiscriminator,
         writesClassDiscriminator = json.configuration.classDiscriminatorMode != ClassDiscriminatorMode.NONE,
         namingStrategy = json.configuration.namingStrategy,
+        explicitNulls = json.configuration.explicitNulls,
     ),
     mutableSetOf(),
 )
@@ -49,6 +52,7 @@ private class SchemaContext(
     val classDiscriminator: String,
     val writesClassDiscriminator: Boolean,
     val namingStrategy: JsonNamingStrategy?,
+    val explicitNulls: Boolean,
 )
 
 private fun SerialDescriptor.buildSchema(context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
@@ -112,6 +116,7 @@ private fun SerialDescriptor.classSchema(context: SchemaContext, enclosingTypes:
     }
     val required = (0 until elementsCount)
         .filterNot { isElementOptional(it) }
+        .filterNot { !context.explicitNulls && getElementDescriptor(it).isNullable }
         .map { context.jsonNameOf(this@classSchema, it) }
     if (required.isNotEmpty()) putJsonArray("required") { required.forEach { add(it) } }
 }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
@@ -164,10 +164,28 @@ private fun SerialDescriptor.sealedSchema(context: SchemaContext, enclosingTypes
 private fun SerialDescriptor.variantSchema(discriminator: String?, serialName: String, context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
     val schema = buildSchema(context, enclosingTypes)
     // ClassDiscriminatorMode.NONE writes no discriminator, so advertising one would describe input
-    // this format cannot produce; the variant shapes are still worth showing. Under ALL_JSON_OBJECTS
-    // the class schema already carries it.
-    if (discriminator == null || context.writesClassDiscriminatorOnEveryClass) return schema
-    return schema.withDiscriminator(discriminator, serialName)
+    // this format cannot produce; the variant shapes are still worth showing.
+    if (discriminator == null) return schema
+    if (!context.writesClassDiscriminatorOnEveryClass) return schema.withDiscriminator(discriminator, serialName)
+    // The class schema already carries a discriminator, but under the key the subclass would use on
+    // its own; inside a sealed value Json writes the base's key, so that one wins.
+    val ownDiscriminator = annotations.classDiscriminatorOr(context.classDiscriminator)
+    if (ownDiscriminator == discriminator) return schema
+    return schema.withoutProperty(ownDiscriminator).withDiscriminator(discriminator, serialName)
+}
+
+private fun JsonObject.withoutProperty(name: String): JsonObject {
+    val properties = (this["properties"] as? JsonObject).orEmpty() - name
+    val required = (this["required"] as? JsonArray).orEmpty().filterNot { (it as JsonPrimitive).content == name }
+    return buildJsonObject {
+        for ((key, value) in this@withoutProperty) {
+            when (key) {
+                "properties" -> put(key, JsonObject(properties))
+                "required" -> if (required.isNotEmpty()) putJsonArray(key) { required.forEach { add(it) } }
+                else -> put(key, value)
+            }
+        }
+    }
 }
 
 /** Pins [discriminator] to [serialName] ahead of the object's own properties, as `Json` writes it. */

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpJsonSchema.kt
@@ -38,12 +38,15 @@ import kotlinx.serialization.json.putJsonObject
  * unconstrained `object`, since their subclasses are only known at runtime.
  *
  * The schema follows [json]'s configuration — its class discriminator and naming strategy — so the
- * shape advertised to the caller is the shape the same format decodes.
+ * shape advertised to the caller is the shape the same format decodes. Under
+ * [ClassDiscriminatorMode.ALL_JSON_OBJECTS] every class schema carries the discriminator too, pinned
+ * to the class's serial name, since that is what the format writes.
  */
 internal fun SerialDescriptor.toJsonSchema(json: Json): JsonObject = buildSchema(
     SchemaContext(
         classDiscriminator = json.configuration.classDiscriminator,
         writesClassDiscriminator = json.configuration.classDiscriminatorMode != ClassDiscriminatorMode.NONE,
+        writesClassDiscriminatorOnEveryClass = json.configuration.classDiscriminatorMode == ClassDiscriminatorMode.ALL_JSON_OBJECTS,
         namingStrategy = json.configuration.namingStrategy,
         explicitNulls = json.configuration.explicitNulls,
     ),
@@ -53,6 +56,7 @@ internal fun SerialDescriptor.toJsonSchema(json: Json): JsonObject = buildSchema
 private class SchemaContext(
     val classDiscriminator: String,
     val writesClassDiscriminator: Boolean,
+    val writesClassDiscriminatorOnEveryClass: Boolean,
     val namingStrategy: JsonNamingStrategy?,
     val explicitNulls: Boolean,
 )
@@ -114,18 +118,22 @@ private inline fun SerialDescriptor.guarded(enclosingTypes: MutableSet<String>, 
     }
 }
 
-private fun SerialDescriptor.classSchema(context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject = buildJsonObject {
-    put("type", "object")
-    putJsonObject("properties") {
-        for (index in 0 until elementsCount) {
-            put(context.jsonNameOf(this@classSchema, index), elementSchema(index, context, enclosingTypes))
+private fun SerialDescriptor.classSchema(context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
+    val schema = buildJsonObject {
+        put("type", "object")
+        putJsonObject("properties") {
+            for (index in 0 until elementsCount) {
+                put(context.jsonNameOf(this@classSchema, index), elementSchema(index, context, enclosingTypes))
+            }
         }
+        val required = (0 until elementsCount)
+            .filterNot { isElementOptional(it) }
+            .filterNot { !context.explicitNulls && getElementDescriptor(it).isNullable }
+            .map { context.jsonNameOf(this@classSchema, it) }
+        if (required.isNotEmpty()) putJsonArray("required") { required.forEach { add(it) } }
     }
-    val required = (0 until elementsCount)
-        .filterNot { isElementOptional(it) }
-        .filterNot { !context.explicitNulls && getElementDescriptor(it).isNullable }
-        .map { context.jsonNameOf(this@classSchema, it) }
-    if (required.isNotEmpty()) putJsonArray("required") { required.forEach { add(it) } }
+    if (!context.writesClassDiscriminatorOnEveryClass) return schema
+    return schema.withDiscriminator(annotations.classDiscriminatorOr(context.classDiscriminator), serialName)
 }
 
 /**
@@ -135,9 +143,7 @@ private fun SerialDescriptor.classSchema(context: SchemaContext, enclosingTypes:
  * discriminator pinned to a constant.
  */
 private fun SerialDescriptor.sealedSchema(context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
-    // A type-level annotation overrides the format-wide discriminator, the same way Json resolves it.
-    val discriminator = annotations.filterIsInstance<JsonClassDiscriminator>().firstOrNull()?.discriminator
-        ?: context.classDiscriminator
+    val discriminator = annotations.classDiscriminatorOr(context.classDiscriminator)
     val subclasses = getElementDescriptor(1)
     return buildJsonObject {
         putJsonArray("oneOf") {
@@ -157,11 +163,17 @@ private fun SerialDescriptor.sealedSchema(context: SchemaContext, enclosingTypes
 
 private fun SerialDescriptor.variantSchema(discriminator: String?, serialName: String, context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
     val schema = buildSchema(context, enclosingTypes)
-    val properties = schema["properties"] as? JsonObject ?: JsonObject(emptyMap())
-    val required = (schema["required"] as? JsonArray).orEmpty().map { (it as JsonPrimitive).content }
     // ClassDiscriminatorMode.NONE writes no discriminator, so advertising one would describe input
-    // this format cannot produce; the variant shapes are still worth showing.
-    if (discriminator == null) return schema
+    // this format cannot produce; the variant shapes are still worth showing. Under ALL_JSON_OBJECTS
+    // the class schema already carries it.
+    if (discriminator == null || context.writesClassDiscriminatorOnEveryClass) return schema
+    return schema.withDiscriminator(discriminator, serialName)
+}
+
+/** Pins [discriminator] to [serialName] ahead of the object's own properties, as `Json` writes it. */
+private fun JsonObject.withDiscriminator(discriminator: String, serialName: String): JsonObject {
+    val properties = this["properties"] as? JsonObject ?: JsonObject(emptyMap())
+    val required = (this["required"] as? JsonArray).orEmpty().map { (it as JsonPrimitive).content }
     val discriminatorSchema = buildJsonObject {
         put("type", "string")
         put("const", serialName)
@@ -170,9 +182,12 @@ private fun SerialDescriptor.variantSchema(discriminator: String?, serialName: S
         put("type", "object")
         put("properties", JsonObject(mapOf(discriminator to discriminatorSchema) + properties))
         putJsonArray("required") { (listOf(discriminator) + required).forEach { add(it) } }
-        schema["description"]?.let { put("description", it) }
+        this@withDiscriminator["description"]?.let { put("description", it) }
     }
 }
+
+// A type-level annotation overrides the format-wide discriminator, the same way Json resolves it.
+private fun List<Annotation>.classDiscriminatorOr(default: String): String = filterIsInstance<JsonClassDiscriminator>().firstOrNull()?.discriminator ?: default
 
 private fun SerialDescriptor.elementSchema(index: Int, context: SchemaContext, enclosingTypes: MutableSet<String>): JsonObject {
     val schema = getElementDescriptor(index).buildSchema(context, enclosingTypes)

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -233,10 +233,12 @@ class DefaultMcpServerService(
                 // Forward the arguments as raw JSON so structured (object/array) parameters keep
                 // their shape; the command's parameter DSL decodes each value by its declared type.
                 val arguments = request.arguments ?: emptyMap()
+                val sessionId = arguments["sessionId"]?.jsonContent
+                    ?: return@addPluginTool errorResult("Missing required argument: sessionId")
                 // A tool is listed for as long as any session offers it, so a call naming a session
                 // that no longer has the plugin is a caller mistake rather than a server fault.
                 toolRegistry.dispatch(toolName, arguments)?.toCallToolResult()
-                    ?: errorResult("no plugin instance handles $toolName for the requested sessionId")
+                    ?: errorResult("no plugin instance handles $toolName for session '$sessionId'; pick a session from jetwhale.listSessions")
             }
         }
     }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -27,8 +27,6 @@ import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.SseServerTransport
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
-import io.modelcontextprotocol.kotlin.sdk.types.TextContent
-import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -225,6 +225,9 @@ class DefaultMcpServerService(
                 name = toolName,
                 description = descriptor.description,
                 inputSchema = inputSchema,
+                // A command that declares no output shape advertises none, so an agent keeps reading
+                // that tool's answer as text.
+                outputSchema = descriptor.outputSchema?.toToolSchema(),
                 resolvePluginIdForSession = { sessionId -> toolRegistry.pluginIdFor(toolName, sessionId) },
             ) { request ->
                 // Forward the arguments as raw JSON so structured (object/array) parameters keep

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -226,8 +226,7 @@ class DefaultMcpServerService(
                 name = toolName,
                 description = descriptor.description,
                 inputSchema = inputSchema,
-                // A command that declares no output shape advertises none, so an agent keeps reading
-                // that tool's answer as text.
+                // A command that declares no output shape advertises none, whatever it answers with.
                 outputSchema = descriptor.outputSchema?.toToolSchema(),
                 resolvePluginIdForSession = { sessionId -> toolRegistry.pluginIdFor(toolName, sessionId) },
             ) { request ->

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonNull
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.seconds
 
@@ -233,7 +234,9 @@ class DefaultMcpServerService(
                 // Forward the arguments as raw JSON so structured (object/array) parameters keep
                 // their shape; the command's parameter DSL decodes each value by its declared type.
                 val arguments = request.arguments ?: emptyMap()
-                val sessionId = arguments["sessionId"]?.jsonContent
+                // An explicit null is as absent as no key at all, which is how the command's own
+                // argument accessors read it.
+                val sessionId = arguments["sessionId"]?.takeUnless { it is JsonNull }?.jsonContent
                     ?: return@addPluginTool errorResult("Missing required argument: sessionId")
                 // A tool is listed for as long as any session offers it, so a call naming a session
                 // that no longer has the plugin is a caller mistake rather than a server fault.

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -25,10 +25,10 @@ import io.ktor.server.sse.sse
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.SseServerTransport
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -230,8 +230,10 @@ class DefaultMcpServerService(
                 // Forward the arguments as raw JSON so structured (object/array) parameters keep
                 // their shape; the command's parameter DSL decodes each value by its declared type.
                 val arguments = request.arguments ?: emptyMap()
-                val result = toolRegistry.dispatch(toolName, arguments)
-                CallToolResult(content = listOf(TextContent(result ?: "null")))
+                // A tool is listed for as long as any session offers it, so a call naming a session
+                // that no longer has the plugin is a caller mistake rather than a server fault.
+                toolRegistry.dispatch(toolName, arguments)?.toCallToolResult()
+                    ?: errorResult("no plugin instance handles $toolName for the requested sessionId")
             }
         }
     }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommand.kt
@@ -50,7 +50,7 @@ abstract class HostMcpCommand :
             permission = McpToolPermission.HostGroup(group),
         ) { request ->
             try {
-                execute(JetWhaleMcpArguments(JsonObject(request.arguments ?: emptyMap()))).toCallToolResult()
+                run(JetWhaleMcpArguments(JsonObject(request.arguments ?: emptyMap()))).toCallToolResult()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: JetWhaleMcpException) {

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommand.kt
@@ -2,11 +2,9 @@ package com.kitakkun.jetwhale.host.mcp
 
 import com.kitakkun.jetwhale.host.model.McpHostToolGroup
 import com.kitakkun.jetwhale.host.model.McpToolPermission
-import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
-import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpTextCommand
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonObject
 
@@ -30,7 +28,7 @@ import kotlinx.serialization.json.JsonObject
  * ```
  */
 abstract class HostMcpCommand :
-    JetWhaleMcpCommand(),
+    JetWhaleMcpTextCommand(),
     JetWhaleMcpTool {
 
     // Lazy, never an eager property: base-class initializers run before the subclass declares its
@@ -52,11 +50,10 @@ abstract class HostMcpCommand :
             permission = McpToolPermission.HostGroup(group),
         ) { request ->
             try {
-                val result = execute(JetWhaleMcpArguments(JsonObject(request.arguments ?: emptyMap())))
-                CallToolResult(content = listOf(TextContent(result)))
+                execute(JetWhaleMcpArguments(JsonObject(request.arguments ?: emptyMap()))).toCallToolResult()
             } catch (e: CancellationException) {
                 throw e
-            } catch (e: JetWhaleMcpArgumentException) {
+            } catch (e: JetWhaleMcpException) {
                 errorResult(e.message.orEmpty())
             } catch (e: Exception) {
                 // Host tools do real I/O — downloads, socket binds, plugin loading. A failure has to

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolExtensions.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolExtensions.kt
@@ -1,7 +1,11 @@
 package com.kitakkun.jetwhale.host.mcp
 
+import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.JsonObject
@@ -26,6 +30,24 @@ fun JetWhaleMcpToolDescriptor.toToolSchema(
         },
     ),
     required = leadingProperties.keys.toList() + parameters.filterValues { it.required }.keys,
+)
+
+/**
+ * Translates a plugin's result into the MCP wire type.
+ *
+ * Plugins are deliberately kept away from the MCP library's own types, so this is the single place
+ * where the SDK's vocabulary and the protocol's meet.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+fun JetWhaleMcpResult.toCallToolResult(): CallToolResult = CallToolResult(
+    content = content.map { block ->
+        when (block) {
+            is JetWhaleMcpContent.Text -> TextContent(block.text)
+            is JetWhaleMcpContent.Image -> ImageContent(data = block.base64Data, mimeType = block.mimeType)
+        }
+    },
+    isError = isError,
+    structuredContent = structuredContent,
 )
 
 fun errorResult(message: String): CallToolResult = CallToolResult(

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolExtensions.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolExtensions.kt
@@ -1,6 +1,5 @@
 package com.kitakkun.jetwhale.host.mcp
 
-import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
@@ -8,6 +7,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -38,7 +38,6 @@ fun JetWhaleMcpToolDescriptor.toToolSchema(
  * Plugins are deliberately kept away from the MCP library's own types, so this is the single place
  * where the SDK's vocabulary and the protocol's meet.
  */
-@OptIn(ExperimentalJetWhaleApi::class)
 fun JetWhaleMcpResult.toCallToolResult(): CallToolResult = CallToolResult(
     content = content.map { block ->
         when (block) {
@@ -48,6 +47,15 @@ fun JetWhaleMcpResult.toCallToolResult(): CallToolResult = CallToolResult(
     },
     isError = isError,
     structuredContent = structuredContent,
+)
+
+/**
+ * Narrows a derived object schema onto MCP's [ToolSchema], which pins `type` to `"object"` and
+ * carries only the property schemas and the required list.
+ */
+fun JsonObject.toToolSchema(): ToolSchema = ToolSchema(
+    properties = this["properties"] as? JsonObject,
+    required = (this["required"] as? JsonArray)?.mapNotNull { it.jsonContent },
 )
 
 fun errorResult(message: String): CallToolResult = CallToolResult(

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistrar.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistrar.kt
@@ -179,7 +179,8 @@ private val McpHostToolGroup.displayName: String
  *
  * A structured payload follows the blocks on its own line. It is the whole answer for a tool that
  * replies only in `structuredContent`, and it reads as the machine-readable detail behind the prose
- * for a tool that sends both.
+ * for a tool that sends both — unless a text block already spells it out, which is what the protocol
+ * asks a structured tool to do for clients that read nothing else.
  */
 private fun CallToolResult.renderForHistory(): String {
     val renderedBlocks = content.map { block ->
@@ -188,5 +189,6 @@ private fun CallToolResult.renderForHistory(): String {
             else -> "<${block.type.value}>"
         }
     }
-    return (renderedBlocks + listOfNotNull(structuredContent?.toString())).joinToString(separator = "\n")
+    val structured = structuredContent?.toString()?.takeUnless { it in renderedBlocks }
+    return (renderedBlocks + listOfNotNull(structured)).joinToString(separator = "\n")
 }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistrar.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistrar.kt
@@ -38,6 +38,8 @@ class McpToolRegistrar(
             description = description,
             inputSchema = inputSchema,
             permission = permission,
+            // Built-in tools describe their answer in prose rather than as structured content.
+            outputSchema = null,
             // Tools that drive a plugin UI declare this argument; the rest report no target.
             resolvePluginId = { request -> request.arguments?.get("pluginId")?.jsonContent },
             handler = handler,
@@ -50,11 +52,15 @@ class McpToolRegistrar(
      * Plugin tool schemas only carry `sessionId` — the owning plugin is an implementation detail the
      * agent never names — so attribution has to be resolved from the session instead of read off the
      * arguments. Without this the plugin's own tools would be the only ones the UI cannot attribute.
+     *
+     * [outputSchema] is null for a tool whose command declares no output shape, which is how it says
+     * it answers with unstructured text.
      */
     fun addPluginTool(
         name: String,
         description: String,
         inputSchema: ToolSchema,
+        outputSchema: ToolSchema?,
         resolvePluginIdForSession: (sessionId: String) -> String?,
         handler: suspend ClientConnection.(CallToolRequest) -> CallToolResult,
     ) {
@@ -63,6 +69,7 @@ class McpToolRegistrar(
             description = description,
             inputSchema = inputSchema,
             permission = McpToolPermission.PluginTool(name),
+            outputSchema = outputSchema,
             resolvePluginId = { request ->
                 request.arguments?.get("sessionId")?.jsonContent?.let(resolvePluginIdForSession)
             },
@@ -75,6 +82,7 @@ class McpToolRegistrar(
         description: String,
         inputSchema: ToolSchema,
         permission: McpToolPermission,
+        outputSchema: ToolSchema?,
         resolvePluginId: (CallToolRequest) -> String?,
         handler: suspend ClientConnection.(CallToolRequest) -> CallToolResult,
     ) {
@@ -91,6 +99,7 @@ class McpToolRegistrar(
             name = name,
             description = description,
             inputSchema = inputSchema,
+            outputSchema = outputSchema,
         ) { request ->
             val targetPluginId = resolvePluginId(request)
             // Checked per call, not only when the tool list was built: a tool list is fixed for the

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistrar.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistrar.kt
@@ -38,7 +38,7 @@ class McpToolRegistrar(
             description = description,
             inputSchema = inputSchema,
             permission = permission,
-            // Built-in tools describe their answer in prose rather than as structured content.
+            // No built-in tool advertises an output schema, whatever it answers with.
             outputSchema = null,
             // Tools that drive a plugin UI declare this argument; the rest report no target.
             resolvePluginId = { request -> request.arguments?.get("pluginId")?.jsonContent },
@@ -53,8 +53,8 @@ class McpToolRegistrar(
      * agent never names — so attribution has to be resolved from the session instead of read off the
      * arguments. Without this the plugin's own tools would be the only ones the UI cannot attribute.
      *
-     * [outputSchema] is null for a tool whose command declares no output shape, which is how it says
-     * it answers with unstructured text.
+     * [outputSchema] is null for a tool whose command declares no output shape; its answer may still
+     * be structured, the agent is just not told the shape in advance.
      */
     fun addPluginTool(
         name: String,

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
@@ -7,14 +7,13 @@ import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -73,9 +72,9 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
      * The [arguments] map must contain a `sessionId` key that identifies the target session.
      * That key is stripped before forwarding to the plugin.
      *
-     * @return The result string, or null if not found or plugin returned null.
+     * @return The command's result, or null if the call could not be routed to a plugin instance.
      */
-    suspend fun dispatch(toolName: String, arguments: Map<String, JsonElement>): String? {
+    suspend fun dispatch(toolName: String, arguments: Map<String, JsonElement>): JetWhaleMcpResult? {
         val sessionId = (arguments["sessionId"] as? JsonPrimitive)?.content ?: return null
         val entry = registrations[toolName] ?: return null
         val pluginId = entry.sessionToPlugin[sessionId] ?: return null
@@ -87,9 +86,9 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
         return try {
             command.execute(JetWhaleMcpArguments(JsonObject(arguments - "sessionId")))
         } catch (e: JetWhaleMcpArgumentException) {
-            // A caller mistake becomes a payload the AI agent can read and correct, instead of
-            // an MCP-level failure.
-            buildJsonObject { put("error", e.message.orEmpty()) }.toString()
+            // A caller mistake becomes a failed result the AI agent can read and correct, instead
+            // of an MCP-level failure.
+            JetWhaleMcpResult.error(e.message.orEmpty())
         }
     }
 

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
@@ -84,7 +84,7 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
         ) as? JetWhaleMcpCapablePlugin ?: return null
         val command = plugin.mcpCommands.firstOrNull { it.name == toolName } ?: return null
         return try {
-            command.execute(JetWhaleMcpArguments(JsonObject(arguments - "sessionId")))
+            command.run(JetWhaleMcpArguments(JsonObject(arguments - "sessionId")))
         } catch (e: JetWhaleMcpException) {
             // A failure the command chose to report becomes a failed result the AI agent can read
             // and correct, instead of an MCP-level failure.

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
@@ -4,9 +4,9 @@ import com.kitakkun.jetwhale.host.model.McpCapablePlugins
 import com.kitakkun.jetwhale.host.model.McpToolParameterSummary
 import com.kitakkun.jetwhale.host.model.McpToolSummary
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
-import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -85,9 +85,9 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
         val command = plugin.mcpCommands.firstOrNull { it.name == toolName } ?: return null
         return try {
             command.execute(JetWhaleMcpArguments(JsonObject(arguments - "sessionId")))
-        } catch (e: JetWhaleMcpArgumentException) {
-            // A caller mistake becomes a failed result the AI agent can read and correct, instead
-            // of an MCP-level failure.
+        } catch (e: JetWhaleMcpException) {
+            // A failure the command chose to report becomes a failed result the AI agent can read
+            // and correct, instead of an MCP-level failure.
             JetWhaleMcpResult.error(e.message.orEmpty())
         }
     }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommands.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommands.kt
@@ -34,7 +34,7 @@ class GetLogsCommand(
     private val level by enumOrNull("Only return entries logged at this level.", LogLevel.entries)
     private val contains by stringOrNull("Only return entries whose message contains this substring, case-insensitively.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
         val requestedLimit = arguments[limit] ?: DEFAULT_LIMIT
         if (requestedLimit !in 1..MAX_LIMIT) {
             throw JetWhaleMcpArgumentException("invalid limit: expected 1..$MAX_LIMIT but was $requestedLimit")
@@ -68,7 +68,7 @@ class ClearLogsCommand(
     override val description: String =
         "Host-wide: discards every captured host log entry. Clear before reproducing an issue so that jetwhale.getLogs afterwards shows only what the reproduction produced."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
         val cleared = logCaptureService.logs.value.size
         logCaptureService.clearLogs()
         return Json.encodeToString(ClearLogsResult(cleared = cleared))

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommand.kt
@@ -49,7 +49,7 @@ class HostNavigationCommand(
     private val sessionId by stringOrNull("Only for PLUGIN. Defaults to the session already selected in the drawer.")
     private val settingsSection by enumOrNull("Only for SETTINGS. Defaults to GENERAL.", HostSettingsSection.entries)
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
         val request = arguments.toRequest()
         hostNavigationService.navigate(request)
 

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommands.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommands.kt
@@ -42,7 +42,7 @@ class ListInstalledPluginsCommand(
     override val description: String =
         "Host-wide: lists every plugin installed into the debug tool and whether it is enabled, plus the official plugins that could still be installed and any jar that failed to load or is awaiting trust. Use jetwhale.listPlugins instead to see what a particular debug session advertises."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
         val loaded = pluginFactoryRepository.loadedPlugins
         val enabledPluginIds = enabledPluginsRepository.enabledPluginIdsFlow.first()
 
@@ -93,7 +93,7 @@ class SetPluginEnabledCommand(
     private val pluginId by string("The plugin to toggle; from jetwhale.listInstalledPlugins.")
     private val enabled by boolean("True to enable the plugin, false to disable it.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
         val targetPluginId = arguments[pluginId]
         if (targetPluginId !in pluginFactoryRepository.loadedPlugins) {
             throw JetWhaleMcpArgumentException("invalid pluginId: '$targetPluginId' is not installed. See jetwhale.listInstalledPlugins.")
@@ -142,7 +142,7 @@ class InstallOfficialPluginCommand(
 
     private val pluginId by string("The official plugin to install; from the availableOfficial list of jetwhale.listInstalledPlugins.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
         // Whether an agent may install at all is the Manage plugins permission, enforced for every
         // tool in the group by McpToolRegistrar before this runs.
         val targetPluginId = arguments[pluginId]

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommands.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommands.kt
@@ -38,7 +38,7 @@ class UpdateSettingsCommand(
     private val persistData by booleanOrNull("Whether captured debug data survives a host restart.")
     private val restartDebugServer by booleanOrNull("Whether to restart the debug server so ws/wss changes take effect now. Defaults to true when a ws/wss setting changed.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
         // Validate every port before writing any of them, so a bad argument late in the list cannot
         // leave the settings half-applied.
         val newServerPort = arguments[serverPort]?.requireValidPort("serverPort")
@@ -124,7 +124,7 @@ class RestartDebugServerCommand(
     override val description: String =
         "Host-wide: stops and restarts the debug WebSocket server that agents connect to. This disconnects every session — every sessionId you hold becomes invalid and each app has to reconnect."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
         restartDebugServer(settingsRepository, debugWebSocketServer)
         val status = debugWebSocketServer.statusFlow.value.toJson()
         return Json.encodeToString(

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommand.kt
@@ -49,7 +49,7 @@ class HostStatusCommand(
     override val description: String =
         "Host-wide: one snapshot of the debug tool — its version, both servers, how many sessions and plugins are live, and the current settings. Call this first to orient yourself before any other jetwhale tool."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
         val sessions = debugSessionRepository.debugSessionsFlow.firstOrNull().orEmpty()
 
         return Json.encodeToString(

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -6,10 +6,13 @@ import com.kitakkun.jetwhale.host.model.McpToolPermission
 import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpParameterDescriptor
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpTextCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -542,6 +545,31 @@ class DefaultMcpServerServiceTest {
     }
 
     @Test
+    fun `a structured payload mirrored into text is recorded once`() = runBlocking {
+        val serviceWithTool = DefaultMcpServerService(
+            pluginInstanceService = pluginInstanceService,
+            mcpActivityRepository = mcpActivityRepository,
+            builtInTools = setOf(MirroredStructuredMcpTool("fake.mirrored")),
+        )
+        val mirroredPort = java.net.ServerSocket(0).use { it.localPort }
+        serviceWithTool.start(host, mirroredPort)
+        // Stopping the server clears recorded activity, so the history has to be read while it runs.
+        val record = try {
+            val client = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$mirroredPort/sse")
+            try {
+                client.callTool("fake.mirrored", emptyMap())
+            } finally {
+                client.close()
+            }
+            mcpActivityRepository.activityFlow.value.recentCalls.single()
+        } finally {
+            serviceWithTool.stop()
+        }
+
+        assertEquals("""{"width":120}""", record.response)
+    }
+
+    @Test
     fun `a throwing tool call is recorded in history as a failure`() = runBlocking {
         val serviceWithTool = DefaultMcpServerService(
             pluginInstanceService = pluginInstanceService,
@@ -602,6 +630,83 @@ class DefaultMcpServerServiceTest {
         assertEquals("com.example.test.greet", invocation.toolName)
         assertEquals(testPluginId, invocation.pluginId)
         assertEquals(testSessionId, invocation.sessionId)
+    }
+
+    @OptIn(ExperimentalJetWhaleApi::class)
+    @Test
+    fun `a plugin error result reaches the agent flagged as an error`() = runBlocking {
+        val toolName = "com.example.test.fails"
+        val callResult = callPluginTool(FixedResultPlugin(toolName, JetWhaleMcpResult.error("no widget with id: 7")), toolName)
+
+        assertEquals(true, callResult.isError)
+        assertEquals("no widget with id: 7", callResult.content.filterIsInstance<TextContent>().single().text)
+    }
+
+    @OptIn(ExperimentalJetWhaleApi::class)
+    @Test
+    fun `a caller mistake a plugin throws reaches the agent flagged as an error`() = runBlocking {
+        val toolName = "com.example.test.rejects"
+        val callResult = callPluginTool(RejectingMcpCapablePlugin(toolName), toolName)
+
+        // Thrown rather than returned, and it still has to arrive as a failure the agent can correct.
+        assertEquals(true, callResult.isError)
+        assertEquals("unknown widget id", callResult.content.filterIsInstance<TextContent>().single().text)
+    }
+
+    @OptIn(ExperimentalJetWhaleApi::class)
+    @Test
+    fun `a plugin structured result arrives as structuredContent`() = runBlocking {
+        val toolName = "com.example.test.measures"
+        val payload = buildJsonObject {
+            put("width", 120)
+            put("height", 40)
+        }
+        val callResult = callPluginTool(FixedResultPlugin(toolName, JetWhaleMcpResult.json(payload)), toolName)
+
+        assertEquals(payload, callResult.structuredContent)
+        assertEquals(false, callResult.isError)
+        // The same payload is repeated as text, for agents that read nothing else.
+        assertEquals(payload.toString(), callResult.content.filterIsInstance<TextContent>().single().text)
+    }
+
+    @OptIn(ExperimentalJetWhaleApi::class)
+    @Test
+    fun `a plugin image result arrives as an image block`() = runBlocking {
+        val toolName = "com.example.test.captures"
+        val callResult = callPluginTool(
+            FixedResultPlugin(toolName, JetWhaleMcpResult.image(base64Data = "AAAA", mimeType = "image/png")),
+            toolName,
+        )
+
+        val image = callResult.content.filterIsInstance<ImageContent>().single()
+        assertEquals("AAAA", image.data)
+        assertEquals("image/png", image.mimeType)
+    }
+
+    /**
+     * Starts the service with [plugin] loaded for one session and calls [toolName] on it. Every
+     * result-shape test needs the same registration dance, and only the answer is interesting.
+     */
+    @OptIn(ExperimentalJetWhaleApi::class)
+    private suspend fun callPluginTool(plugin: JetWhaleHostPlugin, toolName: String): CallToolResult {
+        val pluginId = "com.example.test"
+        val sessionId = "test-session-result"
+        every { pluginInstanceService.getLoadedPluginInstances() } returns listOf(
+            LoadedPluginInstance(pluginId, sessionId, plugin),
+        )
+        every { pluginInstanceService.getPluginInstanceForSession(pluginId, sessionId) } returns plugin
+
+        service.start(host, port)
+        return try {
+            val client = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$port/sse")
+            try {
+                client.callTool(toolName, mapOf("sessionId" to sessionId))
+            } finally {
+                client.close()
+            }
+        } finally {
+            service.stop()
+        }
     }
 
     @Test
@@ -681,6 +786,20 @@ private class StructuredMcpTool(private val name: String) : JetWhaleMcpTool {
     }
 }
 
+/**
+ * Repeats its structured payload as a text block, which is what the protocol asks a structured tool
+ * to do for clients that read nothing else — and what [JetWhaleMcpResult.json] produces.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+private class MirroredStructuredMcpTool(private val name: String) : JetWhaleMcpTool {
+    override fun register(registrar: McpToolRegistrar) {
+        val payload = buildJsonObject { put("width", 120) }
+        registrar.addTool(name = name, description = "Repeats its payload as text", inputSchema = ToolSchema()) { _ ->
+            CallToolResult(content = listOf(TextContent(payload.toString())), structuredContent = payload)
+        }
+    }
+}
+
 private class FailingMcpTool(private val name: String) : JetWhaleMcpTool {
     override fun register(registrar: McpToolRegistrar) {
         registrar.addTool(name = name, description = "Always throws", inputSchema = ToolSchema(), permission = McpToolPermission.Unrestricted) { _ ->
@@ -694,13 +813,45 @@ private class FakeMcpCapablePlugin(private val toolName: String = "com.example.t
     JetWhaleMcpCapablePlugin {
 
     override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
-        object : JetWhaleMcpCommand() {
+        object : JetWhaleMcpTextCommand() {
             override val name = toolName
             override val description = "Greet by name"
 
             private val greetName by string("Name to greet", name = "name")
 
-            override suspend fun execute(arguments: JetWhaleMcpArguments): String = "Hello, ${arguments[greetName]}!"
+            override suspend fun executeText(arguments: JetWhaleMcpArguments): String = "Hello, ${arguments[greetName]}!"
+        },
+    )
+}
+
+/** A plugin whose single tool always answers with [result], to check how it reaches the wire. */
+@OptIn(ExperimentalJetWhaleApi::class)
+private class FixedResultPlugin(private val toolName: String, private val result: JetWhaleMcpResult) :
+    JetWhaleHostPlugin(),
+    JetWhaleMcpCapablePlugin {
+
+    override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
+        object : JetWhaleMcpCommand() {
+            override val name = toolName
+            override val description = "Answers with a fixed result"
+
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = result
+        },
+    )
+}
+
+/** A plugin whose single tool rejects every call the way a command reports a caller mistake. */
+@OptIn(ExperimentalJetWhaleApi::class)
+private class RejectingMcpCapablePlugin(private val toolName: String) :
+    JetWhaleHostPlugin(),
+    JetWhaleMcpCapablePlugin {
+
+    override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
+        object : JetWhaleMcpTextCommand() {
+            override val name = toolName
+            override val description = "Always rejects the call"
+
+            override suspend fun executeText(arguments: JetWhaleMcpArguments): String = throw JetWhaleMcpArgumentException("unknown widget id")
         },
     )
 }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -552,7 +552,9 @@ class DefaultMcpServerServiceTest {
         val serviceWithTool = DefaultMcpServerService(
             pluginInstanceService = pluginInstanceService,
             mcpActivityRepository = mcpActivityRepository,
+            mcpPermissionsRepository = FakeMcpPermissionsRepository(),
             builtInTools = setOf(MirroredStructuredMcpTool("fake.mirrored")),
+            statusHolder = McpServerStatusHolder(),
         )
         val mirroredPort = java.net.ServerSocket(0).use { it.localPort }
         serviceWithTool.start(host, mirroredPort)
@@ -635,7 +637,6 @@ class DefaultMcpServerServiceTest {
         assertEquals(testSessionId, invocation.sessionId)
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `a plugin error result reaches the agent flagged as an error`() = runBlocking {
         val toolName = "com.example.test.fails"
@@ -645,7 +646,6 @@ class DefaultMcpServerServiceTest {
         assertEquals("no widget with id: 7", callResult.content.filterIsInstance<TextContent>().single().text)
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `a caller mistake a plugin throws reaches the agent flagged as an error`() = runBlocking {
         val toolName = "com.example.test.rejects"
@@ -656,7 +656,6 @@ class DefaultMcpServerServiceTest {
         assertEquals("unknown widget id", callResult.content.filterIsInstance<TextContent>().single().text)
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `a plugin structured result arrives as structuredContent`() = runBlocking {
         val toolName = "com.example.test.measures"
@@ -672,7 +671,6 @@ class DefaultMcpServerServiceTest {
         assertEquals(payload.toString(), callResult.content.filterIsInstance<TextContent>().single().text)
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `a plugin image result arrives as an image block`() = runBlocking {
         val toolName = "com.example.test.captures"
@@ -686,7 +684,6 @@ class DefaultMcpServerServiceTest {
         assertEquals("image/png", image.mimeType)
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `a declared output schema reaches the agent on the listed tool`() = runBlocking {
         val toolName = "com.example.test.measures"
@@ -699,7 +696,6 @@ class DefaultMcpServerServiceTest {
         assertEquals(listOf("width", "height"), outputSchema.required)
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `a command that declares no output advertises none`() = runBlocking {
         val toolName = "com.example.test.greet"
@@ -709,7 +705,6 @@ class DefaultMcpServerServiceTest {
         assertNull(tool.outputSchema)
     }
 
-    @OptIn(ExperimentalJetWhaleApi::class)
     @Test
     fun `a declared output answers with structured content shaped like its schema`() = runBlocking {
         val toolName = "com.example.test.measures"
@@ -729,7 +724,6 @@ class DefaultMcpServerServiceTest {
      * Starts the service with [plugin] loaded for one session and reads [toolName] off the tool
      * list, which is where an agent learns what the tool takes and answers with.
      */
-    @OptIn(ExperimentalJetWhaleApi::class)
     private suspend fun describePluginTool(plugin: JetWhaleHostPlugin, toolName: String): Tool {
         val pluginId = "com.example.test"
         val sessionId = "test-session-schema"
@@ -755,7 +749,6 @@ class DefaultMcpServerServiceTest {
      * Starts the service with [plugin] loaded for one session and calls [toolName] on it. Every
      * result-shape test needs the same registration dance, and only the answer is interesting.
      */
-    @OptIn(ExperimentalJetWhaleApi::class)
     private suspend fun callPluginTool(plugin: JetWhaleHostPlugin, toolName: String): CallToolResult {
         val pluginId = "com.example.test"
         val sessionId = "test-session-result"
@@ -858,11 +851,10 @@ private class StructuredMcpTool(private val name: String) : JetWhaleMcpTool {
  * Repeats its structured payload as a text block, which is what the protocol asks a structured tool
  * to do for clients that read nothing else — and what [JetWhaleMcpResult.json] produces.
  */
-@OptIn(ExperimentalJetWhaleApi::class)
 private class MirroredStructuredMcpTool(private val name: String) : JetWhaleMcpTool {
     override fun register(registrar: McpToolRegistrar) {
         val payload = buildJsonObject { put("width", 120) }
-        registrar.addTool(name = name, description = "Repeats its payload as text", inputSchema = ToolSchema()) { _ ->
+        registrar.addTool(name = name, description = "Repeats its payload as text", inputSchema = ToolSchema(), permission = McpToolPermission.Unrestricted) { _ ->
             CallToolResult(content = listOf(TextContent(payload.toString())), structuredContent = payload)
         }
     }
@@ -893,7 +885,6 @@ private class FakeMcpCapablePlugin(private val toolName: String = "com.example.t
 }
 
 /** A plugin whose single tool always answers with [result], to check how it reaches the wire. */
-@OptIn(ExperimentalJetWhaleApi::class)
 private class FixedResultPlugin(private val toolName: String, private val result: JetWhaleMcpResult) :
     JetWhaleHostPlugin(),
     JetWhaleMcpCapablePlugin {
@@ -912,7 +903,6 @@ private class FixedResultPlugin(private val toolName: String, private val result
 private data class WidgetMeasurement(val width: Int, val height: Int, val label: String = "")
 
 /** A plugin whose single tool declares the `@Serializable` shape of its answer. */
-@OptIn(ExperimentalJetWhaleApi::class)
 private class DeclaredOutputPlugin(private val toolName: String) :
     JetWhaleHostPlugin(),
     JetWhaleMcpCapablePlugin {
@@ -930,7 +920,6 @@ private class DeclaredOutputPlugin(private val toolName: String) :
 }
 
 /** A plugin whose single tool rejects every call the way a command reports a caller mistake. */
-@OptIn(ExperimentalJetWhaleApi::class)
 private class RejectingMcpCapablePlugin(private val toolName: String) :
     JetWhaleHostPlugin(),
     JetWhaleMcpCapablePlugin {

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -36,6 +36,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -749,7 +750,26 @@ class DefaultMcpServerServiceTest {
      * Starts the service with [plugin] loaded for one session and calls [toolName] on it. Every
      * result-shape test needs the same registration dance, and only the answer is interesting.
      */
-    private suspend fun callPluginTool(plugin: JetWhaleHostPlugin, toolName: String): CallToolResult {
+    @Test
+    fun `a plugin tool called without a sessionId is told which argument is missing`() = runBlocking {
+        val toolName = "com.example.test.greet"
+        val callResult = callPluginTool(FakeMcpCapablePlugin(toolName), toolName, arguments = emptyMap())
+
+        assertEquals(true, callResult.isError)
+        assertContains(callResult.content.filterIsInstance<TextContent>().single().text, "Missing required argument: sessionId")
+    }
+
+    @Test
+    fun `a plugin tool called for a session that does not have it names that session`() = runBlocking {
+        val toolName = "com.example.test.greet"
+        val callResult = callPluginTool(FakeMcpCapablePlugin(toolName), toolName, arguments = mapOf("sessionId" to "session-gone"))
+
+        assertEquals(true, callResult.isError)
+        // The two mistakes need different corrections, so the agent must be able to tell them apart.
+        assertContains(callResult.content.filterIsInstance<TextContent>().single().text, "session 'session-gone'")
+    }
+
+    private suspend fun callPluginTool(plugin: JetWhaleHostPlugin, toolName: String, arguments: Map<String, Any?> = mapOf("sessionId" to "test-session-result")): CallToolResult {
         val pluginId = "com.example.test"
         val sessionId = "test-session-result"
         every { pluginInstanceService.getLoadedPluginInstances() } returns listOf(
@@ -761,7 +781,7 @@ class DefaultMcpServerServiceTest {
         return try {
             val client = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$port/sse")
             try {
-                client.callTool(toolName, mapOf("sessionId" to sessionId))
+                client.callTool(toolName, arguments)
             } finally {
                 client.close()
             }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -760,6 +760,16 @@ class DefaultMcpServerServiceTest {
     }
 
     @Test
+    fun `a plugin tool called with a null sessionId is told the argument is missing`() = runBlocking {
+        val toolName = "com.example.test.greet"
+        val callResult = callPluginTool(FakeMcpCapablePlugin(toolName), toolName, arguments = mapOf("sessionId" to null))
+
+        assertEquals(true, callResult.isError)
+        // Routing on the literal text "null" would blame a session that was never named.
+        assertContains(callResult.content.filterIsInstance<TextContent>().single().text, "Missing required argument: sessionId")
+    }
+
+    @Test
     fun `a plugin tool called for a session that does not have it names that session`() = runBlocking {
         val toolName = "com.example.test.greet"
         val callResult = callPluginTool(FakeMcpCapablePlugin(toolName), toolName, arguments = mapOf("sessionId" to "session-gone"))

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -10,10 +10,8 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
-import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpParameterDescriptor
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpTextCommand
-import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -24,6 +24,7 @@ import io.modelcontextprotocol.kotlin.sdk.client.mcpSse
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
@@ -31,12 +32,14 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -683,6 +686,71 @@ class DefaultMcpServerServiceTest {
         assertEquals("image/png", image.mimeType)
     }
 
+    @OptIn(ExperimentalJetWhaleApi::class)
+    @Test
+    fun `a declared output schema reaches the agent on the listed tool`() = runBlocking {
+        val toolName = "com.example.test.measures"
+        val tool = describePluginTool(DeclaredOutputPlugin(toolName), toolName)
+
+        val outputSchema = assertNotNull(tool.outputSchema, "Expected an output schema on $tool")
+        assertEquals("object", outputSchema.type)
+        assertEquals(listOf("width", "height", "label"), outputSchema.properties?.keys?.toList())
+        // Only the properties without a default have to be present in the answer.
+        assertEquals(listOf("width", "height"), outputSchema.required)
+    }
+
+    @OptIn(ExperimentalJetWhaleApi::class)
+    @Test
+    fun `a command that declares no output advertises none`() = runBlocking {
+        val toolName = "com.example.test.greet"
+        val tool = describePluginTool(FakeMcpCapablePlugin(toolName), toolName)
+
+        // A text-only tool must keep saying nothing about its output rather than promising a shape.
+        assertNull(tool.outputSchema)
+    }
+
+    @OptIn(ExperimentalJetWhaleApi::class)
+    @Test
+    fun `a declared output answers with structured content shaped like its schema`() = runBlocking {
+        val toolName = "com.example.test.measures"
+        val callResult = callPluginTool(DeclaredOutputPlugin(toolName), toolName)
+
+        assertEquals(false, callResult.isError)
+        assertEquals(
+            buildJsonObject {
+                put("width", 120)
+                put("height", 40)
+            },
+            callResult.structuredContent,
+        )
+    }
+
+    /**
+     * Starts the service with [plugin] loaded for one session and reads [toolName] off the tool
+     * list, which is where an agent learns what the tool takes and answers with.
+     */
+    @OptIn(ExperimentalJetWhaleApi::class)
+    private suspend fun describePluginTool(plugin: JetWhaleHostPlugin, toolName: String): Tool {
+        val pluginId = "com.example.test"
+        val sessionId = "test-session-schema"
+        every { pluginInstanceService.getLoadedPluginInstances() } returns listOf(
+            LoadedPluginInstance(pluginId, sessionId, plugin),
+        )
+        every { pluginInstanceService.getPluginInstanceForSession(pluginId, sessionId) } returns plugin
+
+        service.start(host, port)
+        return try {
+            val client = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$port/sse")
+            try {
+                client.listTools().tools.single { it.name == toolName }
+            } finally {
+                client.close()
+            }
+        } finally {
+            service.stop()
+        }
+    }
+
     /**
      * Starts the service with [plugin] loaded for one session and calls [toolName] on it. Every
      * result-shape test needs the same registration dance, and only the answer is interesting.
@@ -836,6 +904,27 @@ private class FixedResultPlugin(private val toolName: String, private val result
             override val description = "Answers with a fixed result"
 
             override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = result
+        },
+    )
+}
+
+@Serializable
+private data class WidgetMeasurement(val width: Int, val height: Int, val label: String = "")
+
+/** A plugin whose single tool declares the `@Serializable` shape of its answer. */
+@OptIn(ExperimentalJetWhaleApi::class)
+private class DeclaredOutputPlugin(private val toolName: String) :
+    JetWhaleHostPlugin(),
+    JetWhaleMcpCapablePlugin {
+
+    override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
+        object : JetWhaleMcpCommand() {
+            override val name = toolName
+            override val description = "Measures the selected widget"
+
+            private val measurement = serializableOutput<WidgetMeasurement>()
+
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = measurement.result(WidgetMeasurement(width = 120, height = 40))
         },
     )
 }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommandTest.kt
@@ -123,7 +123,7 @@ private class EchoHostCommand : HostMcpCommand() {
     private val text by string("Text to echo back.")
     private val times by intOrNull("How many times to repeat it.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[text].repeat(arguments[times] ?: 1)
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[text].repeat(arguments[times] ?: 1)
 }
 
 private class ExplodingHostCommand : HostMcpCommand() {
@@ -131,5 +131,5 @@ private class ExplodingHostCommand : HostMcpCommand() {
     override val group: McpHostToolGroup = McpHostToolGroup.OBSERVE
     override val description: String = "Always fails."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = throw IllegalStateException("boom")
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String = throw IllegalStateException("boom")
 }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpPermissionEnforcementTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpPermissionEnforcementTest.kt
@@ -232,7 +232,7 @@ private class ObserveCommand : HostMcpCommand() {
     override val group: McpHostToolGroup = McpHostToolGroup.OBSERVE
     override val description: String = "Observes."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = "observed"
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String = "observed"
 }
 
 private class RestartCommand : HostMcpCommand() {
@@ -240,7 +240,7 @@ private class RestartCommand : HostMcpCommand() {
     override val group: McpHostToolGroup = McpHostToolGroup.SETTINGS_AND_SERVERS
     override val description: String = "Restarts."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = "restarted"
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String = "restarted"
 }
 
 /** Stands in for the built-in UI tools: takes a `pluginId`, so the check resolves per call. */

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistryTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistryTest.kt
@@ -8,6 +8,7 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpTextCommand
 import dev.mokkery.answering.returns
@@ -111,6 +112,18 @@ class McpToolRegistryTest {
     }
 
     @Test
+    fun `dispatch turns a failure that is not about the arguments into a failed result`() = runBlocking {
+        val plugin = FailingPlugin("a.fail")
+        registry.register("com.example.a", "session-1", plugin)
+        every { pluginInstanceService.getPluginInstanceForSession("com.example.a", "session-1") } returns plugin
+
+        val result = registry.dispatch("a.fail", mapOf("sessionId" to JsonPrimitive("session-1")))
+
+        assertEquals(true, result?.isError)
+        assertEquals(listOf(JetWhaleMcpContent.Text("the device disconnected")), result?.content)
+    }
+
+    @Test
     fun `dispatch reports an unroutable call as no result at all`() = runBlocking {
         registry.register("com.example.a", "session-1", FakeTooledPlugin("a.greet"))
 
@@ -146,6 +159,20 @@ private class RejectingPlugin(private val toolName: String) :
             override val name = toolName
             override val description = "Always rejects the call"
             override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = throw JetWhaleMcpArgumentException("no widget with id: 7")
+        },
+    )
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+private class FailingPlugin(private val toolName: String) :
+    JetWhaleHostPlugin(),
+    JetWhaleMcpCapablePlugin {
+
+    override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
+        object : JetWhaleMcpCommand() {
+            override val name = toolName
+            override val description = "Always fails for a reason unrelated to its arguments"
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = throw JetWhaleMcpException("the device disconnected")
         },
     )
 }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistryTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistryTest.kt
@@ -3,17 +3,28 @@ package com.kitakkun.jetwhale.host.mcp
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpTextCommand
+import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.mock
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalJetWhaleApi::class)
 class McpToolRegistryTest {
 
-    private val registry = McpToolRegistry(mock<PluginInstanceService>())
+    private val pluginInstanceService = mock<PluginInstanceService>()
+
+    private val registry = McpToolRegistry(pluginInstanceService)
 
     @Test
     fun `no plugins are reported as MCP-capable before anything registers`() {
@@ -75,6 +86,40 @@ class McpToolRegistryTest {
         assertEquals(null, registry.pluginIdFor("a.greet", "session-2"))
         assertEquals(null, registry.pluginIdFor("nope", "session-1"))
     }
+
+    @Test
+    fun `dispatch hands back the command's own result`() = runBlocking {
+        val plugin = FakeTooledPlugin("a.greet")
+        registry.register("com.example.a", "session-1", plugin)
+        every { pluginInstanceService.getPluginInstanceForSession("com.example.a", "session-1") } returns plugin
+
+        val result = registry.dispatch("a.greet", mapOf("sessionId" to JsonPrimitive("session-1")))
+
+        assertEquals(JetWhaleMcpResult.text("ok"), result)
+    }
+
+    @Test
+    fun `dispatch turns a caller mistake into a failed result rather than throwing`() = runBlocking {
+        val plugin = RejectingPlugin("a.reject")
+        registry.register("com.example.a", "session-1", plugin)
+        every { pluginInstanceService.getPluginInstanceForSession("com.example.a", "session-1") } returns plugin
+
+        val result = registry.dispatch("a.reject", mapOf("sessionId" to JsonPrimitive("session-1")))
+
+        assertEquals(true, result?.isError)
+        assertEquals(listOf(JetWhaleMcpContent.Text("no widget with id: 7")), result?.content)
+    }
+
+    @Test
+    fun `dispatch reports an unroutable call as no result at all`() = runBlocking {
+        registry.register("com.example.a", "session-1", FakeTooledPlugin("a.greet"))
+
+        // A tool nobody registered, and a session that does not have the tool: neither is a plugin
+        // failure, so neither may be answered with an error result the plugin never produced.
+        assertNull(registry.dispatch("a.missing", mapOf("sessionId" to JsonPrimitive("session-1"))))
+        assertNull(registry.dispatch("a.greet", mapOf("sessionId" to JsonPrimitive("session-2"))))
+        assertNull(registry.dispatch("a.greet", emptyMap()))
+    }
 }
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -83,10 +128,24 @@ private class FakeTooledPlugin(private vararg val toolNames: String) :
     JetWhaleMcpCapablePlugin {
 
     override val mcpCommands: List<JetWhaleMcpCommand> = toolNames.map { toolName ->
-        object : JetWhaleMcpCommand() {
+        object : JetWhaleMcpTextCommand() {
             override val name = toolName
             override val description = "Fake tool for testing"
-            override suspend fun execute(arguments: JetWhaleMcpArguments): String = "ok"
+            override suspend fun executeText(arguments: JetWhaleMcpArguments): String = "ok"
         }
     }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+private class RejectingPlugin(private val toolName: String) :
+    JetWhaleHostPlugin(),
+    JetWhaleMcpCapablePlugin {
+
+    override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
+        object : JetWhaleMcpCommand() {
+            override val name = toolName
+            override val description = "Always rejects the call"
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = throw JetWhaleMcpArgumentException("no widget with id: 7")
+        },
+    )
 }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostCommandTestSupport.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostCommandTestSupport.kt
@@ -1,0 +1,17 @@
+package com.kitakkun.jetwhale.host.mcp.tools.host
+
+import com.kitakkun.jetwhale.host.mcp.HostMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+
+/**
+ * Runs a host command and returns the text it answered with.
+ *
+ * Host commands all answer with text, but they say so through a [com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult],
+ * which is the shape every tool result shares. Tests assert on the text, so this unwraps it in one
+ * place rather than at every call site.
+ */
+internal suspend fun HostMcpCommand.executeForText(arguments: JetWhaleMcpArguments): String = execute(arguments)
+    .content
+    .filterIsInstance<JetWhaleMcpContent.Text>()
+    .joinToString(separator = "") { it.text }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommandsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommandsTest.kt
@@ -36,7 +36,7 @@ class HostLogCommandsTest {
 
     @Test
     fun `getLogs returns the newest entries last`() = runBlocking {
-        val result = GetLogsCommand(logCaptureService).execute(arguments()).decodeLogs()
+        val result = GetLogsCommand(logCaptureService).executeForText(arguments()).decodeLogs()
 
         assertEquals(listOf("first info", "second boom", "third info"), result.logs.map { it.message })
         assertEquals(3, result.returned)
@@ -45,7 +45,7 @@ class HostLogCommandsTest {
 
     @Test
     fun `getLogs keeps only the most recent entries when a limit is given`() = runBlocking {
-        val result = GetLogsCommand(logCaptureService).execute(arguments("limit" to JsonPrimitive(2))).decodeLogs()
+        val result = GetLogsCommand(logCaptureService).executeForText(arguments("limit" to JsonPrimitive(2))).decodeLogs()
 
         assertEquals(listOf("second boom", "third info"), result.logs.map { it.message })
         assertEquals(2, result.returned)
@@ -54,7 +54,7 @@ class HostLogCommandsTest {
 
     @Test
     fun `getLogs filters by level`() = runBlocking {
-        val result = GetLogsCommand(logCaptureService).execute(arguments("level" to JsonPrimitive("ERROR"))).decodeLogs()
+        val result = GetLogsCommand(logCaptureService).executeForText(arguments("level" to JsonPrimitive("ERROR"))).decodeLogs()
 
         assertEquals(listOf("second boom"), result.logs.map { it.message })
         assertEquals(1, result.total)
@@ -62,7 +62,7 @@ class HostLogCommandsTest {
 
     @Test
     fun `getLogs filters by substring case-insensitively`() = runBlocking {
-        val result = GetLogsCommand(logCaptureService).execute(arguments("contains" to JsonPrimitive("BOOM"))).decodeLogs()
+        val result = GetLogsCommand(logCaptureService).executeForText(arguments("contains" to JsonPrimitive("BOOM"))).decodeLogs()
 
         assertEquals(listOf("second boom"), result.logs.map { it.message })
     }
@@ -70,7 +70,7 @@ class HostLogCommandsTest {
     @Test
     fun `getLogs rejects a limit above the hard cap`(): Unit = runBlocking {
         assertFailsWith<JetWhaleMcpArgumentException> {
-            GetLogsCommand(logCaptureService).execute(arguments("limit" to JsonPrimitive(1001)))
+            GetLogsCommand(logCaptureService).executeForText(arguments("limit" to JsonPrimitive(1001)))
         }
     }
 
@@ -78,7 +78,7 @@ class HostLogCommandsTest {
     fun `getLogs truncates an oversized message`() = runBlocking {
         logs.value = listOf(logEntry("x".repeat(3000), LogLevel.INFO))
 
-        val message = GetLogsCommand(logCaptureService).execute(arguments()).decodeLogs().logs.single().message
+        val message = GetLogsCommand(logCaptureService).executeForText(arguments()).decodeLogs().logs.single().message
 
         assertEquals(2000 + "…(truncated)".length, message.length)
         assertTrue(message.endsWith("…(truncated)"))
@@ -86,7 +86,7 @@ class HostLogCommandsTest {
 
     @Test
     fun `clearLogs reports how many entries were dropped`() = runBlocking {
-        val json = ClearLogsCommand(logCaptureService).execute(arguments())
+        val json = ClearLogsCommand(logCaptureService).executeForText(arguments())
 
         assertEquals(3, Json.decodeFromString<ClearLogsResult>(json).cleared)
         verify { logCaptureService.clearLogs() }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommandTest.kt
@@ -85,7 +85,7 @@ class HostNavigationCommandTest {
         )
 
         val result = command
-            .execute(arguments("destination" to JsonPrimitive("SETTINGS"), "settingsSection" to JsonPrimitive("SERVER")))
+            .executeForText(arguments("destination" to JsonPrimitive("SETTINGS"), "settingsSection" to JsonPrimitive("SERVER")))
             .decode()
 
         assertTrue(result.applied)
@@ -100,7 +100,7 @@ class HostNavigationCommandTest {
         )
 
         val result = command
-            .execute(arguments("destination" to JsonPrimitive("SETTINGS"), "settingsSection" to JsonPrimitive("PLUGINS")))
+            .executeForText(arguments("destination" to JsonPrimitive("SETTINGS"), "settingsSection" to JsonPrimitive("PLUGINS")))
             .decode()
 
         assertFalse(result.applied)
@@ -108,7 +108,7 @@ class HostNavigationCommandTest {
 
     @Test
     fun `navigate reports not-applied when the host window never confirms`() = runBlocking {
-        val result = command.execute(arguments("destination" to JsonPrimitive("INFO"))).decode()
+        val result = command.executeForText(arguments("destination" to JsonPrimitive("INFO"))).decode()
 
         assertFalse(result.applied)
         assertContains(result.reason.orEmpty(), "did not report")
@@ -126,7 +126,7 @@ class HostNavigationCommandTest {
         )
 
         val result = command
-            .execute(arguments("destination" to JsonPrimitive("PLUGIN"), "pluginId" to JsonPrimitive("com.example.agent")))
+            .executeForText(arguments("destination" to JsonPrimitive("PLUGIN"), "pluginId" to JsonPrimitive("com.example.agent")))
             .decode()
 
         assertTrue(result.applied)
@@ -135,14 +135,14 @@ class HostNavigationCommandTest {
 
     @Test
     fun `navigate requires a pluginId when the destination is PLUGIN`(): Unit = runBlocking {
-        val error = assertFailsWithArgumentException { command.execute(arguments("destination" to JsonPrimitive("PLUGIN"))) }
+        val error = assertFailsWithArgumentException { command.executeForText(arguments("destination" to JsonPrimitive("PLUGIN"))) }
         assertContains(error, "pluginId is required")
     }
 
     @Test
     fun `navigate rejects a pluginId that is not installed`(): Unit = runBlocking {
         val error = assertFailsWithArgumentException {
-            command.execute(arguments("destination" to JsonPrimitive("PLUGIN"), "pluginId" to JsonPrimitive("com.example.missing")))
+            command.executeForText(arguments("destination" to JsonPrimitive("PLUGIN"), "pluginId" to JsonPrimitive("com.example.missing")))
         }
         assertContains(error, "is not installed")
     }
@@ -150,7 +150,7 @@ class HostNavigationCommandTest {
     @Test
     fun `navigate rejects a plugin that is installed but disabled`(): Unit = runBlocking {
         val error = assertFailsWithArgumentException {
-            command.execute(arguments("destination" to JsonPrimitive("PLUGIN"), "pluginId" to JsonPrimitive("com.example.disabled")))
+            command.executeForText(arguments("destination" to JsonPrimitive("PLUGIN"), "pluginId" to JsonPrimitive("com.example.disabled")))
         }
         assertContains(error, "disabled")
     }
@@ -158,7 +158,7 @@ class HostNavigationCommandTest {
     @Test
     fun `navigate rejects a session that does not exist`(): Unit = runBlocking {
         val error = assertFailsWithArgumentException {
-            command.execute(
+            command.executeForText(
                 arguments(
                     "destination" to JsonPrimitive("PLUGIN"),
                     "pluginId" to JsonPrimitive("com.example.agent"),
@@ -174,7 +174,7 @@ class HostNavigationCommandTest {
         every { reconciliationService.requiresAgent("com.example.hostonly") } returns true
 
         val error = assertFailsWithArgumentException {
-            command.execute(
+            command.executeForText(
                 arguments(
                     "destination" to JsonPrimitive("PLUGIN"),
                     "pluginId" to JsonPrimitive("com.example.hostonly"),

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommandsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommandsTest.kt
@@ -81,7 +81,7 @@ class HostPluginCommandsTest {
 
     @Test
     fun `listInstalledPlugins reports each plugin's enabled state`() = runBlocking {
-        val result = listInstalledPlugins.execute(arguments()).decodeList()
+        val result = listInstalledPlugins.executeForText(arguments()).decodeList()
 
         val plugin = result.installed.single()
         assertEquals("com.example.local", plugin.pluginId)
@@ -92,7 +92,7 @@ class HostPluginCommandsTest {
 
     @Test
     fun `listInstalledPlugins marks an official plugin that is not installed`() = runBlocking {
-        val official = listInstalledPlugins.execute(arguments()).decodeList().availableOfficial.single { it.pluginId == officialPluginId }
+        val official = listInstalledPlugins.executeForText(arguments()).decodeList().availableOfficial.single { it.pluginId == officialPluginId }
 
         assertFalse(official.installed)
     }
@@ -101,14 +101,14 @@ class HostPluginCommandsTest {
     fun `listInstalledPlugins marks an official plugin that is already installed`() = runBlocking {
         loadedPlugins[officialPluginId] = loadedPlugin(officialPluginId, "Network Inspector", requiresAgent = true)
 
-        val official = listInstalledPlugins.execute(arguments()).decodeList().availableOfficial.single { it.pluginId == officialPluginId }
+        val official = listInstalledPlugins.executeForText(arguments()).decodeList().availableOfficial.single { it.pluginId == officialPluginId }
 
         assertTrue(official.installed)
     }
 
     @Test
     fun `listInstalledPlugins reports failed and untrusted jars`() = runBlocking {
-        val result = listInstalledPlugins.execute(arguments()).decodeList()
+        val result = listInstalledPlugins.executeForText(arguments()).decodeList()
 
         assertEquals("/plugins/broken.jar", result.failedJars.single().jarPath)
         assertEquals("/plugins/unknown.jar", result.untrustedJars.single())
@@ -117,7 +117,7 @@ class HostPluginCommandsTest {
     @Test
     fun `setPluginEnabled rejects a pluginId that is not installed`(): Unit = runBlocking {
         val error = assertFailsWith<JetWhaleMcpArgumentException> {
-            setPluginEnabled.execute(arguments("pluginId" to JsonPrimitive("com.example.missing"), "enabled" to JsonPrimitive(true)))
+            setPluginEnabled.executeForText(arguments("pluginId" to JsonPrimitive("com.example.missing"), "enabled" to JsonPrimitive(true)))
         }
         assertContains(error.message.orEmpty(), "is not installed")
     }
@@ -125,7 +125,7 @@ class HostPluginCommandsTest {
     @Test
     fun `setPluginEnabled disables a plugin without waiting for instantiation`() = runBlocking {
         val result = setPluginEnabled
-            .execute(arguments("pluginId" to JsonPrimitive("com.example.local"), "enabled" to JsonPrimitive(false)))
+            .executeForText(arguments("pluginId" to JsonPrimitive("com.example.local"), "enabled" to JsonPrimitive(false)))
             .let { Json.decodeFromString<SetPluginEnabledResult>(it) }
 
         assertFalse(result.enabled)
@@ -137,7 +137,7 @@ class HostPluginCommandsTest {
     @Test
     fun `installOfficialPlugin rejects a pluginId that is not in the official catalog`(): Unit = runBlocking {
         val error = assertFailsWith<JetWhaleMcpArgumentException> {
-            installOfficialPlugin.execute(arguments("pluginId" to JsonPrimitive("com.evil.backdoor")))
+            installOfficialPlugin.executeForText(arguments("pluginId" to JsonPrimitive("com.evil.backdoor")))
         }
         assertContains(error.message.orEmpty(), "is not an official plugin")
     }
@@ -147,7 +147,7 @@ class HostPluginCommandsTest {
         installProgress.value = PluginInstallProgress.DownloadingPlugin
 
         val error = assertFailsWith<JetWhaleMcpArgumentException> {
-            installOfficialPlugin.execute(arguments("pluginId" to JsonPrimitive(officialPluginId)))
+            installOfficialPlugin.executeForText(arguments("pluginId" to JsonPrimitive(officialPluginId)))
         }
         assertContains(error.message.orEmpty(), "already in progress")
     }
@@ -155,7 +155,7 @@ class HostPluginCommandsTest {
     @Test
     fun `installOfficialPlugin installs the catalog entry and points at the next step`() = runBlocking {
         val result = installOfficialPlugin
-            .execute(arguments("pluginId" to JsonPrimitive(officialPluginId)))
+            .executeForText(arguments("pluginId" to JsonPrimitive(officialPluginId)))
             .let { Json.decodeFromString<InstallOfficialPluginResult>(it) }
 
         assertTrue(result.installed)
@@ -171,7 +171,7 @@ class HostPluginCommandsTest {
         loadedPlugins[officialPluginId] = loadedPlugin(officialPluginId, "Network Inspector", requiresAgent = true)
 
         val result = installOfficialPlugin
-            .execute(arguments("pluginId" to JsonPrimitive(officialPluginId)))
+            .executeForText(arguments("pluginId" to JsonPrimitive(officialPluginId)))
             .let { Json.decodeFromString<InstallOfficialPluginResult>(it) }
 
         assertTrue(result.alreadyInstalled)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommandsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommandsTest.kt
@@ -43,7 +43,7 @@ class HostSettingsCommandsTest {
 
     @Test
     fun `updateSettings applies only the arguments that were supplied`() = runBlocking {
-        val result = updateSettings.execute(arguments("persistData" to JsonPrimitive(true))).decodeSettings()
+        val result = updateSettings.executeForText(arguments("persistData" to JsonPrimitive(true))).decodeSettings()
 
         assertEquals(mapOf("persistData" to "true"), result.applied)
         verifySuspend { settingsRepository.updatePersistData(true) }
@@ -52,7 +52,7 @@ class HostSettingsCommandsTest {
 
     @Test
     fun `updateSettings persists the mcp port without restarting the mcp server`() = runBlocking {
-        val result = updateSettings.execute(arguments("mcpServerPort" to JsonPrimitive(7100))).decodeSettings()
+        val result = updateSettings.executeForText(arguments("mcpServerPort" to JsonPrimitive(7100))).decodeSettings()
 
         assertFalse(result.mcpServerRestarted)
         assertFalse(result.debugServerRestarted)
@@ -64,7 +64,7 @@ class HostSettingsCommandsTest {
     @Test
     fun `updateSettings restarts the debug server when the ws port changed`() = runBlocking {
         serverPortFlow.value = 5090
-        val result = updateSettings.execute(arguments("serverPort" to JsonPrimitive(5090))).decodeSettings()
+        val result = updateSettings.executeForText(arguments("serverPort" to JsonPrimitive(5090))).decodeSettings()
 
         assertTrue(result.debugServerRestarted)
         verifySuspend { debugWebSocketServer.stop() }
@@ -74,7 +74,7 @@ class HostSettingsCommandsTest {
     @Test
     fun `updateSettings restarts the debug server when adb auto port mapping changed`() = runBlocking {
         // The setting is read when the server starts, so it is inert until the server restarts.
-        val result = updateSettings.execute(arguments("adbAutoPortMappingEnabled" to JsonPrimitive(true))).decodeSettings()
+        val result = updateSettings.executeForText(arguments("adbAutoPortMappingEnabled" to JsonPrimitive(true))).decodeSettings()
 
         assertTrue(result.debugServerRestarted)
         verifySuspend { debugWebSocketServer.stop() }
@@ -82,14 +82,14 @@ class HostSettingsCommandsTest {
 
     @Test
     fun `updateSettings does not claim a change is pending once it has restarted the server`() = runBlocking {
-        val result = updateSettings.execute(arguments("adbAutoPortMappingEnabled" to JsonPrimitive(true))).decodeSettings()
+        val result = updateSettings.executeForText(arguments("adbAutoPortMappingEnabled" to JsonPrimitive(true))).decodeSettings()
 
         assertFalse(result.notes.any { "still running" in it })
     }
 
     @Test
     fun `updateSettings can persist a ws change without restarting when asked`() = runBlocking {
-        val result = updateSettings.execute(
+        val result = updateSettings.executeForText(
             arguments(
                 "serverPort" to JsonPrimitive(5090),
                 "restartDebugServer" to JsonPrimitive(false),
@@ -104,7 +104,7 @@ class HostSettingsCommandsTest {
     @Test
     fun `updateSettings rejects an out-of-range port before writing anything`(): Unit = runBlocking {
         assertFailsWith<JetWhaleMcpArgumentException> {
-            updateSettings.execute(
+            updateSettings.executeForText(
                 arguments(
                     "persistData" to JsonPrimitive(true),
                     "serverPort" to JsonPrimitive(70000),
@@ -116,12 +116,12 @@ class HostSettingsCommandsTest {
 
     @Test
     fun `updateSettings rejects a call that changes nothing`(): Unit = runBlocking {
-        assertFailsWith<JetWhaleMcpArgumentException> { updateSettings.execute(arguments()) }
+        assertFailsWith<JetWhaleMcpArgumentException> { updateSettings.executeForText(arguments()) }
     }
 
     @Test
     fun `restartDebugServer starts with the configured wss port when wss is enabled`() = runBlocking {
-        RestartDebugServerCommand(settingsRepository, debugWebSocketServer).execute(arguments())
+        RestartDebugServerCommand(settingsRepository, debugWebSocketServer).executeForText(arguments())
 
         verifySuspend { debugWebSocketServer.stop() }
         verifySuspend { debugWebSocketServer.start("localhost", 5080, 5443) }
@@ -132,7 +132,7 @@ class HostSettingsCommandsTest {
         wssEnabledFlow.value = false
 
         val result = RestartDebugServerCommand(settingsRepository, debugWebSocketServer)
-            .execute(arguments())
+            .executeForText(arguments())
             .let { Json.decodeFromString<RestartDebugServerResult>(it) }
 
         verifySuspend { debugWebSocketServer.start("localhost", 5080, null) }
@@ -142,7 +142,7 @@ class HostSettingsCommandsTest {
     @Test
     fun `restartDebugServer reports the state the server ended up in`() = runBlocking {
         val result = RestartDebugServerCommand(settingsRepository, debugWebSocketServer)
-            .execute(arguments())
+            .executeForText(arguments())
             .let { Json.decodeFromString<RestartDebugServerResult>(it) }
 
         assertEquals("Started", result.state)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommandTest.kt
@@ -84,7 +84,7 @@ class HostStatusCommandTest {
 
     @Test
     fun `getStatus reports the debug server and mcp server endpoints`() = runBlocking {
-        val status = command.execute(arguments()).decode()
+        val status = command.executeForText(arguments()).decode()
 
         assertEquals("Started", status.debugServer.state)
         assertEquals(5080, status.debugServer.port)
@@ -95,7 +95,7 @@ class HostStatusCommandTest {
 
     @Test
     fun `getStatus reports the host version and whether it is a snapshot`() = runBlocking {
-        val status = command.execute(arguments()).decode()
+        val status = command.executeForText(arguments()).decode()
 
         assertEquals("1.2.3-SNAPSHOT", status.host.version)
         assertTrue(status.host.isSnapshot)
@@ -103,7 +103,7 @@ class HostStatusCommandTest {
 
     @Test
     fun `getStatus counts sessions by whether they are still connected`() = runBlocking {
-        val status = command.execute(arguments()).decode()
+        val status = command.executeForText(arguments()).decode()
 
         assertEquals(2, status.sessions.total)
         assertEquals(1, status.sessions.active)
@@ -111,7 +111,7 @@ class HostStatusCommandTest {
 
     @Test
     fun `getStatus reports a null ui block before the host window has composed`() = runBlocking {
-        assertNull(command.execute(arguments()).decode().ui)
+        assertNull(command.executeForText(arguments()).decode().ui)
     }
 
     @Test
@@ -122,7 +122,7 @@ class HostStatusCommandTest {
             selectedPluginId = "com.example",
         )
 
-        val ui = requireNotNull(command.execute(arguments()).decode().ui)
+        val ui = requireNotNull(command.executeForText(arguments()).decode().ui)
         assertEquals("PLUGIN", ui.destination)
         assertEquals("com.example", ui.pluginId)
         assertEquals("s1", ui.selectedSessionId)
@@ -130,13 +130,13 @@ class HostStatusCommandTest {
 
     @Test
     fun `getStatus reports that no install is in flight`() = runBlocking {
-        assertFalse(command.execute(arguments()).decode().plugins.installInProgress)
+        assertFalse(command.executeForText(arguments()).decode().plugins.installInProgress)
     }
 
     @Test
     fun `getStatus reports which permissions the agent has`() = runBlocking {
         // Without this an agent could only discover a denial by calling a tool and being refused.
-        val permissions = command.execute(arguments()).decode().permissions
+        val permissions = command.executeForText(arguments()).decode().permissions
 
         assertEquals(McpHostToolGroup.entries.map { it.name }.sorted(), permissions.allowedHostGroups)
         assertTrue(permissions.deniedHostGroups.isEmpty())
@@ -152,7 +152,7 @@ class HostStatusCommandTest {
         permissions.setPluginInspectAllowed("com.example.secret", allowed = false)
         permissions.setPluginToolAllowed("com.example.secret.wipe", allowed = false)
 
-        val reported = command.execute(arguments()).decode().permissions
+        val reported = command.executeForText(arguments()).decode().permissions
 
         assertContains(reported.deniedHostGroups, McpHostToolGroup.SETTINGS_AND_SERVERS.name)
         assertFalse(McpHostToolGroup.SETTINGS_AND_SERVERS.name in reported.allowedHostGroups)

--- a/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHeadlessPluginFactory.kt
+++ b/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHeadlessPluginFactory.kt
@@ -6,6 +6,7 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpTextCommand
 
 // Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
 @Suppress("UNUSED")
@@ -28,11 +29,11 @@ private class ExampleHeadlessPlugin :
 }
 
 @OptIn(ExperimentalJetWhaleApi::class)
-private class EchoCommand : JetWhaleMcpCommand() {
+private class EchoCommand : JetWhaleMcpTextCommand() {
     override val name = "com.kitakkun.jetwhale.example.headless.echo"
     override val description = "Echoes the given text back, to show a headless plugin doing its work over MCP."
 
     private val text by string("Text to echo back.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[text]
+    override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[text]
 }

--- a/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostPluginFactory.kt
+++ b/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostPluginFactory.kt
@@ -10,6 +10,8 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpTextCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMessagingHostPlugin
 import com.kitakkun.jetwhale.plugins.example.protocol.ButtonClicked
 import com.kitakkun.jetwhale.plugins.example.protocol.Ping
@@ -64,27 +66,23 @@ private class ExampleHostPlugin :
     override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
         object : JetWhaleMcpCommand() {
             override val name = "com.kitakkun.jetwhale.example.sendPing"
-            override val description = "Sends a Ping request to the debuggee and returns whether a Pong reply was received."
+            override val description = "Sends a Ping request to the debuggee and reports whether a Pong reply came back."
 
-            override suspend fun execute(arguments: JetWhaleMcpArguments): String {
-                val pongReceived = try {
-                    messenger.request(Ping)
-                    true
-                } catch (e: JetWhaleMessagingException) {
-                    false
-                }
-                return buildJsonObject {
-                    put("pongReceived", pongReceived)
-                }.toString()
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = try {
+                messenger.request(Ping)
+                JetWhaleMcpResult.json(buildJsonObject { put("pongReceived", true) })
+            } catch (e: JetWhaleMessagingException) {
+                // An unanswered Ping is the debuggee failing to respond, not an answer of "no".
+                JetWhaleMcpResult.error("the debuggee did not answer Ping: ${e.message}")
             }
         },
-        object : JetWhaleMcpCommand() {
+        object : JetWhaleMcpTextCommand() {
             override val name = "com.kitakkun.jetwhale.example.getEventLogs"
             override val description = "Returns the list of event log entries accumulated by the Example plugin."
 
             private val limit by intOrNull("Maximum number of log entries to return. Returns all entries if omitted.")
 
-            override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+            override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
                 val limit = arguments[this.limit]
                 val logs = if (limit != null) eventLogs.takeLast(limit) else eventLogs.toList()
                 return Json.encodeToJsonElement(logs).toString()

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/GetBackStackCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/GetBackStackCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
@@ -17,21 +18,23 @@ internal class GetBackStackCommand(
 
     private val stackId by stringOrNull("Which back stack to read. Returns every registered stack if omitted.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val requested = arguments[stackId]
         val stacks = controller.stacks().filter { requested == null || it.stackId == requested }
-        return buildJsonObject {
-            putJsonArray("stacks") { stacks.forEach { add(it.toMcpJson()) } }
-            if (stacks.isEmpty()) {
-                put(
-                    "note",
-                    if (requested == null) {
-                        "The app has no Navigation 3 back stack registered; it must call TrackNavBackStack (or registerBackStack) first."
-                    } else {
-                        "No back stack is registered as '$requested'."
-                    },
-                )
-            }
-        }.toString()
+        return JetWhaleMcpResult.json(
+            buildJsonObject {
+                putJsonArray("stacks") { stacks.forEach { add(it.toMcpJson()) } }
+                if (stacks.isEmpty()) {
+                    put(
+                        "note",
+                        if (requested == null) {
+                            "The app has no Navigation 3 back stack registered; it must call TrackNavBackStack (or registerBackStack) first."
+                        } else {
+                            "No back stack is registered as '$requested'."
+                        },
+                    )
+                }
+            },
+        )
     }
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/ListNavKeyTypesCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/ListNavKeyTypesCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 
 @OptIn(ExperimentalJetWhaleApi::class)
 internal class ListNavKeyTypesCommand(
@@ -12,5 +13,5 @@ internal class ListNavKeyTypesCommand(
     override val description =
         "Lists the NavKey types this app can be navigated to, each with its fields and a ready-to-fill JSON template. Fill a template in and pass it to pushNavKey."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = controller.keyTypes().toMcpJson().toString()
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.json(controller.keyTypes().toMcpJson())
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/MoveNavKeyToTopCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/MoveNavKeyToTopCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -16,11 +17,13 @@ internal class MoveNavKeyToTopCommand(
     private val index by int("Index of the entry to bring to the top (0 is the root).")
     private val stackId by stringOrNull("Which back stack to edit. Defaults to the app's only one.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val target = resolveStackId(arguments[stackId], controller.stacks().map { it.stackId })
-        return controller.mutate(
-            stackId = target,
-            operations = listOf(NavBackStackOperation.MoveToTop(index = arguments[index])),
-        ).toMcpJson()
+        return JetWhaleMcpResult.json(
+            controller.mutate(
+                stackId = target,
+                operations = listOf(NavBackStackOperation.MoveToTop(index = arguments[index])),
+            ).toMcpJson(),
+        )
     }
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/Nav3BackStackController.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/Nav3BackStackController.kt
@@ -72,11 +72,11 @@ internal fun NavBackStackSnapshot.toMcpJson(): JsonObject = buildJsonObject {
 }
 
 /** The outcome of a mutation as a tool result, with the resulting stack so the caller can verify it. */
-internal fun MutationResult.toMcpJson(): String = buildJsonObject {
+internal fun MutationResult.toMcpJson(): JsonObject = buildJsonObject {
     put("applied", error == null)
     error?.let { put("error", it) }
     snapshot?.let { put("stack", it.toMcpJson()) }
-}.toString()
+}
 
 internal fun List<NavKeyTypeDescriptor>.toMcpJson(): JsonObject = buildJsonObject {
     putJsonArray("keyTypes") {

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/PopBackStackCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/PopBackStackCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -18,13 +19,13 @@ internal class PopBackStackCommand(
     private val inclusive by booleanOrNull("With toIndex: also pop the entry at that index. Defaults to false.")
     private val stackId by stringOrNull("Which back stack to pop. Defaults to the app's only one.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val target = resolveStackId(arguments[stackId], controller.stacks().map { it.stackId })
         val requestedIndex = arguments[toIndex]
         val operation = when (requestedIndex) {
             null -> NavBackStackOperation.Pop(count = arguments[count] ?: 1)
             else -> NavBackStackOperation.PopTo(index = requestedIndex, inclusive = arguments[inclusive] ?: false)
         }
-        return controller.mutate(stackId = target, operations = listOf(operation)).toMcpJson()
+        return JetWhaleMcpResult.json(controller.mutate(stackId = target, operations = listOf(operation)).toMcpJson())
     }
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/PushNavKeyCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/PushNavKeyCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -17,12 +18,12 @@ internal class PushNavKeyCommand(
     private val index by intOrNull("Insert the key at this index instead of on top of the stack (0 is the root).")
     private val stackId by stringOrNull("Which back stack to push onto. Defaults to the app's only one.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val target = resolveStackId(arguments[stackId], controller.stacks().map { it.stackId })
         val result = controller.mutate(
             stackId = target,
             operations = listOf(NavBackStackOperation.Push(key = arguments[key], index = arguments[index])),
         )
-        return result.toMcpJson()
+        return JetWhaleMcpResult.json(result.toMcpJson())
     }
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/RemoveNavKeyCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/RemoveNavKeyCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -16,11 +17,13 @@ internal class RemoveNavKeyCommand(
     private val index by int("Index of the entry to remove (0 is the root).")
     private val stackId by stringOrNull("Which back stack to edit. Defaults to the app's only one.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val target = resolveStackId(arguments[stackId], controller.stacks().map { it.stackId })
-        return controller.mutate(
-            stackId = target,
-            operations = listOf(NavBackStackOperation.RemoveAt(index = arguments[index])),
-        ).toMcpJson()
+        return JetWhaleMcpResult.json(
+            controller.mutate(
+                stackId = target,
+                operations = listOf(NavBackStackOperation.RemoveAt(index = arguments[index])),
+            ).toMcpJson(),
+        )
     }
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/ReplaceBackStackCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/ReplaceBackStackCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 import kotlinx.serialization.json.JsonObject
 
@@ -18,7 +19,7 @@ internal class ReplaceBackStackCommand(
     private val keys by jsonArray("The new back stack as a JSON array of NavKey objects, root first, e.g. [{\"type\":\"Home\"},{\"type\":\"Detail\",\"id\":\"42\"}]. Must not be empty.")
     private val stackId by stringOrNull("Which back stack to replace. Defaults to the app's only one.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val target = resolveStackId(arguments[stackId], controller.stacks().map { it.stackId })
         val newKeys = arguments[keys]
         if (newKeys.isEmpty()) {
@@ -27,9 +28,11 @@ internal class ReplaceBackStackCommand(
         newKeys.forEachIndexed { index, element ->
             if (element !is JsonObject) throw JetWhaleMcpArgumentException("keys[$index] is not a JSON object")
         }
-        return controller.mutate(
-            stackId = target,
-            operations = listOf(NavBackStackOperation.ReplaceAll(keys = newKeys.toList())),
-        ).toMcpJson()
+        return JetWhaleMcpResult.json(
+            controller.mutate(
+                stackId = target,
+                operations = listOf(NavBackStackOperation.ReplaceAll(keys = newKeys.toList())),
+            ).toMcpJson(),
+        )
     }
 }

--- a/jetwhale-plugins/nav3/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/Nav3McpCommandsTest.kt
+++ b/jetwhale-plugins/nav3/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/Nav3McpCommandsTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalJetWhaleApi::class)
 private fun JetWhaleMcpCommand.run(arguments: JsonObject = buildJsonObject { }): JsonObject = runBlocking {
-    Json.parseToJsonElement(execute(JetWhaleMcpArguments(arguments))).jsonObject
+    checkNotNull(execute(JetWhaleMcpArguments(arguments)).structuredContent)
 }
 
 @OptIn(ExperimentalJetWhaleApi::class)

--- a/jetwhale-plugins/nav3/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/Nav3McpCommandsTest.kt
+++ b/jetwhale-plugins/nav3/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/Nav3McpCommandsTest.kt
@@ -7,7 +7,6 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.plugins.nav3.protocol.MutationResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject

--- a/jetwhale-plugins/network/host/build.gradle.kts
+++ b/jetwhale-plugins/network/host/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.jvm)
+    alias(libs.plugins.kotlinxSerialization)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.jetbrainsCompose)
     // Provides packagePlugin / installPlugin / stageDevPlugin / runJetWhale / runJetWhaleHot (published).

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/AddMockRuleCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/AddMockRuleCommand.kt
@@ -9,9 +9,6 @@ import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
 import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonObject
 import java.util.UUID
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -42,6 +39,8 @@ internal class AddMockRuleCommand(
     )
     private val delayMs by longOrNull("Artificial delay before the mocked response is delivered, in milliseconds. Defaults to 0.")
 
+    private val createdRule = serializableOutput<MockRule>()
+
     override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val rule = MockRule(
             id = UUID.randomUUID().toString(),
@@ -60,7 +59,7 @@ internal class AddMockRuleCommand(
             ),
         )
         return when (val failure = syncMockRules(mockRules() + rule)) {
-            null -> JetWhaleMcpResult.json(Json.encodeToJsonElement(rule).jsonObject)
+            null -> createdRule.result(rule)
             else -> syncErrorResult(failure)
         }
     }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/AddMockRuleCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/AddMockRuleCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.network.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
 import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
@@ -10,6 +11,7 @@ import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
 import java.util.UUID
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -40,7 +42,7 @@ internal class AddMockRuleCommand(
     )
     private val delayMs by longOrNull("Artificial delay before the mocked response is delivered, in milliseconds. Defaults to 0.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val rule = MockRule(
             id = UUID.randomUUID().toString(),
             name = arguments[ruleName] ?: "",
@@ -58,8 +60,8 @@ internal class AddMockRuleCommand(
             ),
         )
         return when (val failure = syncMockRules(mockRules() + rule)) {
-            null -> Json.encodeToJsonElement(rule).toString()
-            else -> syncErrorJson(failure)
+            null -> JetWhaleMcpResult.json(Json.encodeToJsonElement(rule).jsonObject)
+            else -> syncErrorResult(failure)
         }
     }
 

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ClearTransactionsCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ClearTransactionsCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.network.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -13,5 +14,5 @@ internal class ClearTransactionsCommand(
     override val name = "$TOOL_PREFIX.clearTransactions"
     override val description = "Clears the captured HTTP transaction list."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = buildJsonObject { put("clearedCount", clearTransactions()) }.toString()
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.json(buildJsonObject { put("clearedCount", clearTransactions()) })
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ClearTransactionsCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ClearTransactionsCommand.kt
@@ -4,8 +4,6 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 @OptIn(ExperimentalJetWhaleApi::class)
 internal class ClearTransactionsCommand(
@@ -14,5 +12,7 @@ internal class ClearTransactionsCommand(
     override val name = "$TOOL_PREFIX.clearTransactions"
     override val description = "Clears the captured HTTP transaction list."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.json(buildJsonObject { put("clearedCount", clearTransactions()) })
+    private val cleared = serializableOutput<ClearedTransactionsResult>()
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = cleared.result(ClearedTransactionsResult(clearedCount = clearTransactions()))
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/GetMockConfigCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/GetMockConfigCommand.kt
@@ -5,10 +5,6 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.put
 
 @OptIn(ExperimentalJetWhaleApi::class)
 internal class GetMockConfigCommand(
@@ -18,10 +14,9 @@ internal class GetMockConfigCommand(
     override val name = "$TOOL_PREFIX.getMockConfig"
     override val description = "Returns the current mock configuration: the global enabled flag and all mock rules."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.json(
-        buildJsonObject {
-            put("enabled", mockingEnabled())
-            put("rules", Json.encodeToJsonElement(mockRules()))
-        },
+    private val mockConfig = serializableOutput<MockConfigResult>()
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = mockConfig.result(
+        MockConfigResult(enabled = mockingEnabled(), rules = mockRules()),
     )
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/GetMockConfigCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/GetMockConfigCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.network.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
@@ -17,8 +18,10 @@ internal class GetMockConfigCommand(
     override val name = "$TOOL_PREFIX.getMockConfig"
     override val description = "Returns the current mock configuration: the global enabled flag and all mock rules."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = buildJsonObject {
-        put("enabled", mockingEnabled())
-        put("rules", Json.encodeToJsonElement(mockRules()))
-    }.toString()
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.json(
+        buildJsonObject {
+            put("enabled", mockingEnabled())
+            put("rules", Json.encodeToJsonElement(mockRules()))
+        },
+    )
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/GetTransactionCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/GetTransactionCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 
 @OptIn(ExperimentalJetWhaleApi::class)
 internal class GetTransactionCommand(
@@ -15,10 +16,10 @@ internal class GetTransactionCommand(
 
     private val txId by string("The transaction id from listTransactions.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val txId = arguments[this.txId]
         val transaction = transactions().firstOrNull { it.txId == txId }
             ?: throw JetWhaleMcpArgumentException("no transaction with txId: $txId")
-        return redactForMcp(transaction).toDetailJson().toString()
+        return JetWhaleMcpResult.json(redactForMcp(transaction).toDetailJson())
     }
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ListTransactionsCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ListTransactionsCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -36,7 +37,7 @@ internal class ListTransactionsCommand(
         "Only include transactions with this HTTP method (case-insensitive).",
     )
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val urlContains = arguments[this.urlContains]
         val method = arguments[this.method]
         val limit = arguments[this.limit]
@@ -72,9 +73,11 @@ internal class ListTransactionsCommand(
             else -> filtered.take(limit)
         }
         val nextCursor = page.lastOrNull()?.txId?.takeIf { afterTxId != null && page.size < filtered.size }
-        return buildJsonObject {
-            put("transactions", JsonArray(page.map { redactForMcp(it).toSummaryJson() }))
-            nextCursor?.let { put("nextCursor", it) }
-        }.toString()
+        return JetWhaleMcpResult.json(
+            buildJsonObject {
+                put("transactions", JsonArray(page.map { redactForMcp(it).toSummaryJson() }))
+                nextCursor?.let { put("nextCursor", it) }
+            },
+        )
     }
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommands.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommands.kt
@@ -1,13 +1,16 @@
 package com.kitakkun.jetwhale.plugins.network.host
 
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 // Shared by the network plugin's MCP command classes (one class per file in this package).
 
 internal const val TOOL_PREFIX = "com.kitakkun.jetwhale.network"
 
-internal fun errorJson(message: String): String = buildJsonObject { put("error", message) }.toString()
-
-internal fun syncErrorJson(failure: JetWhaleMessagingException): String = errorJson("failed to apply on the debuggee: ${failure.message}")
+/**
+ * The rules live on the debuggee, so a command that could not hand its change over there has not
+ * applied it — the caller is told so rather than reading a success payload.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal fun syncErrorResult(failure: JetWhaleMessagingException): JetWhaleMcpResult = JetWhaleMcpResult.error("failed to apply on the debuggee: ${failure.message}")

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpJson.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpJson.kt
@@ -13,8 +13,11 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 
-// This module compiles without the kotlinx-serialization compiler plugin, so MCP results are
-// assembled with the JsonObject builders instead of @Serializable DTOs.
+// The transaction views stay hand-assembled rather than declared as `@Serializable` result types:
+// their keys are conditional (a transaction carries a response, a failure, or neither), which a
+// data class would have to flatten into nullable properties that are advertised on every
+// transaction and written even when they do not apply. The mock-configuration tools, whose answers
+// have one fixed shape, declare theirs — see NetworkMcpResults.kt.
 
 /** Compact one-line-per-transaction view for listTransactions. */
 internal fun HttpTransaction.toSummaryJson(): JsonObject = buildJsonObject {

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpResults.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpResults.kt
@@ -1,0 +1,40 @@
+package com.kitakkun.jetwhale.plugins.network.host
+
+import com.kitakkun.jetwhale.annotations.McpDescription
+import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
+import kotlinx.serialization.Serializable
+
+// Answer shapes of the mock-configuration tools. Each is declared as a command's output, so the
+// schema an AI agent reads and the payload it receives are derived from the same type.
+
+@Serializable
+internal data class MockConfigResult(
+    @McpDescription("Whether response mocking is enabled globally on the debuggee.")
+    val enabled: Boolean,
+    @McpDescription("Every configured mock rule, in the order they are matched.")
+    val rules: List<MockRule>,
+)
+
+@Serializable
+internal data class MockRulesResult(
+    @McpDescription("The mock rules now in effect on the debuggee.")
+    val rules: List<MockRule>,
+)
+
+@Serializable
+internal data class MockingEnabledResult(
+    @McpDescription("Whether response mocking is now enabled globally on the debuggee.")
+    val enabled: Boolean,
+)
+
+@Serializable
+internal data class RemovedMockRuleResult(
+    @McpDescription("Id of the mock rule that was removed.")
+    val removedId: String,
+)
+
+@Serializable
+internal data class ClearedTransactionsResult(
+    @McpDescription("How many captured transactions were discarded.")
+    val clearedCount: Int,
+)

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/RemoveMockRuleCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/RemoveMockRuleCommand.kt
@@ -7,8 +7,6 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 @OptIn(ExperimentalJetWhaleApi::class)
 internal class RemoveMockRuleCommand(
@@ -20,13 +18,15 @@ internal class RemoveMockRuleCommand(
 
     private val id by string("The rule id from getMockConfig or addMockRule.")
 
+    private val removed = serializableOutput<RemovedMockRuleResult>()
+
     override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val id = arguments[this.id]
         val current = mockRules()
         val remaining = current.filterNot { it.id == id }
         if (remaining.size == current.size) throw JetWhaleMcpArgumentException("no mock rule with id: $id")
         return when (val failure = syncMockRules(remaining)) {
-            null -> JetWhaleMcpResult.json(buildJsonObject { put("removedId", id) })
+            null -> removed.result(RemovedMockRuleResult(removedId = id))
             else -> syncErrorResult(failure)
         }
     }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/RemoveMockRuleCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/RemoveMockRuleCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import kotlinx.serialization.json.buildJsonObject
@@ -19,14 +20,14 @@ internal class RemoveMockRuleCommand(
 
     private val id by string("The rule id from getMockConfig or addMockRule.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val id = arguments[this.id]
         val current = mockRules()
         val remaining = current.filterNot { it.id == id }
         if (remaining.size == current.size) throw JetWhaleMcpArgumentException("no mock rule with id: $id")
         return when (val failure = syncMockRules(remaining)) {
-            null -> buildJsonObject { put("removedId", id) }.toString()
-            else -> syncErrorJson(failure)
+            null -> JetWhaleMcpResult.json(buildJsonObject { put("removedId", id) })
+            else -> syncErrorResult(failure)
         }
     }
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockRulesCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockRulesCommand.kt
@@ -6,10 +6,6 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.put
 
 @OptIn(ExperimentalJetWhaleApi::class)
 internal class SetMockRulesCommand(
@@ -22,10 +18,12 @@ internal class SetMockRulesCommand(
 
     private val rules by serializable<List<MockRule>>("The full list of mock rules to apply, replacing the current set.")
 
+    private val appliedRules = serializableOutput<MockRulesResult>()
+
     override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val newRules = arguments[rules]
         return when (val failure = syncMockRules(newRules)) {
-            null -> JetWhaleMcpResult.json(buildJsonObject { put("rules", Json.encodeToJsonElement(newRules)) })
+            null -> appliedRules.result(MockRulesResult(rules = newRules))
             else -> syncErrorResult(failure)
         }
     }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockRulesCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockRulesCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.network.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import kotlinx.serialization.json.Json
@@ -21,11 +22,11 @@ internal class SetMockRulesCommand(
 
     private val rules by serializable<List<MockRule>>("The full list of mock rules to apply, replacing the current set.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val newRules = arguments[rules]
         return when (val failure = syncMockRules(newRules)) {
-            null -> buildJsonObject { put("rules", Json.encodeToJsonElement(newRules)) }.toString()
-            else -> syncErrorJson(failure)
+            null -> JetWhaleMcpResult.json(buildJsonObject { put("rules", Json.encodeToJsonElement(newRules)) })
+            else -> syncErrorResult(failure)
         }
     }
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockingEnabledCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockingEnabledCommand.kt
@@ -5,8 +5,6 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 @OptIn(ExperimentalJetWhaleApi::class)
 internal class SetMockingEnabledCommand(
@@ -17,10 +15,12 @@ internal class SetMockingEnabledCommand(
 
     private val enabled by boolean("true to enable mocking, false to disable.")
 
+    private val mockingEnabled = serializableOutput<MockingEnabledResult>()
+
     override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val enabled = arguments[this.enabled]
         return when (val failure = syncMockingEnabled(enabled)) {
-            null -> JetWhaleMcpResult.json(buildJsonObject { put("enabled", enabled) })
+            null -> mockingEnabled.result(MockingEnabledResult(enabled = enabled))
             else -> syncErrorResult(failure)
         }
     }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockingEnabledCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockingEnabledCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.network.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -16,11 +17,11 @@ internal class SetMockingEnabledCommand(
 
     private val enabled by boolean("true to enable mocking, false to disable.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val enabled = arguments[this.enabled]
         return when (val failure = syncMockingEnabled(enabled)) {
-            null -> buildJsonObject { put("enabled", enabled) }.toString()
-            else -> syncErrorJson(failure)
+            null -> JetWhaleMcpResult.json(buildJsonObject { put("enabled", enabled) })
+            else -> syncErrorResult(failure)
         }
     }
 }

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -6,6 +6,7 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpTextCommand
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
@@ -27,6 +28,7 @@ import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -323,5 +325,100 @@ class McpParameterDslTest {
             execute(SerializableCommand(), "rules" to buildJsonArray { add(buildJsonObject { put("id", "rule-1") }) })
         }
         assertTrue("invalid rules" in exception.message!!, exception.message!!)
+    }
+
+    // -- Output declaration ---------------------------------------------------------------------
+
+    private class OutputCommand : JetWhaleMcpCommand() {
+        override val name = "test.output"
+        override val description = "answers with a mock configuration"
+        private val mockConfig = serializableOutput<MockConfigResult>()
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = mockConfig.result(
+            MockConfigResult(enabled = true, rules = listOf(MockRule(id = "r1", matcher = MockMatcher(urlPattern = "/api"), response = MockResponseSpec()))),
+        )
+    }
+
+    // The output schema follows the command's format for the same reason a parameter's does.
+    private class SnakeCaseOutputCommand : JetWhaleMcpCommand(Json(from = DefaultArgumentJson) { namingStrategy = JsonNamingStrategy.SnakeCase }) {
+        override val name = "test.snakeCaseOutput"
+        override val description = "answers with a snake_case mock configuration"
+        private val mockConfig = serializableOutput<MockConfigResult>()
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = mockConfig.result(MockConfigResult(enabled = false, rules = emptyList()))
+    }
+
+    @Test
+    fun `the derived output schema advertises the properties and the ones without defaults`() {
+        val schema = assertNotNull(OutputCommand().toDescriptor().outputSchema)
+        assertEquals("object", (schema.getValue("type") as JsonPrimitive).content)
+        assertEquals(listOf("enabled", "rules"), schema.obj("properties").keys.toList())
+        assertEquals(listOf("enabled", "rules"), schema.strings("required"))
+
+        val rule = schema.property("rules").obj("items")
+        assertEquals(listOf("id", "matcher", "response"), rule.strings("required"))
+        assertEquals(
+            "Whether response mocking is enabled globally on the debuggee.",
+            (schema.property("enabled").getValue("description") as JsonPrimitive).content,
+        )
+    }
+
+    @Test
+    fun `a declared output answers with structured content matching its schema`() {
+        val result = runBlocking { OutputCommand().execute(JetWhaleMcpArguments(JsonObject(emptyMap()))) }
+        val payload = assertNotNull(result.structuredContent)
+        assertEquals(setOf("enabled", "rules"), payload.keys)
+        assertTrue(payload.getValue("enabled") is JsonPrimitive)
+        // The same payload is repeated as text, which is what JetWhaleMcpResult.json produces.
+        assertEquals(payload.toString(), execute(OutputCommand()))
+    }
+
+    @Test
+    fun `a command that declares no output advertises none`() {
+        assertNull(StringMapCommand().toDescriptor().outputSchema)
+    }
+
+    @Test
+    fun `a custom format drives both the advertised output names and the encoding`() {
+        val command = SnakeCaseOutputCommand()
+        val rule = assertNotNull(command.toDescriptor().outputSchema).property("rules").obj("items")
+        assertEquals(listOf("method", "url_pattern", "match_type"), rule.property("matcher").obj("properties").keys.toList())
+    }
+
+    @Test
+    fun `an output type that is not a JSON object fails fast`() {
+        val exception = assertFailsWith<IllegalStateException> {
+            object : JetWhaleMcpCommand() {
+                override val name = "test.listOutput"
+                override val description = "tries to answer with a bare list"
+                private val rules = serializableOutput<List<MockRule>>()
+                override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = rules.result(emptyList())
+            }
+        }
+        assertTrue("does not serialize to a JSON object" in exception.message!!, exception.message!!)
+    }
+
+    @Test
+    fun `declaring a second output fails fast`() {
+        val exception = assertFailsWith<IllegalStateException> {
+            object : JetWhaleMcpCommand() {
+                override val name = "test.twoOutputs"
+                override val description = "declares two outputs"
+                val config = serializableOutput<MockConfigResult>()
+                val rules = serializableOutput<MockRulesResult>()
+                override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = config.result(MockConfigResult(enabled = true, rules = emptyList()))
+            }
+        }
+        assertTrue("more than one output" in exception.message!!, exception.message!!)
+    }
+
+    @Test
+    fun `declaring an output after the schema was read fails fast`() {
+        val command = object : JetWhaleMcpCommand() {
+            override val name = "test.lateOutput"
+            override val description = "declares its output inside execute"
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = serializableOutput<MockRulesResult>().result(MockRulesResult(rules = emptyList()))
+        }
+        command.toDescriptor()
+        val exception = assertFailsWith<IllegalStateException> { execute(command) }
+        assertTrue("after its schema was read" in exception.message!!, exception.message!!)
     }
 }

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -15,6 +15,7 @@ import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.PluginFrame
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -369,6 +370,57 @@ class McpParameterDslTest {
         assertTrue(payload.getValue("enabled") is JsonPrimitive)
         // The same payload is repeated as text, which is what JetWhaleMcpResult.json produces.
         assertEquals(payload.toString(), execute(OutputCommand()))
+    }
+
+    @Test
+    fun `a declared output refuses a successful answer built without it`() {
+        val command = object : JetWhaleMcpCommand() {
+            override val name = "test.bypassedOutput"
+            override val description = "declares an output and then answers around it"
+            private val mockConfig = serializableOutput<MockConfigResult>()
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.json(buildJsonObject { put("enabled", true) })
+        }
+
+        // The agent was promised the declared shape, and nothing checked this payload against it.
+        val exception = assertFailsWith<IllegalStateException> {
+            runBlocking { command.run(JetWhaleMcpArguments(JsonObject(emptyMap()))) }
+        }
+        assertTrue("declares an output but answered without it" in exception.message!!, exception.message!!)
+    }
+
+    @Test
+    fun `a declared output still lets the command report a failure`() {
+        val command = object : JetWhaleMcpCommand() {
+            override val name = "test.failingOutput"
+            override val description = "declares an output and fails"
+            private val mockConfig = serializableOutput<MockConfigResult>()
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.error("the debuggee is gone")
+        }
+
+        val result = runBlocking { command.run(JetWhaleMcpArguments(JsonObject(emptyMap()))) }
+
+        assertTrue(result.isError)
+    }
+
+    @Serializable
+    private data class Answer(val detail: String?)
+
+    @Test
+    fun `a format without explicit nulls does not require a nullable property it would leave out`() {
+        val implicitNulls = Json(from = DefaultArgumentJson) { explicitNulls = false }
+        val command = object : JetWhaleMcpCommand(implicitNulls) {
+            override val name = "test.implicitNulls"
+            override val description = "answers with a possibly absent detail"
+            val answer = serializableOutput<Answer>()
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = answer.result(Answer(detail = null))
+        }
+
+        val schema = assertNotNull(command.toDescriptor().outputSchema)
+        val payload = assertNotNull(runBlocking { command.run(JetWhaleMcpArguments(JsonObject(emptyMap()))) }.structuredContent)
+
+        // The format drops the null on the wire, so a schema requiring it would be broken by its own payload.
+        assertNull(schema["required"])
+        assertEquals(emptySet(), payload.keys)
     }
 
     @Test

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -5,6 +5,8 @@ import com.kitakkun.jetwhale.host.sdk.DefaultArgumentJson
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpTextCommand
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
 import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
@@ -30,7 +32,10 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalJetWhaleApi::class, ExperimentalSerializationApi::class)
 class McpParameterDslTest {
-    private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))) }
+    private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking {
+        command.execute(JetWhaleMcpArguments(JsonObject(args.toMap())))
+            .content.filterIsInstance<JetWhaleMcpContent.Text>().joinToString(separator = "\n") { it.text }
+    }
 
     private fun JetWhaleMcpCommand.schemaOf(parameter: String): JsonObject = toDescriptor().parameters.getValue(parameter).schema
 
@@ -40,73 +45,73 @@ class McpParameterDslTest {
 
     private fun JsonObject.strings(key: String): List<String> = (get(key) as JsonArray).map { (it as JsonPrimitive).content }
 
-    private class StringMapCommand : JetWhaleMcpCommand() {
+    private class StringMapCommand : JetWhaleMcpTextCommand() {
         override val name = "test.stringMap"
         override val description = "echoes a string map"
         val headers by stringMap("A string-to-string map.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[headers].entries.joinToString(",") { "${it.key}=${it.value}" }
+        override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[headers].entries.joinToString(",") { "${it.key}=${it.value}" }
     }
 
-    private class OptionalStringMapCommand : JetWhaleMcpCommand() {
+    private class OptionalStringMapCommand : JetWhaleMcpTextCommand() {
         override val name = "test.optionalStringMap"
         override val description = "echoes an optional string map"
         val headers by stringMapOrNull("An optional string-to-string map.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[headers]?.size?.toString() ?: "absent"
+        override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[headers]?.size?.toString() ?: "absent"
     }
 
-    private class StringListCommand : JetWhaleMcpCommand() {
+    private class StringListCommand : JetWhaleMcpTextCommand() {
         override val name = "test.stringList"
         override val description = "echoes a string list"
         val items by stringList("A list of strings.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[items].joinToString(",")
+        override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[items].joinToString(",")
     }
 
-    private class JsonObjectCommand : JetWhaleMcpCommand() {
+    private class JsonObjectCommand : JetWhaleMcpTextCommand() {
         override val name = "test.jsonObject"
         override val description = "echoes a raw json object"
         val payload by jsonObject("A raw JSON object.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[payload].toString()
+        override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[payload].toString()
     }
 
-    private class JsonArrayCommand : JetWhaleMcpCommand() {
+    private class JsonArrayCommand : JetWhaleMcpTextCommand() {
         override val name = "test.jsonArray"
         override val description = "echoes a raw json array"
         val payload by jsonArray("A raw JSON array.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[payload].size.toString()
+        override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[payload].size.toString()
     }
 
-    private class EnumCommand : JetWhaleMcpCommand() {
+    private class EnumCommand : JetWhaleMcpTextCommand() {
         override val name = "test.enum"
         override val description = "echoes an enum"
         val matchType by enum("How the pattern is compared.", MockMatchType.entries)
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[matchType].name
+        override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[matchType].name
     }
 
-    private class SerializableCommand : JetWhaleMcpCommand() {
+    private class SerializableCommand : JetWhaleMcpTextCommand() {
         override val name = "test.serializable"
         override val description = "echoes serializable mock rules"
         val rules by serializable<List<MockRule>>("The mock rules to apply.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[rules].joinToString(",") { "${it.id}:${it.matcher.matchType}" }
+        override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[rules].joinToString(",") { "${it.id}:${it.matcher.matchType}" }
     }
 
     // Both the advertised schema and the decoder come from this format, so they cannot disagree.
     private class SnakeCaseCommand :
-        JetWhaleMcpCommand(
+        JetWhaleMcpTextCommand(
             Json(from = DefaultArgumentJson) { namingStrategy = JsonNamingStrategy.SnakeCase },
         ) {
         override val name = "test.snakeCase"
         override val description = "echoes mock rules named in snake_case"
         val rules by serializable<List<MockRule>>("The mock rules to apply.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[rules].single().matcher.urlPattern
+        override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[rules].single().matcher.urlPattern
     }
 
     // PluginFrame is a sealed interface whose subclasses (including those of the nested sealed
     // Reply) kotlinx flattens into one set of leaves.
-    private class SealedCommand : JetWhaleMcpCommand() {
+    private class SealedCommand : JetWhaleMcpTextCommand() {
         override val name = "test.sealed"
         override val description = "echoes a plugin frame"
         val frame by serializable<PluginFrame>("A plugin frame.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[frame].let { "${it::class.simpleName}:${it.pluginId}" }
+        override suspend fun executeText(arguments: JetWhaleMcpArguments): String = arguments[frame].let { "${it::class.simpleName}:${it.pluginId}" }
     }
 
     @Test

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNamingStrategy
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
@@ -424,6 +425,60 @@ class McpParameterDslTest {
     }
 
     @Test
+    fun `a nullable property's schema admits null under the default format`() {
+        val command = object : JetWhaleMcpCommand() {
+            override val name = "test.explicitNulls"
+            override val description = "answers with a possibly null detail"
+            val answer = serializableOutput<Answer>()
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = answer.result(Answer(detail = null))
+        }
+
+        val schema = assertNotNull(command.toDescriptor().outputSchema)
+        val payload = assertNotNull(runBlocking { command.run(JetWhaleMcpArguments(JsonObject(emptyMap()))) }.structuredContent)
+
+        // The default format writes the null out, so the schema has to admit what its own payload carries.
+        assertEquals(listOf("detail"), schema.strings("required"))
+        assertEquals(listOf("string", "null"), schema.property("detail").strings("type"))
+        assertEquals(JsonNull, payload["detail"])
+    }
+
+    @Test
+    fun `a nullable enum property's schema lists null among its entries`() {
+        // Parameters and outputs share the walker, so the enum case is checked on the cheaper side.
+        val nullableEnum = NullableEnumCommand().toDescriptor().parameters.getValue("choice").schema.property("kind")
+
+        assertEquals(listOf("string", "null"), nullableEnum.strings("type"))
+        assertEquals(listOf(JsonPrimitive("GET"), JsonPrimitive("POST"), JsonNull), (nullableEnum.getValue("enum") as JsonArray).toList())
+    }
+
+    @Serializable
+    private enum class Verb { GET, POST }
+
+    @Serializable
+    private data class Choice(val kind: Verb?)
+
+    private class NullableEnumCommand : JetWhaleMcpCommand() {
+        override val name = "test.nullableEnum"
+        override val description = "takes a possibly null enum"
+        private val choice by serializable<Choice>("A choice.")
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text("ok")
+    }
+
+    @Test
+    fun `an output type that is a map fails fast`() {
+        val exception = assertFailsWith<IllegalStateException> {
+            object : JetWhaleMcpCommand() {
+                override val name = "test.mapOutput"
+                override val description = "tries to answer with a bare map"
+                private val counts = serializableOutput<Map<String, Int>>()
+                override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = counts.result(emptyMap())
+            }
+        }
+        // MCP's ToolSchema carries only named properties, so a map's value schema would be lost on the wire.
+        assertTrue("named properties" in exception.message!!, exception.message!!)
+    }
+
+    @Test
     fun `a command that declares no output advertises none`() {
         assertNull(StringMapCommand().toDescriptor().outputSchema)
     }
@@ -445,7 +500,7 @@ class McpParameterDslTest {
                 override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = rules.result(emptyList())
             }
         }
-        assertTrue("does not serialize to a JSON object" in exception.message!!, exception.message!!)
+        assertTrue("does not serialize to a JSON object with named properties" in exception.message!!, exception.message!!)
     }
 
     @Test

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -15,7 +15,15 @@ import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.PluginFrame
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -510,6 +518,30 @@ class McpParameterDslTest {
         val serialName = (schema.property("type").getValue("const") as JsonPrimitive).content
         assertEquals(listOf("type", "detail"), schema.strings("required"))
         assertEquals(JsonPrimitive(serialName), payload["type"])
+    }
+
+    // Describes an object yet writes an array: the declaration check passes, the encoding does not.
+    private object ArrayAnswerSerializer : KSerializer<Answer> {
+        private val wire = ListSerializer(String.serializer())
+        override val descriptor: SerialDescriptor = buildClassSerialDescriptor("ArrayAnswer") { element<String>("detail") }
+        override fun serialize(encoder: Encoder, value: Answer) = encoder.encodeSerializableValue(wire, listOf(value.detail.orEmpty()))
+        override fun deserialize(decoder: Decoder): Answer = Answer(decoder.decodeSerializableValue(wire).single())
+    }
+
+    @Test
+    fun `an output whose serializer writes something other than an object is refused when it runs`() {
+        val command = object : JetWhaleMcpCommand() {
+            override val name = "test.scalarOutput"
+            override val description = "declares an object and encodes a string"
+            val answer = serializableOutput(ArrayAnswerSerializer)
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = answer.result(Answer(detail = "d"))
+        }
+        assertNotNull(command.toDescriptor().outputSchema)
+
+        val exception = assertFailsWith<IllegalStateException> {
+            runBlocking { command.run(JetWhaleMcpArguments(JsonObject(emptyMap()))) }
+        }
+        assertTrue("does not fit the output schema" in exception.message!!, exception.message!!)
     }
 
     @Test

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -16,6 +16,7 @@ import com.kitakkun.jetwhale.protocol.messaging.PluginFrame
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -476,6 +477,39 @@ class McpParameterDslTest {
         }
         // MCP's ToolSchema carries only named properties, so a map's value schema would be lost on the wire.
         assertTrue("named properties" in exception.message!!, exception.message!!)
+    }
+
+    @Test
+    fun `a text command cannot declare an output`() {
+        val exception = assertFailsWith<IllegalStateException> {
+            object : JetWhaleMcpTextCommand() {
+                override val name = "test.textWithOutput"
+                override val description = "a text command that tries to promise a shape"
+                private val mockConfig = serializableOutput<MockConfigResult>()
+                override suspend fun executeText(arguments: JetWhaleMcpArguments): String = "ok"
+            }
+        }
+        // Its execute never goes through the declaration, so every successful call would be refused.
+        assertTrue("cannot declare an output" in exception.message!!, exception.message!!)
+    }
+
+    @Test
+    fun `a format that writes the discriminator on every object advertises it on every class`() {
+        val everyObject = Json(from = DefaultArgumentJson) { classDiscriminatorMode = ClassDiscriminatorMode.ALL_JSON_OBJECTS }
+        val command = object : JetWhaleMcpCommand(everyObject) {
+            override val name = "test.discriminatorEverywhere"
+            override val description = "answers with a discriminated object"
+            val answer = serializableOutput<Answer>()
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = answer.result(Answer(detail = "d"))
+        }
+
+        val schema = assertNotNull(command.toDescriptor().outputSchema)
+        val payload = assertNotNull(runBlocking { command.run(JetWhaleMcpArguments(JsonObject(emptyMap()))) }.structuredContent)
+
+        // What the format writes, the schema has to name — for the root and for nested classes alike.
+        val serialName = (schema.property("type").getValue("const") as JsonPrimitive).content
+        assertEquals(listOf("type", "detail"), schema.strings("required"))
+        assertEquals(JsonPrimitive(serialName), payload["type"])
     }
 
     @Test

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -16,6 +16,7 @@ import com.kitakkun.jetwhale.protocol.messaging.PluginFrame
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
@@ -27,6 +28,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonNull
@@ -35,6 +37,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -542,6 +545,38 @@ class McpParameterDslTest {
             runBlocking { command.run(JetWhaleMcpArguments(JsonObject(emptyMap()))) }
         }
         assertTrue("does not fit the output schema" in exception.message!!, exception.message!!)
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @Serializable
+    @JsonClassDiscriminator("kind")
+    private sealed interface Shape
+
+    @Serializable
+    @SerialName("circle")
+    private data class Circle(val radius: Int) : Shape
+
+    @Serializable
+    private data class Drawing(val shape: Shape)
+
+    @Test
+    fun `a sealed base's own discriminator wins over the per-class one under ALL_JSON_OBJECTS`() {
+        val everyObject = Json(from = DefaultArgumentJson) { classDiscriminatorMode = ClassDiscriminatorMode.ALL_JSON_OBJECTS }
+        val command = object : JetWhaleMcpCommand(everyObject) {
+            override val name = "test.sealedDiscriminatorEverywhere"
+            override val description = "answers with a discriminated sealed value"
+            val drawing = serializableOutput<Drawing>()
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = drawing.result(Drawing(Circle(radius = 2)))
+        }
+
+        val schema = assertNotNull(command.toDescriptor().outputSchema)
+        val payload = assertNotNull(runBlocking { command.run(JetWhaleMcpArguments(JsonObject(emptyMap()))) }.structuredContent)
+        val circle = (schema.property("shape").getValue("oneOf") as JsonArray).single { "kind" in it.jsonObject.obj("properties") }.jsonObject
+
+        // Json writes the base's key inside a sealed value, not the one the subclass would use alone.
+        assertEquals(listOf("kind", "radius"), circle.strings("required"))
+        assertEquals("circle", (circle.property("kind").getValue("const") as JsonPrimitive).content)
+        assertEquals(setOf("kind", "radius"), payload.getValue("shape").jsonObject.keys)
     }
 
     @Test

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommandsTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommandsTest.kt
@@ -4,11 +4,15 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpTextCommand
 import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
 import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -23,6 +27,8 @@ import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -36,15 +42,19 @@ class NetworkMcpCommandsTest {
 
     private fun listCommand(data: List<HttpTransaction> = transactions) = ListTransactionsCommand(transactions = { data }, redactForMcp = { it })
 
-    private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, String>): String = executeJson(command, *args.map { (key, value) -> key to JsonPrimitive(value) }.toTypedArray())
+    private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, String>): JetWhaleMcpResult = executeJson(command, *args.map { (key, value) -> key to JsonPrimitive(value) }.toTypedArray())
 
-    private fun executeJson(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))) }
+    private fun executeJson(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): JetWhaleMcpResult = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))) }
 
-    private fun txIdsOf(result: String): List<String> = Json.parseToJsonElement(result).jsonObject
+    private val JetWhaleMcpResult.text: String get() = content.filterIsInstance<JetWhaleMcpContent.Text>().joinToString(separator = "\n") { it.text }
+
+    private val JetWhaleMcpResult.json: JsonObject get() = assertNotNull(structuredContent, "Expected a structured payload in $this")
+
+    private fun txIdsOf(result: JetWhaleMcpResult): List<String> = result.json
         .getValue("transactions").jsonArray
         .map { it.jsonObject.getValue("txId").jsonPrimitive.content }
 
-    private fun nextCursorOf(result: String): String? = Json.parseToJsonElement(result).jsonObject["nextCursor"]?.jsonPrimitive?.content
+    private fun nextCursorOf(result: JetWhaleMcpResult): String? = result.json["nextCursor"]?.jsonPrimitive?.content
 
     @Test
     fun `listTransactions without arguments returns all oldest first`() {
@@ -132,7 +142,7 @@ class NetworkMcpCommandsTest {
         )
         val rule = synced!!.single()
         assertEquals(mapOf("Content-Type" to "application/json", "X-Trace" to "abc"), rule.response.headers)
-        assertTrue("application/json" in result, result)
+        assertTrue("application/json" in result.text, result.text)
     }
 
     @Test
@@ -184,7 +194,42 @@ class NetworkMcpCommandsTest {
         )
         val result = executeJson(command, "rules" to Json.encodeToJsonElement(edited))
         assertEquals(edited, synced)
-        assertTrue("edited" in result, result)
+        assertTrue("edited" in result.text, result.text)
+    }
+
+    @Test
+    fun `a change the debuggee did not accept is reported as a failed result`() {
+        val failure = JetWhaleMessagingException("connection closed")
+
+        val setEnabled = execute(SetMockingEnabledCommand { failure }, "enabled" to "true")
+        assertTrue(setEnabled.isError, setEnabled.text)
+        assertTrue("connection closed" in setEnabled.text, setEnabled.text)
+
+        val addRule = execute(
+            AddMockRuleCommand(mockRules = { emptyList() }, syncMockRules = { failure }),
+            "urlPattern" to "/x",
+        )
+        assertTrue(addRule.isError, addRule.text)
+
+        val setRules = executeJson(SetMockRulesCommand { failure }, "rules" to Json.parseToJsonElement("[]"))
+        assertTrue(setRules.isError, setRules.text)
+
+        val removeRule = execute(
+            RemoveMockRuleCommand(
+                mockRules = { listOf(MockRule(id = "r1", matcher = MockMatcher(urlPattern = "/a"), response = MockResponseSpec())) },
+                syncMockRules = { failure },
+            ),
+            "id" to "r1",
+        )
+        assertTrue(removeRule.isError, removeRule.text)
+    }
+
+    @Test
+    fun `a change the debuggee accepted answers with a structured payload`() {
+        val result = execute(SetMockingEnabledCommand { null }, "enabled" to "true")
+
+        assertFalse(result.isError)
+        assertEquals(buildJsonObject { put("enabled", true) }, result.structuredContent)
     }
 
     @Test
@@ -201,11 +246,11 @@ class NetworkMcpCommandsTest {
 
     @Test
     fun `declaring a parameter after the schema was read fails fast`() {
-        val command = object : JetWhaleMcpCommand() {
+        val command = object : JetWhaleMcpTextCommand() {
             override val name = "test.late"
             override val description = "declares a parameter inside execute"
 
-            override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+            override suspend fun executeText(arguments: JetWhaleMcpArguments): String {
                 val late by stringOrNull("declared too late")
                 return late.name
             }
@@ -218,14 +263,14 @@ class NetworkMcpCommandsTest {
     @Test
     fun `declaring the same parameter name twice fails fast`() {
         val exception = assertFailsWith<IllegalStateException> {
-            object : JetWhaleMcpCommand() {
+            object : JetWhaleMcpTextCommand() {
                 override val name = "test.dup"
                 override val description = "declares the same name twice"
 
                 private val first by stringOrNull("first declaration", name = "x")
                 private val second by stringOrNull("second declaration", name = "x")
 
-                override suspend fun execute(arguments: JetWhaleMcpArguments): String = "unused"
+                override suspend fun executeText(arguments: JetWhaleMcpArguments): String = "unused"
             }
         }
         assertTrue("declared twice" in exception.message!!, exception.message!!)

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeMcpCommands.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeMcpCommands.kt
@@ -1,19 +1,18 @@
 package com.kitakkun.jetwhale.plugins.semantics.host
 
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 // Shared by the Compose Semantics Inspector's MCP command classes (one class per file in this package).
 
 /** Tool names are globally unique across plugins, so they carry the pluginId by convention. */
 internal const val TOOL_PREFIX = "com.kitakkun.jetwhale.semantics"
 
-internal fun errorJson(message: String): String = buildJsonObject { put("error", message) }.toString()
-
 /**
  * Every tool here reaches into the running app, so a disconnected or unresponsive agent is a normal
- * outcome rather than a bug: it is reported to the caller as an error payload instead of failing
+ * outcome rather than a bug: it is reported to the caller as a failed result instead of failing
  * the MCP server.
  */
-internal fun agentErrorJson(failure: JetWhaleMessagingException): String = errorJson("the app did not answer: ${failure.message}")
+@OptIn(ExperimentalJetWhaleApi::class)
+internal fun appDidNotAnswerResult(failure: JetWhaleMessagingException): JetWhaleMcpResult = JetWhaleMcpResult.error("the app did not answer: ${failure.message}")

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
@@ -44,7 +45,7 @@ internal class FindNodesCommand(
     private val includeInvisible by booleanOrNull("Include nodes that are not laid out or fully clipped away. Defaults to false.")
     private val limit by intOrNull("Maximum number of nodes to return, in tree order. Returns all matches if omitted.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val limit = arguments[limit]
         if (limit != null && limit <= 0) throw JetWhaleMcpArgumentException("invalid limit: $limit (expected a positive integer)")
 
@@ -70,7 +71,7 @@ internal class FindNodesCommand(
                 ),
             )
         } catch (e: JetWhaleMessagingException) {
-            return agentErrorJson(e)
+            return appDidNotAnswerResult(e)
         }
 
         val matches = snapshot.roots.flatMap { root ->
@@ -79,13 +80,15 @@ internal class FindNodesCommand(
         }
         val page = if (limit == null) matches else matches.take(limit)
 
-        return buildJsonObject {
-            put("nodes", JsonArray(page.map { (rootId, node) -> node.toMcpJson(rootId = rootId, includeChildren = false) }))
-            put("totalMatches", matches.size)
-            put("truncated", page.size < matches.size)
-            if (snapshot.warnings.isNotEmpty()) {
-                put("warnings", JsonArray(snapshot.warnings.map { JsonPrimitive(it) }))
-            }
-        }.toString()
+        return JetWhaleMcpResult.json(
+            buildJsonObject {
+                put("nodes", JsonArray(page.map { (rootId, node) -> node.toMcpJson(rootId = rootId, includeChildren = false) }))
+                put("totalMatches", matches.size)
+                put("truncated", page.size < matches.size)
+                if (snapshot.warnings.isNotEmpty()) {
+                    put("warnings", JsonArray(snapshot.warnings.map { JsonPrimitive(it) }))
+                }
+            },
+        )
     }
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/GetNodeTreeCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/GetNodeTreeCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
@@ -37,7 +38,7 @@ internal class GetNodeTreeCommand(
         "Return only this root. Use it to look at just the dialog on top, for example. Returns every root if omitted.",
     )
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val snapshot = try {
             capture(
                 NodeTreeCaptureOptions(
@@ -47,7 +48,7 @@ internal class GetNodeTreeCommand(
                 ),
             )
         } catch (e: JetWhaleMessagingException) {
-            return agentErrorJson(e)
+            return appDidNotAnswerResult(e)
         }
 
         val requestedRootId = arguments[rootId]
@@ -64,6 +65,6 @@ internal class GetNodeTreeCommand(
             roots
         }
 
-        return snapshot.copy(roots = pruned).toMcpJson().toString()
+        return JetWhaleMcpResult.json(snapshot.copy(roots = pruned).toMcpJson())
     }
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeAtCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeAtCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.semantics.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeHitTesting
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
@@ -32,14 +33,14 @@ internal class NodeAtCommand(
     private val y by int("Y coordinate in screen pixels.")
     private val merged by booleanOrNull("Search the merged tree (default true). See getNodeTree.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val pointX = arguments[x].toFloat()
         val pointY = arguments[y].toFloat()
 
         val snapshot = try {
             capture(NodeTreeCaptureOptions(merged = arguments[merged] ?: true))
         } catch (e: JetWhaleMessagingException) {
-            return agentErrorJson(e)
+            return appDidNotAnswerResult(e)
         }
 
         val hit = NodeHitTesting.nodeAt(snapshot.roots, pointX, pointY)
@@ -47,8 +48,10 @@ internal class NodeAtCommand(
             snapshot.roots.firstOrNull { it.rootId == ref.rootId }?.findNode(ref.nodeId)
         }
 
-        return buildJsonObject {
-            put("node", node?.toMcpJson(rootId = hit?.rootId, includeChildren = false) ?: JsonNull)
-        }.toString()
+        return JetWhaleMcpResult.json(
+            buildJsonObject {
+                put("node", node?.toMcpJson(rootId = hit?.rootId, includeChildren = false) ?: JsonNull)
+            },
+        )
     }
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/PerformNodeActionCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/PerformNodeActionCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
@@ -40,7 +41,7 @@ internal class PerformNodeActionCommand(
     private val scrollX by intOrNull("Horizontal scroll distance in pixels for ScrollBy. Defaults to 0.")
     private val scrollY by intOrNull("Vertical scroll distance in pixels for ScrollBy. Defaults to 0.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val nodeId = arguments[nodeId]
         val action = arguments[action]
         val result: NodeActionResult
@@ -58,16 +59,18 @@ internal class PerformNodeActionCommand(
                 ),
             )
         } catch (e: JetWhaleMessagingException) {
-            return agentErrorJson(e)
+            return appDidNotAnswerResult(e)
         }
 
-        return buildJsonObject {
-            put("performed", result.performed)
-            put("rootId", rootId)
-            put("nodeId", nodeId)
-            put("action", action.name)
-            result.message?.let { put("message", it) }
-        }.toString()
+        return JetWhaleMcpResult.json(
+            buildJsonObject {
+                put("performed", result.performed)
+                put("rootId", rootId)
+                put("nodeId", nodeId)
+                put("action", action.name)
+                result.message?.let { put("message", it) }
+            },
+        )
     }
 
     /**

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
 import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
@@ -52,27 +53,31 @@ internal class GetViewAttributesCommand(
     private val rootId by string("The root the node belongs to, as reported by findNodes or getNodeTree.")
     private val nodeId by int("The View node's id, as reported by findNodes or getNodeTree. It is negative.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val rootId = arguments[rootId]
         val nodeId = arguments[nodeId]
         val response = try {
             getAttributes(GetViewAttributes(rootId = rootId, nodeId = nodeId))
         } catch (e: JetWhaleMessagingException) {
-            return agentErrorJson(e)
+            return appDidNotAnswerResult(e)
         }
         val snapshot = response.snapshot
-            ?: return buildJsonObject {
-                put("rootId", rootId)
-                put("nodeId", nodeId)
-                put("message", response.message ?: "this node has no View attributes")
-            }.toString()
+            ?: return JetWhaleMcpResult.json(
+                buildJsonObject {
+                    put("rootId", rootId)
+                    put("nodeId", nodeId)
+                    put("message", response.message ?: "this node has no View attributes")
+                },
+            )
 
-        return buildJsonObject {
-            put("rootId", snapshot.rootId)
-            put("nodeId", snapshot.nodeId)
-            put("viewClass", snapshot.viewClass)
-            put("attributes", JsonArray(snapshot.attributes.map { it.toMcpJson() }))
-        }.toString()
+        return JetWhaleMcpResult.json(
+            buildJsonObject {
+                put("rootId", snapshot.rootId)
+                put("nodeId", snapshot.nodeId)
+                put("viewClass", snapshot.viewClass)
+                put("attributes", JsonArray(snapshot.attributes.map { it.toMcpJson() }))
+            },
+        )
     }
 }
 
@@ -99,7 +104,7 @@ internal class SetViewAttributeCommand(
             "\"match_parent\" — or a pixel figure \"500\".",
     )
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val rootId = arguments[rootId]
         val nodeId = arguments[nodeId]
         val attributeId = arguments[attributeId]
@@ -110,7 +115,7 @@ internal class SetViewAttributeCommand(
             // a fresh read; it also means an unknown id is caught here, where the known ids can be listed.
             val response = getAttributes(GetViewAttributes(rootId = rootId, nodeId = nodeId))
             val snapshot = response.snapshot
-                ?: return errorJson(response.message ?: "this node has no View attributes")
+                ?: return JetWhaleMcpResult.error(response.message ?: "this node has no View attributes")
             val current = snapshot.attributes.firstOrNull { it.id == attributeId }
                 ?: throw JetWhaleMcpArgumentException(
                     "unknown attributeId: $attributeId (this ${snapshot.viewClass} exposes ${snapshot.attributes.joinToString { it.id }})",
@@ -126,17 +131,19 @@ internal class SetViewAttributeCommand(
                 ),
             )
         } catch (e: JetWhaleMessagingException) {
-            return agentErrorJson(e)
+            return appDidNotAnswerResult(e)
         }
 
-        return buildJsonObject {
-            put("applied", result.applied)
-            put("rootId", rootId)
-            put("nodeId", nodeId)
-            put("attributeId", attributeId)
-            result.message?.let { put("message", it) }
-            result.attribute?.let { put("attribute", it.toMcpJson()) }
-        }.toString()
+        return JetWhaleMcpResult.json(
+            buildJsonObject {
+                put("applied", result.applied)
+                put("rootId", rootId)
+                put("nodeId", nodeId)
+                put("attributeId", attributeId)
+                result.message?.let { put("message", it) }
+                result.attribute?.let { put("attribute", it.toMcpJson()) }
+            },
+        )
     }
 }
 

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeAtCommandTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeAtCommandTest.kt
@@ -4,7 +4,6 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeAtCommandTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeAtCommandTest.kt
@@ -68,5 +68,5 @@ private fun nodeAt(x: Int, y: Int, withDialog: Boolean = false): JsonObject {
             ),
         )
     }
-    return Json.parseToJsonElement(result).jsonObject
+    return checkNotNull(result.structuredContent)
 }

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommandsTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommandsTest.kt
@@ -27,7 +27,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalJetWhaleApi::class)
 private fun JetWhaleMcpCommand.run(arguments: JsonObject): JsonObject = runBlocking {
-    Json.parseToJsonElement(execute(JetWhaleMcpArguments(arguments))).jsonObject
+    checkNotNull(execute(JetWhaleMcpArguments(arguments)).structuredContent)
 }
 
 private fun attribute(

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommandsTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommandsTest.kt
@@ -12,7 +12,6 @@ import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray


### PR DESCRIPTION
## Why

`JetWhaleMcpCommand.execute` returned a bare `String`, and the host wrapped it as
`CallToolResult(content = listOf(TextContent(result ?: "null")))`. Three things a plugin tool could
not do:

- **Report failure.** An AI agent saw every call as a success. The network tools returned
  `{"error": "failed to apply on the debuggee: ..."}` as an ordinary answer, which the agent had no
  reason to distinguish from a result.
- **Return structured JSON as such** — everything was flattened to text.
- **Return an image**, which a screenshot-style plugin needs.

## What

`execute` now returns a **`JetWhaleMcpResult`**, a JetWhale-owned type. The MCP library's
`CallToolResult` / `ContentBlock` stay out of the plugin SDK, so a plugin is insulated from
`io.modelcontextprotocol:kotlin-sdk` version churn.

```kotlin
JetWhaleMcpResult.text("3 widgets are selected")
JetWhaleMcpResult.json(buildJsonObject { put("selectedCount", 3) })
JetWhaleMcpResult.image(base64Data = png, mimeType = "image/png")
JetWhaleMcpResult.error("no widget with id: $id")
```

Shape: `content: List<JetWhaleMcpContent>` (a sealed `Text` / `Image`) + `structuredContent:
JsonObject?` + `isError: Boolean`. The constructor is internal and the factories are the only way in,
so a later case (audio, resource links, text alongside an image) is an added factory rather than a
breaking constructor change. `json(...)` mirrors its payload into a text block as the protocol asks,
so agents that read only text still get the whole answer.

**Text-only commands keep their one-liner**: `JetWhaleMcpTextCommand` seals `execute` and asks for
`executeText(arguments): String`.

Host side: `McpToolRegistry.dispatch` returns `JetWhaleMcpResult?`; `DefaultMcpServerService`
converts it via a single `JetWhaleMcpResult.toCallToolResult()` — text → `TextContent`, image →
`ImageContent`, structured → `structuredContent`, failure → `isError = true`. That pairs with the
registrar's new `isError` handling, so a plugin that reports a failure is recorded as a failed call
in the history pane too.

## Declaring the shape of the answer

A tool could describe its input richly through the parameter DSL but said nothing about its output,
so an agent had to call it once just to learn what came back. `serializableOutput<T>()` mirrors the
input DSL's `serializable<T>()`: the output schema is derived from `T`'s serializer through the same
`SerialDescriptor` walk and the same `json` instance, so the two sides cannot drift.

```kotlin
private val config = serializableOutput<MockConfig>()

override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult =
    config.result(store.current())
```

The declaration hands back a `JetWhaleMcpOutput<T>` whose `result(value)` builds the matching result,
and the host holds the command to it: `result` stamps the answer with the declaration that encoded
it, and `JetWhaleMcpCommand.run` (what the host calls) refuses a successful answer a declared output
did not produce, so a `json(...)` around a hand-assembled object cannot go out under the schema. A
failed result still passes, since a failure is not the tool's answer. The schema also follows the
format's `explicitNulls`: a nullable property is not required under a format that drops nulls, and
its schema admits JSON `null` next to its type. A root `Map` is refused like a list, since MCP's
`ToolSchema` carries only named properties and would drop the map's value schema. `T` must serialize to a JSON object, which MCP
requires of an output schema, so a bare list is rejected at construction instead of being advertised
and refused on the wire.

**Declaring nothing stays the default**: a text-only tool advertises no `outputSchema`, which is what
most MCP servers in the wild do. The Network Inspector's mock-configuration tools declare their
answers; `listTransactions` / `getTransaction` deliberately do not, since a transaction carries a
response, a failure, or neither, and a DTO would flatten that into nullable properties on every row.

## Failing without blaming the arguments

`JetWhaleMcpArgumentException` was a command's only route to a failed result, but its name says the
arguments were wrong. Failures that have nothing to do with the arguments — the device disconnected,
the target view is gone — had no name to reach for. The Network Inspector already showed the strain:
`GetTransactionCommand` and `RemoveMockRuleCommand` throw it for domain lookups that came up empty.

`JetWhaleMcpException` is now the failure a command throws, with `JetWhaleMcpArgumentException` as
its subclass for the argument case the accessors raise. `McpToolRegistry` catches the base, so both
still become a failed result rather than an MCP-level failure, and **every existing throw site keeps
compiling and behaving identically**.

This matters most on `JetWhaleMcpTextCommand.executeText`: whatever it returns is reported as a
success, so a command returning `"error: no such widget"` tells the agent the tool worked and that
was the answer — and JetWhale's own call history records it as a success too. Its KDoc now says so
and points at the throw.

`JetWhaleMcpResult` stays a plain class with hand-written `equals` / `hashCode` / `toString`: a data
class would generate a **public** `copy()` and `componentN` even though the constructor is `internal`
([KT-11914](https://youtrack.jetbrains.com/issue/KT-11914)), handing plugins exactly the bypass the
factories exist to prevent.

## Host-scoped commands

The host-scoped commands from #191 landed on `main` while this branch was being written, so they
still declared `execute(): String`. They all answer with text, so `HostMcpCommand` now extends
`JetWhaleMcpTextCommand` and its nine subclasses override `executeText`; registration converts
through `toCallToolResult()` rather than wrapping a string in `TextContent` by hand, which is what
lets a host command grow a structured or image answer later without touching the registration path.
Their catch widens to `JetWhaleMcpException` for the same reason as above.

## Rebase onto main

The Compose Semantics Inspector, the Navigation 3 plugin and the headless example landed on `main`
with commands declaring `execute(): String`. They already answer with JSON objects, so they now return
them through `JetWhaleMcpResult.json(...)`. The semantics tools reported an unresponsive app as an
`{"error": ...}` payload flagged as success, which is the exact shape this branch exists to remove,
so that path is now a failed result. A Navigation 3 mutation the app refused keeps its
`applied: false` answer with the resulting stack alongside: a failed result cannot carry structured
content today, and the caller is meant to read where the stack stands. That is a candidate for a
later `JetWhaleMcpResult` factory.

`ExperimentalJetWhaleApi` follows `main` to `jetwhale-annotations`, and the registrar keeps both the
permission (from `main`) and the output schema (from this branch) on every tool.

## Behaviour changes

- A plugin tool called without `sessionId` is told `Missing required argument: sessionId`, and one
  called for a session that no longer has the plugin is told which session, so the two mistakes get
  different corrections.

- A `JetWhaleMcpArgumentException` is now an `isError` result with the message as plain text,
  instead of an `{"error": ...}` text payload flagged as success.
- A call that no plugin instance can handle (stale `sessionId`) is now an `isError` result instead
  of the literal text `"null"`.
- `com.kitakkun.jetwhale.example.sendPing` reports an unanswered Ping as a failure rather than
  `{"pongReceived": false}`.
- `McpToolRegistrar.renderForHistory` no longer repeats a structured payload that a text block
  already spells out — without this, every `json(...)` result would appear twice in call history.

## Migration for plugin authors

Small and mechanical (`@ExperimentalJetWhaleApi` surface, so a break is in scope):

| Before                                     | After                                                        |
|--------------------------------------------|--------------------------------------------------------------|
| `execute(...): String = "text"`            | `JetWhaleMcpTextCommand` + `executeText(...): String`, or `JetWhaleMcpResult.text(...)` |
| `execute(...): String = json.toString()`   | `execute(...): JetWhaleMcpResult = JetWhaleMcpResult.json(json)` |
| `return errorJson("...")`                  | `return JetWhaleMcpResult.error("...")`                      |
| `throw JetWhaleMcpArgumentException("device gone")` | `throw JetWhaleMcpException("device gone")` — the argument one still works, and stays right when the arguments really are at fault |

All in-repo plugins are migrated: `jetwhale-plugins/example/host` (2 commands) and the 8 command
files in `jetwhale-plugins/network/host`, whose sync failures now use `syncErrorResult(...)`.

## Tests

New coverage in `DefaultMcpServerServiceTest` (end-to-end over the real SSE transport): a plugin
error result arrives with `isError`, a thrown `JetWhaleMcpArgumentException` does too, a structured
result lands in `structuredContent`, an image result arrives as an `ImageContent` block, and a
mirrored payload is recorded once. `McpToolRegistryTest` covers `dispatch` returning the command's
result, turning a caller mistake into a failure, and reporting an unroutable call as `null`.
`NetworkMcpCommandsTest` gains sync-failure and structured-payload assertions. `McpToolRegistryTest`
also covers a failure that is not about the arguments becoming a failed result. Host-command tests
read the answer back through a new `executeForText` helper, so they assert on the same public surface
an MCP client sees rather than the protected `executeText`.

`./gradlew spotlessCheck build` — BUILD SUCCESSFUL; CI green on `test`, `spotless` and
`check-legacy-abi`.

## Docs

`docs/guide/developing-plugins.md` gains a "What a tool answers with" section (factory table, when to
use `error`, the `JetWhaleMcpTextCommand` shortcut) and the examples are updated.




