### PR TITLE
feat(host): let the server ports be set on the command line

### DIFF
--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -63,7 +63,8 @@ to the [MCP Server](/guide/mcp-server) guide.
 ### Overriding the ports at startup
 
 Each port can also be chosen on the command line, which is handy when several hosts have to run side
-by side (for example one per git worktree) and would otherwise fight over the same defaults:
+by side (for example one per checkout of the app you are debugging) and would otherwise fight over
+the same defaults:
 
 | Option | Overrides |
 |--------|-----------|
@@ -79,10 +80,17 @@ it *is* the port the host reports — the **Settings → Server** screen shows i
 running server never disagree. Changing a port on that screen afterwards wins: the new value is saved
 and the override for that port is retired for the rest of the session.
 
-When launching through Gradle, pass them with `--args`:
+Pass them to the [runnable uber jar](/guide/getting-started):
 
 ```bash
-./gradlew :jetwhale-host:app:run --args="--server-port 5081 --mcp-server-port 7081"
+java -jar jetwhale-host-<version>-<osArch>.jar --server-port 5081 --mcp-server-port 7081
+```
+
+When you launch the host from a plugin project with
+[`runJetWhale`](/guide/developing-plugins) (or `runJetWhaleHot`), pass them with `--args`:
+
+```bash
+./gradlew :myPlugin:runJetWhale --args="--server-port 5081 --mcp-server-port 7081"
 ```
 
 ### SSL certificates

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -60,6 +60,31 @@ The **MCP Server** section also offers copy-ready connection snippets — a `cla
 and a JSON config block, both carrying the port the MCP server is currently running on — plus a link
 to the [MCP Server](/guide/mcp-server) guide.
 
+### Overriding the ports at startup
+
+Each port can also be chosen on the command line, which is handy when several hosts have to run side
+by side (for example one per git worktree) and would otherwise fight over the same defaults:
+
+| Option | Overrides |
+|--------|-----------|
+| `--server-port <port>` | **Debug server port** |
+| `--wss-port <port>` | **wss port** |
+| `--mcp-server-port <port>` | **MCP server port** |
+
+An option that is not passed keeps using the saved setting. `--wss-port` only picks the port: wss is
+still served only when it is enabled in the settings.
+
+An override applies to that launch only and is never written back, but for as long as it is in force
+it *is* the port the host reports — the **Settings → Server** screen shows it, so the screen and the
+running server never disagree. Changing a port on that screen afterwards wins: the new value is saved
+and the override for that port is retired for the rest of the session.
+
+When launching through Gradle, pass them with `--args`:
+
+```bash
+./gradlew :jetwhale-host:app:run --args="--server-port 5081 --mcp-server-port 7081"
+```
+
 ### SSL certificates
 
 To let agents connect over [wss](/guide/getting-started#secure-connections-wss), the host serves TLS

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
@@ -23,7 +23,7 @@ import com.kitakkun.jetwhale.host.component.ShuttingDownDialog
 import com.kitakkun.jetwhale.host.di.JetWhaleAppGraph
 import com.kitakkun.jetwhale.host.model.PersistedWindowState
 import com.kitakkun.jetwhale.host.ui.isShortcutModifierPressed
-import dev.zacsweers.metro.createGraph
+import dev.zacsweers.metro.createGraphFactory
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
@@ -58,9 +58,10 @@ private val DefaultWindowSize = DpSize(1280.dp, 800.dp)
 fun main(args: Array<String>) = runBlocking {
     configureAppMetadata()
 
-    CommandLineArgumentsParser().parse(args)
+    val cliOptions = CommandLineArgumentsParser().parse(args)
 
-    val appGraph: JetWhaleAppGraph = createGraph()
+    val appGraph: JetWhaleAppGraph = createGraphFactory<JetWhaleAppGraph.Factory>()
+        .create(serverPortOverrides = cliOptions.serverPortOverrides)
 
     // Start capturing logs
     appGraph.logCaptureService.startCapture()

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsParser.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsParser.kt
@@ -1,8 +1,11 @@
 package com.kitakkun.jetwhale.host.cli
 
+import com.kitakkun.jetwhale.host.model.ServerPortOverrides
+
 data class JetWhaleCliOptions(
     val pluginDirs: List<String>,
     val logLevel: JetWhaleLogLevel,
+    val serverPortOverrides: ServerPortOverrides,
 )
 
 enum class JetWhaleLogLevel {
@@ -16,11 +19,14 @@ class CommandLineArgumentsParser {
     fun parse(args: Array<String>): JetWhaleCliOptions {
         val pluginDirs = mutableListOf<String>()
         var logLevel: JetWhaleLogLevel = JetWhaleLogLevel.WARN
+        var serverPort: Int? = null
+        var wssPort: Int? = null
+        var mcpServerPort: Int? = null
 
         val iterator = args.iterator()
 
         while (iterator.hasNext()) {
-            when (iterator.next()) {
+            when (val argument = iterator.next()) {
                 "--plugin-dir" -> {
                     if (iterator.hasNext()) {
                         pluginDirs.add(iterator.next())
@@ -43,6 +49,12 @@ class CommandLineArgumentsParser {
                     }
                 }
 
+                "--server-port" -> serverPort = iterator.nextPort(argument)
+
+                "--wss-port" -> wssPort = iterator.nextPort(argument)
+
+                "--mcp-server-port" -> mcpServerPort = iterator.nextPort(argument)
+
                 else -> {
                     // Ignore unknown arguments
                 }
@@ -52,6 +64,21 @@ class CommandLineArgumentsParser {
         return JetWhaleCliOptions(
             pluginDirs = pluginDirs,
             logLevel = logLevel,
+            serverPortOverrides = ServerPortOverrides(
+                serverPort = serverPort,
+                wssPort = wssPort,
+                mcpServerPort = mcpServerPort,
+            ),
         )
+    }
+
+    private fun Iterator<String>.nextPort(option: String): Int {
+        if (!hasNext()) error("Expected a port number after $option")
+        val rawPort = next()
+        val port = rawPort.toIntOrNull()
+        // Reject out-of-range values here rather than letting the server fail to bind later: the
+        // failure would surface long after startup, without naming the option that caused it.
+        check(port != null && port in 1..65535) { "Expected a port number in 1..65535 after $option, but was: $rawPort" }
+        return port
     }
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
@@ -15,6 +15,7 @@ import com.kitakkun.jetwhale.host.model.PluginComposeSceneService
 import com.kitakkun.jetwhale.host.model.PluginHotReloadService
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.model.PluginTrustService
+import com.kitakkun.jetwhale.host.model.ServerPortOverrides
 import com.kitakkun.jetwhale.host.model.ThemeSubscriptionKey
 import com.kitakkun.jetwhale.host.model.UpdateCheckMutationKey
 import com.kitakkun.jetwhale.host.model.WindowStateRepository
@@ -54,6 +55,13 @@ interface JetWhaleAppGraph : ScreenContext {
     val debuggerSettingsRepository: DebuggerSettingsRepository
     val updateCheckMutationKey: UpdateCheckMutationKey
     val windowStateRepository: WindowStateRepository
+
+    @DependencyGraph.Factory
+    fun interface Factory {
+        // The command line is only readable from main(), so the launch port overrides enter the
+        // graph here instead of being provided from within it.
+        fun create(@Provides serverPortOverrides: ServerPortOverrides): JetWhaleAppGraph
+    }
 
     @Provides
     fun provideSwrClient(): SwrClientPlus = SwrCachePlus(SwrCachePlusPolicy(SwrCacheScope()))

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsResolverTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsResolverTest.kt
@@ -1,7 +1,9 @@
 package com.kitakkun.jetwhale.host.cli
 
+import com.kitakkun.jetwhale.host.model.ServerPortOverrides
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class CommandLineArgumentsResolverTest {
@@ -60,6 +62,69 @@ class CommandLineArgumentsResolverTest {
 
         assertFailsWith<IllegalStateException> {
             resolver.parse(args)
+        }
+    }
+
+    @Test
+    fun `port options override the persisted ports`() {
+        val resolver = CommandLineArgumentsParser()
+        val args = arrayOf(
+            "--server-port",
+            "5081",
+            "--wss-port",
+            "5444",
+            "--mcp-server-port",
+            "7081",
+        )
+
+        val options = resolver.parse(args)
+
+        assertEquals(
+            ServerPortOverrides(serverPort = 5081, wssPort = 5444, mcpServerPort = 7081),
+            options.serverPortOverrides,
+        )
+    }
+
+    @Test
+    fun `ports left unspecified stay null so the persisted settings win`() {
+        val resolver = CommandLineArgumentsParser()
+        val args = arrayOf(
+            "--server-port",
+            "5081",
+        )
+
+        val options = resolver.parse(args)
+
+        assertEquals(
+            ServerPortOverrides(serverPort = 5081, wssPort = null, mcpServerPort = null),
+            options.serverPortOverrides,
+        )
+    }
+
+    @Test
+    fun `a missing port value is rejected`() {
+        val resolver = CommandLineArgumentsParser()
+
+        assertFailsWith<IllegalStateException> {
+            resolver.parse(arrayOf("--server-port"))
+        }
+    }
+
+    @Test
+    fun `a non-numeric port is rejected`() {
+        val resolver = CommandLineArgumentsParser()
+
+        assertFailsWith<IllegalStateException> {
+            resolver.parse(arrayOf("--server-port", "not-a-port"))
+        }
+    }
+
+    @Test
+    fun `an out-of-range port is rejected`() {
+        val resolver = CommandLineArgumentsParser()
+
+        assertFailsWith<IllegalStateException> {
+            resolver.parse(arrayOf("--mcp-server-port", "65536"))
         }
     }
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
@@ -7,17 +7,22 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import com.kitakkun.jetwhale.host.data.DebuggerSettingsDataStoreQualifier
 import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.ServerPortOverrides
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
@@ -25,8 +30,14 @@ import kotlinx.coroutines.flow.stateIn
 class DefaultDebuggerSettingsRepository(
     @param:DebuggerSettingsDataStoreQualifier
     private val dataStore: DataStore<Preferences>,
+    launchPortOverrides: ServerPortOverrides,
 ) : DebuggerSettingsRepository {
     private val coroutineScope = CoroutineScope(Dispatchers.IO)
+
+    // Ports named on the command line shadow the stored ones for the rest of the session, so every
+    // reader of this repository — the servers, the settings screen, the restart flows — sees the
+    // ports actually in use. Picking a port in the settings screen drops the matching override.
+    private val portOverrides = MutableStateFlow(launchPortOverrides)
 
     override val adbAutoPortMappingEnabledFlow = dataStore.data
         .mapNotNull { it[KEY_ADB_AUTO_PORT_MAPPING_ENABLED] }
@@ -50,24 +61,27 @@ class DefaultDebuggerSettingsRepository(
         )
     override val serverPortFlow = dataStore.data
         .map { it[KEY_SERVER_PORT] ?: DEFAULT_SERVER_PORT }
+        .overriddenBy(ServerPortOverrides::serverPort)
         .stateIn(
             scope = coroutineScope,
             started = SharingStarted.Eagerly,
-            initialValue = DEFAULT_SERVER_PORT,
+            initialValue = launchPortOverrides.serverPort ?: DEFAULT_SERVER_PORT,
         )
     override val mcpServerPortFlow = dataStore.data
         .map { it[KEY_MCP_SERVER_PORT] ?: DEFAULT_MCP_SERVER_PORT }
+        .overriddenBy(ServerPortOverrides::mcpServerPort)
         .stateIn(
             scope = coroutineScope,
             started = SharingStarted.Eagerly,
-            initialValue = DEFAULT_MCP_SERVER_PORT,
+            initialValue = launchPortOverrides.mcpServerPort ?: DEFAULT_MCP_SERVER_PORT,
         )
     override val wssPortFlow = dataStore.data
         .map { it[KEY_WSS_PORT] ?: DEFAULT_WSS_PORT }
+        .overriddenBy(ServerPortOverrides::wssPort)
         .stateIn(
             scope = coroutineScope,
             started = SharingStarted.Eagerly,
-            initialValue = DEFAULT_WSS_PORT,
+            initialValue = launchPortOverrides.wssPort ?: DEFAULT_WSS_PORT,
         )
     override val wssEnabledFlow = dataStore.data
         .map { it[KEY_WSS_ENABLED] ?: DEFAULT_WSS_ENABLED }
@@ -98,24 +112,27 @@ class DefaultDebuggerSettingsRepository(
     }
 
     override suspend fun updateServerPort(port: Int) {
+        dropOverride { it.copy(serverPort = null) }
         dataStore.edit { prefs ->
             prefs[KEY_SERVER_PORT] = port
         }
     }
 
-    override suspend fun readServerPort(): Int = dataStore.data.first()[KEY_SERVER_PORT] ?: DEFAULT_SERVER_PORT
+    override suspend fun readServerPort(): Int = portOverrides.value.serverPort ?: dataStore.data.first()[KEY_SERVER_PORT] ?: DEFAULT_SERVER_PORT
 
-    override suspend fun readMcpServerPort(): Int = dataStore.data.first()[KEY_MCP_SERVER_PORT] ?: DEFAULT_MCP_SERVER_PORT
+    override suspend fun readMcpServerPort(): Int = portOverrides.value.mcpServerPort ?: dataStore.data.first()[KEY_MCP_SERVER_PORT] ?: DEFAULT_MCP_SERVER_PORT
 
     override suspend fun updateMcpServerPort(port: Int) {
+        dropOverride { it.copy(mcpServerPort = null) }
         dataStore.edit { prefs ->
             prefs[KEY_MCP_SERVER_PORT] = port
         }
     }
 
-    override suspend fun readWssPort(): Int = dataStore.data.first()[KEY_WSS_PORT] ?: DEFAULT_WSS_PORT
+    override suspend fun readWssPort(): Int = portOverrides.value.wssPort ?: dataStore.data.first()[KEY_WSS_PORT] ?: DEFAULT_WSS_PORT
 
     override suspend fun updateWssPort(port: Int) {
+        dropOverride { it.copy(wssPort = null) }
         dataStore.edit { prefs ->
             prefs[KEY_WSS_PORT] = port
         }
@@ -125,6 +142,18 @@ class DefaultDebuggerSettingsRepository(
         dataStore.edit { prefs ->
             prefs[KEY_WSS_ENABLED] = enabled
         }
+    }
+
+    /** Lets a launch override win over the stored value this flow carries. */
+    private fun Flow<Int>.overriddenBy(selectOverride: (ServerPortOverrides) -> Int?): Flow<Int> = combine(portOverrides) { storedPort, overrides -> selectOverride(overrides) ?: storedPort }
+
+    /**
+     * Retires the launch override for a port the user just picked in the settings screen. Without
+     * this the saved value would keep losing to the override for the rest of the session, leaving
+     * the settings screen showing a port the user did not choose.
+     */
+    private fun dropOverride(drop: (ServerPortOverrides) -> ServerPortOverrides) {
+        portOverrides.update(drop)
     }
 
     companion object Companion {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
@@ -112,10 +112,10 @@ class DefaultDebuggerSettingsRepository(
     }
 
     override suspend fun updateServerPort(port: Int) {
-        dropOverride { it.copy(serverPort = null) }
         dataStore.edit { prefs ->
             prefs[KEY_SERVER_PORT] = port
         }
+        dropOverride { it.copy(serverPort = null) }
     }
 
     override suspend fun readServerPort(): Int = portOverrides.value.serverPort ?: dataStore.data.first()[KEY_SERVER_PORT] ?: DEFAULT_SERVER_PORT
@@ -123,19 +123,19 @@ class DefaultDebuggerSettingsRepository(
     override suspend fun readMcpServerPort(): Int = portOverrides.value.mcpServerPort ?: dataStore.data.first()[KEY_MCP_SERVER_PORT] ?: DEFAULT_MCP_SERVER_PORT
 
     override suspend fun updateMcpServerPort(port: Int) {
-        dropOverride { it.copy(mcpServerPort = null) }
         dataStore.edit { prefs ->
             prefs[KEY_MCP_SERVER_PORT] = port
         }
+        dropOverride { it.copy(mcpServerPort = null) }
     }
 
     override suspend fun readWssPort(): Int = portOverrides.value.wssPort ?: dataStore.data.first()[KEY_WSS_PORT] ?: DEFAULT_WSS_PORT
 
     override suspend fun updateWssPort(port: Int) {
-        dropOverride { it.copy(wssPort = null) }
         dataStore.edit { prefs ->
             prefs[KEY_WSS_PORT] = port
         }
+        dropOverride { it.copy(wssPort = null) }
     }
 
     override suspend fun updateWssEnabled(enabled: Boolean) {
@@ -151,6 +151,9 @@ class DefaultDebuggerSettingsRepository(
      * Retires the launch override for a port the user just picked in the settings screen. Without
      * this the saved value would keep losing to the override for the rest of the session, leaving
      * the settings screen showing a port the user did not choose.
+     *
+     * Call this only once the new port is stored: retiring the override first would uncover the
+     * previously stored port until the write lands, publishing an effective port nobody asked for.
      */
     private fun dropOverride(drop: (ServerPortOverrides) -> ServerPortOverrides) {
         portOverrides.update(drop)

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepositoryTest.kt
@@ -1,0 +1,95 @@
+package com.kitakkun.jetwhale.host.data.settings
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.kitakkun.jetwhale.host.model.ServerPortOverrides
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultDebuggerSettingsRepositoryTest {
+    private val noOverrides = ServerPortOverrides(serverPort = null, wssPort = null, mcpServerPort = null)
+
+    // Each repository gets its own store file, so stored ports never leak between tests.
+    private fun newDataStore(): DataStore<Preferences> {
+        val directory = Files.createTempDirectory("jetwhale-debugger-settings-test")
+        return PreferenceDataStoreFactory.createWithPath(scope = CoroutineScope(Dispatchers.IO)) {
+            "$directory/debugger_settings.preferences_pb".toPath()
+        }
+    }
+
+    /** Awaits [expected] rather than sampling, since the store's first emission is asynchronous. */
+    private suspend fun assertEmits(expected: Int, flow: Flow<Int>) {
+        withTimeout(5_000) { flow.first { it == expected } }
+    }
+
+    @Test
+    fun `launch overrides win over the stored ports`() = runBlocking {
+        val dataStore = newDataStore()
+        DefaultDebuggerSettingsRepository(dataStore, noOverrides).run {
+            updateServerPort(5080)
+            updateWssPort(5443)
+            updateMcpServerPort(7080)
+        }
+
+        val repository = DefaultDebuggerSettingsRepository(
+            dataStore,
+            ServerPortOverrides(serverPort = 5081, wssPort = 5444, mcpServerPort = 7081),
+        )
+
+        assertEquals(5081, repository.readServerPort())
+        assertEquals(5444, repository.readWssPort())
+        assertEquals(7081, repository.readMcpServerPort())
+        assertEmits(5081, repository.serverPortFlow)
+        assertEmits(5444, repository.wssPortFlow)
+        assertEmits(7081, repository.mcpServerPortFlow)
+    }
+
+    @Test
+    fun `a port left unoverridden keeps its stored value`() = runBlocking {
+        val dataStore = newDataStore()
+        DefaultDebuggerSettingsRepository(dataStore, noOverrides).updateMcpServerPort(7080)
+
+        val repository = DefaultDebuggerSettingsRepository(
+            dataStore,
+            ServerPortOverrides(serverPort = 5081, wssPort = null, mcpServerPort = null),
+        )
+
+        assertEquals(7080, repository.readMcpServerPort())
+        assertEmits(7080, repository.mcpServerPortFlow)
+    }
+
+    @Test
+    fun `picking a port after launch retires its override`() = runBlocking {
+        val repository = DefaultDebuggerSettingsRepository(
+            newDataStore(),
+            ServerPortOverrides(serverPort = 5081, wssPort = null, mcpServerPort = null),
+        )
+
+        repository.updateServerPort(5082)
+
+        assertEquals(5082, repository.readServerPort())
+        assertEmits(5082, repository.serverPortFlow)
+    }
+
+    @Test
+    fun `retiring one override leaves the others in force`() = runBlocking {
+        val repository = DefaultDebuggerSettingsRepository(
+            newDataStore(),
+            ServerPortOverrides(serverPort = 5081, wssPort = 5444, mcpServerPort = 7081),
+        )
+
+        repository.updateServerPort(5082)
+
+        assertEquals(5444, repository.readWssPort())
+        assertEquals(7081, repository.readMcpServerPort())
+    }
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/ServerPortOverrides.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/ServerPortOverrides.kt
@@ -1,0 +1,16 @@
+package com.kitakkun.jetwhale.host.model
+
+/**
+ * Ports handed to this launch on the command line, taking precedence over the stored settings.
+ *
+ * A `null` member means "use the stored setting". Overrides are never written back to the settings
+ * store, so several hosts (e.g. one per git worktree) can run side by side without fighting over the
+ * default ports or over each other's saved configuration. They are applied by
+ * [DebuggerSettingsRepository] rather than at each call site, so the servers, the settings screen and
+ * the restart flows all agree on the ports actually in use.
+ */
+data class ServerPortOverrides(
+    val serverPort: Int?,
+    val wssPort: Int?,
+    val mcpServerPort: Int?,
+)


### PR DESCRIPTION
## Why

Running two hosts side by side — one per git worktree, say — made them fight over the default ports (5080 / 5443 / 7080), so only the first one to start could be exercised.

## What

Three new options name the ports a launch binds. An option that is not passed keeps using the stored setting.

| Option | Overrides | Default |
|---|---|---|
| `--server-port` | Debug WebSocket server (ws) | 5080 |
| `--wss-port` | wss server | 5443 |
| `--mcp-server-port` | MCP server | 7080 |

```bash
./gradlew :jetwhale-host:app:run --args="--server-port 5081 --wss-port 5444 --mcp-server-port 7081"
```

`--wss-port` only picks the port; whether wss is served at all still follows the setting.

## How

The overrides enter the graph through a `@DependencyGraph.Factory` (the command line is only readable from `main()`) and are applied by `DefaultDebuggerSettingsRepository`, layered over the DataStore values, rather than at each start call site. That way the servers, the settings screen, the ADB reverse wiring and the port-change restart flows all report the ports actually in use instead of disagreeing with each other — `ApplicationLifecycleOwner` needs no change at all.

Overrides are never written back to the store. Picking a port in **Settings → Server** saves that value and retires the matching override for the rest of the session, so an explicit choice always wins; the other ports' overrides stay in force.

Out-of-range and non-numeric values are rejected at parse time, so the option that caused the problem is named instead of surfacing later as a bind failure.

## Testing

- `CommandLineArgumentsResolverTest` — parsing, per-port defaults, and rejection of missing / non-numeric / out-of-range values.
- `DefaultDebuggerSettingsRepositoryTest` (new) — overrides beating stored ports, unoverridden ports keeping their stored value, an override retiring when the port is changed afterwards, and the other overrides staying in force.
- `./gradlew spotlessCheck :jetwhale-host:app:test :jetwhale-host:core:data:test` — green.
- Launched the host with all three options while another host was already holding 5080 / 5443 / 7080, and confirmed with `lsof` that the second instance bound 5081 / 5444 / 7081 and served on them.