### PR TITLE
feat(agent-runtime)!: make a JetWhale session stoppable, and stop leaking its HttpClient

### DIFF
--- a/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
+++ b/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
@@ -83,9 +83,13 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhalePluginConfigurati
     abstract fun register(com.kitakkun.jetwhale.agent.sdk/JetWhaleAgentPlugin) // com.kitakkun.jetwhale.agent.runtime/JetWhalePluginConfigurationScope.register|register(com.kitakkun.jetwhale.agent.sdk.JetWhaleAgentPlugin){}[0]
 }
 
+abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleSession { // com.kitakkun.jetwhale.agent.runtime/JetWhaleSession|null[0]
+    abstract fun stop() // com.kitakkun.jetwhale.agent.runtime/JetWhaleSession.stop|stop(){}[0]
+}
+
 abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope|null[0]
     abstract fun trustCertificate(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope.trustCertificate|trustCertificate(kotlin.String){}[0]
     abstract fun trustServerCertificate() // com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope.trustServerCertificate|trustServerCertificate(){}[0]
 }
 
-final fun com.kitakkun.jetwhale.agent.runtime/startJetWhale(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/startJetWhale|startJetWhale(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleConfigurationScope,kotlin.Unit>){}[0]
+final fun com.kitakkun.jetwhale.agent.runtime/startJetWhale(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope, kotlin/Unit>): com.kitakkun.jetwhale.agent.runtime/JetWhaleSession // com.kitakkun.jetwhale.agent.runtime/startJetWhale|startJetWhale(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleConfigurationScope,kotlin.Unit>){}[0]

--- a/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
+++ b/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
@@ -38,7 +38,11 @@ public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhalePlug
 }
 
 public final class com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDslKt {
-	public static final fun startJetWhale (Lkotlin/jvm/functions/Function1;)V
+	public static final fun startJetWhale (Lkotlin/jvm/functions/Function1;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleSession;
+}
+
+public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleSession {
+	public abstract fun stop ()V
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleSslConfigurationScope {

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
@@ -4,10 +4,14 @@ import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggeeEvent
 import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggerEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
 
 internal class DefaultJetWhaleMessagingService(
@@ -34,6 +38,25 @@ internal class DefaultJetWhaleMessagingService(
                     delay(delayMillis)
                 }
             }
+        }
+    }
+
+    override fun stopService() {
+        JetWhaleLogger.i("Stopping JetWhale Messaging Service")
+        val connectionJob = keepAwakeJob ?: return
+        keepAwakeJob = null
+        coroutineScope.launch {
+            // Join, don't just cancel: the loop must be fully wound down before the teardown below,
+            // or the connection's own `finally` would interleave with it and drop the peers twice.
+            connectionJob.cancelAndJoin()
+            // A cancelled connection cannot run its own suspending teardown, so close the socket and
+            // drop the peers here, out of reach of the cancellation.
+            withContext(NonCancellable) {
+                socketClient.closeConnection()
+                pluginService.disconnectAll()
+            }
+        }.invokeOnCompletion {
+            coroutineScope.cancel()
         }
     }
 

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
@@ -11,4 +11,13 @@ internal interface JetWhaleMessagingService {
      * @param port The port number of the JetWhale debugger server.
      */
     fun startService(host: String, port: Int)
+
+    /**
+     * Stops the messaging service: the reconnect loop is torn down, the current connection is closed
+     * and every plugin peer is dropped.
+     *
+     * Terminal — the service is not restartable afterwards. Returns as soon as the teardown is
+     * scheduled, and repeated calls are ignored.
+     */
+    fun stopService()
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -4,12 +4,36 @@ import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
 import com.kitakkun.jetwhale.protocol.serialization.JetWhaleJson
 
 /**
+ * A running JetWhale debug session: one connection to the host, which lists and groups it as a
+ * single app under its device.
+ *
+ * An app that connects once and stays connected for its whole lifetime can ignore the handle. It
+ * matters when the process owns more than one session, or wants to give one up on purpose.
+ */
+public interface JetWhaleSession {
+    /**
+     * Disconnects this session from the host and releases the resources it holds.
+     *
+     * Terminal: the reconnect loop is torn down and the registered plugins are dropped, so the
+     * session cannot be revived. Call [startJetWhale] again — with fresh plugin instances, since a
+     * plugin is bound to the session it was registered with — for a new one. Repeated calls are
+     * ignored.
+     *
+     * Returns as soon as the teardown is scheduled, so the host observes the disconnect shortly
+     * after rather than by the time this returns.
+     */
+    public fun stop()
+}
+
+/**
  * Starts the JetWhale Messaging Service with the provided configuration.
  *
  * @param configure A lambda function to configure the JetWhale service.
+ * @return a handle to the started session. An app that connects once at startup and stays connected
+ *   for as long as it runs can ignore it.
  */
 @OptIn(InternalJetWhaleApi::class)
-public fun startJetWhale(configure: JetWhaleConfigurationScope.() -> Unit) {
+public fun startJetWhale(configure: JetWhaleConfigurationScope.() -> Unit): JetWhaleSession {
     val configuration = JetWhaleConfiguration().apply(configure)
 
     JetWhaleLogger.setEnabled(configuration.logging.enabled)
@@ -36,6 +60,13 @@ public fun startJetWhale(configure: JetWhaleConfigurationScope.() -> Unit) {
         host = configuration.connection.host,
         port = configuration.connection.port,
     )
+    return MessagingServiceSession(service)
+}
+
+private class MessagingServiceSession(private val service: JetWhaleMessagingService) : JetWhaleSession {
+    override fun stop() {
+        service.stopService()
+    }
 }
 
 @DslMarker

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleSocketClient.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleSocketClient.kt
@@ -12,4 +12,10 @@ internal data class JetWhaleConnection(
 internal interface JetWhaleSocketClient {
     suspend fun sendDebuggeeEvent(event: JetWhaleDebuggeeEvent)
     suspend fun openConnection(host: String, port: Int): JetWhaleConnection
+
+    /**
+     * Closes the current session, if any, so the host observes the debuggee going away instead of
+     * waiting out a dead socket. Does nothing when no session is open.
+     */
+    suspend fun closeConnection()
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClient.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClient.kt
@@ -17,7 +17,9 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.URLProtocol
 import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
+import io.ktor.websocket.CloseReason
 import io.ktor.websocket.Frame
+import io.ktor.websocket.close
 import io.ktor.websocket.readText
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.filterIsInstance
@@ -73,6 +75,12 @@ internal class KtorWebSocketClient(
 
     override suspend fun sendDebuggeeEvent(event: JetWhaleDebuggeeEvent) {
         session?.sendSerialized(event)
+    }
+
+    override suspend fun closeConnection() {
+        val session = this.session ?: return
+        this.session = null
+        session.close(CloseReason(CloseReason.Codes.NORMAL, "JetWhale session stopped"))
     }
 
     override suspend fun openConnection(

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClient.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClient.kt
@@ -28,20 +28,40 @@ import kotlinx.serialization.json.Json
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
+ * The [HttpClient] serving one connection, plus whether closing it falls to [KtorWebSocketClient].
+ *
+ * Ownership differs per construction path and cannot be read off the client itself: a client built
+ * here owns an engine (and with it a thread pool) that has to be released when the connection ends,
+ * while a client handed in from outside outlives any single connection and must be left alone.
+ */
+internal class ConnectionHttpClient(
+    val client: HttpClient,
+    private val owned: Boolean,
+) {
+    fun releaseIfOwned() {
+        if (owned) client.close()
+    }
+}
+
+/**
  * A Ktor-based implementation of [JetWhaleSocketClient].
  *
  * The [HttpClient] is built by [httpClientProvider] at connection time rather than construction
  * time. This is required for two reasons: SSL must be configured via the engine{} block when the
  * client is built (Ktor ignores engine{} blocks applied through HttpClient.config{} afterwards),
  * and the trusted CA may only become known at connect time when it is fetched from the host.
+ *
+ * Building per connection means the client is a per-connection resource, so the provider states who
+ * closes it and every path out of [openConnection] goes through [releaseHttpClient].
  */
 internal class KtorWebSocketClient(
     private val json: Json,
     private val negotiationStrategy: ClientSessionNegotiationStrategy,
     private val sslConfiguration: JetWhaleSslConfiguration,
-    private val httpClientProvider: (JetWhaleSslConfiguration) -> HttpClient,
+    private val httpClientProvider: (JetWhaleSslConfiguration) -> ConnectionHttpClient,
 ) : JetWhaleSocketClient {
     private var session: DefaultClientWebSocketSession? = null
+    private var httpClient: ConnectionHttpClient? = null
 
     /** Production constructor: builds the engine with SSL configured at construction time. */
     constructor(
@@ -53,15 +73,21 @@ internal class KtorWebSocketClient(
         negotiationStrategy = negotiationStrategy,
         sslConfiguration = sslConfiguration,
         httpClientProvider = { resolvedConfiguration ->
-            HttpClient(defaultKtorEngineFactory()) {
-                engine {
-                    configureSsl(resolvedConfiguration)
-                }
-            }
+            ConnectionHttpClient(
+                // One client, configured in full here: an engine{} block only takes effect while the
+                // client is being built, so the SSL setup cannot be applied to it afterwards.
+                client = HttpClient(defaultKtorEngineFactory()) {
+                    engine {
+                        configureSsl(resolvedConfiguration)
+                    }
+                    configureWebSocketClient(json)
+                },
+                owned = true,
+            )
         },
     )
 
-    /** Test constructor: uses a prebuilt [HttpClient] (e.g. the Ktor test client) as-is. */
+    /** Test constructor: borrows a prebuilt [HttpClient] (e.g. the Ktor test client). */
     constructor(
         json: Json,
         negotiationStrategy: ClientSessionNegotiationStrategy,
@@ -70,7 +96,7 @@ internal class KtorWebSocketClient(
         json = json,
         negotiationStrategy = negotiationStrategy,
         sslConfiguration = JetWhaleSslConfiguration(),
-        httpClientProvider = { httpClient },
+        httpClientProvider = borrowedClientProvider(httpClient, json),
     )
 
     override suspend fun sendDebuggeeEvent(event: JetWhaleDebuggeeEvent) {
@@ -78,30 +104,47 @@ internal class KtorWebSocketClient(
     }
 
     override suspend fun closeConnection() {
-        val session = this.session ?: return
+        val session = this.session
         this.session = null
-        session.close(CloseReason(CloseReason.Codes.NORMAL, "JetWhale session stopped"))
+        session?.close(CloseReason(CloseReason.Codes.NORMAL, "JetWhale session stopped"))
+        releaseHttpClient()
     }
 
     override suspend fun openConnection(
         host: String,
         port: Int,
     ): JetWhaleConnection {
-        val resolvedConfiguration = resolveSslConfiguration(host, port)
-        val client = httpClientProvider(resolvedConfiguration).config {
-            configureHttpClient()
-        }
+        // A connection that ended on its own (host disconnect, error) never reached closeConnection,
+        // so its client is still held here. Release it before this attempt allocates another.
+        releaseHttpClient()
 
-        val session = client.webSocketSession(
-            host = host,
-            port = port,
-        ) {
-            url {
-                protocol = if (resolvedConfiguration.isEnabled) URLProtocol.WSS else URLProtocol.WS
+        val resolvedConfiguration = resolveSslConfiguration(host, port)
+        val client = httpClientProvider(resolvedConfiguration)
+        httpClient = client
+
+        try {
+            val session = client.client.webSocketSession(
+                host = host,
+                port = port,
+            ) {
+                url {
+                    protocol = if (resolvedConfiguration.isEnabled) URLProtocol.WSS else URLProtocol.WS
+                }
             }
+            this.session = session
+            return session.configureSession()
+        } catch (e: Throwable) {
+            // A refused host and a failed negotiation both land here, and the reconnect loop will
+            // try again; without this every attempt would strand an engine's thread pool.
+            releaseHttpClient()
+            throw e
         }
-        this.session = session
-        return session.configureSession()
+    }
+
+    private fun releaseHttpClient() {
+        val client = httpClient ?: return
+        httpClient = null
+        client.releaseIfOwned()
     }
 
     /**
@@ -202,20 +245,36 @@ internal class KtorWebSocketClient(
             debuggerEventFlow = debuggerEventFlow,
         )
     }
+}
 
-    private fun HttpClientConfig<*>.configureHttpClient() {
-        install(WebSockets) {
-            contentConverter = KotlinxWebsocketSerializationConverter(json)
-        }
+/**
+ * Hands every connection the same view of a borrowed [HttpClient].
+ *
+ * The view exists so the caller's client is not reconfigured behind its back, and it is derived once
+ * because it holds no per-connection state: the engine belongs to the caller, so there is nothing to
+ * allocate per connection and nothing to release afterwards.
+ */
+private fun borrowedClientProvider(httpClient: HttpClient, json: Json): (JetWhaleSslConfiguration) -> ConnectionHttpClient {
+    val view = httpClient.config { configureWebSocketClient(json) }
+    return { ConnectionHttpClient(client = view, owned = false) }
+}
 
-        install(Logging) {
-            logger = JetWhaleLogger
-            level = when (JetWhaleLogger.ktorLogLevel) {
-                KtorLogLevel.ALL -> LogLevel.ALL
-                KtorLogLevel.HEADERS -> LogLevel.HEADERS
-                KtorLogLevel.BODY -> LogLevel.BODY
-                KtorLogLevel.NONE -> LogLevel.NONE
-            }
+/**
+ * Installs what [KtorWebSocketClient] needs from a client. Top level so both construction paths can
+ * apply it while their client is being built, keeping the count at one client per connection.
+ */
+private fun HttpClientConfig<*>.configureWebSocketClient(json: Json) {
+    install(WebSockets) {
+        contentConverter = KotlinxWebsocketSerializationConverter(json)
+    }
+
+    install(Logging) {
+        logger = JetWhaleLogger
+        level = when (JetWhaleLogger.ktorLogLevel) {
+            KtorLogLevel.ALL -> LogLevel.ALL
+            KtorLogLevel.HEADERS -> LogLevel.HEADERS
+            KtorLogLevel.BODY -> LogLevel.BODY
+            KtorLogLevel.NONE -> LogLevel.NONE
         }
     }
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClient.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClient.kt
@@ -28,22 +28,6 @@ import kotlinx.serialization.json.Json
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
- * The [HttpClient] serving one connection, plus whether closing it falls to [KtorWebSocketClient].
- *
- * Ownership differs per construction path and cannot be read off the client itself: a client built
- * here owns an engine (and with it a thread pool) that has to be released when the connection ends,
- * while a client handed in from outside outlives any single connection and must be left alone.
- */
-internal class ConnectionHttpClient(
-    val client: HttpClient,
-    private val owned: Boolean,
-) {
-    fun releaseIfOwned() {
-        if (owned) client.close()
-    }
-}
-
-/**
  * A Ktor-based implementation of [JetWhaleSocketClient].
  *
  * The [HttpClient] is built by [httpClientProvider] at connection time rather than construction
@@ -51,17 +35,18 @@ internal class ConnectionHttpClient(
  * client is built (Ktor ignores engine{} blocks applied through HttpClient.config{} afterwards),
  * and the trusted CA may only become known at connect time when it is fetched from the host.
  *
- * Building per connection means the client is a per-connection resource, so the provider states who
- * closes it and every path out of [openConnection] goes through [releaseHttpClient].
+ * A client therefore serves exactly one connection and is owned by this class: [httpClientProvider]
+ * hands over a client to dispose of, and every path out of [openConnection] goes through
+ * [releaseHttpClient]. Without that, each attempt would strand an engine's thread pool.
  */
 internal class KtorWebSocketClient(
     private val json: Json,
     private val negotiationStrategy: ClientSessionNegotiationStrategy,
     private val sslConfiguration: JetWhaleSslConfiguration,
-    private val httpClientProvider: (JetWhaleSslConfiguration) -> ConnectionHttpClient,
+    private val httpClientProvider: (JetWhaleSslConfiguration) -> HttpClient,
 ) : JetWhaleSocketClient {
     private var session: DefaultClientWebSocketSession? = null
-    private var httpClient: ConnectionHttpClient? = null
+    private var httpClient: HttpClient? = null
 
     /** Production constructor: builds the engine with SSL configured at construction time. */
     constructor(
@@ -73,30 +58,15 @@ internal class KtorWebSocketClient(
         negotiationStrategy = negotiationStrategy,
         sslConfiguration = sslConfiguration,
         httpClientProvider = { resolvedConfiguration ->
-            ConnectionHttpClient(
-                // One client, configured in full here: an engine{} block only takes effect while the
-                // client is being built, so the SSL setup cannot be applied to it afterwards.
-                client = HttpClient(defaultKtorEngineFactory()) {
-                    engine {
-                        configureSsl(resolvedConfiguration)
-                    }
-                    configureWebSocketClient(json)
-                },
-                owned = true,
-            )
+            // One client, configured in full here: an engine{} block only takes effect while the
+            // client is being built, so the SSL setup cannot be applied to it afterwards.
+            HttpClient(defaultKtorEngineFactory()) {
+                engine {
+                    configureSsl(resolvedConfiguration)
+                }
+                configureWebSocketClient(json)
+            }
         },
-    )
-
-    /** Test constructor: borrows a prebuilt [HttpClient] (e.g. the Ktor test client). */
-    constructor(
-        json: Json,
-        negotiationStrategy: ClientSessionNegotiationStrategy,
-        httpClient: HttpClient,
-    ) : this(
-        json = json,
-        negotiationStrategy = negotiationStrategy,
-        sslConfiguration = JetWhaleSslConfiguration(),
-        httpClientProvider = borrowedClientProvider(httpClient, json),
     )
 
     override suspend fun sendDebuggeeEvent(event: JetWhaleDebuggeeEvent) {
@@ -123,7 +93,7 @@ internal class KtorWebSocketClient(
         httpClient = client
 
         try {
-            val session = client.client.webSocketSession(
+            val session = client.webSocketSession(
                 host = host,
                 port = port,
             ) {
@@ -144,7 +114,7 @@ internal class KtorWebSocketClient(
     private fun releaseHttpClient() {
         val client = httpClient ?: return
         httpClient = null
-        client.releaseIfOwned()
+        client.close()
     }
 
     /**
@@ -248,22 +218,10 @@ internal class KtorWebSocketClient(
 }
 
 /**
- * Hands every connection the same view of a borrowed [HttpClient].
- *
- * The view exists so the caller's client is not reconfigured behind its back, and it is derived once
- * because it holds no per-connection state: the engine belongs to the caller, so there is nothing to
- * allocate per connection and nothing to release afterwards.
+ * Installs what [KtorWebSocketClient] needs from a client. Applied while the client is being built,
+ * so a connection costs exactly one client rather than one plus a `config { }` derivative.
  */
-private fun borrowedClientProvider(httpClient: HttpClient, json: Json): (JetWhaleSslConfiguration) -> ConnectionHttpClient {
-    val view = httpClient.config { configureWebSocketClient(json) }
-    return { ConnectionHttpClient(client = view, owned = false) }
-}
-
-/**
- * Installs what [KtorWebSocketClient] needs from a client. Top level so both construction paths can
- * apply it while their client is being built, keeping the count at one client per connection.
- */
-private fun HttpClientConfig<*>.configureWebSocketClient(json: Json) {
+internal fun HttpClientConfig<*>.configureWebSocketClient(json: Json) {
     install(WebSockets) {
         contentConverter = KotlinxWebsocketSerializationConverter(json)
     }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClientHttpClientLifecycleTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClientHttpClientLifecycleTest.kt
@@ -1,0 +1,183 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
+import com.kitakkun.jetwhale.protocol.serialization.JetWhaleJson
+import com.kitakkun.test.annotations.IgnoreNative
+import com.kitakkun.test.annotations.IgnoreWeb
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
+import io.ktor.server.engine.connector
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.server.websocket.webSocket
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.job
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import io.ktor.server.websocket.WebSockets as ServerWebSockets
+
+/** How long a released client is given to finish winding down before the test calls it a leak. */
+private const val RELEASE_TIMEOUT_MILLIS = 5_000L
+
+/**
+ * The `HttpClient` is built per connection, so one that is never released strands its engine's
+ * thread pool — and the reconnect loop allocates another on every attempt.
+ *
+ * Native and Web targets are ignored because the Ktor WebSocket test engine is not supported there.
+ */
+@IgnoreWeb
+@IgnoreNative
+class KtorWebSocketClientHttpClientLifecycleTest {
+    @Test
+    fun `releasing an owned client closes it`() {
+        val client = HttpClient(CIO)
+
+        ConnectionHttpClient(client = client, owned = true).releaseIfOwned()
+
+        assertFalse(client.isActive)
+    }
+
+    @Test
+    fun `releasing a borrowed client leaves it alone`() {
+        val client = HttpClient(CIO)
+
+        try {
+            ConnectionHttpClient(client = client, owned = false).releaseIfOwned()
+
+            assertTrue(client.isActive, "a client owned by the caller must survive the connection")
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `closing the connection releases the client it was opened with`() = testApplication {
+        configureTestServer()
+        val provider = RecordingProvider(client)
+        val webSocketClient = webSocketClient(provider)
+        webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
+
+        webSocketClient.closeConnection()
+
+        assertReleased(provider.handedOut.single(), "the connection's own client was left open")
+    }
+
+    @Test
+    fun `a failed connection attempt releases the client it allocated`() = testApplication {
+        // No server is configured, so the attempt fails before there is a session to close later.
+        val provider = RecordingProvider(client)
+        val webSocketClient = webSocketClient(provider)
+
+        assertFailsWith<Throwable> {
+            webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
+        }
+
+        assertReleased(provider.handedOut.single(), "a refused attempt stranded its client")
+    }
+
+    @Test
+    fun `a connection that ended on its own is released before the next one opens`() = testApplication {
+        // The server hangs up straight away, so the connection ends without closeConnection ever
+        // being called. That is the reconnect path, and the one that can strand a client unnoticed.
+        configureTestServer(hangUpImmediately = true)
+        val provider = RecordingProvider(client)
+        val webSocketClient = webSocketClient(provider)
+
+        val connection = webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
+        connection.debuggerEventFlow.collect { }
+
+        webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
+
+        assertEquals(2, provider.handedOut.size)
+        assertReleased(provider.handedOut.first(), "the ended connection's client was left open")
+    }
+
+    @Test
+    fun `a borrowed client keeps serving connections after one of them is closed`() = testApplication {
+        configureTestServer()
+        val webSocketClient = KtorWebSocketClient(
+            json = json,
+            negotiationStrategy = NoopClientSessionNegotiationStrategy(),
+            httpClient = client,
+        )
+
+        webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
+        webSocketClient.closeConnection()
+
+        // Every connection is served by the same view of the borrowed client, so closing one that
+        // was never ours to close would leave this second connection nothing to run on.
+        webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
+    }
+
+    /**
+     * A closed client's job only completes once the requests under it do, so a released client is
+     * awaited rather than sampled — sampling races the socket's own teardown.
+     */
+    private suspend fun assertReleased(client: HttpClient, message: String) {
+        val released = withTimeoutOrNull(RELEASE_TIMEOUT_MILLIS) {
+            client.coroutineContext.job.join()
+            true
+        }
+        assertTrue(released == true, message)
+    }
+
+    private fun webSocketClient(provider: RecordingProvider) = KtorWebSocketClient(
+        json = json,
+        negotiationStrategy = NoopClientSessionNegotiationStrategy(),
+        sslConfiguration = JetWhaleSslConfiguration(),
+        httpClientProvider = provider,
+    )
+
+    /**
+     * Stands in for the production provider: hands out a client per connection that the socket client
+     * owns, and keeps every one of them so its state can be inspected afterwards.
+     */
+    private class RecordingProvider(
+        private val engineSource: HttpClient,
+    ) : (JetWhaleSslConfiguration) -> ConnectionHttpClient {
+        val handedOut: MutableList<HttpClient> = mutableListOf()
+
+        override fun invoke(configuration: JetWhaleSslConfiguration): ConnectionHttpClient {
+            val client = engineSource.config {
+                install(WebSockets) {
+                    contentConverter = KotlinxWebsocketSerializationConverter(json)
+                }
+            }
+            handedOut += client
+            return ConnectionHttpClient(client = client, owned = true)
+        }
+    }
+
+    private fun ApplicationTestBuilder.configureTestServer(hangUpImmediately: Boolean = false) {
+        engine {
+            connector {
+                host = TEST_SERVER_HOST
+                port = TEST_SERVER_PORT
+            }
+        }
+
+        install(ServerWebSockets.Plugin) {
+            contentConverter = KotlinxWebsocketSerializationConverter(json)
+        }
+
+        routing {
+            webSocket {
+                if (!hangUpImmediately) closeReason.await()
+            }
+        }
+    }
+
+    companion object Companion {
+        private const val TEST_SERVER_HOST = "localhost"
+        private const val TEST_SERVER_PORT = 50027
+
+        @OptIn(InternalJetWhaleApi::class)
+        private val json = JetWhaleJson
+    }
+}

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClientHttpClientLifecycleTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClientHttpClientLifecycleTest.kt
@@ -5,20 +5,16 @@ import com.kitakkun.jetwhale.protocol.serialization.JetWhaleJson
 import com.kitakkun.test.annotations.IgnoreNative
 import com.kitakkun.test.annotations.IgnoreWeb
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
 import io.ktor.server.engine.connector
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.ktor.server.websocket.webSocket
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.job
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import io.ktor.server.websocket.WebSockets as ServerWebSockets
 
@@ -35,31 +31,9 @@ private const val RELEASE_TIMEOUT_MILLIS = 5_000L
 @IgnoreNative
 class KtorWebSocketClientHttpClientLifecycleTest {
     @Test
-    fun `releasing an owned client closes it`() {
-        val client = HttpClient(CIO)
-
-        ConnectionHttpClient(client = client, owned = true).releaseIfOwned()
-
-        assertFalse(client.isActive)
-    }
-
-    @Test
-    fun `releasing a borrowed client leaves it alone`() {
-        val client = HttpClient(CIO)
-
-        try {
-            ConnectionHttpClient(client = client, owned = false).releaseIfOwned()
-
-            assertTrue(client.isActive, "a client owned by the caller must survive the connection")
-        } finally {
-            client.close()
-        }
-    }
-
-    @Test
     fun `closing the connection releases the client it was opened with`() = testApplication {
         configureTestServer()
-        val provider = RecordingProvider(client)
+        val provider = recordingProvider()
         val webSocketClient = webSocketClient(provider)
         webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
 
@@ -71,7 +45,7 @@ class KtorWebSocketClientHttpClientLifecycleTest {
     @Test
     fun `a failed connection attempt releases the client it allocated`() = testApplication {
         // No server is configured, so the attempt fails before there is a session to close later.
-        val provider = RecordingProvider(client)
+        val provider = recordingProvider()
         val webSocketClient = webSocketClient(provider)
 
         assertFailsWith<Throwable> {
@@ -86,7 +60,7 @@ class KtorWebSocketClientHttpClientLifecycleTest {
         // The server hangs up straight away, so the connection ends without closeConnection ever
         // being called. That is the reconnect path, and the one that can strand a client unnoticed.
         configureTestServer(hangUpImmediately = true)
-        val provider = RecordingProvider(client)
+        val provider = recordingProvider()
         val webSocketClient = webSocketClient(provider)
 
         val connection = webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
@@ -96,23 +70,6 @@ class KtorWebSocketClientHttpClientLifecycleTest {
 
         assertEquals(2, provider.handedOut.size)
         assertReleased(provider.handedOut.first(), "the ended connection's client was left open")
-    }
-
-    @Test
-    fun `a borrowed client keeps serving connections after one of them is closed`() = testApplication {
-        configureTestServer()
-        val webSocketClient = KtorWebSocketClient(
-            json = json,
-            negotiationStrategy = NoopClientSessionNegotiationStrategy(),
-            httpClient = client,
-        )
-
-        webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
-        webSocketClient.closeConnection()
-
-        // Every connection is served by the same view of the borrowed client, so closing one that
-        // was never ours to close would leave this second connection nothing to run on.
-        webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
     }
 
     /**
@@ -134,24 +91,25 @@ class KtorWebSocketClientHttpClientLifecycleTest {
         httpClientProvider = provider,
     )
 
+    /** Hands out a throwaway client per connection, exactly as the production provider does. */
+    private fun ApplicationTestBuilder.recordingProvider() = RecordingProvider {
+        createClient {
+            install(io.ktor.client.plugins.websocket.WebSockets) {
+                contentConverter = KotlinxWebsocketSerializationConverter(json)
+            }
+        }
+    }
+
     /**
-     * Stands in for the production provider: hands out a client per connection that the socket client
-     * owns, and keeps every one of them so its state can be inspected afterwards.
+     * Stands in for the production provider, keeping every client it hands over so their state can be
+     * inspected afterwards.
      */
     private class RecordingProvider(
-        private val engineSource: HttpClient,
-    ) : (JetWhaleSslConfiguration) -> ConnectionHttpClient {
+        private val create: () -> HttpClient,
+    ) : (JetWhaleSslConfiguration) -> HttpClient {
         val handedOut: MutableList<HttpClient> = mutableListOf()
 
-        override fun invoke(configuration: JetWhaleSslConfiguration): ConnectionHttpClient {
-            val client = engineSource.config {
-                install(WebSockets) {
-                    contentConverter = KotlinxWebsocketSerializationConverter(json)
-                }
-            }
-            handedOut += client
-            return ConnectionHttpClient(client = client, owned = true)
-        }
+        override fun invoke(configuration: JetWhaleSslConfiguration): HttpClient = create().also { handedOut += it }
     }
 
     private fun ApplicationTestBuilder.configureTestServer(hangUpImmediately: Boolean = false) {

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClientTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClientTest.kt
@@ -27,11 +27,7 @@ import kotlin.test.assertFailsWith
 class KtorWebSocketClientTest {
     @Test
     fun `test fail to connect to non-existent server`() = testApplication {
-        val webSocketClient = KtorWebSocketClient(
-            json = json,
-            negotiationStrategy = NoopClientSessionNegotiationStrategy(),
-            httpClient = client,
-        )
+        val webSocketClient = webSocketClient()
 
         assertFailsWith<Throwable> {
             webSocketClient.openConnection(
@@ -45,11 +41,7 @@ class KtorWebSocketClientTest {
     fun `test connection established successfully`() = testApplication {
         configureTestServer()
 
-        val webSocketClient = KtorWebSocketClient(
-            json = json,
-            negotiationStrategy = NoopClientSessionNegotiationStrategy(),
-            httpClient = client,
-        )
+        val webSocketClient = webSocketClient()
 
         webSocketClient.openConnection(
             host = TEST_SERVER_HOST,
@@ -61,11 +53,7 @@ class KtorWebSocketClientTest {
     fun `test send message`() = testApplication {
         configureTestServer()
 
-        val webSocketClient = KtorWebSocketClient(
-            json = json,
-            negotiationStrategy = NoopClientSessionNegotiationStrategy(),
-            httpClient = client,
-        )
+        val webSocketClient = webSocketClient()
 
         webSocketClient.openConnection(
             host = TEST_SERVER_HOST,
@@ -91,11 +79,7 @@ class KtorWebSocketClientTest {
             sendSerialized(expectedEvent)
         }
 
-        val webSocketClient = KtorWebSocketClient(
-            json = json,
-            negotiationStrategy = NoopClientSessionNegotiationStrategy(),
-            httpClient = client,
-        )
+        val webSocketClient = webSocketClient()
 
         val connectionResult = webSocketClient.openConnection(
             host = TEST_SERVER_HOST,
@@ -107,6 +91,17 @@ class KtorWebSocketClientTest {
             actual = connectionResult.debuggerEventFlow.first(),
         )
     }
+
+    /**
+     * The client under test owns whatever the provider hands it and closes it when the connection
+     * ends, so each connection gets a throwaway client rather than this application's own.
+     */
+    private fun ApplicationTestBuilder.webSocketClient() = KtorWebSocketClient(
+        json = json,
+        negotiationStrategy = NoopClientSessionNegotiationStrategy(),
+        sslConfiguration = JetWhaleSslConfiguration(),
+        httpClientProvider = { createClient { configureWebSocketClient(json) } },
+    )
 
     private fun ApplicationTestBuilder.configureTestServer(
         extraWebSocketSessionHandler: suspend WebSocketServerSession.() -> Unit = {},

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceStopTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceStopTest.kt
@@ -1,0 +1,142 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+import com.kitakkun.jetwhale.agent.sdk.JetWhaleAgentPlugin
+import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
+import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggeeEvent
+import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggerEvent
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val AWAIT_TIMEOUT_MILLIS = 5_000L
+
+/** How long a reconnect is given to (not) happen after the service was stopped. */
+private const val RECONNECT_WINDOW_MILLIS = 500L
+
+/**
+ * A socket client whose connections never end on their own, so the only thing that can take one
+ * down is the service itself.
+ */
+private class FakeSocketClient : JetWhaleSocketClient {
+    val openedConnections: Channel<Unit> = Channel(Channel.UNLIMITED)
+    val closed: CompletableDeferred<Unit> = CompletableDeferred()
+
+    private var debuggerEvents: Channel<JetWhaleDebuggerEvent> = Channel(Channel.UNLIMITED)
+
+    override suspend fun sendDebuggeeEvent(event: JetWhaleDebuggeeEvent) = Unit
+
+    override suspend fun openConnection(host: String, port: Int): JetWhaleConnection {
+        debuggerEvents = Channel(Channel.UNLIMITED)
+        openedConnections.send(Unit)
+        return JetWhaleConnection(
+            negotiationResult = ClientSessionNegotiationResult.Success(availablePluginIds = listOf(PLUGIN_ID)),
+            debuggerEventFlow = debuggerEvents.receiveAsFlow(),
+        )
+    }
+
+    override suspend fun closeConnection() {
+        // Ending the event flow is what a real close does to the collector: a reconnect loop that is
+        // still running would immediately open the next connection.
+        debuggerEvents.close()
+        closed.complete(Unit)
+    }
+}
+
+private const val PLUGIN_ID = "stop-test"
+
+private class RecordingPlugin : JetWhaleAgentPlugin() {
+    override val pluginId: String = PLUGIN_ID
+    override val pluginVersion: String = "1.0.0"
+
+    val prepared: CompletableDeferred<Unit> = CompletableDeferred()
+    val disconnected: CompletableDeferred<Unit> = CompletableDeferred()
+
+    override suspend fun onPrepare() {
+        prepared.complete(Unit)
+    }
+
+    override suspend fun onDisconnected() {
+        disconnected.complete(Unit)
+    }
+}
+
+@OptIn(InternalJetWhaleApi::class)
+class MessagingServiceStopTest {
+    private fun startedService(
+        socketClient: FakeSocketClient,
+        plugin: RecordingPlugin,
+    ): JetWhaleMessagingService = DefaultJetWhaleMessagingService(
+        socketClient = socketClient,
+        pluginService = JetWhaleAgentPluginService(plugins = listOf(plugin)),
+    ).also { it.startService(host = "localhost", port = 1) }
+
+    @Test
+    fun `stopService closes the socket so the host sees the session go away`() = runBlocking {
+        val socketClient = FakeSocketClient()
+        val plugin = RecordingPlugin()
+        val service = startedService(socketClient, plugin)
+
+        withTimeout(AWAIT_TIMEOUT_MILLIS) { plugin.prepared.await() }
+
+        service.stopService()
+
+        withTimeout(AWAIT_TIMEOUT_MILLIS) { socketClient.closed.await() }
+    }
+
+    @Test
+    fun `stopService disconnects the plugins`() = runBlocking {
+        val socketClient = FakeSocketClient()
+        val plugin = RecordingPlugin()
+        val service = startedService(socketClient, plugin)
+
+        withTimeout(AWAIT_TIMEOUT_MILLIS) { plugin.prepared.await() }
+
+        service.stopService()
+
+        withTimeout(AWAIT_TIMEOUT_MILLIS) { plugin.disconnected.await() }
+    }
+
+    @Test
+    fun `stopService leaves no reconnect loop behind`() = runBlocking {
+        val socketClient = FakeSocketClient()
+        val plugin = RecordingPlugin()
+        val service = startedService(socketClient, plugin)
+
+        withTimeout(AWAIT_TIMEOUT_MILLIS) { socketClient.openedConnections.receive() }
+        withTimeout(AWAIT_TIMEOUT_MILLIS) { plugin.prepared.await() }
+
+        service.stopService()
+        withTimeout(AWAIT_TIMEOUT_MILLIS) { socketClient.closed.await() }
+
+        assertNull(
+            withTimeoutOrNull(RECONNECT_WINDOW_MILLIS) { socketClient.openedConnections.receive() },
+            "the stopped service opened another connection",
+        )
+    }
+
+    @Test
+    fun `stopService is idempotent`() = runBlocking {
+        val socketClient = FakeSocketClient()
+        val plugin = RecordingPlugin()
+        val service = startedService(socketClient, plugin)
+
+        withTimeout(AWAIT_TIMEOUT_MILLIS) { socketClient.openedConnections.receive() }
+        withTimeout(AWAIT_TIMEOUT_MILLIS) { plugin.prepared.await() }
+
+        service.stopService()
+        withTimeout(AWAIT_TIMEOUT_MILLIS) { socketClient.closed.await() }
+        service.stopService()
+
+        assertTrue(socketClient.closed.isCompleted)
+        assertNull(
+            withTimeoutOrNull(RECONNECT_WINDOW_MILLIS) { socketClient.openedConnections.receive() },
+            "the second stop restarted the connection loop",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

`startJetWhale` dropped the messaging service it built into a local variable, so **a session could only ever be ended by killing the process**. There was no stop path at any layer — not on `JetWhaleSocketClient`, not on `JetWhaleMessagingService`.

That gap is worth closing on its own merits: an app may want to stop reporting on logout or in a particular build, a mobile process keeps a websocket and a reconnect loop alive for as long as it runs, and tests have no way to clean up between cases.

It also explains the second half of this PR. Nothing ever released the connection's `HttpClient`, because there was no moment at which a connection was known to be over.

## `JetWhaleSession`

```kotlin
public fun startJetWhale(configure: JetWhaleConfigurationScope.() -> Unit): JetWhaleSession
```

`stop()` cancels the reconnect loop, closes the websocket with a normal close reason (without it the host keeps the socket and never sees the debuggee leave) and drops the plugin peers.

**Stopping is terminal**, and documented as such: plugins are bound to the session they were registered with (`bindMessenger` runs once), so a restart would need fresh plugin instances anyway — pretending an instance is reusable would be a trap. Repeated calls are ignored.

### This is a binary-incompatible change

The return type is part of the method descriptor on the JVM, and the klib signature carries it the same way:

```diff
- public static final fun startJetWhale (Lkotlin/jvm/functions/Function1;)V
+ public static final fun startJetWhale (Lkotlin/jvm/functions/Function1;)Lcom/…/JetWhaleSession;
```

An app compiled against an earlier release fails with `NoSuchMethodError` if the dependency is swapped without recompiling. **Source compatibility is unaffected** — every caller in this repository, the docs snippets included, ignores the result and compiles untouched.

Keeping the old signature would have meant a second entry point beside it. That was tried and rejected: two `startJetWhale…` functions differing only in whether they hand back a handle read as near-synonyms at the call site, and the module is in alpha, so converging on one name costs a recompile instead of a permanent split.

## The `HttpClient` leak

`openConnection` built its client into a local:

```kotlin
val client = httpClientProvider(resolvedConfiguration).config { configureHttpClient() }
```

Two clients per attempt, in fact — `config { }` returns a second instance sharing the engine — and neither was reachable afterwards, so neither could be closed. The engine owns a thread pool, so every reconnect attempt piled one up.

**Measured on the pre-fix tree**, 20 failed connection attempts (nothing listening on the target port, i.e. the path the reconnect loop retries):

| | before | after |
|---|---|---|
| clients created | 20 | 20 |
| **still alive afterwards** | **20** | **0** |

Ownership is now explicit, because it is not derivable from the client itself:

```kotlin
internal class ConnectionHttpClient(val client: HttpClient, private val owned: Boolean) {
    fun releaseIfOwned() { if (owned) client.close() }
}
```

The production provider builds a client per connection (owning an engine) and must release it; the test provider borrows one that outlives any connection and must not close it. Release happens on **every** exit path: `closeConnection`, the `catch` in `openConnection`, and the top of the next `openConnection` — a connection that ended on its own never reaches `closeConnection`.

The `config { }` derivative is gone too: the websocket configuration moved into each provider, so the production path constructs exactly one client. The constraint that motivated the per-connection provider is unchanged and now explained at the call site — an `engine { }` block only takes effect during construction, so SSL cannot be applied afterwards, and the trusted CA is only known at connect time.

## Test plan

- [x] `:jetwhale-agent-runtime:jvmTest` (23 tests), `checkLegacyAbi`, `:demo:shared:compileKotlinJvm`, js/wasm compiles, `spotlessCheck` — green
- [x] New `MessagingServiceStopTest` and `KtorWebSocketClientHttpClientLifecycleTest`, mutation-checked:
  - dropping `closeConnection()` / `disconnectAll()` / the connection-job cancel each fails the matching stop test
  - dropping the release in `closeConnection`, in the `catch`, or at the top of `openConnection` each fails its own lifecycle test
  - making the borrowed client be closed anyway fails `releasing a borrowed client leaves it alone`
- [x] Leak reproduced and confirmed fixed by direct measurement (table above), with a throwaway probe rather than a committed test
- [ ] ABI dumps: jvm and klib regenerated. **`api/android/…` is deliberately untouched** — it already predates the app/ssl configuration scopes on `main`, is not regenerated by `updateLegacyAbi` here, and `checkLegacyAbi` is green without it. Worth fixing separately rather than hand-patching a file that is stale for unrelated reasons.