### PR TITLE
fix(host): drop disconnected debug sessions, and tell the user they went

### DIFF
--- a/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
@@ -12,6 +12,8 @@
     <string name="select_app">アプリを選択</string>
     <string name="session_secure_connection">暗号化された接続 (wss)</string>
     <string name="session_local_connection">ローカル接続 (ADB)</string>
+    <string name="session_disconnected_message">%1$s が切断されました</string>
+    <string name="sessions_disconnected_message">%1$d 件のセッションが切断されました</string>
     <string name="initializing">初期化中...</string>
     <string name="unlocking_trust_registry">信頼済みプラグインレジストリを検証中…</string>
     <string name="shutting_down">シャットダウン中...</string>

--- a/jetwhale-host/app/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="select_app">Select App</string>
     <string name="session_secure_connection">Secure connection (wss)</string>
     <string name="session_local_connection">Local connection (ADB)</string>
+    <string name="session_disconnected_message">%1$s disconnected</string>
+    <string name="sessions_disconnected_message">%1$d sessions disconnected</string>
     <string name="initializing">Initializing...</string>
     <string name="unlocking_trust_registry">Unlocking trust registry…</string>
     <string name="shutting_down">Shutting down...</string>

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/JetWhaleToolingScaffold.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/JetWhaleToolingScaffold.kt
@@ -1,12 +1,20 @@
 package com.kitakkun.jetwhale.host.drawer
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.PermanentNavigationDrawer
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.component.ToolingDrawer
 import com.kitakkun.jetwhale.host.model.DebugSession
 import kotlinx.collections.immutable.persistentListOf
@@ -24,6 +32,7 @@ fun ToolingScaffold(
     onClickBringBack: (DrawerPluginItemUiState) -> Unit,
     onSelectSession: (DebugSession) -> Unit,
     onSetPluginEnabled: (pluginId: String, enabled: Boolean) -> Unit,
+    snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
@@ -48,7 +57,17 @@ fun ToolingScaffold(
                 )
             },
             content = {
-                content()
+                // The drawer is not a Scaffold, so the snackbar is overlaid on the content area
+                // only: messages stay clear of the drawer and of any popped-out plugin window.
+                Box(modifier = Modifier.fillMaxSize()) {
+                    content()
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(16.dp),
+                    )
+                }
             },
             modifier = modifier,
         )
@@ -75,6 +94,7 @@ private fun ToolingScaffoldPreview() {
         isPoppedOut = { false },
         onClickBringBack = {},
         onSetPluginEnabled = { _, _ -> },
+        snackbarHostState = remember { SnackbarHostState() },
     ) {
         Text("Hello, World!")
     }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionDropdownMenuItem.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionDropdownMenuItem.kt
@@ -57,13 +57,11 @@ fun SessionSecurityIcon(
 fun SessionDropdownMenuItem(
     displayName: String,
     selected: Boolean,
-    isActive: Boolean,
     transportSecurity: SessionTransportSecurity,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     DropdownMenuItem(
-        enabled = isActive,
         leadingIcon = {
             if (selected) {
                 Icon(
@@ -78,7 +76,8 @@ fun SessionDropdownMenuItem(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 SessionSecurityIcon(transportSecurity)
-                Badge(containerColor = if (isActive) Color.Green else Color.LightGray)
+                // Every listed session is connected, so the badge only ever reads as connected.
+                Badge(containerColor = Color.Green)
             }
         },
         text = { Text(displayName) },

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/SessionSelectorView.kt
@@ -39,10 +39,9 @@ import kotlinx.collections.immutable.ImmutableList
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Two-level session selector. Only active sessions are shown; disconnected sessions are hidden
- * entirely while remaining in the repository. Sessions are grouped by device, and within the
- * selected device the concrete app (session) can be picked. Each entry keeps the transport-security
- * lock indicator so the connection type stays visible per session.
+ * Two-level session selector over the connected sessions. Sessions are grouped by device, and within
+ * the selected device the concrete app (session) can be picked. Each entry keeps the
+ * transport-security lock indicator so the connection type stays visible per session.
  */
 @Composable
 fun SessionSelectorView(
@@ -50,9 +49,8 @@ fun SessionSelectorView(
     sessions: ImmutableList<DebugSession>,
     onSelectSession: (DebugSession) -> Unit,
 ) {
-    val activeSessions = remember(sessions) { sessions.filter { it.isActive } }
-    val devices = remember(activeSessions) {
-        activeSessions.groupBy { it.groupingDeviceId }.entries.toList()
+    val devices = remember(sessions) {
+        sessions.groupBy { it.groupingDeviceId }.entries.toList()
     }
     val selectedDeviceId = selectedSession?.groupingDeviceId
     val appsForSelectedDevice = remember(devices, selectedDeviceId) {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ShrunkToolingDrawerView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ShrunkToolingDrawerView.kt
@@ -101,12 +101,11 @@ fun ShrunkToolingDrawerView(
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
             ) {
-                sessions.filter { it.isActive }.forEach { session ->
+                sessions.forEach { session ->
                     SessionDropdownMenuItem(
                         selected = session.id == selectedSessionId,
-                        isActive = session.isActive,
                         transportSecurity = session.transportSecurity,
-                        displayName = "${session.deviceDisplayName} · ${session.appDisplayName}",
+                        displayName = session.deviceAndAppDisplayName,
                         onClick = {
                             onSelectSession(session)
                             expanded = false

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -26,8 +26,21 @@ sealed interface ToolingScaffoldScreenAction {
 }
 
 sealed interface ToolingScaffoldScreenActionResult {
-    data class SessionClosed(val closedSessionIds: List<String>) : ToolingScaffoldScreenActionResult
+    /** Carries the sessions themselves, since they are gone from the session list by the time this is handled. */
+    data class SessionClosed(val closedSessions: ImmutableList<DebugSession>) : ToolingScaffoldScreenActionResult
     data class SetPluginEnabledFailed(val error: Throwable) : ToolingScaffoldScreenActionResult
+}
+
+/**
+ * The sessions present in [previous] but missing from [current], i.e. the ones that disconnected
+ * since the last session-list update.
+ */
+internal fun closedSessions(
+    previous: List<DebugSession>,
+    current: List<DebugSession>,
+): List<DebugSession> {
+    val currentIds = current.mapTo(mutableSetOf()) { it.id }
+    return previous.filterNot { it.id in currentIds }
 }
 
 @Composable
@@ -75,15 +88,19 @@ fun toolingScaffoldPresenter(
     }
 
     LaunchedEffect(debugSessions) {
-        if (selectedSession?.isActive != true) {
-            selectedSessionId = debugSessions.firstOrNull { it.isActive }?.id.orEmpty()
+        if (selectedSession == null) {
+            selectedSessionId = debugSessions.firstOrNull()?.id.orEmpty()
         }
     }
 
+    // Comparing against the previous session list keeps a disconnect reported exactly once, instead
+    // of re-reporting every session that has ever closed on each session-list update.
+    var knownSessions by remember { mutableStateOf<List<DebugSession>>(emptyList()) }
     LaunchedEffect(debugSessions) {
-        val inactiveSessionIds = debugSessions.filterNot { it.isActive }.map { it.id }
-        if (inactiveSessionIds.isEmpty()) return@LaunchedEffect
-        screenChannel.emit(ToolingScaffoldScreenActionResult.SessionClosed(inactiveSessionIds))
+        val closedSessions = closedSessions(previous = knownSessions, current = debugSessions)
+        knownSessions = debugSessions
+        if (closedSessions.isEmpty()) return@LaunchedEffect
+        screenChannel.emit(ToolingScaffoldScreenActionResult.SessionClosed(closedSessions.toImmutableList()))
     }
 
     ActionEffect(screenChannel) { action ->

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -1,11 +1,18 @@
 package com.kitakkun.jetwhale.host.drawer
 
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import com.kitakkun.jetwhale.host.Res
 import com.kitakkun.jetwhale.host.architecture.ActionResultEffect
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.model.DebugSession
+import com.kitakkun.jetwhale.host.session_disconnected_message
+import com.kitakkun.jetwhale.host.sessions_disconnected_message
+import org.jetbrains.compose.resources.getString
 import soil.query.compose.rememberSubscription
 
 @Composable
@@ -28,11 +35,19 @@ fun ToolingScaffoldRoot(
         state4 = rememberSubscription(screenContext.failedPluginJarPathsSubscriptionKey),
     ) { loadedPlugins, debugSessions, enabledPluginIds, failedJars ->
         val screenChannel = rememberScreenChannel<ToolingScaffoldScreenAction, ToolingScaffoldScreenActionResult>()
+        val snackbarHostState = remember { SnackbarHostState() }
         ActionResultEffect(screenChannel) { result ->
             when (result) {
-                // No message sink yet; results are routed through the channel so a future
-                // Root-side handler (e.g. a Snackbar) can surface them during the rollout.
-                is ToolingScaffoldScreenActionResult.SessionClosed -> Unit
+                is ToolingScaffoldScreenActionResult.SessionClosed -> {
+                    // A single disconnect names the session; a simultaneous batch (the server
+                    // stopping, say) is collapsed into a count so the queue stays short enough to
+                    // read. showSnackbar suspends until dismissed, which serializes the queue.
+                    val closedSessions = result.closedSessions
+                    val message = closedSessions.singleOrNull()
+                        ?.let { getString(Res.string.session_disconnected_message, it.deviceAndAppDisplayName) }
+                        ?: getString(Res.string.sessions_disconnected_message, closedSessions.size)
+                    snackbarHostState.showSnackbar(message = message, duration = SnackbarDuration.Short)
+                }
 
                 is ToolingScaffoldScreenActionResult.SetPluginEnabledFailed -> Unit
             }
@@ -81,6 +96,7 @@ fun ToolingScaffoldRoot(
             onSetPluginEnabled = { pluginId, enabled ->
                 screenChannel.send(ToolingScaffoldScreenAction.SetPluginEnabled(pluginId, enabled))
             },
+            snackbarHostState = snackbarHostState,
             content = content,
         )
     }

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/drawer/ClosedSessionsTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/drawer/ClosedSessionsTest.kt
@@ -1,0 +1,60 @@
+package com.kitakkun.jetwhale.host.drawer
+
+import com.kitakkun.jetwhale.host.model.DebugSession
+import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ClosedSessionsTest {
+    @Test
+    fun `a session that disappeared is reported as closed`() {
+        val closed = closedSessions(
+            previous = listOf(session("session-1"), session("session-2")),
+            current = listOf(session("session-2")),
+        )
+
+        assertEquals(listOf("session-1"), closed.map { it.id })
+    }
+
+    /**
+     * The disconnect must be announced once. Re-reporting on every later session-list update is what
+     * made a long-gone session pop up again each time another session connected or closed.
+     */
+    @Test
+    fun `a session already gone from the previous list is not reported again`() {
+        val closed = closedSessions(
+            previous = listOf(session("session-2")),
+            current = listOf(session("session-2"), session("session-3")),
+        )
+
+        assertEquals(emptyList(), closed)
+    }
+
+    @Test
+    fun `sessions that disappeared together are reported together`() {
+        val closed = closedSessions(
+            previous = listOf(session("session-1"), session("session-2")),
+            current = emptyList(),
+        )
+
+        assertEquals(listOf("session-1", "session-2"), closed.map { it.id })
+    }
+
+    @Test
+    fun `the first session list reports nothing as closed`() {
+        val closed = closedSessions(
+            previous = emptyList(),
+            current = listOf(session("session-1")),
+        )
+
+        assertEquals(emptyList(), closed)
+    }
+
+    private fun session(id: String) = DebugSession(
+        id = id,
+        name = id,
+        transportSecurity = SessionTransportSecurity.PLAINTEXT,
+        installedPlugins = persistentListOf(),
+    )
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
@@ -199,15 +199,15 @@ class DefaultPluginHotReloadService(
     }
 
     /**
-     * Recreates plugin instances for the active sessions that have the plugin installed, so that the
+     * Recreates plugin instances for the connected sessions that have the plugin installed, so that the
      * UI can immediately render the freshly loaded code. Only runs when the plugin is enabled.
      */
     private suspend fun reinitializeInstances(pluginId: String) {
         if (!enabledPluginsRepository.isPluginEnabled(pluginId)) return
 
         // The target-session rule (host-only vs agent-backed) lives in the reconciliation service.
-        val activeSessions = debugSessionRepository.debugSessionsFlow.first().filter { it.isActive }
-        val activeSessionIds = reconciliationService.targetSessionIds(pluginId, activeSessions)
+        val connectedSessions = debugSessionRepository.debugSessionsFlow.first()
+        val activeSessionIds = reconciliationService.targetSessionIds(pluginId, connectedSessions)
 
         if (activeSessionIds.isEmpty()) return
 

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationService.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 @Inject
@@ -39,25 +38,25 @@ class DefaultPluginSessionReconciliationService(
     }
 
     override fun reconciliationEvents(): Flow<PluginReconciliationEvent> = channelFlow {
-        // Enable/session reconciliation: whenever the enabled set or the active sessions change,
+        // Enable/session reconciliation: whenever the enabled set or the connected sessions change,
         // (re)initialize instances for the sessions each enabled plugin should target. Instances are
         // also (re)initialized as sessions come and go because this reacts to the session flow too.
         launch {
             combine(
                 enabledPluginsRepository.enabledPluginIdsFlow,
-                sessionRepository.debugSessionsFlow.map { sessions -> sessions.filter { it.isActive } },
+                sessionRepository.debugSessionsFlow,
                 // Loading a plugin is a reconciliation trigger in its own right. The enabled set only
                 // ever grows (nothing removes an id when a jar is deleted or its trust revoked), so
                 // installing a jar whose pluginId is already enabled changes neither of the flows
                 // above — without this the freshly loaded plugin would never get an instance, and
                 // opening it would fail until the next enable toggle, session, or app restart.
                 pluginFactoryRepository.loadedPluginsFlow,
-            ) { enabledPluginIds, activeSessions, _ -> enabledPluginIds to activeSessions }
-                .collect { (enabledPluginIds, activeSessions) ->
+            ) { enabledPluginIds, connectedSessions, _ -> enabledPluginIds to connectedSessions }
+                .collect { (enabledPluginIds, connectedSessions) ->
                     enabledPluginIds.forEach { pluginId ->
                         val activatedSessionIds = pluginInstanceService.initializePluginInstancesForSessionsIfNeeded(
                             pluginId = pluginId,
-                            sessionIds = targetSessionIds(pluginId, activeSessions),
+                            sessionIds = targetSessionIds(pluginId, connectedSessions),
                         )
                         // Only newly-initialized sessions are notified (some may already have the
                         // instance from an earlier reconciliation), and only for agent-backed plugins

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultDebugWebSocketServer.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultDebugWebSocketServer.kt
@@ -52,7 +52,7 @@ class DefaultDebugWebSocketServer(
         serverMonitoringJob?.cancel()
         serverMonitoringJob = null
         ktorWebSocketServer.stop()
-        sessionRepository.markAllSessionsInactive()
+        sessionRepository.unregisterAllDebugSessions()
         pluginInstanceService.clearAllPluginInstances()
         mutableServerStoppedFlow.emit(Unit)
     }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/session/DefaultDebugSessionRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/session/DefaultDebugSessionRepository.kt
@@ -40,7 +40,6 @@ class DefaultDebugSessionRepository : DebugSessionRepository {
                     DebugSession(
                         id = sessionId,
                         name = sessionName,
-                        isActive = true,
                         transportSecurity = transportSecurity,
                         installedPlugins = installedPlugins.toImmutableList(),
                         appName = appMetadata.appName,
@@ -55,19 +54,11 @@ class DefaultDebugSessionRepository : DebugSessionRepository {
 
     override fun unregisterDebugSession(sessionId: String) {
         mutableDebugSessions.update { sessions ->
-            sessions.toMutableMap().apply {
-                this[sessionId]?.let {
-                    this[sessionId] = it.copy(isActive = false)
-                }
-            }.toPersistentMap()
+            sessions.toMutableMap().apply { remove(sessionId) }.toPersistentMap()
         }
     }
 
-    override fun markAllSessionsInactive() {
-        mutableDebugSessions.update { sessions ->
-            sessions.mapValues { (_, session) ->
-                session.copy(isActive = false)
-            }.toPersistentMap()
-        }
+    override fun unregisterAllDebugSessions() {
+        mutableDebugSessions.update { persistentMapOf() }
     }
 }

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationServiceTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationServiceTest.kt
@@ -33,10 +33,9 @@ class DefaultPluginSessionReconciliationServiceTest {
     private val pluginId = "com.example.plugin"
     private val sessionId = "session-1"
 
-    private val activeSession = DebugSession(
+    private val connectedSession = DebugSession(
         id = sessionId,
         name = "test",
-        isActive = true,
         transportSecurity = SessionTransportSecurity.LOOPBACK,
         installedPlugins = persistentListOf(JetWhalePluginInfo(pluginId, "1.0.0")),
     )
@@ -63,7 +62,7 @@ class DefaultPluginSessionReconciliationServiceTest {
         val factoryRepository = FakePluginFactoryRepository()
         val instanceService = FakePluginInstanceService(factoryRepository)
         val service = DefaultPluginSessionReconciliationService(
-            sessionRepository = FakeDebugSessionRepository(MutableStateFlow(persistentListOf(activeSession))),
+            sessionRepository = FakeDebugSessionRepository(MutableStateFlow(persistentListOf(connectedSession))),
             enabledPluginsRepository = FakeEnabledPluginsRepository(setOf(pluginId)),
             pluginFactoryRepository = factoryRepository,
             pluginInstanceService = instanceService,
@@ -93,7 +92,7 @@ class DefaultPluginSessionReconciliationServiceTest {
         ) = Unit
 
         override fun unregisterDebugSession(sessionId: String) = Unit
-        override fun markAllSessionsInactive() = Unit
+        override fun unregisterAllDebugSessions() = Unit
     }
 
     private class FakeEnabledPluginsRepository(enabled: Set<String>) : EnabledPluginsRepository {

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/session/DefaultDebugSessionRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/session/DefaultDebugSessionRepositoryTest.kt
@@ -1,0 +1,68 @@
+package com.kitakkun.jetwhale.host.data.session
+
+import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
+import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultDebugSessionRepositoryTest {
+    @Test
+    fun `registered sessions are exposed through the flow`() = runBlocking {
+        val repository = DefaultDebugSessionRepository()
+
+        repository.register("session-1")
+        repository.register("session-2")
+
+        assertEquals(setOf("session-1", "session-2"), repository.sessionIds())
+    }
+
+    /**
+     * Reconnecting always yields a fresh session id, so keeping disconnected sessions would make the
+     * repository grow with every connect/disconnect cycle for the lifetime of the host process.
+     */
+    @Test
+    fun `unregistering a session drops it instead of keeping it as history`() = runBlocking {
+        val repository = DefaultDebugSessionRepository()
+
+        repository.register("session-1")
+        repository.register("session-2")
+        repository.unregisterDebugSession("session-1")
+
+        assertEquals(setOf("session-2"), repository.sessionIds())
+    }
+
+    @Test
+    fun `unregistering an unknown session leaves the known ones untouched`() = runBlocking {
+        val repository = DefaultDebugSessionRepository()
+
+        repository.register("session-1")
+        repository.unregisterDebugSession("session-unknown")
+
+        assertEquals(setOf("session-1"), repository.sessionIds())
+    }
+
+    @Test
+    fun `unregistering all sessions empties the repository`() = runBlocking {
+        val repository = DefaultDebugSessionRepository()
+
+        repository.register("session-1")
+        repository.register("session-2")
+        repository.unregisterAllDebugSessions()
+
+        assertEquals(emptySet(), repository.sessionIds())
+    }
+
+    private suspend fun DefaultDebugSessionRepository.register(sessionId: String) {
+        registerDebugSession(
+            sessionId = sessionId,
+            sessionName = sessionId,
+            transportSecurity = SessionTransportSecurity.PLAINTEXT,
+            installedPlugins = emptyList(),
+            appMetadata = JetWhaleAppMetadata(),
+        )
+    }
+
+    private suspend fun DefaultDebugSessionRepository.sessionIds(): Set<String> = debugSessionsFlow.first().mapTo(mutableSetOf()) { it.id }
+}

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/SessionTools.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/SessionTools.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
 /**
- * Returns a JSON string listing all currently known debug sessions.
+ * Returns a JSON string listing the debug sessions currently connected to the host.
  */
 suspend fun listSessions(debugSessionRepository: DebugSessionRepository): String {
     val sessions = debugSessionRepository.debugSessionsFlow.firstOrNull() ?: return "[]"
@@ -64,7 +64,6 @@ suspend fun listPlugins(
 private fun DebugSession.toSessionInfo() = SessionInfo(
     sessionId = id,
     sessionName = name,
-    isActive = isActive,
     installedPlugins = installedPlugins.map { it.pluginId },
     appName = appName,
     deviceId = deviceId,
@@ -79,7 +78,7 @@ class ListSessionsMcpTool(
     override fun register(server: Server) {
         server.addTool(
             name = "jetwhale.listSessions",
-            description = "Lists all active debug sessions currently connected to JetWhale.",
+            description = "Lists the debug sessions currently connected to JetWhale.",
             inputSchema = ToolSchema(),
         ) { _ ->
             val json = listSessions(debugSessionRepository)
@@ -121,7 +120,6 @@ class ListPluginsMcpTool(
 data class SessionInfo(
     val sessionId: String,
     val sessionName: String?,
-    val isActive: Boolean,
     val installedPlugins: List<String>,
     val appName: String? = null,
     val deviceId: String? = null,

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/SessionToolsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/SessionToolsTest.kt
@@ -33,7 +33,6 @@ class SessionToolsTest {
         val session = DebugSession(
             id = "session-id-123",
             name = "TestDevice",
-            isActive = true,
             transportSecurity = SessionTransportSecurity.PLAINTEXT,
             installedPlugins = persistentListOf(JetWhalePluginInfo("com.example.plugin", "1.0")),
         )
@@ -41,24 +40,7 @@ class SessionToolsTest {
             every { debugSessionsFlow } returns flowOf(persistentListOf(session))
         }
 
-        val expected = """[{"sessionId":"session-id-123","sessionName":"TestDevice","isActive":true,"installedPlugins":["com.example.plugin"]}]"""
-        assertEquals(expected, listSessions(repo))
-    }
-
-    @Test
-    fun `listSessions reflects isActive = false correctly`() = runBlocking {
-        val session = DebugSession(
-            id = "session-id-456",
-            name = "InactiveDevice",
-            isActive = false,
-            transportSecurity = SessionTransportSecurity.PLAINTEXT,
-            installedPlugins = persistentListOf(),
-        )
-        val repo = mock<DebugSessionRepository> {
-            every { debugSessionsFlow } returns flowOf(persistentListOf(session))
-        }
-
-        val expected = """[{"sessionId":"session-id-456","sessionName":"InactiveDevice","isActive":false,"installedPlugins":[]}]"""
+        val expected = """[{"sessionId":"session-id-123","sessionName":"TestDevice","installedPlugins":["com.example.plugin"]}]"""
         assertEquals(expected, listSessions(repo))
     }
 
@@ -77,7 +59,6 @@ class SessionToolsTest {
         val session = DebugSession(
             id = "session-abc",
             name = "Device",
-            isActive = true,
             transportSecurity = SessionTransportSecurity.PLAINTEXT,
             installedPlugins = persistentListOf(JetWhalePluginInfo("com.example.plugin", "1.0")),
         )

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugSession.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugSession.kt
@@ -6,7 +6,6 @@ import kotlinx.collections.immutable.ImmutableList
 data class DebugSession(
     val id: String,
     val name: String?,
-    val isActive: Boolean,
     /** Security of the transport carrying this session. */
     val transportSecurity: SessionTransportSecurity,
     val installedPlugins: ImmutableList<JetWhalePluginInfo>,
@@ -39,4 +38,8 @@ data class DebugSession(
      */
     val appDisplayName: String
         get() = appName ?: displayName
+
+    /** Device and app labels joined, for places that identify a session on a single line. */
+    val deviceAndAppDisplayName: String
+        get() = "$deviceDisplayName · $appDisplayName"
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugSessionRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugSessionRepository.kt
@@ -5,6 +5,11 @@ import com.kitakkun.jetwhale.protocol.negotiation.JetWhalePluginInfo
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Holds the debug sessions currently connected to the host. A session lives only as long as its
+ * connection does: disconnecting drops it instead of keeping it as history, so nothing here grows
+ * with the number of connect/disconnect cycles.
+ */
 interface DebugSessionRepository {
     val debugSessionsFlow: Flow<ImmutableList<DebugSession>>
 
@@ -16,6 +21,9 @@ interface DebugSessionRepository {
         appMetadata: JetWhaleAppMetadata,
     )
 
+    /** Drops the session with [sessionId]. Unknown ids are ignored. */
     fun unregisterDebugSession(sessionId: String)
-    fun markAllSessionsInactive()
+
+    /** Drops every session, for when the server stops and no agent can still be attached. */
+    fun unregisterAllDebugSessions()
 }


### PR DESCRIPTION
## Summary

`DebugSessionRepository.unregisterDebugSession` never unregistered anything. It copied the session with `isActive = false` and left it in the map — and **nothing in the codebase ever removes an entry**. Sessions therefore accumulated for the lifetime of the host process, one more on every reconnect, since a reconnect gets a fresh `sessionId`.

That was invisible in the UI but not everywhere:

- Every consumer already filtered them out — `SessionSelectorView`, `ShrunkToolingDrawerView`, `DefaultPluginSessionReconciliationService`, `DefaultPluginHotReloadService` all did `filter { it.isActive }`. Nobody wanted this data.
- **`jetwhale.listPlugins` and `jetwhale.listSessions` did not filter**, so an agent kept seeing sessions that had hung up. The tool's own description says *"Lists the debug sessions currently connected"*, and `docs/guide/mcp-server.md` says "connected" too.

Treated as a leak rather than deliberate history: no comment or KDoc ever explained retention, and `markAllSessionsInactive()` — the only other writer — arrived in `fd5c1f59 "fix: release resources when the server stops"`, a resource-release context, not a history one.

Removal is safe because the teardown that matters hangs off `DebugWebSocketServer.sessionClosedFlow`, not off the session list: popout windows, compose scenes and plugin instances are all disposed from there.

## Follow-on: `isActive` is gone

Once sessions are removed on disconnect, the flag is always `true`. Rather than leave a field that can only hold one value — and four `filter { it.isActive }` calls that can never drop anything — `DebugSession.isActive` is deleted along with the filters.

**Two consequences worth a decision, not just a review:**

1. **`jetwhale.listSessions` no longer emits `isActive`.** That is an external contract for agents. Dropping a field that is constant is defensible, but keeping `"isActive": true` for compatibility is equally defensible. Easy to put back.
2. `SessionDropdownMenuItem`'s connection badge is now always green (`enabled = isActive` went with it).

## Telling the user

`SessionClosed` was emitted with **every** inactive session on **every** session-list update, and swallowed by the root (`-> Unit`) with a comment promising a future snackbar. Combined with the leak above, wiring a snackbar to it as-is would have re-announced every session that had ever closed.

Now a pure `closedSessions(previous, current)` diffs against the previous list, so a disconnect is reported exactly once, and `ToolingScaffold` overlays a `SnackbarHost` that surfaces it. One session names the device and app; several collapse into a count — `showSnackbar` suspends until dismissal, so announcing them one by one would hold the window for seconds when the server stops. Strings added to both `values/` and `values-ja/`.

## Test plan

- [x] `:jetwhale-host:app:test`, `:jetwhale-host:core:data:test`, `:jetwhale-host:core:mcp:test`, `:jetwhale-host:app:compileKotlin`, `spotlessCheck` — green on the rebased branch
- [x] New `DefaultDebugSessionRepositoryTest` (register / unregister / unknown id / unregister-all) and `ClosedSessionsTest` (only the vanished ones, no re-announcing, simultaneous closes, first update)
- [x] Mutation-checked, each detected then reverted:
  - `unregisterDebugSession` → no-op: `unregistering a session drops it instead of keeping it as history` fails
  - `unregisterAllDebugSessions` → no-op: `unregistering all sessions empties the repository` fails
  - `closedSessions` → `return previous`: both the "reported" and the "not reported again" tests fail
- [ ] **The snackbar itself is not covered.** The app module has no Compose UI test setup, so the tests cover the dedup logic only; the singular/plural message choice is inline in `ToolingScaffoldRoot` and untested.
- [ ] **Not verified on a running host.** In particular the ja/en switch: `ActionResultEffect`'s lambda is not `@Composable`, so the message is resolved with the suspend `getString`, which goes through `Locale.getDefault()` and relies on `AppEnvironment`/`LocalAppLocale` calling `Locale.setDefault` (the CMP-standard pattern already used here).