### PR TITLE
feat(qa-agent): hold several apps in one process, disconnectable one by one

### DIFF
--- a/.claude/skills/plugin-qa/SKILL.md
+++ b/.claude/skills/plugin-qa/SKILL.md
@@ -87,6 +87,7 @@ the two situations:
 |---|---|
 | `"activated": false` | the host has **not enabled this plugin id** — waiting will not help. Enable it with `jetwhale.setPluginEnabled` (§4), or check the id |
 | `"activated": true, "ready": false` | connected, still preparing — keep polling |
+| both false for one app under `apps` | that app was disconnected (see below) — it will never come back |
 
 **Driving the plugin.** `/send` and `/request` speak the messenger's raw layer, so the agent needs no
 compile-time knowledge of the plugin. `messageType` is the payload class's `serialName` (its
@@ -104,6 +105,30 @@ curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' -d '{
 `serialName` wrong and the host reports no registered handler — check it against the plugin's
 protocol module rather than guessing.
 
+**Several apps at once.** A session is *one app*, and the host groups sessions by device into a
+two-level selector (pick a device, then an app under it). One `--app` per app gives you exactly that
+shape from a single process — same device, several apps — which is what you need to check the
+selector, per-session state isolation, and anything that must not leak between apps:
+
+```bash
+-PjetwhaleQaAgentArgs="--app checkout --app catalog --plugin com.example.myplugin"
+```
+
+Every app registers the same `--plugin` set but its own instances, so `checkout` and `catalog` are
+independent sessions. Without `--app` you get the single `qa-agent` app as before, and every `app`
+field below can be omitted; with several, calls that leave it out are refused rather than guessed at.
+
+```bash
+curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' \
+  -d '{"app":"checkout","pluginId":"com.example.myplugin","messageType":"…","payload":{}}'
+```
+
+**Disconnecting one app.** `POST /disconnect {"app":"checkout"}` gives up that app's session alone
+and leaves the others connected — the way to exercise what the host does when a debuggee goes away
+(does the selector fall back, does the scene survive, is per-session state kept or dropped?) without
+killing the process. It is one-way: a stopped session cannot be revived, so restart the agent when
+you need the app back. `POST /shutdown` still stops everything.
+
 **This is send-only.** Inbound handlers resolve their serializer from a reified type parameter
 (`onEvent<E>` / `onRequest<REQ, R>`), so there is no raw shape to register a catch-all against: a
 plugin whose flow depends on the *host* requesting the agent (the Network Inspector's mock replies,
@@ -111,12 +136,16 @@ for one) cannot be answered from here. Drive those from the plugin's own MCP too
 
 - Use **`127.0.0.1`, not `localhost`** — the control API binds loopback IPv4 only, and `localhost`
   can resolve to `::1` first and get connection-refused.
-- It shows up as `appName: qa-agent` / `QA Agent (headless)`, so it is never mistaken for a real
-  device. Its `sessionId` is its own — mock rules and transactions are per session.
-- `GET /plugins` lists what it is impersonating, with each one's `activated` / `ready` state;
+- It shows up under `QA Agent (headless)`, with `appName` per `--app` (`qa-agent` by default), so it
+  is never mistaken for a real device. Each app's `sessionId` is its own — mock rules and
+  transactions are per session.
+- `GET /plugins` lists what it is impersonating, with each one's `activated` / `ready` state
+  aggregated over the still-connected apps plus an `apps` breakdown; `GET /health` carries the same
+  split for the apps themselves, and `ready` there means *every connected app* is ready.
   `POST /shutdown` stops it.
 - `POST /fire` (`{"method":"GET","url":"…"}`) injects real HTTP traffic for the bundled Network
-  Inspector — the one plugin-specific shortcut, and it needs no `--plugin`.
+  Inspector — the one plugin-specific shortcut, and it needs no `--plugin`. The client is
+  instrumented per app, so the traffic is recorded against the app you addressed.
 - On startup the agent logs a failed plain-HTTP CA fetch followed by a successful HTTPS one. That
   is the trust-on-first-use probe, not an error.
 

--- a/tools/qa-agent/build.gradle.kts
+++ b/tools/qa-agent/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
     implementation(libs.ktorServerNetty)
     implementation(libs.ktorServerContentNegotiation)
     implementation(libs.ktorSerializationKotlinxJson)
+
+    testImplementation(libs.kotlinTest)
 }
 
 // Published so plugin authors outside this repository can run it — `runJetWhaleQaAgent` in the

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
@@ -211,6 +211,13 @@ fun main(args: Array<String>) {
                     call.respond(HttpStatusCode.BadRequest, unknownPluginError(spec.pluginId, app.wirePluginsById.keys))
                     return@post
                 }
+                // Refuse before touching the messenger: stop() returns once teardown is scheduled, so
+                // a send here can still succeed for a moment and report an app as reachable after it
+                // was given up. Timing-dependent answers are the last thing a QA run needs.
+                if (!app.isConnected) {
+                    call.respond(SendResponse(sent = false, hint = disconnectedAppHint(app.name)))
+                    return@post
+                }
                 try {
                     val sent = plugin.send(spec.messageType, spec.payload.toString(), spec.policy)
                     val hint = if (sent) {
@@ -242,6 +249,10 @@ fun main(args: Array<String>) {
                 val app = call.resolveApp(apps, spec.app) ?: return@post
                 val plugin = app.wirePluginsById[spec.pluginId] ?: run {
                     call.respond(HttpStatusCode.BadRequest, unknownPluginError(spec.pluginId, app.wirePluginsById.keys))
+                    return@post
+                }
+                if (!app.isConnected) {
+                    call.respond(HttpStatusCode.OK, ErrorResponse(disconnectedAppHint(app.name)))
                     return@post
                 }
                 try {

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/Main.kt
@@ -1,12 +1,6 @@
 package com.kitakkun.jetwhale.tools.qaagent
 
-import com.kitakkun.jetwhale.agent.runtime.KtorLogLevel
-import com.kitakkun.jetwhale.agent.runtime.LogLevel
-import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 import com.kitakkun.jetwhale.agent.sdk.messaging.OfflineSendPolicy
-import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
-import com.kitakkun.jetwhale.plugins.network.agent.ktor.ktorClientPlugin
-import io.ktor.client.HttpClient
 import io.ktor.client.request.request
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -15,6 +9,7 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.install
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
@@ -47,25 +42,31 @@ import kotlin.time.Duration.Companion.milliseconds
  * `/fire`, which injects HTTP traffic for the bundled Network Inspector, is the one plugin-specific
  * convenience on top.
  *
+ * One process can hold **several apps** — one session each, all under the same device, which is how
+ * the host groups them. Every control call takes an optional `app`; with a single app it can be left
+ * out. `/disconnect` gives one app's session up on its own, which is how the host's disconnect
+ * handling gets exercised without stopping the process.
+ *
  * The control API binds loopback IPv4 only, so address it as `127.0.0.1`: `localhost` may resolve to
  * `::1` first and be refused.
  *
  * ```
- * ./gradlew :tools:qa-agent:run --args="--plugin com.example.myplugin"
+ * ./gradlew :tools:qa-agent:run --args="--app checkout --app catalog --plugin com.example.myplugin"
  *
  * curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' -d '{
+ *   "app": "checkout",
  *   "pluginId": "com.example.myplugin",
  *   "messageType": "com.example.myplugin.protocol.ItemAdded",
  *   "payload": {"id": 1, "label": "hello"}
  * }'
  * ```
  */
-private const val DEFAULT_CONTROL_PORT = 7100
-private const val DEFAULT_HOST_PORT = 5443
 private const val BODY_PREVIEW_LIMIT = 2000
 
+/** @param app which app's session to act on. Optional while only one app is running. */
 @Serializable
 private data class FireRequest(
+    val app: String? = null,
     val url: String,
     val method: String = "GET",
     val headers: Map<String, String> = emptyMap(),
@@ -80,8 +81,10 @@ private data class FireResponse(
     val bodyPreview: String,
 )
 
+/** @param app which app's session to send from. Optional while only one app is running. */
 @Serializable
 private data class SendRequest(
+    val app: String? = null,
     val pluginId: String,
     val messageType: String,
     val payload: JsonElement,
@@ -93,8 +96,10 @@ private data class SendRequest(
 @Serializable
 private data class SendResponse(val sent: Boolean, val hint: String? = null)
 
+/** @param app which app's session to request from. Optional while only one app is running. */
 @Serializable
 private data class RequestMessage(
+    val app: String? = null,
     val pluginId: String,
     val messageType: String,
     val payload: JsonElement,
@@ -107,144 +112,88 @@ private data class RequestResponse(
     val reply: JsonElement,
 )
 
+/** @param app which app to disconnect. Optional while only one app is running. */
+@Serializable
+private data class DisconnectRequest(val app: String? = null)
+
+/** @param disconnected false when that app had already given its session up. */
+@Serializable
+private data class DisconnectResponse(val app: String, val disconnected: Boolean)
+
 @Serializable
 private data class ErrorResponse(val error: String)
 
-/** @param ready whether every impersonated plugin can reach the host right now. */
-@Serializable
-private data class HealthResponse(val status: String, val ready: Boolean)
-
 /**
- * @param activated the host enabled this plugin id. False means it is disabled there, and waiting
- *   will not help.
- * @param ready a message sent now would reach the host.
+ * @param ready whether every still-connected app can reach the host right now. False once every app
+ *   has been disconnected: nothing is left to drive.
+ * @param apps per-app breakdown, so a run with several apps can tell which one is holding things up.
  */
 @Serializable
-private data class PluginStatus(val version: String, val activated: Boolean, val ready: Boolean)
-
-/**
- * What the agent impersonates and where it connects.
- *
- * @param plugins plugin ids to register a [WireLevelQaPlugin] for, each with the version to report.
- */
-private data class QaAgentOptions(
-    val plugins: Map<String, String>,
-    val hostName: String,
-    val hostPort: Int,
-    val controlPort: Int,
+private data class HealthResponse(
+    val status: String,
+    val ready: Boolean,
+    val apps: Map<String, AppHealth>,
 )
 
-private const val DEFAULT_PLUGIN_VERSION = "1.0.0"
+/** @param connected false once this app gave its session up via `/disconnect`. */
+@Serializable
+private data class AppHealth(val connected: Boolean, val ready: Boolean)
 
-private val usage = """
-    Usage: qa-agent [options]
+/**
+ * @param activated the host enabled this plugin id in every connected app. False means it is
+ *   disabled there, and waiting will not help.
+ * @param ready a message sent now would reach the host from every connected app.
+ * @param apps the same two flags per app, for a run holding more than one.
+ */
+@Serializable
+private data class PluginStatus(
+    val version: String,
+    val activated: Boolean,
+    val ready: Boolean,
+    val apps: Map<String, AppPluginStatus>,
+)
 
-      --plugin <id>[@<version>]  Register a raw-messaging plugin under this id, so /send and
-                                 /request can drive its host counterpart. Repeatable.
-                                 Version defaults to $DEFAULT_PLUGIN_VERSION.
-      --host <name>              JetWhale host to connect to (default: localhost).
-      --port <n>                 Host debug port (default: $DEFAULT_HOST_PORT).
-      --control-port <n>         Port for this agent's own control API (default: $DEFAULT_CONTROL_PORT).
-""".trimIndent()
-
-private fun parseArgs(args: Array<String>): QaAgentOptions {
-    val plugins = mutableMapOf<String, String>()
-    var hostName = "localhost"
-    var hostPort = DEFAULT_HOST_PORT
-    var controlPort = DEFAULT_CONTROL_PORT
-
-    fun valueOf(index: Int, name: String): String = args.getOrNull(index) ?: error("$name requires a value.\n\n$usage")
-
-    fun intValueOf(index: Int, name: String): Int = valueOf(index, name).toIntOrNull() ?: error("$name requires a number.\n\n$usage")
-
-    var i = 0
-    while (i < args.size) {
-        when (val arg = args[i]) {
-            "--plugin" -> {
-                val (id, version) = valueOf(++i, arg).split("@", limit = 2).let {
-                    it[0] to (it.getOrNull(1) ?: DEFAULT_PLUGIN_VERSION)
-                }
-                plugins[id] = version
-            }
-
-            "--host" -> hostName = valueOf(++i, arg)
-
-            "--port" -> hostPort = intValueOf(++i, arg)
-
-            "--control-port" -> controlPort = intValueOf(++i, arg)
-
-            "--help", "-h" -> {
-                println(usage)
-                exitProcess(0)
-            }
-
-            else -> error("Unknown option: $arg\n\n$usage")
-        }
-        i++
-    }
-
-    return QaAgentOptions(plugins, hostName, hostPort, controlPort)
-}
+@Serializable
+private data class AppPluginStatus(val activated: Boolean, val ready: Boolean)
 
 fun main(args: Array<String>) {
-    val options = parseArgs(args)
-
-    val networkAgentPlugin = JetWhaleNetworkAgentPlugin()
-    val wirePlugins = options.plugins.map { (id, version) -> WireLevelQaPlugin(id, version) }
-
-    startJetWhale {
-        app {
-            // Make this session obvious in jetwhale.listSessions so it is never mistaken for a
-            // real device someone is debugging.
-            appName = "qa-agent"
-            deviceName = "QA Agent (headless)"
-            deviceId = "jetwhale-qa-agent"
-        }
-        connection {
-            host = options.hostName
-            port = options.hostPort
-            ssl {
-                trustServerCertificate()
-            }
-        }
-        logging {
-            enabled = true
-            logLevel = LogLevel.INFO
-            ktorLogLevel = KtorLogLevel.NONE
-        }
-        plugins {
-            register(networkAgentPlugin)
-            wirePlugins.forEach { register(it) }
-        }
+    val options = try {
+        parseArgs(args)
+    } catch (_: HelpRequestedException) {
+        println(usage)
+        exitProcess(0)
     }
 
-    val wirePluginsById = wirePlugins.associateBy { it.pluginId }
-
-    val client = HttpClient {
-        install(networkAgentPlugin.ktorClientPlugin())
-    }
+    val apps = options.apps.associateWith { name -> startQaApp(name, options) }
 
     val server = embeddedServer(Netty, host = "127.0.0.1", port = options.controlPort) {
         install(ContentNegotiation) { json() }
         routing {
             get("/health") {
                 // `ready` is what a caller must poll before sending: the control API answers long
-                // before the debug session is up, and a send in that window is silently dropped.
+                // before the debug sessions are up, and a send in that window is silently dropped.
+                val connected = apps.values.filter { it.isConnected }
                 call.respond(
                     HealthResponse(
                         status = "ok",
-                        ready = wirePluginsById.values.all { it.isReady },
+                        ready = connected.isNotEmpty() && connected.all { it.isReady },
+                        apps = apps.mapValues { (_, app) -> AppHealth(connected = app.isConnected, ready = app.isReady) },
                     ),
                 )
             }
 
             get("/plugins") {
                 call.respond(
-                    wirePluginsById.mapValues { (_, plugin) ->
+                    // Every app registers the same plugin ids, so the plugin stays the top-level key
+                    // and a single-app run reads exactly as it did before there were several.
+                    options.plugins.mapValues { (pluginId, version) ->
+                        val perApp = apps.mapValues { (_, app) -> app.pluginStatus(pluginId) }
+                        val connected = perApp.filterKeys { apps.getValue(it).isConnected }.values
                         PluginStatus(
-                            version = plugin.pluginVersion,
-                            activated = plugin.isActivated,
-                            ready = plugin.isReady,
+                            version = version,
+                            activated = connected.isNotEmpty() && connected.all { it.activated },
+                            ready = connected.isNotEmpty() && connected.all { it.ready },
+                            apps = perApp,
                         )
                     },
                 )
@@ -257,13 +206,25 @@ fun main(args: Array<String>) {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse("Malformed request: ${e.message}"))
                     return@post
                 }
-                val plugin = wirePluginsById[spec.pluginId] ?: run {
-                    call.respond(HttpStatusCode.BadRequest, unknownPluginError(spec.pluginId, wirePluginsById.keys))
+                val app = call.resolveApp(apps, spec.app) ?: return@post
+                val plugin = app.wirePluginsById[spec.pluginId] ?: run {
+                    call.respond(HttpStatusCode.BadRequest, unknownPluginError(spec.pluginId, app.wirePluginsById.keys))
                     return@post
                 }
                 try {
                     val sent = plugin.send(spec.messageType, spec.payload.toString(), spec.policy)
-                    call.respond(SendResponse(sent = sent, hint = if (sent) null else dropHint(plugin)))
+                    val hint = if (sent) {
+                        null
+                    } else {
+                        sendDropHint(
+                            pluginId = plugin.pluginId,
+                            appName = app.name,
+                            appConnected = app.isConnected,
+                            activated = plugin.isActivated,
+                            ready = plugin.isReady,
+                        )
+                    }
+                    call.respond(SendResponse(sent = sent, hint = hint))
                 } catch (e: Exception) {
                     // FAIL policy while offline lands here; that is an answer about the connection,
                     // not a malformed call.
@@ -278,8 +239,9 @@ fun main(args: Array<String>) {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse("Malformed request: ${e.message}"))
                     return@post
                 }
-                val plugin = wirePluginsById[spec.pluginId] ?: run {
-                    call.respond(HttpStatusCode.BadRequest, unknownPluginError(spec.pluginId, wirePluginsById.keys))
+                val app = call.resolveApp(apps, spec.app) ?: return@post
+                val plugin = app.wirePluginsById[spec.pluginId] ?: run {
+                    call.respond(HttpStatusCode.BadRequest, unknownPluginError(spec.pluginId, app.wirePluginsById.keys))
                     return@post
                 }
                 try {
@@ -306,11 +268,21 @@ fun main(args: Array<String>) {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse("Malformed request: ${e.message}"))
                     return@post
                 }
+                val app = call.resolveApp(apps, spec.app) ?: return@post
+                if (!app.isConnected) {
+                    // The client is instrumented per app, so traffic fired here would be captured for
+                    // a session that no longer exists — silently invisible in the inspector.
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        ErrorResponse("App '${app.name}' was disconnected, so its traffic is no longer recorded."),
+                    )
+                    return@post
+                }
                 try {
                     lateinit var status: HttpStatusCode
                     lateinit var preview: String
                     val elapsed = measureTimeMillis {
-                        val response = client.request(spec.url) {
+                        val response = app.httpClient.request(spec.url) {
                             method = HttpMethod.parse(spec.method.uppercase())
                             spec.contentType?.let { contentType(ContentType.parse(it)) }
                             spec.headers.forEach { (name, value) -> headers.append(name, value) }
@@ -327,6 +299,17 @@ fun main(args: Array<String>) {
                 }
             }
 
+            post("/disconnect") {
+                val spec = try {
+                    call.receive<DisconnectRequest>()
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Malformed request: ${e.message}"))
+                    return@post
+                }
+                val app = call.resolveApp(apps, spec.app) ?: return@post
+                call.respond(DisconnectResponse(app = app.name, disconnected = app.disconnect()))
+            }
+
             post("/shutdown") {
                 call.respond(mapOf("status" to "stopping"))
                 thread {
@@ -338,14 +321,40 @@ fun main(args: Array<String>) {
     }
 
     println("qa-agent: control API on http://127.0.0.1:${options.controlPort} (host ${options.hostName}:${options.hostPort})")
+    println("qa-agent: apps ${options.apps.joinToString()}")
     println(
-        if (wirePluginsById.isEmpty()) {
+        if (options.plugins.isEmpty()) {
             "qa-agent: no --plugin given; only /fire (Network Inspector) is available."
         } else {
-            "qa-agent: impersonating ${wirePluginsById.keys.joinToString()}"
+            "qa-agent: impersonating ${options.plugins.keys.joinToString()}"
         },
     )
     runBlocking { server.start(wait = true) }
+}
+
+/**
+ * A disconnected app keeps the plugin's activation flag — the host never deactivated it, the session
+ * simply went away — so both flags are reported against the session actually being held.
+ */
+private fun QaApp.pluginStatus(pluginId: String): AppPluginStatus {
+    val plugin = wirePluginsById.getValue(pluginId)
+    return AppPluginStatus(
+        activated = isConnected && plugin.isActivated,
+        ready = isConnected && plugin.isReady,
+    )
+}
+
+/**
+ * Resolves the app a call is addressed to, answering the caller itself when it cannot be resolved
+ * and returning null so the handler stops without touching a session.
+ */
+private suspend fun ApplicationCall.resolveApp(apps: Map<String, QaApp>, requested: String?): QaApp? = when (val resolution = resolveAppName(requested, apps.keys)) {
+    is AppResolution.Resolved -> apps.getValue(resolution.name)
+
+    is AppResolution.Failed -> {
+        respond(HttpStatusCode.BadRequest, ErrorResponse(resolution.error))
+        null
+    }
 }
 
 private fun unknownPluginError(pluginId: String, known: Set<String>) = ErrorResponse(
@@ -355,20 +364,6 @@ private fun unknownPluginError(pluginId: String, known: Set<String>) = ErrorResp
         "No plugin is registered under '$pluginId'. Registered: ${known.joinToString()}."
     },
 )
-
-/**
- * Why a send was dropped. Both cases look identical from the caller's side — `sent: false` — but only
- * one of them is worth waiting out.
- */
-private fun dropHint(plugin: WireLevelQaPlugin): String = when {
-    !plugin.isActivated ->
-        "The host has not enabled '${plugin.pluginId}' for this session, so nothing is listening. " +
-            "Enable the plugin in the host, or check the id."
-
-    !plugin.isReady -> "Connected but not prepared yet — poll /health until \"ready\": true."
-
-    else -> "The connection was unavailable. Retry, or send with \"policy\": \"QUEUE\" to buffer it."
-}
 
 /** Replies are opaque here — hand back JSON as JSON, and anything else as a string. */
 private fun String.asJsonOrString(): JsonElement = runCatching { Json.parseToJsonElement(this) }.getOrElse { JsonPrimitive(this) }

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAgentOptions.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAgentOptions.kt
@@ -1,0 +1,91 @@
+package com.kitakkun.jetwhale.tools.qaagent
+
+internal const val DEFAULT_CONTROL_PORT = 7100
+internal const val DEFAULT_HOST_PORT = 5443
+internal const val DEFAULT_PLUGIN_VERSION = "1.0.0"
+
+/** App name used when the run does not ask for any, so the common single-session case needs no flag. */
+internal const val DEFAULT_APP_NAME = "qa-agent"
+
+/**
+ * What the agent impersonates and where it connects.
+ *
+ * @param apps names of the apps to connect as, one session each. Never empty.
+ * @param plugins plugin ids to register a [WireLevelQaPlugin] for, each with the version to report.
+ *   Every app registers the same set, so the same plugin can be driven per session.
+ */
+internal data class QaAgentOptions(
+    val apps: List<String>,
+    val plugins: Map<String, String>,
+    val hostName: String,
+    val hostPort: Int,
+    val controlPort: Int,
+)
+
+internal val usage = """
+    Usage: qa-agent [options]
+
+      --app <name>               Connect as an app of this name, as its own session. Repeatable, so
+                                 one process can hold several apps under one device — which is how
+                                 the host groups them. Default: one app named $DEFAULT_APP_NAME.
+      --plugin <id>[@<version>]  Register a raw-messaging plugin under this id, so /send and
+                                 /request can drive its host counterpart. Registered for every app.
+                                 Repeatable. Version defaults to $DEFAULT_PLUGIN_VERSION.
+      --host <name>              JetWhale host to connect to (default: localhost).
+      --port <n>                 Host debug port (default: $DEFAULT_HOST_PORT).
+      --control-port <n>         Port for this agent's own control API (default: $DEFAULT_CONTROL_PORT).
+""".trimIndent()
+
+internal fun parseArgs(args: Array<String>): QaAgentOptions {
+    val apps = mutableListOf<String>()
+    val plugins = mutableMapOf<String, String>()
+    var hostName = "localhost"
+    var hostPort = DEFAULT_HOST_PORT
+    var controlPort = DEFAULT_CONTROL_PORT
+
+    fun valueOf(index: Int, name: String): String = args.getOrNull(index) ?: error("$name requires a value.\n\n$usage")
+
+    fun intValueOf(index: Int, name: String): Int = valueOf(index, name).toIntOrNull() ?: error("$name requires a number.\n\n$usage")
+
+    var i = 0
+    while (i < args.size) {
+        when (val arg = args[i]) {
+            "--app" -> {
+                val name = valueOf(++i, arg)
+                // Names key every control call, so a duplicate would make one of the two sessions
+                // unreachable rather than merely confusing.
+                require(name !in apps) { "--app $name was given twice; app names address sessions and must be unique.\n\n$usage" }
+                apps += name
+            }
+
+            "--plugin" -> {
+                val (id, version) = valueOf(++i, arg).split("@", limit = 2).let {
+                    it[0] to (it.getOrNull(1) ?: DEFAULT_PLUGIN_VERSION)
+                }
+                plugins[id] = version
+            }
+
+            "--host" -> hostName = valueOf(++i, arg)
+
+            "--port" -> hostPort = intValueOf(++i, arg)
+
+            "--control-port" -> controlPort = intValueOf(++i, arg)
+
+            "--help", "-h" -> throw HelpRequestedException()
+
+            else -> error("Unknown option: $arg\n\n$usage")
+        }
+        i++
+    }
+
+    return QaAgentOptions(
+        apps = apps.ifEmpty { listOf(DEFAULT_APP_NAME) },
+        plugins = plugins,
+        hostName = hostName,
+        hostPort = hostPort,
+        controlPort = controlPort,
+    )
+}
+
+/** Thrown for `--help`, so parsing stays free of process exits and can be tested. */
+internal class HelpRequestedException : RuntimeException()

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaApp.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaApp.kt
@@ -1,0 +1,139 @@
+package com.kitakkun.jetwhale.tools.qaagent
+
+import com.kitakkun.jetwhale.agent.runtime.JetWhaleSession
+import com.kitakkun.jetwhale.agent.runtime.KtorLogLevel
+import com.kitakkun.jetwhale.agent.runtime.LogLevel
+import com.kitakkun.jetwhale.agent.runtime.startJetWhale
+import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
+import com.kitakkun.jetwhale.plugins.network.agent.ktor.ktorClientPlugin
+import io.ktor.client.HttpClient
+
+/** Device the agent's apps are reported under, so the host groups them into one two-level selector entry. */
+private const val QA_DEVICE_ID = "jetwhale-qa-agent"
+private const val QA_DEVICE_NAME = "QA Agent (headless)"
+
+/**
+ * One impersonated app: its own debug session, its own plugin instances and its own instrumented
+ * HTTP client.
+ *
+ * A session on the host is one app, so nothing may be shared between apps here. Two apps registering
+ * the same plugin instance would fight over its single messenger, and traffic fired through a shared
+ * client would land in whichever session happened to own the capture.
+ */
+internal class QaApp(
+    val name: String,
+    val wirePluginsById: Map<String, WireLevelQaPlugin>,
+    val httpClient: HttpClient,
+    private val session: JetWhaleSession,
+) {
+    /**
+     * Whether this app's session is still held. False once [disconnect] gave it up — which is
+     * terminal, since a stopped session cannot be revived.
+     */
+    @Volatile
+    var isConnected: Boolean = true
+        private set
+
+    /** Whether every impersonated plugin could reach the host right now. Vacuously true with none registered. */
+    val isReady: Boolean get() = isConnected && wirePluginsById.values.all { it.isReady }
+
+    /**
+     * Drops this app's session, so the host sees the app go away while the agent's other apps stay
+     * connected. This is the point of running several: it exercises the host's disconnect handling
+     * without taking the whole process down.
+     *
+     * @return false when the session had already been given up.
+     */
+    fun disconnect(): Boolean {
+        if (!isConnected) return false
+        isConnected = false
+        session.stop()
+        httpClient.close()
+        return true
+    }
+}
+
+/** Connects one app and returns the handle the control API drives it through. */
+internal fun startQaApp(name: String, options: QaAgentOptions): QaApp {
+    val networkAgentPlugin = JetWhaleNetworkAgentPlugin()
+    val wirePlugins = options.plugins.map { (id, version) -> WireLevelQaPlugin(id, version) }
+
+    val session = startJetWhale {
+        app {
+            // Make this session obvious in jetwhale.listSessions so it is never mistaken for a
+            // real device someone is debugging.
+            appName = name
+            deviceName = QA_DEVICE_NAME
+            deviceId = QA_DEVICE_ID
+        }
+        connection {
+            host = options.hostName
+            port = options.hostPort
+            ssl {
+                trustServerCertificate()
+            }
+        }
+        logging {
+            enabled = true
+            logLevel = LogLevel.INFO
+            ktorLogLevel = KtorLogLevel.NONE
+        }
+        plugins {
+            register(networkAgentPlugin)
+            wirePlugins.forEach { register(it) }
+        }
+    }
+
+    return QaApp(
+        name = name,
+        wirePluginsById = wirePlugins.associateBy { it.pluginId },
+        httpClient = HttpClient {
+            install(networkAgentPlugin.ktorClientPlugin())
+        },
+        session = session,
+    )
+}
+
+internal sealed interface AppResolution {
+    data class Resolved(val name: String) : AppResolution
+    data class Failed(val error: String) : AppResolution
+}
+
+/**
+ * Picks the app a control call is addressed to.
+ *
+ * [requested] may be omitted, which is the usual case: a run without `--app` has exactly one app and
+ * naming it every time would be noise. With several, the call has to say which one — guessing would
+ * silently drive the wrong session, and a wrong session is exactly what these runs are testing for.
+ */
+internal fun resolveAppName(requested: String?, known: Collection<String>): AppResolution = when {
+    requested != null && requested in known -> AppResolution.Resolved(requested)
+    requested != null -> AppResolution.Failed("No app named '$requested'. Started with: ${known.joinToString()}.")
+    known.isEmpty() -> AppResolution.Failed("No app is running.")
+    known.size == 1 -> AppResolution.Resolved(known.first())
+    else -> AppResolution.Failed("Several apps are running (${known.joinToString()}); name one with \"app\".")
+}
+
+/**
+ * Why a send was dropped. Every case looks identical from the caller's side — `sent: false` — but
+ * only one of them is worth waiting out.
+ */
+internal fun sendDropHint(
+    pluginId: String,
+    appName: String,
+    appConnected: Boolean,
+    activated: Boolean,
+    ready: Boolean,
+): String = when {
+    !appConnected ->
+        "App '$appName' was disconnected via /disconnect, so it holds no session. " +
+            "Restart the agent to get it back."
+
+    !activated ->
+        "The host has not enabled '$pluginId' for app '$appName', so nothing is listening. " +
+            "Enable the plugin in the host, or check the id."
+
+    !ready -> "Connected but not prepared yet — poll /health until \"ready\": true."
+
+    else -> "The connection was unavailable. Retry, or send with \"policy\": \"QUEUE\" to buffer it."
+}

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaApp.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaApp.kt
@@ -7,6 +7,7 @@ import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
 import com.kitakkun.jetwhale.plugins.network.agent.ktor.ktorClientPlugin
 import io.ktor.client.HttpClient
+import java.util.concurrent.atomic.AtomicBoolean
 
 /** Device the agent's apps are reported under, so the host groups them into one two-level selector entry. */
 private const val QA_DEVICE_ID = "jetwhale-qa-agent"
@@ -26,13 +27,13 @@ internal class QaApp(
     val httpClient: HttpClient,
     private val session: JetWhaleSession,
 ) {
+    private val connected = AtomicBoolean(true)
+
     /**
      * Whether this app's session is still held. False once [disconnect] gave it up — which is
      * terminal, since a stopped session cannot be revived.
      */
-    @Volatile
-    var isConnected: Boolean = true
-        private set
+    val isConnected: Boolean get() = connected.get()
 
     /** Whether every impersonated plugin could reach the host right now. Vacuously true with none registered. */
     val isReady: Boolean get() = isConnected && wirePluginsById.values.all { it.isReady }
@@ -42,11 +43,13 @@ internal class QaApp(
      * connected. This is the point of running several: it exercises the host's disconnect handling
      * without taking the whole process down.
      *
+     * Ktor serves requests in parallel, so the claim is staked with a compare-and-set: only one
+     * caller of two concurrent disconnects is told it did the disconnecting.
+     *
      * @return false when the session had already been given up.
      */
     fun disconnect(): Boolean {
-        if (!isConnected) return false
-        isConnected = false
+        if (!connected.compareAndSet(true, false)) return false
         session.stop()
         httpClient.close()
         return true
@@ -114,6 +117,9 @@ internal fun resolveAppName(requested: String?, known: Collection<String>): AppR
     else -> AppResolution.Failed("Several apps are running (${known.joinToString()}); name one with \"app\".")
 }
 
+/** Why nothing addressed to an app that has been given up can arrive. */
+internal fun disconnectedAppHint(appName: String): String = "App '$appName' was disconnected via /disconnect, so it holds no session. Restart the agent to get it back."
+
 /**
  * Why a send was dropped. Every case looks identical from the caller's side — `sent: false` — but
  * only one of them is worth waiting out.
@@ -125,9 +131,7 @@ internal fun sendDropHint(
     activated: Boolean,
     ready: Boolean,
 ): String = when {
-    !appConnected ->
-        "App '$appName' was disconnected via /disconnect, so it holds no session. " +
-            "Restart the agent to get it back."
+    !appConnected -> disconnectedAppHint(appName)
 
     !activated ->
         "The host has not enabled '$pluginId' for app '$appName', so nothing is listening. " +

--- a/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/AppResolutionTest.kt
+++ b/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/AppResolutionTest.kt
@@ -1,0 +1,49 @@
+package com.kitakkun.jetwhale.tools.qaagent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AppResolutionTest {
+    @Test
+    fun `a single app makes the app field optional`() {
+        assertEquals(AppResolution.Resolved("qa-agent"), resolveAppName(requested = null, known = listOf("qa-agent")))
+    }
+
+    @Test
+    fun `a named app is resolved even when it is the only one`() {
+        assertEquals(AppResolution.Resolved("qa-agent"), resolveAppName(requested = "qa-agent", known = listOf("qa-agent")))
+    }
+
+    @Test
+    fun `a named app is resolved among several`() {
+        assertEquals(AppResolution.Resolved("catalog"), resolveAppName(requested = "catalog", known = listOf("checkout", "catalog")))
+    }
+
+    @Test
+    fun `omitting the app among several is refused rather than guessed`() {
+        val resolution = resolveAppName(requested = null, known = listOf("checkout", "catalog"))
+
+        val error = assertIsFailed(resolution)
+        assertTrue(error.contains("checkout") && error.contains("catalog"), "the message should list the choices: $error")
+    }
+
+    @Test
+    fun `an unknown app name reports what was started instead`() {
+        val resolution = resolveAppName(requested = "payments", known = listOf("checkout", "catalog"))
+
+        val error = assertIsFailed(resolution)
+        assertTrue(error.contains("payments"), "the message should quote the unknown name: $error")
+        assertTrue(error.contains("checkout"), "the message should list what is running: $error")
+    }
+
+    @Test
+    fun `no app at all fails instead of resolving to nothing`() {
+        assertIsFailed(resolveAppName(requested = null, known = emptyList()))
+    }
+
+    private fun assertIsFailed(resolution: AppResolution): String {
+        assertTrue(resolution is AppResolution.Failed, "expected a failure but got $resolution")
+        return resolution.error
+    }
+}

--- a/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAgentOptionsTest.kt
+++ b/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAgentOptionsTest.kt
@@ -1,0 +1,52 @@
+package com.kitakkun.jetwhale.tools.qaagent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class QaAgentOptionsTest {
+    @Test
+    fun `a run without --app connects as the single default app`() {
+        val options = parseArgs(arrayOf("--plugin", "com.example.myplugin"))
+
+        assertEquals(listOf(DEFAULT_APP_NAME), options.apps)
+    }
+
+    @Test
+    fun `each --app becomes its own app, in the order given`() {
+        val options = parseArgs(arrayOf("--app", "checkout", "--app", "catalog"))
+
+        assertEquals(listOf("checkout", "catalog"), options.apps)
+    }
+
+    @Test
+    fun `a repeated app name is rejected because names address sessions`() {
+        val failure = assertFailsWith<IllegalArgumentException> {
+            parseArgs(arrayOf("--app", "checkout", "--app", "checkout"))
+        }
+
+        assertTrue(failure.message.orEmpty().contains("checkout"), "the message should name the duplicate")
+    }
+
+    @Test
+    fun `every app registers the same plugins`() {
+        val options = parseArgs(arrayOf("--app", "checkout", "--app", "catalog", "--plugin", "com.example.a", "--plugin", "com.example.b@2.0.0"))
+
+        assertEquals(mapOf("com.example.a" to DEFAULT_PLUGIN_VERSION, "com.example.b" to "2.0.0"), options.plugins)
+    }
+
+    @Test
+    fun `connection options fall back to the local host defaults`() {
+        val options = parseArgs(emptyArray())
+
+        assertEquals("localhost", options.hostName)
+        assertEquals(DEFAULT_HOST_PORT, options.hostPort)
+        assertEquals(DEFAULT_CONTROL_PORT, options.controlPort)
+    }
+
+    @Test
+    fun `--help does not exit the process from the parser`() {
+        assertFailsWith<HelpRequestedException> { parseArgs(arrayOf("--help")) }
+    }
+}

--- a/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAppTest.kt
+++ b/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAppTest.kt
@@ -2,17 +2,18 @@ package com.kitakkun.jetwhale.tools.qaagent
 
 import com.kitakkun.jetwhale.agent.runtime.JetWhaleSession
 import io.ktor.client.HttpClient
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 private class RecordingSession : JetWhaleSession {
-    var stopCount: Int = 0
-        private set
+    private val stops = AtomicInteger()
+    val stopCount: Int get() = stops.get()
 
     override fun stop() {
-        stopCount++
+        stops.incrementAndGet()
     }
 }
 

--- a/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAppTest.kt
+++ b/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAppTest.kt
@@ -1,0 +1,59 @@
+package com.kitakkun.jetwhale.tools.qaagent
+
+import com.kitakkun.jetwhale.agent.runtime.JetWhaleSession
+import io.ktor.client.HttpClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private class RecordingSession : JetWhaleSession {
+    var stopCount: Int = 0
+        private set
+
+    override fun stop() {
+        stopCount++
+    }
+}
+
+class QaAppTest {
+    private fun qaApp(session: JetWhaleSession): QaApp = QaApp(
+        name = "checkout",
+        wirePluginsById = emptyMap(),
+        httpClient = HttpClient(),
+        session = session,
+    )
+
+    @Test
+    fun `disconnect gives up the app's own session`() {
+        val session = RecordingSession()
+        val app = qaApp(session)
+
+        assertTrue(app.disconnect())
+
+        assertEquals(1, session.stopCount)
+        assertFalse(app.isConnected)
+    }
+
+    @Test
+    fun `disconnecting twice reports the second call as a no-op`() {
+        val session = RecordingSession()
+        val app = qaApp(session)
+
+        app.disconnect()
+
+        assertFalse(app.disconnect(), "the second disconnect had nothing left to give up")
+        assertEquals(1, session.stopCount)
+    }
+
+    @Test
+    fun `a disconnected app is never ready, so health stops counting it as drivable`() {
+        val app = qaApp(RecordingSession())
+
+        assertTrue(app.isReady, "an app with no plugins registered has nothing to wait for")
+
+        app.disconnect()
+
+        assertFalse(app.isReady)
+    }
+}

--- a/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/SendDropHintTest.kt
+++ b/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/SendDropHintTest.kt
@@ -1,0 +1,65 @@
+package com.kitakkun.jetwhale.tools.qaagent
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Every dropped send looks the same to the caller, so the hint is the only thing telling a QA run
+ * whether to wait, fix the host, or give up on that app.
+ */
+class SendDropHintTest {
+    @Test
+    fun `a disconnected app says the session is gone rather than telling the caller to wait`() {
+        val hint = sendDropHint(
+            pluginId = "com.example.myplugin",
+            appName = "checkout",
+            appConnected = false,
+            activated = true,
+            ready = true,
+        )
+
+        assertTrue(hint.contains("/disconnect"), hint)
+        assertTrue(!hint.contains("poll"), "a stopped session never becomes ready: $hint")
+    }
+
+    @Test
+    fun `a plugin the host never enabled names the app it was not enabled for`() {
+        val hint = sendDropHint(
+            pluginId = "com.example.myplugin",
+            appName = "checkout",
+            appConnected = true,
+            activated = false,
+            ready = false,
+        )
+
+        assertTrue(hint.contains("com.example.myplugin"), hint)
+        assertTrue(hint.contains("checkout"), hint)
+        assertTrue(!hint.contains("poll"), "waiting does not enable a plugin: $hint")
+    }
+
+    @Test
+    fun `an activated but unprepared plugin is the one case worth waiting out`() {
+        val hint = sendDropHint(
+            pluginId = "com.example.myplugin",
+            appName = "checkout",
+            appConnected = true,
+            activated = true,
+            ready = false,
+        )
+
+        assertTrue(hint.contains("poll"), hint)
+    }
+
+    @Test
+    fun `an otherwise healthy drop suggests buffering`() {
+        val hint = sendDropHint(
+            pluginId = "com.example.myplugin",
+            appName = "checkout",
+            appConnected = true,
+            activated = true,
+            ready = true,
+        )
+
+        assertTrue(hint.contains("QUEUE"), hint)
+    }
+}


### PR DESCRIPTION
## Summary

A JetWhale session is **one app's connection**, and sessions are grouped by device — the host's selector is two-level for exactly that reason ("Sessions are grouped by device, and within the selected device the concrete app (session) can be picked"). So "one device, several apps" is a shape the host is built to display.

The QA agent could not produce it. One process meant one session, so reproducing a multi-app device meant running several agents, each with its own control port to keep track of.

It now holds any number of apps, and can drop them individually:

```bash
qa-agent --app checkout --app catalog --plugin com.example.myplugin
# one device (jetwhale-qa-agent), two sessions

curl -s -X POST 127.0.0.1:7100/disconnect -d '{"app":"checkout"}'
# catalog stays connected
```

Per-app disconnect is the point as much as the multiplicity is: it is how a host's "a session went away" handling gets exercised without killing the whole agent. `startJetWhale` returning a stoppable handle (#196) is what makes it possible.

## Control API

| Endpoint | Request | Response |
|---|---|---|
| `GET /health` | — | `{"status","ready","apps":{"<app>":{"connected","ready"}}}` |
| `GET /plugins` | — | `{"<pluginId>":{"version","activated","ready","apps":{…}}}` |
| `POST /send` | `{app?, pluginId, messageType, payload, policy?}` | `{sent, hint?}` |
| `POST /request` | `{app?, pluginId, messageType, payload, timeoutMs?}` | `{durationMs, reply}` |
| `POST /fire` | `{app?, url, method?, headers?, body?, contentType?}` | `{status, durationMs, bodyPreview}` |
| `POST /disconnect` | `{app?}` | `{app, disconnected}` — `false` when it was already given up |
| `POST /shutdown` | — | unchanged; stops the process |

Each app gets its own session, its own `WireLevelQaPlugin` instances and its own instrumented `HttpClient`, so `/fire` records traffic against the session you addressed. Firing at a disconnected app is a 400 rather than traffic that silently goes nowhere.

`ready` on `/health` means every **still-connected** app is ready and at least one app is connected.

## Backward compatibility

- No `--app` → exactly one app named `qa-agent`, with the same device and app names as before.
- `app` is optional everywhere and resolves to the single app. With several, **omitting it is a 400 listing the choices** rather than a guess — quietly driving the wrong session is the class of bug these runs exist to find.
- `/plugins` keeps the plugin id as its top-level key and keeps `version` / `activated` / `ready` there, aggregated over connected apps, with `apps` added underneath. A single-app response is what it was plus one field, so `resp[pluginId].ready` still works. Same for `/health.ready`.

## Test plan

- [x] `:tools:qa-agent:build` (19 tests), `spotlessCheck` — green, cherry-picked onto current `main`
- [x] New `QaAgentOptionsTest`, `AppResolutionTest`, `QaAppTest`, `SendDropHintTest`, mutation-checked — each detected, then reverted:
  - dropping the `--app` default → `a run without --app connects as the single default app`
  - dropping the duplicate-`--app` `require` → `a repeated app name is rejected…`
  - making `resolveAppName` guess instead of failing → `omitting the app among several is refused…`
  - dropping the `!appConnected` hint branch → `a disconnected app says the session is gone…`
  - dropping `disconnect()`'s idempotency guard → `disconnecting twice…`
  - dropping `isConnected &&` from `QaApp.isReady` → `a disconnected app is never ready…`
- [x] **Exercised against a running host**, two apps at once, rebased onto current `main`:
  - `--app checkout --app catalog` → `/health` reports `{"ready":true,"apps":{"checkout":{"connected":true,"ready":true},"catalog":{"connected":true,"ready":true}}}`, and `/plugins` shows the plugin activated and ready under both
  - `POST /disconnect {"app":"checkout"}` → `{"app":"checkout","disconnected":true}`, and the host follows: `jetwhale.getStatus` goes from `{total: 3, active: 3}` to `{total: 3, active: 2}` while `catalog` keeps running
  - Per-app disconnect is therefore usable as a trigger for host-side disconnect handling — #200 puts a snackbar on exactly that event
