### PR TITLE
fix(mcp): redact the semantics tree the way screenshots are redacted

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -354,13 +354,16 @@ protected `json` property, for encoding the result.
 The Network Inspector's own tools (`com.kitakkun.jetwhale.network.*`) are a complete in-repo
 example — see `jetwhale-plugins/network/host`.
 
-### Hiding sensitive UI from MCP screenshots
+### Hiding sensitive UI from MCP captures
 
-`jetwhale.screenshot` renders the same Compose scene the host window shows. If your plugin UI
-displays values that AI agents should not see, read the `LocalIsScreenshotCapture`
-CompositionLocal — it is `true` only while the scene is being rendered for an MCP screenshot
-capture — and blank or mask the sensitive content while it is raised. The interactive window never
-observes the raised state, so there is no on-screen flicker.
+`jetwhale.screenshot` renders the same Compose scene the host window shows, and
+`jetwhale.getAccessibilityTree` reads that scene's semantics — which carry your `Text` and
+`contentDescription` strings verbatim. If your plugin UI displays values that AI agents should not
+see, read the `LocalIsScreenshotCapture` CompositionLocal — it is `true` only while the scene is
+being rendered for either of those captures — and blank or mask the sensitive content while it is
+raised. Masking only in the drawing layer is not enough: the semantics tree would still hand over
+the original string. The interactive window never observes the raised state, so there is no
+on-screen flicker.
 
 The `LocalJetWhaleDarkTheme` CompositionLocal tells your plugin whether the host is rendering it in
 a dark theme — the host provides the authoritative value from its actually-applied color scheme.

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -359,7 +359,7 @@ example — see `jetwhale-plugins/network/host`.
 `jetwhale.screenshot` renders the same Compose scene the host window shows, and
 `jetwhale.getAccessibilityTree` reads that scene's semantics — which carry your `Text` and
 `contentDescription` strings verbatim. If your plugin UI displays values that AI agents should not
-see, read the `LocalIsScreenshotCapture` CompositionLocal — it is `true` only while the scene is
+see, read the `LocalIsMcpCapture` CompositionLocal — it is `true` only while the scene is
 being rendered for either of those captures — and blank or mask the sensitive content while it is
 raised. Masking only in the drawing layer is not enough: the semantics tree would still hand over
 the original string. The interactive window never observes the raised state, so there is no

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -109,8 +109,9 @@ The [Network Inspector](/guide/network-inspector#mcp-tools) ships a full set of 
 (`com.kitakkun.jetwhale.network.*`) for reading captured traffic and managing mock rules.
 
 ::: tip Sensitive values
-Plugin UIs can hide sensitive content from `jetwhale.screenshot` captures via the
-`LocalIsScreenshotCapture` CompositionLocal, and the Network Inspector's
+Plugin UIs can hide sensitive content from `jetwhale.screenshot` **and**
+`jetwhale.getAccessibilityTree` — both raise the same `LocalIsScreenshotCapture` CompositionLocal,
+because the semantics tree carries the same strings the pixels do. The Network Inspector's
 [redaction rules](/guide/network-inspector#redacting-sensitive-values) support an `MCP_ONLY` scope
 that keeps values visible to you but hidden from AI agents.
 :::

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -110,7 +110,7 @@ The [Network Inspector](/guide/network-inspector#mcp-tools) ships a full set of 
 
 ::: tip Sensitive values
 Plugin UIs can hide sensitive content from `jetwhale.screenshot` **and**
-`jetwhale.getAccessibilityTree` — both raise the same `LocalIsScreenshotCapture` CompositionLocal,
+`jetwhale.getAccessibilityTree` — both raise the same `LocalIsMcpCapture` CompositionLocal,
 because the semantics tree carries the same strings the pixels do. The Network Inspector's
 [redaction rules](/guide/network-inspector#redacting-sensitive-values) support an `MCP_ONLY` scope
 that keeps values visible to you but hidden from AI agents.

--- a/docs/guide/network-inspector.md
+++ b/docs/guide/network-inspector.md
@@ -162,4 +162,5 @@ Like every MCP tool, they take a required `sessionId` (from `jetwhale.listSessio
 
 [Redaction rules](#redacting-sensitive-values) apply to MCP output as well: values redacted with
 `RedactionScope.MCP_ONLY` are hidden from these tools' results **and** from `jetwhale.screenshot`
-captures of the Network Inspector UI, while staying visible to you in the host window.
+and `jetwhale.getAccessibilityTree` captures of the Network Inspector UI, while staying visible to
+you in the host window.

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -311,6 +311,10 @@ public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhalePluginSto
 	public abstract fun remove (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/kitakkun/jetwhale/host/sdk/McpCaptureKt {
+	public static final fun getLocalIsMcpCapture ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
 public final class com/kitakkun/jetwhale/host/sdk/RememberPersistentKt {
 	public static final fun getLocalJetWhalePluginStorage ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun rememberPersistent (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Landroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/MutableState;

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpCapture.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/McpCapture.kt
@@ -1,0 +1,19 @@
+package com.kitakkun.jetwhale.host.sdk
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * True while the composition is being read for an MCP client instead of drawn for the interactive
+ * host window.
+ *
+ * Raised by every tool that hands a plugin's UI to an AI agent — `jetwhale.screenshot` for the
+ * pixels and `jetwhale.getAccessibilityTree` for the semantics — because both carry the same
+ * strings.
+ *
+ * A plugin whose [JetWhaleHostPluginUi.Content] shows sensitive values can read this to render them
+ * redacted, keeping them visible on screen while hiding them from MCP-connected AI agents. Redact
+ * the value itself rather than only what is painted: a masked pixel with the original string still
+ * in its `Text` or `contentDescription` is handed over in full by the semantics tree.
+ */
+public val LocalIsMcpCapture: ProvidableCompositionLocal<Boolean> = compositionLocalOf { false }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/ScreenshotCapture.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/ScreenshotCapture.kt
@@ -4,11 +4,14 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 
 /**
- * True while the composition is being rendered for an MCP screenshot capture (the
- * `jetwhale.screenshot` tool) instead of the interactive host window.
+ * True while the composition is being rendered for an MCP capture instead of for the interactive
+ * host window — both `jetwhale.screenshot` and `jetwhale.getAccessibilityTree` raise it, since the
+ * semantics tree carries the same strings the pixels do.
  *
  * A plugin whose [JetWhaleHostPluginUi.Content] shows sensitive values can read this to render
  * them redacted in captures, keeping them visible on screen while hiding them from MCP-connected
  * AI agents.
+ *
+ * The name is historical: it predates the semantics tree being captured the same way.
  */
 public val LocalIsScreenshotCapture: ProvidableCompositionLocal<Boolean> = compositionLocalOf { false }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/ScreenshotCapture.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/ScreenshotCapture.kt
@@ -1,17 +1,12 @@
+// The alias lives on in its original file so the `ScreenshotCaptureKt` facade class keeps existing:
+// a plugin jar compiled against an earlier host-sdk calls it by that name, and moving the
+// declaration would turn a rename into a NoClassDefFoundError at plugin load time.
 package com.kitakkun.jetwhale.host.sdk
 
 import androidx.compose.runtime.ProvidableCompositionLocal
-import androidx.compose.runtime.compositionLocalOf
 
-/**
- * True while the composition is being rendered for an MCP capture instead of for the interactive
- * host window — both `jetwhale.screenshot` and `jetwhale.getAccessibilityTree` raise it, since the
- * semantics tree carries the same strings the pixels do.
- *
- * A plugin whose [JetWhaleHostPluginUi.Content] shows sensitive values can read this to render
- * them redacted in captures, keeping them visible on screen while hiding them from MCP-connected
- * AI agents.
- *
- * The name is historical: it predates the semantics tree being captured the same way.
- */
-public val LocalIsScreenshotCapture: ProvidableCompositionLocal<Boolean> = compositionLocalOf { false }
+@Deprecated(
+    "Renamed to LocalIsMcpCapture: the flag is raised for jetwhale.getAccessibilityTree too, not only for screenshots.",
+    ReplaceWith("LocalIsMcpCapture", "com.kitakkun.jetwhale.host.sdk.LocalIsMcpCapture"),
+)
+public val LocalIsScreenshotCapture: ProvidableCompositionLocal<Boolean> get() = LocalIsMcpCapture

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
@@ -22,7 +22,7 @@ import com.kitakkun.jetwhale.host.model.WindowInfoUpdater
 import com.kitakkun.jetwhale.host.sdk.InternalJetWhaleHostApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
-import com.kitakkun.jetwhale.host.sdk.LocalIsScreenshotCapture
+import com.kitakkun.jetwhale.host.sdk.LocalIsMcpCapture
 import com.kitakkun.jetwhale.host.sdk.LocalJetWhalePluginStorage
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -78,13 +78,13 @@ class DefaultPluginComposeSceneService(
                 density = hostDensity,
                 platformContext = windowUpdatableContext,
             )
-            val isScreenshotCapture = mutableStateOf(false)
+            val isMcpCapture = mutableStateOf(false)
 
             composeScene.setContent {
                 // Expose the plugin's own pluginId-scoped storage so rememberPersistent can reach it.
                 CompositionLocalProvider(
                     LocalJetWhalePluginStorage provides pluginInstance.boundStorageForRuntime(),
-                    LocalIsScreenshotCapture provides isScreenshotCapture.value,
+                    LocalIsMcpCapture provides isMcpCapture.value,
                 ) {
                     pluginBridgeProvider.PluginEntryPoint {
                         // Headless plugins (not a JetWhaleHostPluginUi) render no content.
@@ -98,7 +98,7 @@ class DefaultPluginComposeSceneService(
                 composeScene = composeScene,
                 windowInfoUpdater = windowUpdatableContext,
                 semanticsOwners = windowUpdatableContext.semanticsOwners,
-                isScreenshotCapture = isScreenshotCapture,
+                isMcpCapture = isMcpCapture,
                 pointerIcon = windowUpdatableContext.pointerIcon,
             )
             pluginScenes[sceneKey] = CachedScene(pluginInstance, scene)

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeTool.kt
@@ -70,6 +70,9 @@ class GetAccessibilityTreeMcpTool(
  * bounds (in pixels), and interactivity flags. AI agents can use this to identify
  * elements by name/role and calculate precise click coordinates from [NodeInfo.bounds].
  *
+ * Must be called on the UI thread (Dispatchers.Main): it applies the viewport, renders, and flips
+ * the capture flag, all of which mutate the ComposeScene.
+ *
  * The tree carries the same strings the screenshot shows, so it is captured under
  * [com.kitakkun.jetwhale.host.sdk.LocalIsMcpCapture] exactly like a screenshot is —
  * otherwise it would hand an agent the values a plugin redacts from captures.

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeTool.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.mcp.tools
 
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.ImageBitmap
@@ -68,6 +69,10 @@ class GetAccessibilityTreeMcpTool(
  * Returns a JSON string representing the full node tree, including roles, labels,
  * bounds (in pixels), and interactivity flags. AI agents can use this to identify
  * elements by name/role and calculate precise click coordinates from [NodeInfo.bounds].
+ *
+ * The tree carries the same strings the screenshot shows, so it is captured under
+ * [com.kitakkun.jetwhale.host.sdk.LocalIsScreenshotCapture] exactly like a screenshot is —
+ * otherwise it would hand an agent the values a plugin redacts from captures.
  */
 @OptIn(InternalComposeUiApi::class)
 fun captureAccessibilityTree(scene: PluginComposeScene): String {
@@ -78,11 +83,26 @@ fun captureAccessibilityTree(scene: PluginComposeScene): String {
         ?: IntSize(1280, 720)
     val viewport = McpViewport(size = size, density = scene.composeScene.density)
     applyViewport(scene, viewport)
-    scene.composeScene.render(Canvas(ImageBitmap(size.width, size.height)), System.nanoTime())
 
-    val rootNodes = scene.semanticsOwners.map { it.rootSemanticsNode }
-
-    val nodes = rootNodes.flatMap { traverseSemanticsTree(it) }
+    // Raised only for this off-screen render; being on the UI thread, no interactive frame can
+    // observe the raised state.
+    scene.isScreenshotCapture.value = true
+    val nodes = try {
+        // render() only flushes snapshot apply notifications at its end (before draw), so a write
+        // made right before it is not yet observed by the scene's recomposer and the frame would be
+        // drawn with the stale value. Flush explicitly here so the flag-flip recomposition is applied
+        // within this render pass.
+        Snapshot.sendApplyNotifications()
+        scene.composeScene.render(Canvas(ImageBitmap(size.width, size.height)), System.nanoTime())
+        // Read the semantics while the flag is still raised: lowering it first would leave the tree
+        // one recomposition away from the values that were actually rendered.
+        scene.semanticsOwners.map { it.rootSemanticsNode }.flatMap { traverseSemanticsTree(it) }
+    } finally {
+        scene.isScreenshotCapture.value = false
+        // Flush the restore so the next interactive render observes capture=false immediately rather
+        // than lagging a frame behind.
+        Snapshot.sendApplyNotifications()
+    }
     return Json.encodeToString(AccessibilityTreeResult(nodes))
 }
 

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeTool.kt
@@ -71,7 +71,7 @@ class GetAccessibilityTreeMcpTool(
  * elements by name/role and calculate precise click coordinates from [NodeInfo.bounds].
  *
  * The tree carries the same strings the screenshot shows, so it is captured under
- * [com.kitakkun.jetwhale.host.sdk.LocalIsScreenshotCapture] exactly like a screenshot is —
+ * [com.kitakkun.jetwhale.host.sdk.LocalIsMcpCapture] exactly like a screenshot is —
  * otherwise it would hand an agent the values a plugin redacts from captures.
  */
 @OptIn(InternalComposeUiApi::class)
@@ -86,7 +86,7 @@ fun captureAccessibilityTree(scene: PluginComposeScene): String {
 
     // Raised only for this off-screen render; being on the UI thread, no interactive frame can
     // observe the raised state.
-    scene.isScreenshotCapture.value = true
+    scene.isMcpCapture.value = true
     val nodes = try {
         // render() only flushes snapshot apply notifications at its end (before draw), so a write
         // made right before it is not yet observed by the scene's recomposer and the frame would be
@@ -98,7 +98,7 @@ fun captureAccessibilityTree(scene: PluginComposeScene): String {
         // one recomposition away from the values that were actually rendered.
         scene.semanticsOwners.map { it.rootSemanticsNode }.flatMap { traverseSemanticsTree(it) }
     } finally {
-        scene.isScreenshotCapture.value = false
+        scene.isMcpCapture.value = false
         // Flush the restore so the next interactive render observes capture=false immediately rather
         // than lagging a frame behind.
         Snapshot.sendApplyNotifications()

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotTool.kt
@@ -103,7 +103,7 @@ fun captureScreenshot(
     val composeCanvas = Canvas(imageBitmap)
     // Raised only for this off-screen render; being on the UI thread, no interactive frame can
     // observe the raised state.
-    scene.isScreenshotCapture.value = true
+    scene.isMcpCapture.value = true
     try {
         // render() only flushes snapshot apply notifications at its end (before draw), so a write
         // made right before it is not yet observed by the scene's recomposer and the frame would be
@@ -112,7 +112,7 @@ fun captureScreenshot(
         Snapshot.sendApplyNotifications()
         scene.composeScene.render(composeCanvas, System.nanoTime())
     } finally {
-        scene.isScreenshotCapture.value = false
+        scene.isMcpCapture.value = false
         // Flush the restore so the next interactive render observes capture=false immediately rather
         // than lagging a frame behind.
         Snapshot.sendApplyNotifications()

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeRedactionTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeRedactionTest.kt
@@ -51,6 +51,8 @@ class AccessibilityTreeRedactionTest {
         val tree = withContext(Dispatchers.Main) { captureAccessibilityTree(scene) }
 
         assertFalse(SECRET in tree, "Unredacted content description leaked into the semantics tree: $tree")
+        // Without this the test would also pass if content descriptions stopped being captured at all.
+        assertTrue(MASKED in tree, "Expected the redacted content description in the tree instead: $tree")
     }
 
     @Test

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeRedactionTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeRedactionTest.kt
@@ -1,0 +1,70 @@
+package com.kitakkun.jetwhale.host.mcp.tools
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.host.sdk.LocalIsScreenshotCapture
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private const val SECRET = "Bearer super-secret-token"
+private const val MASKED = "Bearer ***"
+
+/**
+ * The semantics tree carries the same strings the screenshot does, so a plugin that redacts for
+ * capture has to be redacted here too — otherwise the tree is a way around
+ * [LocalIsScreenshotCapture], which exists to keep values on screen but away from MCP agents.
+ */
+class AccessibilityTreeRedactionTest {
+
+    @Test
+    fun `a value the plugin redacts for capture does not reach the semantics tree`() = runBlocking {
+        val scene = createTestScene {
+            val shown = if (LocalIsScreenshotCapture.current) MASKED else SECRET
+            Box(Modifier.size(100.dp).semantics { text = AnnotatedString(shown) })
+        }
+        renderTestScene(scene)
+
+        val tree = withContext(Dispatchers.Main) { captureAccessibilityTree(scene) }
+
+        assertFalse(SECRET in tree, "Unredacted value leaked into the semantics tree: $tree")
+        assertTrue(MASKED in tree, "Expected the redacted value in the tree instead: $tree")
+    }
+
+    @Test
+    fun `a content description the plugin redacts for capture does not reach the semantics tree`() = runBlocking {
+        val scene = createTestScene {
+            val label = if (LocalIsScreenshotCapture.current) MASKED else SECRET
+            Box(Modifier.size(100.dp).semantics { contentDescription = label })
+        }
+        renderTestScene(scene)
+
+        val tree = withContext(Dispatchers.Main) { captureAccessibilityTree(scene) }
+
+        assertFalse(SECRET in tree, "Unredacted content description leaked into the semantics tree: $tree")
+    }
+
+    @Test
+    fun `the interactive composition is left unredacted after a tree capture`() = runBlocking {
+        val observed = mutableListOf<Boolean>()
+        val scene = createTestScene {
+            observed.add(LocalIsScreenshotCapture.current)
+        }
+        renderTestScene(scene)
+
+        withContext(Dispatchers.Main) { captureAccessibilityTree(scene) }
+        renderTestScene(scene)
+
+        assertTrue(observed.contains(true), "The tree capture must render with capture=true")
+        assertFalse(observed.last(), "The composition must return to capture=false afterwards")
+    }
+}

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeRedactionTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeRedactionTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.text
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
-import com.kitakkun.jetwhale.host.sdk.LocalIsScreenshotCapture
+import com.kitakkun.jetwhale.host.sdk.LocalIsMcpCapture
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -22,14 +22,14 @@ private const val MASKED = "Bearer ***"
 /**
  * The semantics tree carries the same strings the screenshot does, so a plugin that redacts for
  * capture has to be redacted here too — otherwise the tree is a way around
- * [LocalIsScreenshotCapture], which exists to keep values on screen but away from MCP agents.
+ * [LocalIsMcpCapture], which exists to keep values on screen but away from MCP agents.
  */
 class AccessibilityTreeRedactionTest {
 
     @Test
     fun `a value the plugin redacts for capture does not reach the semantics tree`() = runBlocking {
         val scene = createTestScene {
-            val shown = if (LocalIsScreenshotCapture.current) MASKED else SECRET
+            val shown = if (LocalIsMcpCapture.current) MASKED else SECRET
             Box(Modifier.size(100.dp).semantics { text = AnnotatedString(shown) })
         }
         renderTestScene(scene)
@@ -43,7 +43,7 @@ class AccessibilityTreeRedactionTest {
     @Test
     fun `a content description the plugin redacts for capture does not reach the semantics tree`() = runBlocking {
         val scene = createTestScene {
-            val label = if (LocalIsScreenshotCapture.current) MASKED else SECRET
+            val label = if (LocalIsMcpCapture.current) MASKED else SECRET
             Box(Modifier.size(100.dp).semantics { contentDescription = label })
         }
         renderTestScene(scene)
@@ -57,7 +57,7 @@ class AccessibilityTreeRedactionTest {
     fun `the interactive composition is left unredacted after a tree capture`() = runBlocking {
         val observed = mutableListOf<Boolean>()
         val scene = createTestScene {
-            observed.add(LocalIsScreenshotCapture.current)
+            observed.add(LocalIsMcpCapture.current)
         }
         renderTestScene(scene)
 

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotToolTest.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.mcp.viewport.McpViewport
 import com.kitakkun.jetwhale.host.mcp.viewport.applyViewport
-import com.kitakkun.jetwhale.host.sdk.LocalIsScreenshotCapture
+import com.kitakkun.jetwhale.host.sdk.LocalIsMcpCapture
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -88,10 +88,10 @@ class ScreenshotToolTest {
     }
 
     @Test
-    fun `LocalIsScreenshotCapture is true only while capturing`() {
+    fun `LocalIsMcpCapture is true only while capturing`() {
         val observed = mutableListOf<Boolean>()
         val scene = createTestScene {
-            observed.add(LocalIsScreenshotCapture.current)
+            observed.add(LocalIsMcpCapture.current)
         }
         renderTestScene(scene)
         captureScreenshot(scene, McpViewport(size = IntSize(100, 100), density = Density(1f)))

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/TestSceneFactory.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/TestSceneFactory.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.model.PluginComposeScene
 import com.kitakkun.jetwhale.host.model.WindowInfoUpdater
-import com.kitakkun.jetwhale.host.sdk.LocalIsScreenshotCapture
+import com.kitakkun.jetwhale.host.sdk.LocalIsMcpCapture
 
 const val TEST_SCENE_WIDTH = 1280
 const val TEST_SCENE_HEIGHT = 720
@@ -24,9 +24,9 @@ const val TEST_SCENE_HEIGHT = 720
 fun createTestScene(content: @Composable () -> Unit = {}): PluginComposeScene {
     val platformContext = TestPlatformContext()
     val composeScene = CanvasLayersComposeScene(platformContext = platformContext)
-    val isScreenshotCapture = mutableStateOf(false)
+    val isMcpCapture = mutableStateOf(false)
     composeScene.setContent {
-        CompositionLocalProvider(LocalIsScreenshotCapture provides isScreenshotCapture.value) {
+        CompositionLocalProvider(LocalIsMcpCapture provides isMcpCapture.value) {
             content()
         }
     }
@@ -34,7 +34,7 @@ fun createTestScene(content: @Composable () -> Unit = {}): PluginComposeScene {
         composeScene = composeScene,
         windowInfoUpdater = platformContext,
         semanticsOwners = platformContext.semanticsOwners,
-        isScreenshotCapture = isScreenshotCapture,
+        isMcpCapture = isMcpCapture,
         pointerIcon = platformContext.pointerIcon,
     )
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeScene.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeScene.kt
@@ -14,9 +14,9 @@ data class PluginComposeScene(
     val composeScene: ComposeScene,
     val windowInfoUpdater: WindowInfoUpdater,
     val semanticsOwners: Set<SemanticsOwner>,
-    // Backs LocalIsScreenshotCapture inside the scene's composition; the screenshot tool flips
+    // Backs LocalIsMcpCapture inside the scene's composition; the screenshot tool flips
     // it around its off-screen render so plugins can hide sensitive values from captures.
-    val isScreenshotCapture: MutableState<Boolean>,
+    val isMcpCapture: MutableState<Boolean>,
     // The cursor the plugin's composition currently asks for via Modifier.pointerHoverIcon. The
     // nested scene owns no window, so whoever renders it must apply this to the real one.
     val pointerIcon: State<PointerIcon>,

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
@@ -13,7 +13,7 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMessagingHostPlugin
-import com.kitakkun.jetwhale.host.sdk.LocalIsScreenshotCapture
+import com.kitakkun.jetwhale.host.sdk.LocalIsMcpCapture
 import com.kitakkun.jetwhale.plugins.network.protocol.GetMockConfig
 import com.kitakkun.jetwhale.plugins.network.protocol.GetRedactionConfig
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
@@ -124,7 +124,7 @@ private class NetworkHostPlugin :
     override fun Content() {
         // MCP screenshot captures are AI-agent-facing like tool results, so MCP_ONLY rules
         // apply to them too; the interactive window keeps showing the raw values.
-        val redactForCapture = LocalIsScreenshotCapture.current && mcpRedactionRules.isNotEmpty()
+        val redactForCapture = LocalIsMcpCapture.current && mcpRedactionRules.isNotEmpty()
         NetworkInspectorScreen(
             transactions = if (redactForCapture) transactions.map { it.redactedForMcp() } else transactions,
             mockRules = mockRules,


### PR DESCRIPTION
## The bug

`LocalIsScreenshotCapture` documents a promise:

> A plugin whose `Content` shows sensitive values can read this to render them redacted in captures, **keeping them visible on screen while hiding them from MCP-connected AI agents.**

Only `jetwhale.screenshot` kept it. `jetwhale.getAccessibilityTree` rendered the scene with the flag down and then read `SemanticsProperties.Text`, `EditableText` and `ContentDescription` straight off the nodes, so anything a plugin redacts from captures was available in full through the tree.

The asymmetry runs the wrong way. The screenshot an agent cannot easily read is masked; the JSON it parses trivially is not:

```json
{"nodes":[{"id":3,"text":"Bearer super-secret-token","bounds":{...}}]}
```

That output is from the new test running against `main`.

**Blast radius.** The Network Inspector gates its redaction on this exact flag — `redactForCapture = LocalIsScreenshotCapture.current && mcpRedactionRules.isNotEmpty()` (`NetworkHostPluginFactory.kt:127`) — so `RedactionScope.MCP_ONLY` was fully bypassed on this path, contradicting what `network-inspector.md` tells users. Any third-party plugin following the documented pattern was equally exposed. Reaching it needs no privilege beyond calling the tool, and the MCP port is unauthenticated.

## The fix

Capture the tree under the same raised flag as a screenshot, with the same `Snapshot.sendApplyNotifications()` on both sides.

One deliberate difference from `captureScreenshot`: the semantics are read **before** the flag is lowered. Lowering first would leave the tree one recomposition away from the values that were actually rendered — a race that would reintroduce the leak intermittently.

## Tests

`AccessibilityTreeRedactionTest`, three cases: `Text`, `contentDescription`, and that the interactive composition is left unredacted afterwards. All three fail on `main` and pass with the fix — mutation-checked in that order, per the `plugin-qa` skill's §7.

`:jetwhale-host:core:mcp:test`, `:jetwhale-host-sdk:build`, `:jetwhale-plugins:network:host:build` and `spotlessCheck` pass.

## Docs

Four passages claimed screenshot-only protection. The plugin-authoring guide now names the general trap this bug was an instance of: **masking in the drawing layer alone still hands the original string to the semantics tree.** That is the part a plugin author is most likely to get wrong on their own.

The CompositionLocal keeps its name. It is public SDK API and renaming it would break plugins for a comment's worth of accuracy; the KDoc notes the name is historical.

## Not covered

- `jetwhale.getLogs` returns the host's own stdout/stderr, which is not a composition and so is outside this flag entirely. If a plugin logs a secret it is in the host log regardless — same exposure as the built-in log viewer, and a separate question from redaction.
- Plugin-contributed MCP tools redact their own results (the Network Inspector does this explicitly via `redactedForMcp()`); nothing here changes that.


---

## Follow-up: the CompositionLocal is renamed (`0512e0df`)

The first commit left the flag called `LocalIsScreenshotCapture` while raising it for the semantics tree, with a KDoc note admitting the name was historical. That note was really an argument for renaming it, so: **`LocalIsMcpCapture`**.

The name mattered here. A plugin author reading only `LocalIsScreenshotCapture` would reasonably conclude the semantics tree is not covered — which is exactly the mistake this PR had to fix in JetWhale's own code.

**Source compatibility.** `LocalIsScreenshotCapture` remains as a `@Deprecated(ReplaceWith(...))` alias delegating to the *same* CompositionLocal instance, so `provides` on one is observed by `current` on the other. Existing plugin sources compile with a warning.

**Binary compatibility.** The alias deliberately stays in `ScreenshotCapture.kt`. A plugin jar compiled against an earlier host-sdk resolves the getter through the `ScreenshotCaptureKt` facade class, so moving the declaration would have turned a source-level rename into a `NoClassDefFoundError` at plugin load. The ABI dump shows the result is purely additive:

```diff
+public final class com/kitakkun/jetwhale/host/sdk/McpCaptureKt {
+	public static final fun getLocalIsMcpCapture ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
```

`ScreenshotCaptureKt.getLocalIsScreenshotCapture()` is untouched.

The `!` in the commit subject marks the deprecation for the changelog; nothing breaks at either level today.
