### PR TITLE
feat(host): show a snackbar when a debug session disconnects

### DIFF
--- a/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
@@ -12,6 +12,8 @@
     <string name="select_app">アプリを選択</string>
     <string name="session_secure_connection">暗号化された接続 (wss)</string>
     <string name="session_local_connection">ローカル接続 (ADB)</string>
+    <string name="session_disconnected_message">%1$s が切断されました</string>
+    <string name="sessions_disconnected_message">%1$d 件のセッションが切断されました</string>
     <string name="initializing">初期化中...</string>
     <string name="unlocking_trust_registry">信頼済みプラグインレジストリを検証中…</string>
     <string name="shutting_down">シャットダウン中...</string>

--- a/jetwhale-host/app/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="select_app">Select App</string>
     <string name="session_secure_connection">Secure connection (wss)</string>
     <string name="session_local_connection">Local connection (ADB)</string>
+    <string name="session_disconnected_message">%1$s disconnected</string>
+    <string name="sessions_disconnected_message">%1$d sessions disconnected</string>
     <string name="initializing">Initializing...</string>
     <string name="unlocking_trust_registry">Unlocking trust registry…</string>
     <string name="shutting_down">Shutting down...</string>

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/JetWhaleToolingScaffold.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/JetWhaleToolingScaffold.kt
@@ -1,12 +1,20 @@
 package com.kitakkun.jetwhale.host.drawer
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.PermanentNavigationDrawer
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.component.ToolingDrawer
 import com.kitakkun.jetwhale.host.model.DebugSession
 import kotlinx.collections.immutable.persistentListOf
@@ -26,6 +34,7 @@ fun ToolingScaffold(
     onClickBringBack: (DrawerPluginItemUiState) -> Unit,
     onSelectSession: (DebugSession) -> Unit,
     onSetPluginEnabled: (pluginId: String, enabled: Boolean) -> Unit,
+    snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
@@ -53,7 +62,17 @@ fun ToolingScaffold(
                 )
             },
             content = {
-                content()
+                // The drawer is not a Scaffold, so the snackbar is overlaid on the content area
+                // only: messages stay clear of the drawer and of any popped-out plugin window.
+                Box(modifier = Modifier.fillMaxSize()) {
+                    content()
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(16.dp),
+                    )
+                }
             },
             modifier = modifier,
         )
@@ -83,6 +102,7 @@ private fun ToolingScaffoldPreview() {
         isPoppedOut = { false },
         onClickBringBack = {},
         onSetPluginEnabled = { _, _ -> },
+        snackbarHostState = remember { SnackbarHostState() },
     ) {
         Text("Hello, World!")
     }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -34,8 +34,25 @@ sealed interface ToolingScaffoldScreenAction {
 }
 
 sealed interface ToolingScaffoldScreenActionResult {
-    data class SessionClosed(val closedSessionIds: List<String>) : ToolingScaffoldScreenActionResult
+    /** Carries the sessions themselves, since a handler wants to name what went, not just its id. */
+    data class SessionClosed(val closedSessions: ImmutableList<DebugSession>) : ToolingScaffoldScreenActionResult
     data class SetPluginEnabledFailed(val error: Throwable) : ToolingScaffoldScreenActionResult
+}
+
+/**
+ * The sessions that were connected in [previouslyConnected] and are not any more — either marked
+ * inactive or gone from the list entirely.
+ *
+ * Comparing against the previous snapshot is what keeps a disconnect reported once. Reading the
+ * current list alone cannot: a disconnected session stays in it, so every later update would
+ * re-report it.
+ */
+internal fun closedSessions(
+    previouslyConnected: List<DebugSession>,
+    current: List<DebugSession>,
+): List<DebugSession> {
+    val stillConnected = current.filter { it.isActive }.mapTo(mutableSetOf()) { it.id }
+    return previouslyConnected.filterNot { it.id in stillConnected }
 }
 
 @Composable
@@ -113,10 +130,12 @@ fun toolingScaffoldPresenter(
         }
     }
 
+    var connectedSessions by remember { mutableStateOf<List<DebugSession>>(emptyList()) }
     LaunchedEffect(debugSessions) {
-        val inactiveSessionIds = debugSessions.filterNot { it.isActive }.map { it.id }
-        if (inactiveSessionIds.isEmpty()) return@LaunchedEffect
-        screenChannel.emit(ToolingScaffoldScreenActionResult.SessionClosed(inactiveSessionIds))
+        val closedSessions = closedSessions(previouslyConnected = connectedSessions, current = debugSessions)
+        connectedSessions = debugSessions.filter { it.isActive }
+        if (closedSessions.isEmpty()) return@LaunchedEffect
+        screenChannel.emit(ToolingScaffoldScreenActionResult.SessionClosed(closedSessions.toImmutableList()))
     }
 
     ActionEffect(screenChannel) { action ->

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -1,16 +1,23 @@
 package com.kitakkun.jetwhale.host.drawer
 
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import com.kitakkun.jetwhale.host.Res
 import com.kitakkun.jetwhale.host.architecture.ActionResultEffect
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.HostNavigationRequest
 import com.kitakkun.jetwhale.host.navigation.toSegmentedMenu
+import com.kitakkun.jetwhale.host.session_disconnected_message
+import com.kitakkun.jetwhale.host.sessions_disconnected_message
 import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
+import org.jetbrains.compose.resources.getString
 import soil.query.compose.rememberSubscription
 
 @Composable
@@ -39,11 +46,19 @@ fun ToolingScaffoldRoot(
         state6 = rememberSubscription(screenContext.mcpCapablePluginsSubscriptionKey),
     ) { loadedPlugins, debugSessions, enabledPluginIds, failedJars, mcpActivity, mcpCapablePlugins ->
         val screenChannel = rememberScreenChannel<ToolingScaffoldScreenAction, ToolingScaffoldScreenActionResult>()
+        val snackbarHostState = remember { SnackbarHostState() }
         ActionResultEffect(screenChannel) { result ->
             when (result) {
-                // No message sink yet; results are routed through the channel so a future
-                // Root-side handler (e.g. a Snackbar) can surface them during the rollout.
-                is ToolingScaffoldScreenActionResult.SessionClosed -> Unit
+                is ToolingScaffoldScreenActionResult.SessionClosed -> {
+                    // A single disconnect names the session; a simultaneous batch (the server
+                    // stopping, say) is collapsed into a count so the queue stays short enough to
+                    // read. showSnackbar suspends until dismissed, which serializes the queue.
+                    val closedSessions = result.closedSessions
+                    val message = closedSessions.singleOrNull()
+                        ?.let { getString(Res.string.session_disconnected_message, it.deviceAndAppDisplayName) }
+                        ?: getString(Res.string.sessions_disconnected_message, closedSessions.size)
+                    snackbarHostState.showSnackbar(message = message, duration = SnackbarDuration.Short)
+                }
 
                 is ToolingScaffoldScreenActionResult.SetPluginEnabledFailed -> Unit
             }
@@ -145,6 +160,7 @@ fun ToolingScaffoldRoot(
             onSetPluginEnabled = { pluginId, enabled ->
                 screenChannel.send(ToolingScaffoldScreenAction.SetPluginEnabled(pluginId, enabled))
             },
+            snackbarHostState = snackbarHostState,
             content = content,
         )
     }

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/drawer/ClosedSessionsTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/drawer/ClosedSessionsTest.kt
@@ -1,0 +1,64 @@
+package com.kitakkun.jetwhale.host.drawer
+
+import com.kitakkun.jetwhale.host.model.DebugSession
+import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ClosedSessionsTest {
+    @Test
+    fun `a session marked inactive is reported as closed`() {
+        val previous = listOf(session("a"), session("b"))
+
+        val closed = closedSessions(previouslyConnected = previous, current = listOf(session("a"), session("b", isActive = false)))
+
+        assertEquals(listOf("b"), closed.map { it.id })
+    }
+
+    @Test
+    fun `a session already disconnected before this update is not reported again`() {
+        // The disconnected session stays in the list, so only the previous snapshot can tell the
+        // difference between "just went" and "went a while ago".
+        val current = listOf(session("a"), session("b", isActive = false))
+
+        val closed = closedSessions(previouslyConnected = listOf(session("a")), current = current)
+
+        assertTrue(closed.isEmpty(), "b disconnected before this update and must not be re-reported")
+    }
+
+    @Test
+    fun `a session that vanished from the list is reported as closed`() {
+        val closed = closedSessions(previouslyConnected = listOf(session("a"), session("b")), current = listOf(session("a")))
+
+        assertEquals(listOf("b"), closed.map { it.id })
+    }
+
+    @Test
+    fun `sessions closing together are all reported`() {
+        val previous = listOf(session("a"), session("b"), session("c"))
+
+        val closed = closedSessions(
+            previouslyConnected = previous,
+            current = listOf(session("a", isActive = false), session("b", isActive = false), session("c")),
+        )
+
+        assertEquals(listOf("a", "b"), closed.map { it.id })
+    }
+
+    @Test
+    fun `the first update reports nothing`() {
+        val closed = closedSessions(previouslyConnected = emptyList(), current = listOf(session("a"), session("b")))
+
+        assertTrue(closed.isEmpty(), "sessions present from the start have not closed")
+    }
+
+    private fun session(id: String, isActive: Boolean = true) = DebugSession(
+        id = id,
+        name = id,
+        isActive = isActive,
+        transportSecurity = SessionTransportSecurity.LOOPBACK,
+        installedPlugins = persistentListOf(),
+    )
+}

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugSession.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebugSession.kt
@@ -39,4 +39,8 @@ data class DebugSession(
      */
     val appDisplayName: String
         get() = appName ?: displayName
+
+    /** Device and app labels joined, for places that identify a session on a single line. */
+    val deviceAndAppDisplayName: String
+        get() = "$deviceDisplayName · $appDisplayName"
 }


### PR DESCRIPTION
Replaces #197, which bundled this with removing disconnected sessions from the repository. That half collided with #191 — `jetwhale.getStatus` reports `sessions: {total, active}` and its test is named *"counts sessions by whether they are still connected"*, so deleting disconnected sessions would have made `active` meaningless and hollowed out an API that had just landed. Only the snackbar is left here; the retention question is untouched.

## Summary

`ToolingScaffoldScreenActionResult.SessionClosed` existed, was emitted, and was swallowed by the root:

```kotlin
// No message sink yet; results are routed through the channel so a future
// Root-side handler (e.g. a Snackbar) can surface them during the rollout.
is ToolingScaffoldScreenActionResult.SessionClosed -> Unit
```

Wiring a snackbar to it as it stood would have misbehaved, because the emit was:

```kotlin
val inactiveSessionIds = debugSessions.filterNot { it.isActive }.map { it.id }
```

— **every** inactive session, on **every** session-list update. Since a disconnected session stays in the repository, each new disconnect would have re-announced all the earlier ones.

## What changed

`closedSessions(previouslyConnected, current)` compares against the previous snapshot, so each disconnect is reported once. The current list on its own cannot distinguish "just went" from "went a while ago" — that is the whole reason the comparison exists, and it is stated as such in the KDoc.

It also treats a session vanishing from the list as a close, so it keeps working if sessions are ever dropped rather than marked inactive.

The result carries the sessions instead of their ids, so the message can name what went, and `ToolingScaffold` overlays a `SnackbarHost` on the drawer's content area — the first snackbar in this app.

**Message wording.** One session names the device and app (`deviceAndAppDisplayName`, joined for single-line identification); several collapse into a count. `showSnackbar` suspends until dismissal, so announcing a batch one by one would hold the window for seconds when the server stops and every session goes at once. Strings added to `values/` and `values-ja/`.

## Test plan

- [x] `:jetwhale-host:app:test`, `:jetwhale-host:core:mcp:test`, `:jetwhale-host:core:data:test`, `:jetwhale-host:app:compileKotlin`, `spotlessCheck` — green on current `main`
- [x] New `ClosedSessionsTest`: marked inactive, already-disconnected (not re-reported), vanished from the list, several at once, first update
- [x] Mutation-checked — `closedSessions` returning `previouslyConnected` unchanged fails four of the five, including *"a session already disconnected before this update is not reported again"*; reverted afterwards
- [ ] **The snackbar itself is not covered by tests.** The app module has no Compose UI test setup, so the tests cover the dedup logic only; the singular/plural choice is inline in `ToolingScaffoldRoot`.
- [x] **Seen on a running host.** Two QA-agent apps connected, then `POST /disconnect {"app":"checkout"}` (from #198) — the snackbar appeared, and the host followed the disconnect: `jetwhale.getStatus` went from `{total: 3, active: 3}` to `{total: 3, active: 2}` while the other app kept running.
- [ ] **The ja/en switch is still unverified.** `ActionResultEffect`'s lambda is not `@Composable`, so the message is resolved with the suspend `getString`, which goes through `Locale.getDefault()` and relies on `AppEnvironment`/`LocalAppLocale` calling `Locale.setDefault` — the CMP-standard pattern already used here. Only one locale was exercised above.
