### PR TITLE
docs(plugin-qa): make explicit ports the default in the QA workflow

### DIFF
--- a/.claude/skills/plugin-qa/SKILL.md
+++ b/.claude/skills/plugin-qa/SKILL.md
@@ -42,8 +42,35 @@ Cannot:
 ## 2. Launch the host
 
 ```bash
-./gradlew :jetwhale-plugins:<plugin>:host:runJetWhaleLocal
+./gradlew :jetwhale-plugins:<plugin>:host:runJetWhaleLocal \
+  --args="--server-port 5081 --wss-port 5444 --mcp-server-port 7081"
 ```
+
+**Name the ports, every time.** A host that cannot bind them still starts, and nothing about the
+run log says so — it just looks like an ordinary host that has no sessions yet, while the ports,
+and therefore every debuggee and the MCP server on them, stay with whoever started first. From
+there you are reading one host's window against another host's MCP server, and the disagreement
+(`listSessions` says three, the window shows one) looks exactly like a bug in whatever you were
+testing. Assume a host is already running: another worktree, another agent, a window left open
+yesterday.
+
+`--args` is `JavaExec`'s own task option and reaches the host's argument parser unchanged
+(`jetwhale-host/app/.../cli/CommandLineArgumentsParser.kt`); `runJetWhale` and `runJetWhaleHot`
+take it the same way. It is the only route — the host launch tasks define no `-P` property for
+arguments, unlike the QA agent's `-PjetwhaleQaAgentArgs` in §3. An override holds for that launch
+only and is never written to the sandbox's settings. Defaults, for reference, are `5080` / `5443` /
+`7080`.
+
+Before believing anything the host reports — a session count, an empty selector, a screenshot —
+confirm that the process holding your ports is yours:
+
+```bash
+pgrep -f com.kitakkun.jetwhale.host.MainKt | wc -l
+lsof -nP -iTCP:5081,5444,7081 -sTCP:LISTEN   # the ports you asked for
+```
+
+Several host processes are normal and not a problem in themselves. A port of yours held by a PID
+that is not your launch's means every observation downstream of it describes someone else's host.
 
 - Run it in the **background, redirected to a file** (`> run.log 2>&1`). Do NOT pipe it through
   `tail`/`grep`: the pipeline buffers and the log file stays empty until the process exits, so you
@@ -69,11 +96,21 @@ messages can be injected on demand. Name the plugin ids it should impersonate:
 ```bash
 # in this repository, from the plugin module
 ./gradlew :jetwhale-plugins:<plugin>:host:runJetWhaleQaAgentLocal \
-  -PjetwhaleQaAgentArgs="--plugin com.example.myplugin"
+  -PjetwhaleQaAgentArgs="--plugin com.example.myplugin --port 5444 --control-port 7101"
 
 # from a plugin's own repository (jetwhalePlugin.hostVersion decides the agent version)
-./gradlew runJetWhaleQaAgent -PjetwhaleQaAgentArgs="--plugin com.example.myplugin"
+./gradlew runJetWhaleQaAgent \
+  -PjetwhaleQaAgentArgs="--plugin com.example.myplugin --port 5444 --control-port 7101"
 ```
+
+**Pin these ports too.** `--port` is the host's **`--wss-port`**, not its `--server-port`: the agent
+connects over wss and fetches the CA from that same port, so it is `5444` here. Leave it at the
+default `5443` while your host is on something else and it will connect, quite happily, to a
+*different* host — §2's failure arriving from the other end. `--control-port` (default `7100`) is
+the agent's own API. That one does fail loudly — `BindException: Address already in use`, and the
+process exits — but it prints its `control API on …` banner *before* binding, so a log skimmed for
+that line is not evidence it came up. Give yours its own port and address it in every `curl` below;
+otherwise a dead agent leaves you driving someone else's debuggee through theirs.
 
 Background it — it holds the session open for as long as it runs. (`./gradlew :tools:qa-agent:run
 --args="…"` runs the same binary without going through a plugin module.)
@@ -94,7 +131,7 @@ compile-time knowledge of the plugin. `messageType` is the payload class's `seri
 fully-qualified name unless it carries `@SerialName`), and `payload` is that class as JSON:
 
 ```bash
-curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' -d '{
+curl -s 127.0.0.1:7101/send -H 'Content-Type: application/json' -d '{
   "pluginId": "com.example.myplugin",
   "messageType": "com.example.myplugin.protocol.ItemAdded",
   "payload": {"id": 1, "label": "hello"}
@@ -119,7 +156,7 @@ independent sessions. Without `--app` you get the single `qa-agent` app as befor
 field below can be omitted; with several, calls that leave it out are refused rather than guessed at.
 
 ```bash
-curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' \
+curl -s 127.0.0.1:7101/send -H 'Content-Type: application/json' \
   -d '{"app":"checkout","pluginId":"com.example.myplugin","messageType":"…","payload":{}}'
 ```
 
@@ -153,17 +190,22 @@ for one) cannot be answered from here. Drive those from the plugin's own MCP too
 
 ## 4. Reaching the tools
 
-The host's MCP server is SSE on `http://localhost:7080/sse`, with **no authentication**. Register
-it and the tools arrive natively as `mcp__jetwhale__*` — no client script needed. `.mcp.json` is
-gitignored (`.gitignore:7`), so each developer creates their own:
+The host's MCP server is SSE on `http://localhost:<mcp-server-port>/sse`, with **no
+authentication**. Register it and the tools arrive natively as `mcp__jetwhale__*` — no client script
+needed. `.mcp.json` is gitignored (`.gitignore:7`), so each developer creates their own — and its
+port must be the `--mcp-server-port` §2 launched with, or the tools answer for another host without
+ever saying so:
 
 ```json
 {
   "mcpServers": {
-    "jetwhale": { "type": "sse", "url": "http://localhost:7080/sse" }
+    "jetwhale": { "type": "sse", "url": "http://localhost:7081/sse" }
   }
 }
 ```
+
+`jetwhale.getStatus` reports the ports the host it answered for is running on; compare them with the
+ones you passed before reading anything else into the result.
 
 The catch: MCP servers connect when the session starts, and this workflow **launches the host
 mid-session**. If the tools are missing or stale, reconnect with `/mcp` after the host is up. Tool
@@ -202,7 +244,9 @@ explains itself.
 `restartDebugServer`, and `updateSettings` when it changes a ws/wss setting, drop **every** session:
 each `sessionId` you hold goes stale and each debuggee has to reconnect. Re-run `listSessions`
 afterwards. Changing `mcpServerPort` never restarts the MCP server — it would kill your own
-connection — so that one only takes effect on the next host start.
+connection — so that one only takes effect on the next host start. `updateSettings` also *retires*
+the matching `--args` override from §2 for the rest of the session, so a port set this way is the
+port from then on — pick one nobody else holds.
 :::
 
 Always `Read` the screenshot afterwards. A screenshot you never open verifies nothing.
@@ -236,9 +280,10 @@ Always `Read` the screenshot afterwards. A screenshot you never open verifies no
 
 - Writes are **debounced 300 ms** (`RememberPersistent.kt`), so sleep 1–2 s after the interaction
   before reading the file.
-- Restart restore is a real check and worth doing: kill the host, relaunch, screenshot, and
-  confirm the UI comes back at the persisted value rather than the coded default. **Wait for the
-  loading spinner to clear** — the first frames after restart are a spinner, not your UI.
+- Restart restore is a real check and worth doing: kill the host, relaunch **with the same
+  `--args` ports**, screenshot, and confirm the UI comes back at the persisted value rather than the
+  coded default. **Wait for the loading spinner to clear** — the first frames after restart are a
+  spinner, not your UI.
 
 ## 7. Prefer a regression test to a one-off check
 

--- a/.claude/skills/plugin-qa/SKILL.md
+++ b/.claude/skills/plugin-qa/SKILL.md
@@ -69,8 +69,9 @@ pgrep -f com.kitakkun.jetwhale.host.MainKt | wc -l
 lsof -nP -iTCP:5081,5444,7081 -sTCP:LISTEN   # the ports you asked for
 ```
 
-Several host processes are normal and not a problem in themselves. A port of yours held by a PID
-that is not your launch's means every observation downstream of it describes someone else's host.
+Several host processes are normal and not a problem in themselves. What matters is which PID holds
+your ports: if it is not the process your launch started, every observation downstream of it
+describes someone else's host.
 
 - Run it in the **background, redirected to a file** (`> run.log 2>&1`). Do NOT pipe it through
   `tail`/`grep`: the pipeline buffers and the log file stays empty until the process exits, so you


### PR DESCRIPTION
## Why

A QA run lost an hour to this yesterday. Two hosts were running — one started for the run, one from another worktree — and the ports told the story only if you went looking:

```
pgrep -f com.kitakkun.jetwhale.host.MainKt | wc -l   → 2
lsof -nP -iTCP:5080,5443,7080 -sTCP:LISTEN           → a single PID holding all three
```

The host that lost the race **started anyway, with no debug server and nothing in its log**. MCP on 7080 answered for the winner while the visible window belonged to the loser, so `jetwhale.listSessions` reported three sessions and the drawer showed one. That was read as a `SessionSelectorView` bug and chased as one.

Nothing was broken. The two observations were of two different processes.

## What changed

Ports are now pinned in the skill's own command examples rather than described in a section of their own — a section gets read once and skipped forever, while a command example gets copied, so the ports travel with the procedure.

```bash
./gradlew :jetwhale-plugins:<plugin>:host:runJetWhaleLocal \
  --args="--server-port 5081 --wss-port 5444 --mcp-server-port 7081"

./gradlew :jetwhale-plugins:<plugin>:host:runJetWhaleQaAgentLocal \
  -PjetwhaleQaAgentArgs="--plugin com.example.myplugin --port 5444 --control-port 7101"
```

Also covered:

- **`--args` is the only way in on the host side.** `runJetWhaleLocal` / `runJetWhale` set `jvmArgumentProviders` but no `argumentProviders` and no `-P` property, so `JavaExec`'s own `--args` is what reaches `MainKt`. The QA agent, by contrast, *does* take `-PjetwhaleQaAgentArgs` — the asymmetry is called out, since it is exactly the kind of thing that gets guessed wrong.
- **The agent's `--port` is the host's `--wss-port`, not its `--server-port`.** Get it wrong and you connect to a different host: yesterday's failure arriving from the other end.
- **Check ownership before believing the host.** `pgrep` + `lsof`, stated as the step that comes *before* trusting any host-side observation.
- The `.mcp.json` URL has to match the `--mcp-server-port` the host was launched with, and `jetwhale.updateSettings` retires the launch overrides for the rest of the session — so a port chosen there must be free too.

## Verified by running it

The agent doing this work exercised every claim rather than reasoning about it:

- The three overrides really bind (`lsof`), coexisting with another host on the defaults; MCP answers on the overridden port.
- The QA agent connects to *that* host on `--port 5444` (confirmed by the `ESTABLISHED` socket, not by inference).
- **The failure reproduces**: a second host on the same three ports starts, binds nothing, and writes no error across 199 log lines.
- A `--control-port` clash, unlike the host's, dies loudly with `BindException` — but its `control API on …` banner prints *before* the bind, so grepping the log for the banner is not evidence the agent came up.

One claim deliberately not made: whether the losing host surfaces an error in Settings → Server was not observed, so the skill says only that the run log stays silent. The code path suggests `DebugWebSocketServerStatus.Error`, but it was not checked.

## Test plan

- [x] `spotlessCheck` — green, rebased onto current `main`
- [x] Documentation only; no code changes