### PR TITLE
refactor(settings): lay the settings screen out as a list and a detail pane

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -39,7 +39,7 @@ import com.kitakkun.jetwhale.host.navigation.followPluginToSession
 import com.kitakkun.jetwhale.host.navigation.isPluginPoppedOut
 import com.kitakkun.jetwhale.host.navigation.openMcpTools
 import com.kitakkun.jetwhale.host.navigation.toHostDestination
-import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
+import com.kitakkun.jetwhale.host.settings.SettingsScreenMenu
 import com.kitakkun.jetwhale.host.ui.AppEnvironment
 import com.kitakkun.jetwhale.host.ui.JetWhaleTheme
 import kotlinx.serialization.modules.SerializersModule
@@ -144,7 +144,7 @@ fun JetWhaleApp() {
                                     onClickSettings = { backStack.addSingleTop(SettingsNavKey()) },
                                     onClickPluginSettings = {
                                         backStack.addSingleTop(
-                                            SettingsNavKey(initialMenu = SettingsScreenSegmentedMenu.Plugins),
+                                            SettingsNavKey(initialMenu = SettingsScreenMenu.Plugins),
                                         )
                                     },
                                     onClickInfo = { backStack.addSingleTop(InfoNavKey) },

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -16,7 +16,7 @@ import com.kitakkun.jetwhale.host.model.HostNavigationRequest
 import com.kitakkun.jetwhale.host.navigation.toSegmentedMenu
 import com.kitakkun.jetwhale.host.session_disconnected_message
 import com.kitakkun.jetwhale.host.sessions_disconnected_message
-import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
+import com.kitakkun.jetwhale.host.settings.SettingsScreenMenu
 import org.jetbrains.compose.resources.getString
 import soil.query.compose.rememberSubscription
 
@@ -33,7 +33,7 @@ fun ToolingScaffoldRoot(
     onClickBringBack: (pluginId: String, sessionId: String) -> Unit,
     onSelectedSessionChange: (selectedSession: DebugSession) -> Unit,
     onNavigateHome: () -> Unit,
-    onNavigateSettings: (SettingsScreenSegmentedMenu) -> Unit,
+    onNavigateSettings: (SettingsScreenMenu) -> Unit,
     onNavigateLogViewer: () -> Unit,
     content: @Composable () -> Unit,
 ) {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -13,7 +13,7 @@ import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.HostNavigationRequest
-import com.kitakkun.jetwhale.host.navigation.toSegmentedMenu
+import com.kitakkun.jetwhale.host.navigation.toMenu
 import com.kitakkun.jetwhale.host.session_disconnected_message
 import com.kitakkun.jetwhale.host.sessions_disconnected_message
 import com.kitakkun.jetwhale.host.settings.SettingsScreenMenu
@@ -107,7 +107,7 @@ fun ToolingScaffoldRoot(
 
                     HostNavigationRequest.LogViewer -> onNavigateLogViewer()
 
-                    is HostNavigationRequest.Settings -> onNavigateSettings(request.section.toSegmentedMenu())
+                    is HostNavigationRequest.Settings -> onNavigateSettings(request.section.toMenu())
 
                     is HostNavigationRequest.Plugin -> {
                         // Only a request that named no session falls back to the drawer's selection.

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMapping.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMapping.kt
@@ -50,7 +50,7 @@ fun List<NavKey>.toHostDestination(): HostDestination {
     }
 }
 
-fun HostSettingsSection.toSegmentedMenu(): SettingsScreenMenu = when (this) {
+fun HostSettingsSection.toMenu(): SettingsScreenMenu = when (this) {
     HostSettingsSection.GENERAL -> SettingsScreenMenu.General
     HostSettingsSection.SERVER -> SettingsScreenMenu.Server
     HostSettingsSection.PLUGINS -> SettingsScreenMenu.Plugins

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMapping.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMapping.kt
@@ -5,7 +5,7 @@ import com.kitakkun.jetwhale.host.model.HostDestination
 import com.kitakkun.jetwhale.host.model.HostDestinationKind
 import com.kitakkun.jetwhale.host.model.HostSettingsSection
 import com.kitakkun.jetwhale.host.model.PoppedOutPlugin
-import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
+import com.kitakkun.jetwhale.host.settings.SettingsScreenMenu
 
 /**
  * Translates the back stack into the destination model that [com.kitakkun.jetwhale.host.model.HostNavigationService]
@@ -50,14 +50,14 @@ fun List<NavKey>.toHostDestination(): HostDestination {
     }
 }
 
-fun HostSettingsSection.toSegmentedMenu(): SettingsScreenSegmentedMenu = when (this) {
-    HostSettingsSection.GENERAL -> SettingsScreenSegmentedMenu.General
-    HostSettingsSection.SERVER -> SettingsScreenSegmentedMenu.Server
-    HostSettingsSection.PLUGINS -> SettingsScreenSegmentedMenu.Plugins
+fun HostSettingsSection.toSegmentedMenu(): SettingsScreenMenu = when (this) {
+    HostSettingsSection.GENERAL -> SettingsScreenMenu.General
+    HostSettingsSection.SERVER -> SettingsScreenMenu.Server
+    HostSettingsSection.PLUGINS -> SettingsScreenMenu.Plugins
 }
 
-private fun SettingsScreenSegmentedMenu.toHostSettingsSection(): HostSettingsSection = when (this) {
-    SettingsScreenSegmentedMenu.General -> HostSettingsSection.GENERAL
-    SettingsScreenSegmentedMenu.Server -> HostSettingsSection.SERVER
-    SettingsScreenSegmentedMenu.Plugins -> HostSettingsSection.PLUGINS
+private fun SettingsScreenMenu.toHostSettingsSection(): HostSettingsSection = when (this) {
+    SettingsScreenMenu.General -> HostSettingsSection.GENERAL
+    SettingsScreenMenu.Server -> HostSettingsSection.SERVER
+    SettingsScreenMenu.Plugins -> HostSettingsSection.PLUGINS
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
@@ -1,7 +1,7 @@
 package com.kitakkun.jetwhale.host.navigation
 
 import androidx.navigation3.runtime.NavKey
-import com.kitakkun.jetwhale.host.settings.SettingsScreenSegmentedMenu
+import com.kitakkun.jetwhale.host.settings.SettingsScreenMenu
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -9,7 +9,7 @@ data object EmptyPluginNavKey : NavKey
 
 @Serializable
 data class SettingsNavKey(
-    val initialMenu: SettingsScreenSegmentedMenu = SettingsScreenSegmentedMenu.General,
+    val initialMenu: SettingsScreenMenu = SettingsScreenMenu.General,
 ) : NavKey
 
 @Serializable

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenRoot.kt
@@ -9,7 +9,7 @@ import com.kitakkun.jetwhale.host.settings.server.ServerSettingsScreenRoot
 context(screenContext: SettingsScreenContext)
 fun SettingsScreenRoot(
     onClickClose: () -> Unit,
-    initialMenu: SettingsScreenSegmentedMenu = SettingsScreenSegmentedMenu.General,
+    initialMenu: SettingsScreenMenu = SettingsScreenMenu.General,
     onOpenLogViewer: () -> Unit = {},
 ) {
     SettingsScreenScaffoldRoot(
@@ -17,13 +17,13 @@ fun SettingsScreenRoot(
         onClickClose = onClickClose,
     ) {
         when (it) {
-            SettingsScreenSegmentedMenu.General -> GeneralSettingsScreenRoot(
+            SettingsScreenMenu.General -> GeneralSettingsScreenRoot(
                 onOpenLogViewer = onOpenLogViewer,
             )
 
-            SettingsScreenSegmentedMenu.Server -> ServerSettingsScreenRoot()
+            SettingsScreenMenu.Server -> ServerSettingsScreenRoot()
 
-            SettingsScreenSegmentedMenu.Plugins -> PluginSettingsScreenRoot()
+            SettingsScreenMenu.Plugins -> PluginSettingsScreenRoot()
         }
     }
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffold.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffold.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Computer
@@ -26,6 +28,7 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.serialization.Serializable
 import org.jetbrains.compose.resources.StringResource
@@ -93,12 +96,17 @@ fun SettingsScreenScaffold(
                 modifier = Modifier
                     .width(MenuPaneWidth)
                     .fillMaxHeight()
+                    // The list grows downward as sections are added, which is the point of it — so it
+                    // has to scroll, or the newest entries are the ones a short window cuts off.
+                    .verticalScroll(rememberScrollState())
                     .padding(8.dp),
             ) {
                 SettingsScreenMenu.entries.forEach { menu ->
                     NavigationDrawerItem(
                         selected = menu == uiState.selectedMenu,
-                        label = { Text(stringResource(menu.labelTextRes)) },
+                        // One line keeps every row the same height, so the list does not reflow when a
+                        // translation is longer than the pane.
+                        label = { Text(stringResource(menu.labelTextRes), maxLines = 1, overflow = TextOverflow.Ellipsis) },
                         icon = { Icon(menu.icon, contentDescription = null) },
                         onClick = { onSelectMenu(menu) },
                     )

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffold.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffold.kt
@@ -4,27 +4,26 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Work
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
@@ -33,7 +32,7 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 @Serializable
-enum class SettingsScreenSegmentedMenu(
+enum class SettingsScreenMenu(
     val labelTextRes: StringResource,
     val icon: ImageVector,
 ) {
@@ -53,21 +52,18 @@ enum class SettingsScreenSegmentedMenu(
 
 val SettingsScreenScaffoldPageContentPadding = PaddingValues(16.dp)
 
+/** Wide enough for the longest section label without wrapping, narrow enough to leave the detail room. */
+private val MenuPaneWidth = 200.dp
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreenScaffold(
     uiState: SettingsScreenScaffoldUiState,
     onClickClose: () -> Unit,
-    onSelectMenu: (SettingsScreenSegmentedMenu) -> Unit,
+    onSelectMenu: (SettingsScreenMenu) -> Unit,
     modifier: Modifier = Modifier,
-    content: @Composable (SettingsScreenSegmentedMenu) -> Unit,
+    content: @Composable (SettingsScreenMenu) -> Unit,
 ) {
-    val pagerState = rememberPagerState(initialPage = uiState.selectedMenu.ordinal) { SettingsScreenSegmentedMenu.entries.size }
-
-    LaunchedEffect(uiState.selectedMenu) {
-        pagerState.animateScrollToPage(uiState.selectedMenu.ordinal)
-    }
-
     Column(
         modifier = modifier
             .fillMaxSize(0.8f)
@@ -75,8 +71,6 @@ fun SettingsScreenScaffold(
                 color = MaterialTheme.colorScheme.surface,
                 shape = MaterialTheme.shapes.medium,
             ),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         TopAppBar(
             title = { Text(stringResource(Res.string.settings_title)) },
@@ -89,24 +83,33 @@ fun SettingsScreenScaffold(
                     )
                 }
             },
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
-        SingleChoiceSegmentedButtonRow {
-            SettingsScreenSegmentedMenu.entries.forEachIndexed { index, menu ->
-                SegmentedButton(
-                    selected = menu == uiState.selectedMenu,
-                    label = { Text(stringResource(menu.labelTextRes)) },
-                    icon = { Icon(menu.icon, null) },
-                    onClick = { onSelectMenu(menu) },
-                    shape = SegmentedButtonDefaults.itemShape(index, SettingsScreenSegmentedMenu.entries.size),
-                )
+        HorizontalDivider()
+
+        Row(modifier = Modifier.fillMaxSize()) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier
+                    .width(MenuPaneWidth)
+                    .fillMaxHeight()
+                    .padding(8.dp),
+            ) {
+                SettingsScreenMenu.entries.forEach { menu ->
+                    NavigationDrawerItem(
+                        selected = menu == uiState.selectedMenu,
+                        label = { Text(stringResource(menu.labelTextRes)) },
+                        icon = { Icon(menu.icon, contentDescription = null) },
+                        onClick = { onSelectMenu(menu) },
+                    )
+                }
             }
-        }
-        HorizontalPager(
-            state = pagerState,
-            userScrollEnabled = false,
-        ) {
-            content(SettingsScreenSegmentedMenu.entries[it])
+            VerticalDivider()
+            // Only the selected section is composed. The pager this replaced kept every section
+            // alive, so each one's subscriptions ran whether or not it was on screen.
+            Column(modifier = Modifier.fillMaxSize()) {
+                content(uiState.selectedMenu)
+            }
         }
     }
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldPresenter.kt
@@ -9,14 +9,14 @@ import com.kitakkun.jetwhale.host.architecture.ActionEffect
 import com.kitakkun.jetwhale.host.architecture.ScreenChannel
 
 sealed interface SettingsScreenScaffoldAction {
-    data class SelectMenu(val menu: SettingsScreenSegmentedMenu) : SettingsScreenScaffoldAction
+    data class SelectMenu(val menu: SettingsScreenMenu) : SettingsScreenScaffoldAction
 }
 
 @Composable
 context(_: SettingsPresenterContext)
 fun settingsScreenScaffoldPresenter(
     screenChannel: ScreenChannel<SettingsScreenScaffoldAction, Nothing>,
-    initialMenu: SettingsScreenSegmentedMenu,
+    initialMenu: SettingsScreenMenu,
 ): SettingsScreenScaffoldUiState {
     var selectedMenu by retain { mutableStateOf(initialMenu) }
 

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldRoot.kt
@@ -7,8 +7,8 @@ import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 context(screenContext: SettingsScreenContext)
 fun SettingsScreenScaffoldRoot(
     onClickClose: () -> Unit,
-    initialMenu: SettingsScreenSegmentedMenu = SettingsScreenSegmentedMenu.General,
-    content: @Composable (SettingsScreenSegmentedMenu) -> Unit,
+    initialMenu: SettingsScreenMenu = SettingsScreenMenu.General,
+    content: @Composable (SettingsScreenMenu) -> Unit,
 ) {
     val screenChannel = rememberScreenChannel<SettingsScreenScaffoldAction, Nothing>()
     val uiState = context(screenContext.presenterContext) {

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldUiState.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldUiState.kt
@@ -1,5 +1,5 @@
 package com.kitakkun.jetwhale.host.settings
 
 data class SettingsScreenScaffoldUiState(
-    val selectedMenu: SettingsScreenSegmentedMenu = SettingsScreenSegmentedMenu.Plugins,
+    val selectedMenu: SettingsScreenMenu = SettingsScreenMenu.Plugins,
 )


### PR DESCRIPTION
## What

Replaces the settings screen's segmented button row + pager with a vertical section list on the left and the selected section on the right.

## Why

The old shape does not grow. The segmented row competes for horizontal space with every section added, and the labels are already the width of the control. A vertical list adds sections downward, where there is room.

The pager also kept **all three sections composed at once**, so every section's `SoilDataBoundary` subscriptions ran whether or not it was on screen — the Server section's certificate and status subscriptions were live while you were reading General. Only the selected section is composed now.

## Notes for review

- `SettingsScreenSegmentedMenu` → `SettingsScreenMenu`. There is no segmented control left for it to be named after, and the enum is referenced from the nav key and the host navigation mapping, so leaving a stale name would spread.
- `SettingsScreenScaffold`'s `content: @Composable (SettingsScreenMenu) -> Unit` signature is unchanged — it is now called once with the selected section rather than once per page, so the section Roots needed no changes at all.
- Left pane is a fixed 200dp of `NavigationDrawerItem`s; the detail pane takes the rest.

## Verified

`:jetwhale-host:app:build`, `:jetwhale-host:feature:settings:build` and `spotlessCheck` pass. The layout was confirmed by running the host — screenshot below.

Follow-up: the MCP permission tree in #201 is built on top of this, which is why the layout change lands first.
