### PR TITLE
feat(settings): give the settings menu a section/page hierarchy

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -170,8 +170,8 @@ fun JetWhaleApp() {
                                         // window must not close them.
                                         backStack.removeAll { it !is EmptyPluginNavKey && it !is PluginPopoutNavKey }
                                     },
-                                    onNavigateSettings = { menu ->
-                                        backStack.addSingleTop(SettingsNavKey(initialPage = menu))
+                                    onNavigateSettings = { page ->
+                                        backStack.addSingleTop(SettingsNavKey(initialPage = page))
                                     },
                                     onNavigateLogViewer = { backStack.addSingleTop(LogViewerNavKey) },
                                     onSelectedSessionChange = { selectedSession ->

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -39,7 +39,7 @@ import com.kitakkun.jetwhale.host.navigation.followPluginToSession
 import com.kitakkun.jetwhale.host.navigation.isPluginPoppedOut
 import com.kitakkun.jetwhale.host.navigation.openMcpTools
 import com.kitakkun.jetwhale.host.navigation.toHostDestination
-import com.kitakkun.jetwhale.host.settings.SettingsScreenMenu
+import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import com.kitakkun.jetwhale.host.ui.AppEnvironment
 import com.kitakkun.jetwhale.host.ui.JetWhaleTheme
 import kotlinx.serialization.modules.SerializersModule
@@ -144,7 +144,7 @@ fun JetWhaleApp() {
                                     onClickSettings = { backStack.addSingleTop(SettingsNavKey()) },
                                     onClickPluginSettings = {
                                         backStack.addSingleTop(
-                                            SettingsNavKey(initialMenu = SettingsScreenMenu.Plugins),
+                                            SettingsNavKey(initialPage = SettingsScreenPage.InstalledPlugins),
                                         )
                                     },
                                     onClickInfo = { backStack.addSingleTop(InfoNavKey) },
@@ -171,7 +171,7 @@ fun JetWhaleApp() {
                                         backStack.removeAll { it !is EmptyPluginNavKey && it !is PluginPopoutNavKey }
                                     },
                                     onNavigateSettings = { menu ->
-                                        backStack.addSingleTop(SettingsNavKey(initialMenu = menu))
+                                        backStack.addSingleTop(SettingsNavKey(initialPage = menu))
                                     },
                                     onNavigateLogViewer = { backStack.addSingleTop(LogViewerNavKey) },
                                     onSelectedSessionChange = { selectedSession ->

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -13,10 +13,10 @@ import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.HostNavigationRequest
-import com.kitakkun.jetwhale.host.navigation.toMenu
+import com.kitakkun.jetwhale.host.navigation.toPage
 import com.kitakkun.jetwhale.host.session_disconnected_message
 import com.kitakkun.jetwhale.host.sessions_disconnected_message
-import com.kitakkun.jetwhale.host.settings.SettingsScreenMenu
+import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import org.jetbrains.compose.resources.getString
 import soil.query.compose.rememberSubscription
 
@@ -33,7 +33,7 @@ fun ToolingScaffoldRoot(
     onClickBringBack: (pluginId: String, sessionId: String) -> Unit,
     onSelectedSessionChange: (selectedSession: DebugSession) -> Unit,
     onNavigateHome: () -> Unit,
-    onNavigateSettings: (SettingsScreenMenu) -> Unit,
+    onNavigateSettings: (SettingsScreenPage) -> Unit,
     onNavigateLogViewer: () -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -107,7 +107,7 @@ fun ToolingScaffoldRoot(
 
                     HostNavigationRequest.LogViewer -> onNavigateLogViewer()
 
-                    is HostNavigationRequest.Settings -> onNavigateSettings(request.section.toMenu())
+                    is HostNavigationRequest.Settings -> onNavigateSettings(request.section.toPage())
 
                     is HostNavigationRequest.Plugin -> {
                         // Only a request that named no session falls back to the drawer's selection.

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMapping.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMapping.kt
@@ -5,7 +5,8 @@ import com.kitakkun.jetwhale.host.model.HostDestination
 import com.kitakkun.jetwhale.host.model.HostDestinationKind
 import com.kitakkun.jetwhale.host.model.HostSettingsSection
 import com.kitakkun.jetwhale.host.model.PoppedOutPlugin
-import com.kitakkun.jetwhale.host.settings.SettingsScreenMenu
+import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
+import com.kitakkun.jetwhale.host.settings.SettingsScreenSection
 
 /**
  * Translates the back stack into the destination model that [com.kitakkun.jetwhale.host.model.HostNavigationService]
@@ -27,7 +28,7 @@ fun List<NavKey>.toHostDestination(): HostDestination {
 
         is SettingsNavKey -> HostDestination(
             kind = HostDestinationKind.SETTINGS,
-            settingsSection = top.initialMenu.toHostSettingsSection(),
+            settingsSection = top.initialPage.toHostSettingsSection(),
             poppedOutPlugins = poppedOut,
         )
 
@@ -50,14 +51,17 @@ fun List<NavKey>.toHostDestination(): HostDestination {
     }
 }
 
-fun HostSettingsSection.toMenu(): SettingsScreenMenu = when (this) {
-    HostSettingsSection.GENERAL -> SettingsScreenMenu.General
-    HostSettingsSection.SERVER -> SettingsScreenMenu.Server
-    HostSettingsSection.PLUGINS -> SettingsScreenMenu.Plugins
+fun HostSettingsSection.toPage(): SettingsScreenPage = when (this) {
+    HostSettingsSection.GENERAL -> SettingsScreenSection.General.firstPage
+    HostSettingsSection.SERVER -> SettingsScreenSection.Connection.firstPage
+    HostSettingsSection.PLUGINS -> SettingsScreenSection.Plugins.firstPage
 }
 
-private fun SettingsScreenMenu.toHostSettingsSection(): HostSettingsSection = when (this) {
-    SettingsScreenMenu.General -> HostSettingsSection.GENERAL
-    SettingsScreenMenu.Server -> HostSettingsSection.SERVER
-    SettingsScreenMenu.Plugins -> HostSettingsSection.PLUGINS
+private fun SettingsScreenPage.toHostSettingsSection(): HostSettingsSection = when (section) {
+    SettingsScreenSection.General -> HostSettingsSection.GENERAL
+
+    // The MCP server used to live under Server; an agent still asks for it by section.
+    SettingsScreenSection.Connection, SettingsScreenSection.AiAgents -> HostSettingsSection.SERVER
+
+    SettingsScreenSection.Plugins -> HostSettingsSection.PLUGINS
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
@@ -1,7 +1,7 @@
 package com.kitakkun.jetwhale.host.navigation
 
 import androidx.navigation3.runtime.NavKey
-import com.kitakkun.jetwhale.host.settings.SettingsScreenMenu
+import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -9,7 +9,7 @@ data object EmptyPluginNavKey : NavKey
 
 @Serializable
 data class SettingsNavKey(
-    val initialMenu: SettingsScreenMenu = SettingsScreenMenu.General,
+    val initialPage: SettingsScreenPage = SettingsScreenPage.Appearance,
 ) : NavKey
 
 @Serializable

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavEntries.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavEntries.kt
@@ -128,7 +128,7 @@ fun EntryProviderScope<NavKey>.settingsEntry(
             },
         ) {
             SettingsScreenRoot(
-                initialMenu = navKey.initialMenu,
+                initialPage = navKey.initialPage,
                 onClickClose = onClickClose,
                 onOpenLogViewer = onOpenLogViewer,
             )

--- a/jetwhale-host/feature/settings/build.gradle.kts
+++ b/jetwhale-host/feature/settings/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(libs.kotlinxCollectionsImmutable)
     implementation(libs.kotlinxDatetime)
     implementation(libs.aboutLibrariesComposeM3)
+    testImplementation(libs.kotlinTest)
 }
 
 compose.resources {

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -1,5 +1,9 @@
 <resources>
     <string name="settings_title">設定</string>
+    <string name="settings_section_connection">接続</string>
+    <string name="settings_section_ai_agents">AIエージェント</string>
+    <string name="settings_page_application">アプリケーション</string>
+    <string name="settings_page_add_plugins">プラグインの追加</string>
     <string name="general">一般</string>
     <string name="server">サーバー</string>
     <string name="plugins">プラグイン</string>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
@@ -1,5 +1,9 @@
 <resources>
     <string name="settings_title">Settings</string>
+    <string name="settings_section_connection">Connection</string>
+    <string name="settings_section_ai_agents">AI Agents</string>
+    <string name="settings_page_application">Application</string>
+    <string name="settings_page_add_plugins">Add Plugins</string>
     <string name="general">General</string>
     <string name="server">Server</string>
     <string name="plugins">Plugins</string>

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenMenu.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenMenu.kt
@@ -1,0 +1,81 @@
+package com.kitakkun.jetwhale.host.settings
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Computer
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.SmartToy
+import androidx.compose.material.icons.filled.Work
+import androidx.compose.ui.graphics.vector.ImageVector
+import kotlinx.serialization.Serializable
+import org.jetbrains.compose.resources.StringResource
+
+/**
+ * A top-level grouping in the settings list. Sections are containers only; pages hold the content.
+ *
+ * The grouping follows what a setting is *about* rather than where it used to live. ADB sits under
+ * Connection because port wiring is how a debuggee reaches the host, not an appearance concern; and
+ * the MCP server has a section of its own because it answers a different question from the debug
+ * server — who may drive this tool, rather than how an app connects to it.
+ */
+@Serializable
+enum class SettingsScreenSection(
+    val labelTextRes: StringResource,
+    val icon: ImageVector,
+) {
+    General(
+        labelTextRes = Res.string.general,
+        icon = Icons.Default.Info,
+    ),
+    Connection(
+        labelTextRes = Res.string.settings_section_connection,
+        icon = Icons.Default.Computer,
+    ),
+    AiAgents(
+        labelTextRes = Res.string.settings_section_ai_agents,
+        icon = Icons.Default.SmartToy,
+    ),
+    Plugins(
+        labelTextRes = Res.string.plugins,
+        icon = Icons.Default.Work,
+    ),
+    ;
+
+    /** Selecting a section means selecting where it starts; a section has no page of its own. */
+    val firstPage: SettingsScreenPage get() = SettingsScreenPage.entries.first { it.section == this }
+}
+
+/** Which section Root already subscribes to a page's data. Independent of where the menu files it. */
+enum class SettingsScreenPageOwner { General, Server, Plugin }
+
+/**
+ * One page of settings — the unit the detail pane renders and the navigation list selects.
+ *
+ * Promoting the old headings to pages keeps each one short enough to take in at a glance, and gives
+ * the ones that keep growing room to do so.
+ */
+@Serializable
+enum class SettingsScreenPage(
+    val section: SettingsScreenSection,
+    val labelTextRes: StringResource,
+    val owner: SettingsScreenPageOwner,
+) {
+    Appearance(SettingsScreenSection.General, Res.string.appearance, SettingsScreenPageOwner.General),
+
+    /** Version, update checks, the app data directory and the log viewer: this install of the host. */
+    Application(SettingsScreenSection.General, Res.string.settings_page_application, SettingsScreenPageOwner.General),
+
+    DebugServer(SettingsScreenSection.Connection, Res.string.debug_server_label, SettingsScreenPageOwner.Server),
+    SslCertificate(SettingsScreenSection.Connection, Res.string.ssl_certificate, SettingsScreenPageOwner.Server),
+
+    /** Auto port wiring and where adb was found — one topic that used to be two headings. */
+    Adb(SettingsScreenSection.Connection, Res.string.adb_support, SettingsScreenPageOwner.General),
+
+    McpServer(SettingsScreenSection.AiAgents, Res.string.mcp_server_label, SettingsScreenPageOwner.Server),
+
+    InstalledPlugins(SettingsScreenSection.Plugins, Res.string.installed_plugins, SettingsScreenPageOwner.Plugin),
+
+    /** Every way a plugin gets in: the official catalog, a local jar, or Maven coordinates. */
+    AddPlugins(SettingsScreenSection.Plugins, Res.string.settings_page_add_plugins, SettingsScreenPageOwner.Plugin),
+
+    PluginSecurity(SettingsScreenSection.Plugins, Res.string.plugin_security, SettingsScreenPageOwner.Plugin),
+}

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenRoot.kt
@@ -9,21 +9,25 @@ import com.kitakkun.jetwhale.host.settings.server.ServerSettingsScreenRoot
 context(screenContext: SettingsScreenContext)
 fun SettingsScreenRoot(
     onClickClose: () -> Unit,
-    initialMenu: SettingsScreenMenu = SettingsScreenMenu.General,
+    initialPage: SettingsScreenPage = SettingsScreenPage.Appearance,
     onOpenLogViewer: () -> Unit = {},
 ) {
     SettingsScreenScaffoldRoot(
-        initialMenu = initialMenu,
+        initialPage = initialPage,
         onClickClose = onClickClose,
-    ) {
-        when (it) {
-            SettingsScreenMenu.General -> GeneralSettingsScreenRoot(
+    ) { page ->
+        // Pages are routed to whichever Root already subscribes to their data, which is not always
+        // the section they are filed under: the menu groups settings by what they are about, while a
+        // Root groups them by what they need to read.
+        when (page.owner) {
+            SettingsScreenPageOwner.General -> GeneralSettingsScreenRoot(
+                page = page,
                 onOpenLogViewer = onOpenLogViewer,
             )
 
-            SettingsScreenMenu.Server -> ServerSettingsScreenRoot()
+            SettingsScreenPageOwner.Server -> ServerSettingsScreenRoot(page = page)
 
-            SettingsScreenMenu.Plugins -> PluginSettingsScreenRoot()
+            SettingsScreenPageOwner.Plugin -> PluginSettingsScreenRoot(page = page)
         }
     }
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffold.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffold.kt
@@ -1,21 +1,22 @@
 package com.kitakkun.jetwhale.host.settings
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Computer
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Work
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -26,46 +27,26 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import kotlinx.serialization.Serializable
-import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
-
-@Serializable
-enum class SettingsScreenMenu(
-    val labelTextRes: StringResource,
-    val icon: ImageVector,
-) {
-    General(
-        labelTextRes = Res.string.general,
-        icon = Icons.Default.Info,
-    ),
-    Server(
-        labelTextRes = Res.string.server,
-        icon = Icons.Default.Computer,
-    ),
-    Plugins(
-        labelTextRes = Res.string.plugins,
-        icon = Icons.Default.Work,
-    ),
-}
 
 val SettingsScreenScaffoldPageContentPadding = PaddingValues(16.dp)
 
-/** Wide enough for the longest section label without wrapping, narrow enough to leave the detail room. */
-private val MenuPaneWidth = 200.dp
+/** Wide enough for the longest label without wrapping, narrow enough to leave the detail room. */
+private val MenuPaneWidth = 220.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreenScaffold(
     uiState: SettingsScreenScaffoldUiState,
     onClickClose: () -> Unit,
-    onSelectMenu: (SettingsScreenMenu) -> Unit,
+    onSelectPage: (SettingsScreenPage) -> Unit,
+    onToggleSection: (SettingsScreenSection) -> Unit,
     modifier: Modifier = Modifier,
-    content: @Composable (SettingsScreenMenu) -> Unit,
+    content: @Composable (SettingsScreenPage) -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -92,7 +73,7 @@ fun SettingsScreenScaffold(
 
         Row(modifier = Modifier.fillMaxSize()) {
             Column(
-                verticalArrangement = Arrangement.spacedBy(4.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
                 modifier = Modifier
                     .width(MenuPaneWidth)
                     .fillMaxHeight()
@@ -101,23 +82,71 @@ fun SettingsScreenScaffold(
                     .verticalScroll(rememberScrollState())
                     .padding(8.dp),
             ) {
-                SettingsScreenMenu.entries.forEach { menu ->
-                    NavigationDrawerItem(
-                        selected = menu == uiState.selectedMenu,
-                        // One line keeps every row the same height, so the list does not reflow when a
-                        // translation is longer than the pane.
-                        label = { Text(stringResource(menu.labelTextRes), maxLines = 1, overflow = TextOverflow.Ellipsis) },
-                        icon = { Icon(menu.icon, contentDescription = null) },
-                        onClick = { onSelectMenu(menu) },
+                SettingsScreenSection.entries.forEach { section ->
+                    SectionHeader(
+                        section = section,
+                        expanded = section in uiState.expandedSections,
+                        onClick = { onToggleSection(section) },
                     )
+                    if (section in uiState.expandedSections) {
+                        SettingsScreenPage.entries.filter { it.section == section }.forEach { page ->
+                            NavigationDrawerItem(
+                                selected = page == uiState.selectedPage,
+                                // One line keeps every row the same height, so the list does not
+                                // reflow when a translation is longer than the pane.
+                                label = {
+                                    Text(
+                                        text = stringResource(page.labelTextRes),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                },
+                                onClick = { onSelectPage(page) },
+                                modifier = Modifier.padding(start = 16.dp),
+                            )
+                        }
+                    }
                 }
             }
             VerticalDivider()
-            // Only the selected section is composed. The pager this replaced kept every section
-            // alive, so each one's subscriptions ran whether or not it was on screen.
+            // Only the selected page is composed. The pager this replaced kept every section alive,
+            // so each one's subscriptions ran whether or not it was on screen.
             Column(modifier = Modifier.fillMaxSize()) {
-                content(uiState.selectedMenu)
+                content(uiState.selectedPage)
             }
         }
+    }
+}
+
+/**
+ * A section row. It collapses rather than selecting anything: the section is a container, and every
+ * setting lives on one of its pages.
+ */
+@Composable
+private fun SectionHeader(
+    section: SettingsScreenSection,
+    expanded: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Icon(section.icon, contentDescription = null)
+        Text(
+            text = stringResource(section.labelTextRes),
+            style = MaterialTheme.typography.titleSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        Icon(
+            imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+            contentDescription = null,
+        )
     }
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldPresenter.kt
@@ -9,26 +9,39 @@ import com.kitakkun.jetwhale.host.architecture.ActionEffect
 import com.kitakkun.jetwhale.host.architecture.ScreenChannel
 
 sealed interface SettingsScreenScaffoldAction {
-    data class SelectMenu(val menu: SettingsScreenMenu) : SettingsScreenScaffoldAction
+    data class SelectPage(val page: SettingsScreenPage) : SettingsScreenScaffoldAction
+    data class ToggleSection(val section: SettingsScreenSection) : SettingsScreenScaffoldAction
 }
 
 @Composable
 context(_: SettingsPresenterContext)
 fun settingsScreenScaffoldPresenter(
     screenChannel: ScreenChannel<SettingsScreenScaffoldAction, Nothing>,
-    initialMenu: SettingsScreenMenu,
+    initialPage: SettingsScreenPage,
 ): SettingsScreenScaffoldUiState {
-    var selectedMenu by retain { mutableStateOf(initialMenu) }
+    var selectedPage by retain { mutableStateOf(initialPage) }
+    // Only the section being visited starts open, so the list opens at a length that can be read
+    // rather than every page of every section at once.
+    var expandedSections by retain { mutableStateOf(setOf(initialPage.section)) }
 
     ActionEffect(screenChannel) { action ->
         when (action) {
-            is SettingsScreenScaffoldAction.SelectMenu -> {
-                selectedMenu = action.menu
+            is SettingsScreenScaffoldAction.SelectPage -> {
+                selectedPage = action.page
+            }
+
+            is SettingsScreenScaffoldAction.ToggleSection -> {
+                expandedSections = if (action.section in expandedSections) {
+                    expandedSections - action.section
+                } else {
+                    expandedSections + action.section
+                }
             }
         }
     }
 
     return SettingsScreenScaffoldUiState(
-        selectedMenu = selectedMenu,
+        selectedPage = selectedPage,
+        expandedSections = expandedSections,
     )
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldRoot.kt
@@ -7,24 +7,22 @@ import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 context(screenContext: SettingsScreenContext)
 fun SettingsScreenScaffoldRoot(
     onClickClose: () -> Unit,
-    initialMenu: SettingsScreenMenu = SettingsScreenMenu.General,
-    content: @Composable (SettingsScreenMenu) -> Unit,
+    initialPage: SettingsScreenPage = SettingsScreenPage.Appearance,
+    content: @Composable (SettingsScreenPage) -> Unit,
 ) {
     val screenChannel = rememberScreenChannel<SettingsScreenScaffoldAction, Nothing>()
     val uiState = context(screenContext.presenterContext) {
         settingsScreenScaffoldPresenter(
             screenChannel = screenChannel,
-            initialMenu = initialMenu,
+            initialPage = initialPage,
         )
     }
 
     SettingsScreenScaffold(
         uiState = uiState,
-        onSelectMenu = { menu ->
-            screenChannel.send(SettingsScreenScaffoldAction.SelectMenu(menu))
-        },
+        onSelectPage = { screenChannel.send(SettingsScreenScaffoldAction.SelectPage(it)) },
+        onToggleSection = { screenChannel.send(SettingsScreenScaffoldAction.ToggleSection(it)) },
         onClickClose = onClickClose,
-    ) { selectedMenu ->
-        content(selectedMenu)
-    }
+        content = content,
+    )
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldUiState.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenScaffoldUiState.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.settings
 
 data class SettingsScreenScaffoldUiState(
-    val selectedMenu: SettingsScreenMenu = SettingsScreenMenu.Plugins,
+    val selectedPage: SettingsScreenPage,
+    val expandedSections: Set<SettingsScreenSection>,
 )

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreen.kt
@@ -31,6 +31,7 @@ import com.kitakkun.jetwhale.host.model.AppLanguage
 import com.kitakkun.jetwhale.host.model.JetWhaleColorSchemeId
 import com.kitakkun.jetwhale.host.model.UpdateCheckResult
 import com.kitakkun.jetwhale.host.settings.Res
+import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import com.kitakkun.jetwhale.host.settings.SettingsScreenScaffoldPageContentPadding
 import com.kitakkun.jetwhale.host.settings.adb_executable_path
 import com.kitakkun.jetwhale.host.settings.adb_support
@@ -63,6 +64,7 @@ import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun GeneralSettingsScreen(
+    page: SettingsScreenPage,
     uiState: GeneralSettingsScreenUiState,
     onCheckedChangePersistData: (Boolean) -> Unit,
     onAutomaticallyWireADBTransportChange: (Boolean) -> Unit,
@@ -80,103 +82,113 @@ fun GeneralSettingsScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = SettingsScreenScaffoldPageContentPadding,
     ) {
-        item {
-            SettingOptionView(
-                label = stringResource(Res.string.appearance),
-            ) {
-                DropdownSettingsItemView(
-                    label = stringResource(Res.string.language_option),
-                    currentItem = uiState.language,
-                    items = AppLanguage.entries,
-                    onSelect = { onSelectLanguage(it) },
-                    itemNameProvider = { it.displayName },
-                )
-                DropdownSettingsItemView(
-                    label = stringResource(Res.string.theme_option),
-                    currentItem = uiState.selectedColorSchemeId,
-                    items = uiState.availableColorSchemes,
-                    onSelect = { onSelectColorScheme(it) },
-                    itemNameProvider = { it.id },
-                )
-            }
-        }
-        item {
-            SettingOptionView(stringResource(Res.string.adb_support)) {
-                SwitchSettingsItemView(
-                    label = stringResource(Res.string.automatically_wire_adb_transport),
-                    isChecked = uiState.automaticallyWireADBTransport,
-                    onCheckedChange = onAutomaticallyWireADBTransportChange,
-                )
-            }
-        }
-        item {
-            SettingOptionView(stringResource(Res.string.maintenance)) {
-                // Not SettingsItemRow here: the path can be very long. The label keeps a min width so
-                // it can't be starved down to one character per line, and the path Card takes the
-                // remaining space (weight) and wraps within it.
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+        if (page == SettingsScreenPage.Appearance) {
+            item {
+                SettingOptionView(
+                    label = stringResource(Res.string.appearance),
                 ) {
-                    Text(
-                        text = stringResource(Res.string.application_data_directory),
-                        modifier = Modifier.widthIn(min = 120.dp),
+                    DropdownSettingsItemView(
+                        label = stringResource(Res.string.language_option),
+                        currentItem = uiState.language,
+                        items = AppLanguage.entries,
+                        onSelect = { onSelectLanguage(it) },
+                        itemNameProvider = { it.displayName },
                     )
-                    Card(modifier = Modifier.weight(1f)) {
+                    DropdownSettingsItemView(
+                        label = stringResource(Res.string.theme_option),
+                        currentItem = uiState.selectedColorSchemeId,
+                        items = uiState.availableColorSchemes,
+                        onSelect = { onSelectColorScheme(it) },
+                        itemNameProvider = { it.id },
+                    )
+                }
+            }
+        }
+        if (page == SettingsScreenPage.Adb) {
+            item {
+                SettingOptionView(stringResource(Res.string.adb_support)) {
+                    SwitchSettingsItemView(
+                        label = stringResource(Res.string.automatically_wire_adb_transport),
+                        isChecked = uiState.automaticallyWireADBTransport,
+                        onCheckedChange = onAutomaticallyWireADBTransportChange,
+                    )
+                }
+            }
+        }
+        if (page == SettingsScreenPage.Application) {
+            item {
+                SettingOptionView(stringResource(Res.string.maintenance)) {
+                    // Not SettingsItemRow here: the path can be very long. The label keeps a min width so
+                    // it can't be starved down to one character per line, and the path Card takes the
+                    // remaining space (weight) and wraps within it.
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
                         Text(
-                            text = uiState.appDataPath,
-                            modifier = Modifier.padding(8.dp),
+                            text = stringResource(Res.string.application_data_directory),
+                            modifier = Modifier.widthIn(min = 120.dp),
                         )
+                        Card(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = uiState.appDataPath,
+                                modifier = Modifier.padding(8.dp),
+                            )
+                        }
+                        IconButton(onClick = onClickOpenAppDataPath) {
+                            Icon(Icons.Default.FolderOpen, null)
+                        }
                     }
-                    IconButton(onClick = onClickOpenAppDataPath) {
-                        Icon(Icons.Default.FolderOpen, null)
+                    Button(onClick = onClickOpenLogViewer) {
+                        Text(stringResource(Res.string.view_application_logs))
                     }
-                }
-                Button(onClick = onClickOpenLogViewer) {
-                    Text(stringResource(Res.string.view_application_logs))
                 }
             }
         }
-        item {
-            SettingOptionView(stringResource(Res.string.updates)) {
-                SettingsItemRow(stringResource(Res.string.current_version)) {
-                    Card {
-                        Text(uiState.currentVersion)
+        if (page == SettingsScreenPage.Application) {
+            item {
+                SettingOptionView(stringResource(Res.string.updates)) {
+                    SettingsItemRow(stringResource(Res.string.current_version)) {
+                        Card {
+                            Text(uiState.currentVersion)
+                        }
                     }
-                }
-                SwitchSettingsItemView(
-                    label = stringResource(Res.string.check_for_updates_on_startup),
-                    isChecked = uiState.checkForUpdatesOnStartup,
-                    onCheckedChange = onCheckForUpdatesOnStartupChange,
-                )
-                UpdateCheckStatusView(
-                    isChecking = uiState.isCheckingForUpdates,
-                    result = uiState.updateCheckResult,
-                    error = uiState.updateCheckError,
-                    onClickInstallUpdate = onClickInstallUpdate,
-                    onClickOpenDownloadPage = onClickOpenDownloadPage,
-                )
-                Button(
-                    onClick = onClickCheckForUpdates,
-                    enabled = !uiState.isCheckingForUpdates,
-                ) {
-                    Text(stringResource(Res.string.check_for_updates))
-                }
-            }
-        }
-        item {
-            SettingOptionView(stringResource(Res.string.health_check)) {
-                SettingsItemRow(stringResource(Res.string.adb_executable_path)) {
-                    Text(
-                        text = uiState.adbPath.ifEmpty { stringResource(Res.string.adb_unavailable) },
+                    SwitchSettingsItemView(
+                        label = stringResource(Res.string.check_for_updates_on_startup),
+                        isChecked = uiState.checkForUpdatesOnStartup,
+                        onCheckedChange = onCheckForUpdatesOnStartupChange,
                     )
-                    Spacer(Modifier.width(8.dp))
-                    if (uiState.adbPath.isNotEmpty()) {
-                        Icon(
-                            imageVector = Icons.Default.Check,
-                            tint = MaterialTheme.colorScheme.primary,
-                            contentDescription = null,
+                    UpdateCheckStatusView(
+                        isChecking = uiState.isCheckingForUpdates,
+                        result = uiState.updateCheckResult,
+                        error = uiState.updateCheckError,
+                        onClickInstallUpdate = onClickInstallUpdate,
+                        onClickOpenDownloadPage = onClickOpenDownloadPage,
+                    )
+                    Button(
+                        onClick = onClickCheckForUpdates,
+                        enabled = !uiState.isCheckingForUpdates,
+                    ) {
+                        Text(stringResource(Res.string.check_for_updates))
+                    }
+                }
+            }
+        }
+        if (page == SettingsScreenPage.Adb) {
+            item {
+                SettingOptionView(stringResource(Res.string.health_check)) {
+                    SettingsItemRow(stringResource(Res.string.adb_executable_path)) {
+                        Text(
+                            text = uiState.adbPath.ifEmpty { stringResource(Res.string.adb_unavailable) },
                         )
+                        Spacer(Modifier.width(8.dp))
+                        if (uiState.adbPath.isNotEmpty()) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                tint = MaterialTheme.colorScheme.primary,
+                                contentDescription = null,
+                            )
+                        }
                     }
                 }
             }
@@ -260,6 +272,7 @@ private fun UpdateCheckStatusView(
 @Composable
 private fun GeneralSettingsScreenPreview() {
     GeneralSettingsScreen(
+        page = SettingsScreenPage.Appearance,
         uiState = GeneralSettingsScreenUiState(
             automaticallyWireADBTransport = true,
             selectedColorSchemeId = JetWhaleColorSchemeId.BuiltInDynamic,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenRoot.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.settings.SettingsScreenContext
+import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import soil.query.compose.rememberQuery
 import soil.query.compose.rememberSubscription
 import java.awt.Desktop
@@ -11,6 +12,7 @@ import java.awt.Desktop
 @Composable
 context(screenContext: SettingsScreenContext)
 fun GeneralSettingsScreenRoot(
+    page: SettingsScreenPage,
     onOpenLogViewer: () -> Unit = {},
 ) {
     SoilDataBoundary(
@@ -29,6 +31,7 @@ fun GeneralSettingsScreenRoot(
         }
 
         GeneralSettingsScreen(
+            page = page,
             uiState = uiState,
             onCheckedChangePersistData = {
                 screenChannel.send(GeneralSettingsScreenAction.ChangePersistData(it))

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
@@ -126,9 +126,8 @@ fun PluginSettingsScreen(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         modifier = modifier.fillMaxSize(),
     ) {
-        // Installed plugins: header with the install actions kept alongside it, then one card per
-        // plugin. The whole page is a single scrollable list so no section can squeeze another out
-        // of view when the window is short.
+        // One list serving three pages of the Plugins section: each block declares which page it
+        // belongs to, so the section's Root keeps a single set of subscriptions.
         if (page == SettingsScreenPage.InstalledPlugins) {
             item(key = "installed_header") {
                 Text(
@@ -196,20 +195,24 @@ fun PluginSettingsScreen(
                 }
             }
         }
-        uiState.installError?.let { error ->
-            item(key = "install_error") {
-                Text(
-                    text = error,
-                    color = MaterialTheme.colorScheme.onErrorContainer,
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(
-                            color = MaterialTheme.colorScheme.errorContainer,
-                            shape = MaterialTheme.shapes.small,
-                        )
-                        .padding(12.dp),
-                )
+        // Beside the progress it replaces: an install only starts from this page, so its failure has
+        // no business appearing over the installed list or the security settings.
+        if (page == SettingsScreenPage.AddPlugins) {
+            uiState.installError?.let { error ->
+                item(key = "install_error") {
+                    Text(
+                        text = error,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                color = MaterialTheme.colorScheme.errorContainer,
+                                shape = MaterialTheme.shapes.small,
+                            )
+                            .padding(12.dp),
+                    )
+                }
             }
         }
         if (page == SettingsScreenPage.InstalledPlugins) {

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
@@ -161,7 +161,7 @@ fun PluginSettingsScreen(
                 }
             }
         }
-        if (page == SettingsScreenPage.AddPlugins) if (uiState.isInstalling) {
+        if (page == SettingsScreenPage.AddPlugins && uiState.isInstalling) {
             item(key = "install_progress") {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -222,21 +222,19 @@ fun PluginSettingsScreen(
                 InstalledPluginRow(plugin = plugin)
             }
         }
-        if (uiState.plugins.isEmpty()) {
-            if (page == SettingsScreenPage.InstalledPlugins) {
-                item(key = "no_plugins") {
-                    Text(
-                        text = stringResource(Res.string.no_plugins_installed),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 16.dp),
-                    )
-                }
+        if (page == SettingsScreenPage.InstalledPlugins && uiState.plugins.isEmpty()) {
+            item(key = "no_plugins") {
+                Text(
+                    text = stringResource(Res.string.no_plugins_installed),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                )
             }
         }
-        if (page == SettingsScreenPage.InstalledPlugins) if (uiState.failedJars.isNotEmpty()) {
+        if (page == SettingsScreenPage.InstalledPlugins && uiState.failedJars.isNotEmpty()) {
             item(key = "failed_jars") {
                 TextButton(
                     onClick = { showFailedJarsDialog = true },
@@ -257,7 +255,7 @@ fun PluginSettingsScreen(
                 }
             }
         }
-        if (page == SettingsScreenPage.PluginSecurity) if (uiState.untrustedJarPaths.isNotEmpty()) {
+        if (page == SettingsScreenPage.PluginSecurity && uiState.untrustedJarPaths.isNotEmpty()) {
             item(key = "untrusted_jars") {
                 UntrustedPluginsSection(
                     untrustedJarPaths = uiState.untrustedJarPaths,
@@ -265,7 +263,7 @@ fun PluginSettingsScreen(
                 )
             }
         }
-        if (page == SettingsScreenPage.AddPlugins) if (uiState.officialPlugins.isNotEmpty()) {
+        if (page == SettingsScreenPage.AddPlugins && uiState.officialPlugins.isNotEmpty()) {
             item(key = "official_header") {
                 Text(
                     text = stringResource(Res.string.official_plugins),

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreen.kt
@@ -38,6 +38,7 @@ import com.kitakkun.jetwhale.host.model.HostOs
 import com.kitakkun.jetwhale.host.model.OfficialPlugin
 import com.kitakkun.jetwhale.host.model.PluginInstallProgress
 import com.kitakkun.jetwhale.host.settings.Res
+import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import com.kitakkun.jetwhale.host.settings.SettingsScreenScaffoldPageContentPadding
 import com.kitakkun.jetwhale.host.settings.add_plugin_from_file
 import com.kitakkun.jetwhale.host.settings.approve_untrusted_plugin
@@ -67,6 +68,7 @@ import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun PluginSettingsScreen(
+    page: SettingsScreenPage,
     uiState: PluginSettingsScreenUiState,
     onClickAddPlugin: () -> Unit,
     onApproveUntrustedJar: (String) -> Unit,
@@ -127,32 +129,39 @@ fun PluginSettingsScreen(
         // Installed plugins: header with the install actions kept alongside it, then one card per
         // plugin. The whole page is a single scrollable list so no section can squeeze another out
         // of view when the window is short.
-        item(key = "installed_header") {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
+        if (page == SettingsScreenPage.InstalledPlugins) {
+            item(key = "installed_header") {
                 Text(
                     text = stringResource(Res.string.installed_plugins),
                     style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.weight(1f),
                 )
-                TextButton(
-                    onClick = onClickAddPlugin,
-                    enabled = !uiState.isInstalling,
+            }
+        }
+        // The install actions sit with the official catalog rather than on the installed list: they
+        // are two more ways in, and splitting them across pages hid that they are the same choice.
+        if (page == SettingsScreenPage.AddPlugins) {
+            item(key = "add_actions") {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text(stringResource(Res.string.add_plugin_from_file), maxLines = 1)
-                }
-                TextButton(
-                    onClick = onClickInstallFromMaven,
-                    enabled = !uiState.isInstalling,
-                ) {
-                    Text(stringResource(Res.string.install_from_maven), maxLines = 1)
+                    TextButton(
+                        onClick = onClickAddPlugin,
+                        enabled = !uiState.isInstalling,
+                    ) {
+                        Text(stringResource(Res.string.add_plugin_from_file), maxLines = 1)
+                    }
+                    TextButton(
+                        onClick = onClickInstallFromMaven,
+                        enabled = !uiState.isInstalling,
+                    ) {
+                        Text(stringResource(Res.string.install_from_maven), maxLines = 1)
+                    }
                 }
             }
         }
-        if (uiState.isInstalling) {
+        if (page == SettingsScreenPage.AddPlugins) if (uiState.isInstalling) {
             item(key = "install_progress") {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -203,27 +212,31 @@ fun PluginSettingsScreen(
                 )
             }
         }
-        items(
-            items = uiState.plugins,
-            // Prefixed so an official catalog entry for the same plugin id cannot collide with it
-            // in this single LazyColumn.
-            key = { plugin -> "installed:${plugin.id}" },
-        ) { plugin ->
-            InstalledPluginRow(plugin = plugin)
-        }
-        if (uiState.plugins.isEmpty()) {
-            item(key = "no_plugins") {
-                Text(
-                    text = stringResource(Res.string.no_plugins_installed),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 16.dp),
-                )
+        if (page == SettingsScreenPage.InstalledPlugins) {
+            items(
+                items = uiState.plugins,
+                // Prefixed so an official catalog entry for the same plugin id cannot collide with it
+                // in this single LazyColumn.
+                key = { plugin -> "installed:${plugin.id}" },
+            ) { plugin ->
+                InstalledPluginRow(plugin = plugin)
             }
         }
-        if (uiState.failedJars.isNotEmpty()) {
+        if (uiState.plugins.isEmpty()) {
+            if (page == SettingsScreenPage.InstalledPlugins) {
+                item(key = "no_plugins") {
+                    Text(
+                        text = stringResource(Res.string.no_plugins_installed),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 16.dp),
+                    )
+                }
+            }
+        }
+        if (page == SettingsScreenPage.InstalledPlugins) if (uiState.failedJars.isNotEmpty()) {
             item(key = "failed_jars") {
                 TextButton(
                     onClick = { showFailedJarsDialog = true },
@@ -244,7 +257,7 @@ fun PluginSettingsScreen(
                 }
             }
         }
-        if (uiState.untrustedJarPaths.isNotEmpty()) {
+        if (page == SettingsScreenPage.PluginSecurity) if (uiState.untrustedJarPaths.isNotEmpty()) {
             item(key = "untrusted_jars") {
                 UntrustedPluginsSection(
                     untrustedJarPaths = uiState.untrustedJarPaths,
@@ -252,7 +265,7 @@ fun PluginSettingsScreen(
                 )
             }
         }
-        if (uiState.officialPlugins.isNotEmpty()) {
+        if (page == SettingsScreenPage.AddPlugins) if (uiState.officialPlugins.isNotEmpty()) {
             item(key = "official_header") {
                 Text(
                     text = stringResource(Res.string.official_plugins),
@@ -271,25 +284,27 @@ fun PluginSettingsScreen(
                 )
             }
         }
-        item(key = "trust_registry_signing") {
-            SettingOptionView(label = stringResource(Res.string.plugin_security)) {
-                SwitchSettingsItemView(
-                    label = stringResource(Res.string.sign_plugin_trust_registry),
-                    isChecked = uiState.signPluginTrustRegistry,
-                    onCheckedChange = onChangeSignPluginTrustRegistry,
-                )
-                // Append only the current OS's credential-store behavior — the prompt story differs
-                // per platform (macOS prompts, Windows DPAPI is silent, Linux depends on the keyring).
-                val osHint = when (HostOs.current) {
-                    HostOs.MAC -> Res.string.sign_plugin_trust_registry_hint_macos
-                    HostOs.WINDOWS -> Res.string.sign_plugin_trust_registry_hint_windows
-                    else -> Res.string.sign_plugin_trust_registry_hint_linux
+        if (page == SettingsScreenPage.PluginSecurity) {
+            item(key = "trust_registry_signing") {
+                SettingOptionView(label = stringResource(Res.string.plugin_security)) {
+                    SwitchSettingsItemView(
+                        label = stringResource(Res.string.sign_plugin_trust_registry),
+                        isChecked = uiState.signPluginTrustRegistry,
+                        onCheckedChange = onChangeSignPluginTrustRegistry,
+                    )
+                    // Append only the current OS's credential-store behavior — the prompt story differs
+                    // per platform (macOS prompts, Windows DPAPI is silent, Linux depends on the keyring).
+                    val osHint = when (HostOs.current) {
+                        HostOs.MAC -> Res.string.sign_plugin_trust_registry_hint_macos
+                        HostOs.WINDOWS -> Res.string.sign_plugin_trust_registry_hint_windows
+                        else -> Res.string.sign_plugin_trust_registry_hint_linux
+                    }
+                    Text(
+                        text = "${stringResource(Res.string.sign_plugin_trust_registry_hint)} ${stringResource(osHint)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
-                Text(
-                    text = "${stringResource(Res.string.sign_plugin_trust_registry_hint)} ${stringResource(osHint)}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
             }
         }
     }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/plugin/PluginSettingsScreenRoot.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.settings.SettingsScreenContext
+import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import soil.query.compose.rememberSubscription
 import java.awt.FileDialog
 import java.awt.Frame
@@ -15,7 +16,7 @@ import java.io.File
 
 @Composable
 context(screenContext: SettingsScreenContext)
-fun PluginSettingsScreenRoot() {
+fun PluginSettingsScreenRoot(page: SettingsScreenPage) {
     var showMavenDialog by remember { mutableStateOf(false) }
 
     SoilDataBoundary(
@@ -40,6 +41,7 @@ fun PluginSettingsScreenRoot() {
             }
 
             PluginSettingsScreen(
+                page = page,
                 uiState = uiState,
                 onClickAddPlugin = {
                     val selectedJar = selectJarFile() ?: return@PluginSettingsScreen

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.settings.Res
+import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import com.kitakkun.jetwhale.host.settings.SettingsScreenScaffoldPageContentPadding
 import com.kitakkun.jetwhale.host.settings.component.SettingOptionView
 import com.kitakkun.jetwhale.host.settings.component.SwitchSettingsItemView
@@ -73,6 +74,7 @@ import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun ServerSettingsScreen(
+    page: SettingsScreenPage,
     uiState: ServerSettingsScreenUiState,
     onDebugPortTextChange: (String) -> Unit,
     onApplyDebugPortChange: () -> Unit,
@@ -175,122 +177,128 @@ fun ServerSettingsScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = SettingsScreenScaffoldPageContentPadding,
     ) {
-        item {
-            SettingOptionView(
-                label = stringResource(Res.string.debug_server_label),
-            ) {
-                Text(
-                    text = serverStateText(uiState.debugServerState),
-                )
-                TextFieldSettingsItemView(
-                    label = stringResource(Res.string.debug_server_port_label),
-                    text = uiState.editingDebugPortText,
-                    onTextChange = onDebugPortTextChange,
-                )
-                if (uiState.isDebugApplyVisible) {
-                    Button(
-                        onClick = onApplyDebugPortChange,
-                        enabled = uiState.isDebugApplyEnabled,
-                    ) {
-                        Text(applyButtonText(isRetry = uiState.isDebugRetry))
+        if (page == SettingsScreenPage.DebugServer) {
+            item {
+                SettingOptionView(
+                    label = stringResource(Res.string.debug_server_label),
+                ) {
+                    Text(
+                        text = serverStateText(uiState.debugServerState),
+                    )
+                    TextFieldSettingsItemView(
+                        label = stringResource(Res.string.debug_server_port_label),
+                        text = uiState.editingDebugPortText,
+                        onTextChange = onDebugPortTextChange,
+                    )
+                    if (uiState.isDebugApplyVisible) {
+                        Button(
+                            onClick = onApplyDebugPortChange,
+                            enabled = uiState.isDebugApplyEnabled,
+                        ) {
+                            Text(applyButtonText(isRetry = uiState.isDebugRetry))
+                        }
                     }
                 }
             }
         }
-        item {
-            SettingOptionView(
-                label = stringResource(Res.string.mcp_server_label),
-            ) {
-                Text(
-                    text = serverStateText(uiState.mcpServerState),
-                )
-                TextFieldSettingsItemView(
-                    label = stringResource(Res.string.mcp_server_port_label),
-                    text = uiState.editingMcpPortText,
-                    onTextChange = onMcpPortTextChange,
-                )
-                if (uiState.isMcpApplyVisible) {
-                    Button(
-                        onClick = onApplyMcpPortChange,
-                        enabled = uiState.isMcpApplyEnabled,
-                    ) {
-                        Text(applyButtonText(isRetry = uiState.isMcpRetry))
+        if (page == SettingsScreenPage.McpServer) {
+            item {
+                SettingOptionView(
+                    label = stringResource(Res.string.mcp_server_label),
+                ) {
+                    Text(
+                        text = serverStateText(uiState.mcpServerState),
+                    )
+                    TextFieldSettingsItemView(
+                        label = stringResource(Res.string.mcp_server_port_label),
+                        text = uiState.editingMcpPortText,
+                        onTextChange = onMcpPortTextChange,
+                    )
+                    if (uiState.isMcpApplyVisible) {
+                        Button(
+                            onClick = onApplyMcpPortChange,
+                            enabled = uiState.isMcpApplyEnabled,
+                        ) {
+                            Text(applyButtonText(isRetry = uiState.isMcpRetry))
+                        }
                     }
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = stringResource(Res.string.mcp_setup_note),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    McpSnippetView(
+                        label = stringResource(Res.string.mcp_setup_claude_code_label),
+                        snippet = uiState.mcpClaudeCodeCommand,
+                    )
+                    McpSnippetView(
+                        label = stringResource(Res.string.mcp_setup_json_label),
+                        snippet = uiState.mcpJsonConfig,
+                    )
+                    OutlinedButton(onClick = onClickOpenMcpGuide) {
+                        Text(stringResource(Res.string.mcp_setup_open_guide))
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    SwitchSettingsItemView(
+                        label = stringResource(Res.string.mcp_plugin_install_allowed_label),
+                        isChecked = uiState.mcpPluginInstallAllowed,
+                        onCheckedChange = onMcpPluginInstallAllowedChange,
+                    )
+                    Text(
+                        text = stringResource(Res.string.mcp_plugin_install_allowed_note),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
-                Spacer(Modifier.height(12.dp))
-                Text(
-                    text = stringResource(Res.string.mcp_setup_note),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                McpSnippetView(
-                    label = stringResource(Res.string.mcp_setup_claude_code_label),
-                    snippet = uiState.mcpClaudeCodeCommand,
-                )
-                McpSnippetView(
-                    label = stringResource(Res.string.mcp_setup_json_label),
-                    snippet = uiState.mcpJsonConfig,
-                )
-                OutlinedButton(onClick = onClickOpenMcpGuide) {
-                    Text(stringResource(Res.string.mcp_setup_open_guide))
-                }
-                Spacer(Modifier.height(12.dp))
-                SwitchSettingsItemView(
-                    label = stringResource(Res.string.mcp_plugin_install_allowed_label),
-                    isChecked = uiState.mcpPluginInstallAllowed,
-                    onCheckedChange = onMcpPluginInstallAllowedChange,
-                )
-                Text(
-                    text = stringResource(Res.string.mcp_plugin_install_allowed_note),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
             }
         }
-        item {
-            SettingOptionView(
-                label = stringResource(Res.string.ssl_certificate),
-            ) {
-                Text(
-                    text = stringResource(Res.string.ssl_certificate_apply_note),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                if (uiState.certificates.isEmpty()) {
-                    Text(stringResource(Res.string.ssl_certificate_no_certificate))
-                }
-                uiState.certificates.forEach { certificate ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Text(
-                            text = buildString {
-                                append(certificate.name)
-                                if (certificate.isActive) append(" (${stringResource(Res.string.ssl_certificate_active)})")
-                            },
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Text(
-                            text = stringResource(Res.string.ssl_certificate_created_at, certificate.createdAt),
-                            style = MaterialTheme.typography.bodySmall,
-                        )
-                        if (!certificate.isActive) {
-                            TextButton(onClick = { onSetActiveCertificate(certificate.id) }) {
-                                Text(stringResource(Res.string.ssl_certificate_set_active))
+        if (page == SettingsScreenPage.SslCertificate) {
+            item {
+                SettingOptionView(
+                    label = stringResource(Res.string.ssl_certificate),
+                ) {
+                    Text(
+                        text = stringResource(Res.string.ssl_certificate_apply_note),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (uiState.certificates.isEmpty()) {
+                        Text(stringResource(Res.string.ssl_certificate_no_certificate))
+                    }
+                    uiState.certificates.forEach { certificate ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                text = buildString {
+                                    append(certificate.name)
+                                    if (certificate.isActive) append(" (${stringResource(Res.string.ssl_certificate_active)})")
+                                },
+                                style = MaterialTheme.typography.bodyMedium,
+                                modifier = Modifier.weight(1f),
+                            )
+                            Text(
+                                text = stringResource(Res.string.ssl_certificate_created_at, certificate.createdAt),
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                            if (!certificate.isActive) {
+                                TextButton(onClick = { onSetActiveCertificate(certificate.id) }) {
+                                    Text(stringResource(Res.string.ssl_certificate_set_active))
+                                }
+                            }
+                            TextButton(onClick = { onShowCertificateDetail(certificate.id) }) {
+                                Text(stringResource(Res.string.ssl_certificate_show_detail))
+                            }
+                            TextButton(onClick = { onDeleteCertificate(certificate.id) }) {
+                                Text(stringResource(Res.string.ssl_certificate_delete))
                             }
                         }
-                        TextButton(onClick = { onShowCertificateDetail(certificate.id) }) {
-                            Text(stringResource(Res.string.ssl_certificate_show_detail))
-                        }
-                        TextButton(onClick = { onDeleteCertificate(certificate.id) }) {
-                            Text(stringResource(Res.string.ssl_certificate_delete))
-                        }
                     }
-                }
-                OutlinedButton(onClick = onAddCertificate) {
-                    Text(stringResource(Res.string.ssl_certificate_add))
+                    OutlinedButton(onClick = onAddCertificate) {
+                        Text(stringResource(Res.string.ssl_certificate_add))
+                    }
                 }
             }
         }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenRoot.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.settings.SettingsScreenContext
+import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import soil.query.compose.rememberSubscription
 import java.awt.Desktop
 
@@ -11,7 +12,7 @@ private const val MCP_GUIDE_URL = "https://kitakkun.github.io/JetWhale/guide/mcp
 
 @Composable
 context(screenContext: SettingsScreenContext)
-fun ServerSettingsScreenRoot() {
+fun ServerSettingsScreenRoot(page: SettingsScreenPage) {
     SoilDataBoundary(
         state1 = rememberSubscription(screenContext.serverStatusSubscriptionKey),
         state2 = rememberSubscription(screenContext.mcpServerStatusSubscriptionKey),
@@ -30,6 +31,7 @@ fun ServerSettingsScreenRoot() {
         }
 
         ServerSettingsScreen(
+            page = page,
             uiState = uiState,
             onDebugPortTextChange = {
                 screenChannel.send(ServerSettingsScreenAction.ChangeDebugPortText(it))

--- a/jetwhale-host/feature/settings/src/test/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenMenuTest.kt
+++ b/jetwhale-host/feature/settings/src/test/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenMenuTest.kt
@@ -1,0 +1,43 @@
+package com.kitakkun.jetwhale.host.settings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SettingsScreenMenuTest {
+
+    @Test
+    fun `every section has at least one page`() {
+        // firstPage resolves with first {}, so a section nobody gave a page to would not fail here —
+        // it would throw when the settings screen tried to open it.
+        val sectionsWithoutPages = SettingsScreenSection.entries
+            .filter { section -> SettingsScreenPage.entries.none { it.section == section } }
+
+        assertTrue(sectionsWithoutPages.isEmpty(), "Sections with no page: $sectionsWithoutPages")
+    }
+
+    @Test
+    fun `a section starts at its first declared page`() {
+        SettingsScreenSection.entries.forEach { section ->
+            assertEquals(
+                SettingsScreenPage.entries.first { it.section == section },
+                section.firstPage,
+                "Wrong entry page for $section",
+            )
+        }
+    }
+
+    @Test
+    fun `pages of a section are declared together`() {
+        // The menu renders pages by filtering the enum per section, so interleaving two sections'
+        // pages would silently reorder the list away from the declaration order it reads as.
+        val sectionRuns = SettingsScreenPage.entries
+            .map { it.section }
+            .fold(mutableListOf<SettingsScreenSection>()) { runs, section ->
+                if (runs.lastOrNull() != section) runs.add(section)
+                runs
+            }
+
+        assertEquals(sectionRuns.distinct(), sectionRuns, "A section's pages are split apart: $sectionRuns")
+    }
+}


### PR DESCRIPTION
## What

Turns the settings list into two levels: collapsible **sections** containing **pages**. Each old heading becomes a page, so the detail pane shows one subject at a time instead of five stacked on a scroll.

```
▾ General      Appearance / Application
▾ Connection   Debug Server / SSL Certificate / ADB
▾ AI Agents    MCP Server
▾ Plugins      Installed Plugins / Add Plugins / Security
```

## The grouping is not the old one

The sections follow what a setting is *about*, not where it happened to sit. Four things were filed oddly:

- **ADB auto-wiring** and **"where adb was found"** (Health Check) were two separate headings under General. They are one topic — and a connection topic, since port wiring is how a debuggee reaches the host. Now one page under Connection.
- **Maintenance** and **Updates** both describe this install of the host. One `Application` page.
- The **official catalog** had its own heading while the other two ways to install a plugin were buttons on the installed list. All three ways in are now `Add Plugins`; the installed list only lists.
- The **MCP server** gets its own section. It answers a different question from the debug server — who may drive this tool, rather than how an app connects to it — and #201 is about to grow a permission tree under it.

## Menu grouping is decoupled from Root structure

A page carries a `SettingsScreenPageOwner` naming which Root renders it. The menu groups by subject; a Root groups by the data it subscribes to, and those are not the same cut — the ADB page is filed under Connection but read by the General Root, which already subscribes to the settings flow.

Doing it the other way (moving content so Roots match sections) would mean re-plumbing subscriptions across three Roots, which is a much larger change for no user-visible gain.

## Compatibility

`SettingsNavKey.initialMenu` becomes `initialPage`. `HostSettingsSection` — what `jetwhale.navigate` accepts from an agent — keeps its `GENERAL / SERVER / PLUGINS` vocabulary and now resolves to the first page of the matching section; Connection and AI Agents both map back to `SERVER`, so agent-driven navigation behaves as before.

## Verified

`:jetwhale-host:app:build`, `:jetwhale-host:feature:settings:build` and `spotlessCheck` pass.

**Not verified: the rendered layout.** The accordion, its expand/collapse affordance and the indented page rows have not been looked at in a running host this round — worth a glance before merging.
