### PR TITLE
docs(plugin-qa): wait for the port, not for a process

### DIFF
--- a/plugins/jetwhale/skills/plugin-qa/SKILL.md
+++ b/plugins/jetwhale/skills/plugin-qa/SKILL.md
@@ -82,10 +82,27 @@ describes someone else's host.
 - Run it in the **background, redirected to a file** (`> run.log 2>&1`). Do NOT pipe it through
   `tail`/`grep`: the pipeline buffers and the log file stays empty until the process exits, so you
   lose all live output.
-- Wait for it properly — Gradle configuration plus the app launch takes minutes on a cold build:
+- Wait for the **MCP port to answer**, not for a process to appear — Gradle configuration plus the
+  app launch takes minutes on a cold build, and the JVM exists long before the port opens. Waiting on
+  `pgrep` means guessing how much longer with a `sleep`, and on a machine running several checkouts
+  it matches somebody else's host and returns immediately.
+
+  Bound the wait and watch the launcher: a build that fails or a port already taken otherwise leaves
+  you spinning until a timeout with nothing to read.
+
   ```bash
-  until pgrep -f com.kitakkun.jetwhale.host.MainKt >/dev/null; do sleep 3; done
+  nohup ./gradlew … > run.log 2>&1 &
+  LAUNCHER=$!
+  DEADLINE=$((SECONDS + 900))
+  until nc -z 127.0.0.1 7081 >/dev/null 2>&1; do
+    kill -0 $LAUNCHER 2>/dev/null || { echo "launcher exited"; tail -30 run.log; break; }
+    [ $SECONDS -ge $DEADLINE ] && { echo "timed out"; tail -30 run.log; break; }
+    sleep 3
+  done
   ```
+
+  Readiness far sooner than a cold build takes is a warning, not a win: it usually means the port was
+  already open. Check the PID against the `lsof` above before believing it.
 - App data lives in an isolated sandbox, `<module>/build/jetwhale-sandbox`, not the developer's
   `~/.jetwhale`. **`clean` wipes it** — never clean between the save and restore halves of a
   persistence check.

--- a/plugins/jetwhale/skills/plugin-qa/SKILL.md
+++ b/plugins/jetwhale/skills/plugin-qa/SKILL.md
@@ -91,12 +91,13 @@ describes someone else's host.
   you spinning until a timeout with nothing to read.
 
   ```bash
-  nohup ./gradlew … > run.log 2>&1 &
+  nohup ./gradlew runJetWhale \
+    --args="--server-port 5081 --wss-port 5444 --mcp-server-port 7081" > run.log 2>&1 &
   LAUNCHER=$!
   DEADLINE=$((SECONDS + 900))
   until nc -z 127.0.0.1 7081 >/dev/null 2>&1; do
-    kill -0 $LAUNCHER 2>/dev/null || { echo "launcher exited"; tail -30 run.log; break; }
-    [ $SECONDS -ge $DEADLINE ] && { echo "timed out"; tail -30 run.log; break; }
+    kill -0 $LAUNCHER 2>/dev/null || { echo "launcher exited"; tail -n 30 run.log; break; }
+    [ $SECONDS -ge $DEADLINE ] && { echo "timed out"; tail -n 30 run.log; break; }
     sleep 3
   done
   ```


### PR DESCRIPTION
## The bug

§2's readiness recipe was:

```bash
until pgrep -f com.kitakkun.jetwhale.host.MainKt >/dev/null; do sleep 3; done
```

It answers the wrong question, three ways:

1. **The JVM exists long before the MCP port opens.** So the wait returns early and the only repair is to guess how much longer with a `sleep`. I had been bolting a blind `sleep 15` on the end.
2. **`pgrep -f` matches any checkout's host.** The section immediately above this one already warns that several checkouts and agents share the machine and tells you to check `lsof` for *your* PID — and then the recipe below it does the opposite. In this session it returned instantly against another worktree's host, and I QA'd that host for several rounds before noticing.
3. **`until` with no bound spins in silence.** A failed build or an already-taken port looks exactly like a slow cold build until you give up. This is what made it feel like it stalls every time.

## The fix

Wait on the MCP port answering, bounded, while watching the launcher so a build failure prints its log instead of stalling:

```bash
nohup ./gradlew … > run.log 2>&1 &
LAUNCHER=$!
DEADLINE=$((SECONDS + 900))
until nc -z 127.0.0.1 7081 >/dev/null 2>&1; do
  kill -0 $LAUNCHER 2>/dev/null || { echo "launcher exited"; tail -30 run.log; break; }
  [ $SECONDS -ge $DEADLINE ] && { echo "timed out"; tail -30 run.log; break; }
  sleep 3
done
```

Plus the residual hazard, because the new check does not remove it: **readiness far sooner than a cold build takes is a warning, not a win** — it usually means the port was already open. The `lsof` check above is what settles whose it is.

That last line is not hypothetical. The first run with the new check reported `READY after 3s`; the reason it was genuine (Gradle fully warm, everything up to date) only became clear after checking the listener's PID, start time and classpath. With the old recipe there was no prompt to check at all.

## Verified

All three paths, on this machine:

| Path | Result |
|---|---|
| Port open (live host on 7081) | detected |
| Port closed (7099) | no false positive |
| Launcher exits before the port opens | branch fires, log tailed |

`nc -z` prints to stdout on success, hence the `>/dev/null 2>&1` rather than the `2>/dev/null` that reads naturally.

## Why here

`plugins/jetwhale/skills/plugin-qa/SKILL.md` is the published skill; the in-repo `.claude/skills/plugin-qa/SKILL.md` defers the whole workflow to it and only covers what differs inside this repository. Waiting for a host is workflow, so it belongs in the published one — and per that file's own closing section, this repository owns keeping it true.
