### PR TITLE
fix(data): make each DataStore a singleton in the graph

### DIFF
--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/DataStoreDependencyProvider.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/DataStoreDependencyProvider.kt
@@ -9,6 +9,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.Qualifier
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 
@@ -28,6 +29,7 @@ annotation class WindowStateDataStoreQualifier
 interface DataStoreDependencyProvider {
     @DebuggerSettingsDataStoreQualifier
     @Provides
+    @SingleIn(AppScope::class)
     fun provideDebuggerSettingsDataStore(
         appDataDirectoryProvider: AppDataDirectoryProvider,
     ): DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath(
@@ -37,6 +39,7 @@ interface DataStoreDependencyProvider {
 
     @ThemeDataStoreQualifier
     @Provides
+    @SingleIn(AppScope::class)
     fun provideThemeDataStore(
         appDataDirectoryProvider: AppDataDirectoryProvider,
     ): DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath(
@@ -46,6 +49,7 @@ interface DataStoreDependencyProvider {
 
     @EnabledPluginsDataStoreQualifier
     @Provides
+    @SingleIn(AppScope::class)
     fun provideEnabledPluginsDataStore(
         appDataDirectoryProvider: AppDataDirectoryProvider,
     ): DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath(
@@ -55,6 +59,7 @@ interface DataStoreDependencyProvider {
 
     @WindowStateDataStoreQualifier
     @Provides
+    @SingleIn(AppScope::class)
     fun provideWindowStateDataStore(
         appDataDirectoryProvider: AppDataDirectoryProvider,
     ): DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath(


### PR DESCRIPTION
## The defect

Every provider in `DataStoreDependencyProvider` is unscoped:

```kotlin
@DebuggerSettingsDataStoreQualifier
@Provides
fun provideDebuggerSettingsDataStore(…): DataStore<Preferences> =
    PreferenceDataStoreFactory.createWithPath(…)
```

An unscoped `@Provides` runs per injection point, so each one builds a **separate `DataStore` over the same file**.

It does not misbehave today, and that is the awkward part: each of the four files has exactly one consumer, and each consumer is itself `@SingleIn(AppScope::class)`, so the DataStore is requested once and the right thing happens by accident. Nothing in the provider says "inject me once" — the constraint is invisible until somebody adds a second consumer.

Adding one produces:

```
IllegalStateException: There are multiple DataStores active for the same file:
  …/dataStorePreferences/debugger_settings.preferences_pb
```

Not just a log line: **two DataStores over one file do not observe each other's writes.** A value written through one is invisible to the other and can be overwritten by it. For a settings store that means a setting that silently fails to stick.

## The fix

`@SingleIn(AppScope::class)` on all four — debugger settings, theme, enabled plugins, window state.

All four rather than only the one that broke: the other three are each one consumer away from the identical fault, and there is no signal at the injection site that would warn the next person.

## How it was found

Adding a second consumer to `debugger_settings` on the MCP-permissions branch (#201), which put a permissions repository beside the settings repository. Split out here because the subject is DI scoping across every persisted setting, not MCP permissions — and it can merge now, while #201 still has design work in flight.

#201 carries the same commit for the moment; rebasing it after this merges will drop the duplicate.

## Verified

`:jetwhale-host:app:build` and `spotlessCheck` pass. On the branch that surfaced it, the exception is gone from the host's startup log after this change.
