### PR TITLE
Enable ADB auto port mapping by default

### DIFF
--- a/docs/guide/adb-auto-port-mapping.md
+++ b/docs/guide/adb-auto-port-mapping.md
@@ -5,13 +5,14 @@ WebSocket server on `localhost`. For that to work, the device needs an
 [`adb reverse`](https://developer.android.com/tools/adb) port forwarding so that `localhost:<port>`
 on the device reaches the host machine.
 
-JetWhale can manage this for you: with **ADB auto port mapping** enabled, the host watches ADB for
+JetWhale manages this for you: with **ADB auto port mapping** enabled, the host watches ADB for
 device connections and sets up (and tears down) the reverse port forwarding automatically — no
 manual `adb reverse` commands needed.
 
 ## Enabling it
 
-Open **Settings → General** in the JetWhale host and toggle **ADB auto port mapping**.
+It is **on by default** — Android debugging needs no setup. The toggle lives under
+**ADB support** in the JetWhale host's settings if you want to turn it off.
 
 While enabled, the host:
 
@@ -46,9 +47,13 @@ JetWhale looks for the `adb` executable in the usual locations, in order:
 If none of these work in your environment, make sure `adb` is on the `PATH` of the shell that
 launches the JetWhale host, or set `ANDROID_HOME`.
 
+On a machine with no `adb` at all — a desktop-, iOS-, or web-only setup — there is nothing to wire,
+so the host reports it once in its logs and leaves auto port mapping inactive. Nothing else about
+the host is affected, which is why the setting ships enabled.
+
 ## Manual setup (if you prefer)
 
-If you'd rather manage the forwarding yourself, leave the setting off and run:
+If you'd rather manage the forwarding yourself, turn the setting off and run:
 
 ```shell
 adb reverse tcp:<serverPort> tcp:<serverPort>

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -194,9 +194,9 @@ falls back to `https` over the wss port, no App Transport Security exception for
 
 - **Desktop / iOS Simulator / Web** debuggees reach the host directly on `localhost` — no extra
   setup.
-- **Android** devices and emulators need `adb reverse` port forwarding. Enable
-  [ADB auto port mapping](/guide/adb-auto-port-mapping) in the host settings and JetWhale wires it
-  up automatically; or run `adb reverse tcp:5080 tcp:5080` yourself.
+- **Android** devices and emulators need `adb reverse` port forwarding.
+  [ADB auto port mapping](/guide/adb-auto-port-mapping) is on by default, so JetWhale wires it up
+  automatically; turn it off in the host settings to run `adb reverse tcp:5080 tcp:5080` yourself.
 
 Launch your app — it appears as a new session in the host. JetWhale supports multiple simultaneous
 sessions, so you can debug several apps or devices at once.

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -19,12 +19,6 @@ The **Settings → General** screen groups the host-wide options:
 | **Language** | UI language of the host: **English** or **Japanese**. |
 | **Theme** | Color scheme: `builtin:dynamic`, `builtin:light`, or `builtin:dark`. |
 
-### ADB support
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| **ADB auto port mapping** | on | Automatically runs `adb reverse` for Android devices as they connect. Inactive on machines without `adb`. See [ADB Auto Port Mapping](/guide/adb-auto-port-mapping). |
-
 ### Maintenance
 
 - **Application data directory** — shows the host's app-data path (normally `~/.jetwhale/`) with a
@@ -38,7 +32,14 @@ The **Settings → General** screen groups the host-wide options:
 - **Check for updates** — check immediately; when an update is found you can install it or open the
   download page.
 
-### Health check
+## ADB support
+
+The **Settings → Connection → ADB support** page carries the Android port forwarding, plus where
+the host found the tool it needs for it:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **ADB auto port mapping** | on | Automatically runs `adb reverse` for Android devices as they connect. Inactive on machines without `adb`. See [ADB Auto Port Mapping](/guide/adb-auto-port-mapping). |
 
 - **adb executable path** — shows where JetWhale found `adb` (see
   [How adb is found](/guide/adb-auto-port-mapping#how-adb-is-found)), or that it is unavailable.

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -23,7 +23,7 @@ The **Settings → General** screen groups the host-wide options:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| **ADB auto port mapping** | off | Automatically runs `adb reverse` for Android devices as they connect. See [ADB Auto Port Mapping](/guide/adb-auto-port-mapping). |
+| **ADB auto port mapping** | on | Automatically runs `adb reverse` for Android devices as they connect. Inactive on machines without `adb`. See [ADB Auto Port Mapping](/guide/adb-auto-port-mapping). |
 
 ### Maintenance
 

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultADBAutoWiringService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultADBAutoWiringService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -59,6 +60,13 @@ class DefaultADBAutoWiringService : ADBAutoWiringService {
                     System.err.println("ADB device tracking ended; re-attaching in ${RECONNECT_DELAY_MS}ms")
                 } catch (e: CancellationException) {
                     throw e
+                } catch (e: AdbUnavailableException) {
+                    // Auto wiring is on by default, so a machine with no Android SDK would otherwise
+                    // retry a binary that will never appear, every RECONNECT_DELAY_MS, forever.
+                    // Report once and stand down; stopping the server clears the job so toggling the
+                    // setting (which restarts the server) tries again.
+                    System.err.println("ADB auto port mapping is inactive: ${e.message}")
+                    return@launch
                 } catch (e: Exception) {
                     System.err.println("ADB device tracking failed; re-attaching in ${RECONNECT_DELAY_MS}ms: ${e.message}")
                 }
@@ -68,9 +76,13 @@ class DefaultADBAutoWiringService : ADBAutoWiringService {
     }
 
     private fun deviceEventFlow(): Flow<DeviceEvent> = callbackFlow {
-        val deviceTrackingProcess = ProcessBuilder(adbPath, "track-devices")
-            .redirectErrorStream(true)
-            .start()
+        val deviceTrackingProcess = try {
+            ProcessBuilder(adbPath, "track-devices")
+                .redirectErrorStream(true)
+                .start()
+        } catch (e: IOException) {
+            throw AdbUnavailableException(adbPath, e)
+        }
 
         launch {
             deviceTrackingProcess.inputStream
@@ -141,6 +153,9 @@ class DefaultADBAutoWiringService : ADBAutoWiringService {
         return exitCode to output
     }
 }
+
+/** The adb executable itself could not be launched — no amount of retrying will bring it back. */
+private class AdbUnavailableException(adbPath: String, cause: IOException) : Exception("adb could not be launched from \"$adbPath\": ${cause.message}", cause)
 
 private sealed interface DeviceEvent {
     data class Connected(val serial: String) : DeviceEvent

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultADBAutoWiringService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultADBAutoWiringService.kt
@@ -38,12 +38,15 @@ class DefaultADBAutoWiringService : ADBAutoWiringService {
     private val adbPath: String by lazy { findAdbPath() }
 
     override fun startAutoWiring(port: Int) {
-        if (!wiredPorts.add(port)) return
+        if (wiredPorts.add(port)) {
+            // Devices that connected before this port was registered still need the new forwarding.
+            wiredDevices.forEach { serial -> wire(serial, port) }
+        }
 
-        // Devices that connected before this port was registered still need the new forwarding.
-        wiredDevices.forEach { serial -> wire(serial, port) }
-
-        if (wiringJob != null) return
+        // A job that has finished — it stood down over a missing adb — must not read as running, or
+        // a port that is already registered would never get tracking back. Restarting the server
+        // calls this again, which is the retry.
+        if (wiringJob?.isActive == true) return
 
         wiringJob = coroutineScope.launch {
             // `adb track-devices` can end at any time (adb server restart/crash, USB hiccup, version
@@ -63,8 +66,7 @@ class DefaultADBAutoWiringService : ADBAutoWiringService {
                 } catch (e: AdbUnavailableException) {
                     // Auto wiring is on by default, so a machine with no Android SDK would otherwise
                     // retry a binary that will never appear, every RECONNECT_DELAY_MS, forever.
-                    // Report once and stand down; stopping the server clears the job so toggling the
-                    // setting (which restarts the server) tries again.
+                    // Report once and stand down until the next startAutoWiring call.
                     System.err.println("ADB auto port mapping is inactive: ${e.message}")
                     return@launch
                 } catch (e: Exception) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultDebugWebSocketServer.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultDebugWebSocketServer.kt
@@ -72,7 +72,10 @@ class DefaultDebugWebSocketServer(
     }
 
     private suspend fun monitorAdbAutoWiring() {
-        if (!settingsRepository.adbAutoPortMappingEnabledFlow.value) return
+        // Read the stored value instead of sampling the flow: the flow reports the default until the
+        // store answers, and this decision is made once per server start. Sampling it too early would
+        // wire devices for a user who turned the setting off, for the whole run.
+        if (!settingsRepository.readAdbAutoPortMappingEnabled()) return
 
         var wiredPorts: List<Int> = emptyList()
         ktorWebSocketServer.statusFlow.collect { status ->

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
@@ -40,11 +40,11 @@ class DefaultDebuggerSettingsRepository(
     private val portOverrides = MutableStateFlow(launchPortOverrides)
 
     override val adbAutoPortMappingEnabledFlow = dataStore.data
-        .mapNotNull { it[KEY_ADB_AUTO_PORT_MAPPING_ENABLED] }
+        .map { it[KEY_ADB_AUTO_PORT_MAPPING_ENABLED] ?: DEFAULT_ADB_AUTO_PORT_MAPPING_ENABLED }
         .stateIn(
             scope = coroutineScope,
             started = SharingStarted.Eagerly,
-            initialValue = false,
+            initialValue = DEFAULT_ADB_AUTO_PORT_MAPPING_ENABLED,
         )
     override val checkForUpdatesOnStartupFlow = dataStore.data
         .map { it[KEY_CHECK_FOR_UPDATES_ON_STARTUP] ?: DEFAULT_CHECK_FOR_UPDATES_ON_STARTUP }
@@ -174,6 +174,7 @@ class DefaultDebuggerSettingsRepository(
 
     companion object Companion {
         private val KEY_ADB_AUTO_PORT_MAPPING_ENABLED = booleanPreferencesKey("adb_auto_port_mapping_enabled")
+        private const val DEFAULT_ADB_AUTO_PORT_MAPPING_ENABLED = true
         private val KEY_CHECK_FOR_UPDATES_ON_STARTUP = booleanPreferencesKey("check_for_updates_on_startup")
         private const val DEFAULT_CHECK_FOR_UPDATES_ON_STARTUP = true
         private val KEY_PERSIST_DATA = booleanPreferencesKey("persist_data")

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
@@ -98,6 +98,8 @@ class DefaultDebuggerSettingsRepository(
             initialValue = DEFAULT_MCP_PLUGIN_INSTALL_ALLOWED,
         )
 
+    override suspend fun readAdbAutoPortMappingEnabled(): Boolean = dataStore.data.first()[KEY_ADB_AUTO_PORT_MAPPING_ENABLED] ?: DEFAULT_ADB_AUTO_PORT_MAPPING_ENABLED
+
     override suspend fun updateAdbAutoPortMappingEnabled(enabled: Boolean) {
         dataStore.edit { prefs ->
             prefs[KEY_ADB_AUTO_PORT_MAPPING_ENABLED] = enabled

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepositoryTest.kt
@@ -27,8 +27,19 @@ class DefaultDebuggerSettingsRepositoryTest {
     }
 
     /** Awaits [expected] rather than sampling, since the store's first emission is asynchronous. */
-    private suspend fun assertEmits(expected: Int, flow: Flow<Int>) {
+    private suspend fun <T> assertEmits(expected: T, flow: Flow<T>) {
         withTimeout(5_000) { flow.first { it == expected } }
+    }
+
+    @Test
+    fun `adb auto port mapping is on until it is turned off`() = runBlocking {
+        val dataStore = newDataStore()
+
+        assertEmits(true, DefaultDebuggerSettingsRepository(dataStore, noOverrides).adbAutoPortMappingEnabledFlow)
+
+        DefaultDebuggerSettingsRepository(dataStore, noOverrides).updateAdbAutoPortMappingEnabled(false)
+
+        assertEmits(false, DefaultDebuggerSettingsRepository(dataStore, noOverrides).adbAutoPortMappingEnabledFlow)
     }
 
     @Test

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepositoryTest.kt
@@ -43,6 +43,15 @@ class DefaultDebuggerSettingsRepositoryTest {
     }
 
     @Test
+    fun `reading adb auto port mapping never reports the default over a stored off`() = runBlocking {
+        val dataStore = newDataStore()
+        DefaultDebuggerSettingsRepository(dataStore, noOverrides).updateAdbAutoPortMappingEnabled(false)
+
+        // A fresh repository has not read the store yet, which is exactly when the server asks.
+        assertEquals(false, DefaultDebuggerSettingsRepository(dataStore, noOverrides).readAdbAutoPortMappingEnabled())
+    }
+
+    @Test
     fun `launch overrides win over the stored ports`() = runBlocking {
         val dataStore = newDataStore()
         DefaultDebuggerSettingsRepository(dataStore, noOverrides).run {

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerSettingsRepository.kt
@@ -16,6 +16,13 @@ interface DebuggerSettingsRepository {
      * installing a plugin loads new code into the host process, so it stays an opt-in.
      */
     val mcpPluginInstallAllowedFlow: StateFlow<Boolean>
+
+    /**
+     * The stored value, awaiting the initial read rather than reporting the default while it is
+     * still unknown. Use this to decide whether to wire; [adbAutoPortMappingEnabledFlow] carries
+     * the default until the store answers, which is fine to display but not to act on.
+     */
+    suspend fun readAdbAutoPortMappingEnabled(): Boolean
     suspend fun readServerPort(): Int
     suspend fun readMcpServerPort(): Int
     suspend fun readWssPort(): Int


### PR DESCRIPTION
Android is the one platform whose debuggee cannot reach the host without setup, and the setup is always the same `adb reverse` the host already knows how to run. With the toggle off by default, every Android user hits a session that never connects and only finds the switch after going looking for it. This turns it on.

## Why this is safe to default on

- `adb reverse tcp:<port> tcp:<port>` opens a loopback path from the device back to the host. No host port becomes reachable from anywhere it was not already, and the wss port is wired only when a certificate is active.
- Turning the setting off still tears down every mapping JetWhale created.
- An explicitly stored `false` is still honoured — only installs that never touched the setting change behaviour.

## Two things the new default breaks, fixed alongside it

**A missing `adb` was retried forever.** `findAdbPath()` falls back to the bare name `adb`, so on a machine with no Android SDK the `ProcessBuilder` in `deviceEventFlow()` throws `IOException` before `track-devices` ever runs. The generic catch treated that like a dropped tracking stream and re-attached after a backoff — every two seconds, for the lifetime of the host, spawning a process that will never exist and printing a line each time. Nobody hit it because nobody without adb turned the setting on. It is now raised as `AdbUnavailableException`, reported once, and stood down; stopping the server clears the job, so toggling the setting still gives adb another chance. Desktop-, iOS-, and web-only setups pay nothing for the new default.

**The flow's `initialValue` stopped being a safe placeholder.** `adbAutoPortMappingEnabledFlow` was built with `mapNotNull`, so it emitted only values that came out of the store and `initialValue = false` stood for "not read yet" — unknown and off were the same value, so sampling it early could never do the wrong thing. Defaulting it to on makes `.value` assert "enabled" while the answer is still unknown, and `monitorAdbAutoWiring()` reads `.value` exactly once per server start and never again. Its `stateIn` collection is separate from the one `readServerPort()` awaits, so nothing orders them: lose that race and a user who turned the setting off gets `adb reverse` for the whole run while the settings screen shows the toggle off. The server now asks a suspending `readAdbAutoPortMappingEnabled()`, in the shape of the other `read*` members; the flow keeps the default for display, where a stale value corrects itself on the next emission.

That last fix costs one more `dataStore.data` collection, which is what the DataStore 1.2.1 lost-update work wants consolidated — the existing `read*` members in this class have the same shape, so it folds in with them.

## Testing

- New `DefaultDebuggerSettingsRepositoryTest` cases: on when unset / off once stored off, and a stored `false` read from a repository that has not collected the store yet.
- `:jetwhale-host:core:data:test`, `:jetwhale-host:core:mcp:test`, `:jetwhale-host:app:compileKotlin`, `spotlessCheck` all pass.