### PR TITLE
Decide wss from the stored value, not the flow's default

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/ApplicationLifecycleOwner.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/ApplicationLifecycleOwner.kt
@@ -40,7 +40,10 @@ class ApplicationLifecycleOwner(
     fun initialize() {
         mutableApplicationStateFlow.update { ApplicationState.INITIALIZING }
         coroutineScope.launch {
-            val wssPort = if (settingsRepository.wssEnabledFlow.value) {
+            // Read the stored value rather than sampling the flow: this runs before anything has
+            // awaited the store, so the flow still carries its default here, and the decision is
+            // made once for the whole run.
+            val wssPort = if (settingsRepository.readWssEnabled()) {
                 settingsRepository.readWssPort()
             } else {
                 null

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
@@ -147,6 +147,8 @@ class DefaultDebuggerSettingsRepository(
         dropOverride { it.copy(wssPort = null) }
     }
 
+    override suspend fun readWssEnabled(): Boolean = dataStore.data.first()[KEY_WSS_ENABLED] ?: DEFAULT_WSS_ENABLED
+
     override suspend fun updateWssEnabled(enabled: Boolean) {
         dataStore.edit { prefs ->
             prefs[KEY_WSS_ENABLED] = enabled

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepositoryTest.kt
@@ -52,6 +52,15 @@ class DefaultDebuggerSettingsRepositoryTest {
     }
 
     @Test
+    fun `reading wss enabled never reports the default over a stored off`() = runBlocking {
+        val dataStore = newDataStore()
+        DefaultDebuggerSettingsRepository(dataStore, noOverrides).updateWssEnabled(false)
+
+        // A fresh repository has not read the store yet, which is exactly when startup asks.
+        assertEquals(false, DefaultDebuggerSettingsRepository(dataStore, noOverrides).readWssEnabled())
+    }
+
+    @Test
     fun `launch overrides win over the stored ports`() = runBlocking {
         val dataStore = newDataStore()
         DefaultDebuggerSettingsRepository(dataStore, noOverrides).run {

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerSettingsRepository.kt
@@ -18,11 +18,13 @@ interface DebuggerSettingsRepository {
     val mcpPluginInstallAllowedFlow: StateFlow<Boolean>
 
     /**
-     * The stored value, awaiting the initial read rather than reporting the default while it is
-     * still unknown. Use this to decide whether to wire; [adbAutoPortMappingEnabledFlow] carries
+     * The stored values, awaiting the initial read rather than reporting the default while it is
+     * still unknown. Decide from these: [adbAutoPortMappingEnabledFlow] and [wssEnabledFlow] carry
      * the default until the store answers, which is fine to display but not to act on.
      */
     suspend fun readAdbAutoPortMappingEnabled(): Boolean
+    suspend fun readWssEnabled(): Boolean
+
     suspend fun readServerPort(): Int
     suspend fun readMcpServerPort(): Int
     suspend fun readWssPort(): Int


### PR DESCRIPTION
Spotted while reviewing #210, which fixes the same shape of bug for ADB auto port mapping.

`ApplicationLifecycleOwner.initialize()` picks the port it hands to `server.start()` by sampling `wssEnabledFlow.value`:

```kotlin
val wssPort = if (settingsRepository.wssEnabledFlow.value) {
    settingsRepository.readWssPort()
} else {
    null
}
```

That is the first thing the coroutine does — before `readServerPort()` awaits the store — and the flow's `stateIn` collection is a separate collection of `dataStore.data` that nothing orders against it. Its `initialValue` is the default `true`. Lose that race and the host starts its TLS connector for a user who turned wss off, for the whole run, while the settings screen shows the toggle off.

The fix is the one #210 arrives at: a suspending `readWssEnabled()` alongside the other `read*` members, asked at the point of decision. The flow keeps the default for display, where a stale value corrects itself on the next emission.

`DefaultServerPortMutationKey` samples the same flow, but it only runs from the settings screen, so the store has answered long before. Left alone.

## Testing

- New `DefaultDebuggerSettingsRepositoryTest` case: a stored `false` read from a repository that has not collected the store yet.
- `:jetwhale-host:core:data:test`, `:jetwhale-host:core:mcp:test`, `:jetwhale-host:app:compileKotlin`, `spotlessCheck` all pass.