### PR TITLE
fix(host): drive a plugin's Compose scene from a single clock

### DIFF
--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeTool.kt
@@ -96,7 +96,7 @@ fun captureAccessibilityTree(scene: PluginComposeScene): String {
         // drawn with the stale value. Flush explicitly here so the flag-flip recomposition is applied
         // within this render pass.
         Snapshot.sendApplyNotifications()
-        scene.composeScene.render(Canvas(ImageBitmap(size.width, size.height)), System.nanoTime())
+        scene.render(Canvas(ImageBitmap(size.width, size.height)))
         // Read the semantics while the flag is still raised: lowering it first would leave the tree
         // one recomposition away from the values that were actually rendered.
         scene.semanticsOwners.map { it.rootSemanticsNode }.flatMap { traverseSemanticsTree(it) }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotTool.kt
@@ -110,7 +110,7 @@ fun captureScreenshot(
         // drawn with the stale value. Flush explicitly here so the flag-flip recomposition is applied
         // within this render pass.
         Snapshot.sendApplyNotifications()
-        scene.composeScene.render(composeCanvas, System.nanoTime())
+        scene.render(composeCanvas)
     } finally {
         scene.isMcpCapture.value = false
         // Flush the restore so the next interactive render observes capture=false immediately rather

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/viewport/McpViewportUtils.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/viewport/McpViewportUtils.kt
@@ -30,7 +30,7 @@ internal fun ensureSceneRendered(scene: PluginComposeScene) {
         ?: IntSize(1280, 720)
     val viewport = McpViewport(size = size, density = scene.composeScene.density)
     applyViewport(scene, viewport)
-    scene.composeScene.render(Canvas(ImageBitmap(size.width, size.height)), System.nanoTime())
+    scene.render(Canvas(ImageBitmap(size.width, size.height)))
 }
 
 @OptIn(InternalComposeUiApi::class)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotToolTest.kt
@@ -79,7 +79,7 @@ class ScreenshotToolTest {
         applyViewport(scene, viewport)
 
         val imageBitmap = ImageBitmap(100, 50)
-        scene.composeScene.render(Canvas(imageBitmap), System.nanoTime())
+        scene.render(Canvas(imageBitmap))
         val pixels = imageBitmap.toPixelMap()
 
         // Sample the center of each box

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/TestSceneFactory.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/TestSceneFactory.kt
@@ -42,7 +42,7 @@ fun createTestScene(content: @Composable () -> Unit = {}): PluginComposeScene {
 @OptIn(InternalComposeUiApi::class)
 fun renderTestScene(scene: PluginComposeScene) {
     scene.composeScene.size = IntSize(TEST_SCENE_WIDTH, TEST_SCENE_HEIGHT)
-    scene.composeScene.render(Canvas(ImageBitmap(TEST_SCENE_WIDTH, TEST_SCENE_HEIGHT)), System.nanoTime())
+    scene.render(Canvas(ImageBitmap(TEST_SCENE_WIDTH, TEST_SCENE_HEIGHT)))
 }
 
 @OptIn(InternalComposeUiApi::class)

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeScene.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeScene.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.host.model
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.semantics.SemanticsOwner
@@ -20,7 +21,23 @@ data class PluginComposeScene(
     // The cursor the plugin's composition currently asks for via Modifier.pointerHoverIcon. The
     // nested scene owns no window, so whoever renders it must apply this to the real one.
     val pointerIcon: State<PointerIcon>,
-)
+) {
+    /**
+     * Renders the scene, driving its animations from [System.nanoTime].
+     *
+     * The scene must never be handed a frame time that moves backwards, and it has more than one
+     * renderer: the host window's draw pass and the MCP tools. The host window's frame time comes
+     * from skiko, which counts from the moment its redrawer was created, while the MCP tools run
+     * off-screen renders with [System.nanoTime], which counts from boot; the two are minutes and
+     * days apart. A backwards jump makes a running animation see a negative elapsed time, and an
+     * underdamped spring then overflows to infinity - Material3's floating text field label
+     * interpolates a NaN lineHeight from it and throws out of the AWT event thread, killing the
+     * host. Owning the clock here keeps every renderer on the same monotonic timeline.
+     */
+    fun render(canvas: Canvas) {
+        composeScene.render(canvas, System.nanoTime())
+    }
+}
 
 interface WindowInfoUpdater {
     val currentIntSize: IntSize

--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreen.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreen.kt
@@ -118,8 +118,14 @@ fun PluginScreen(pluginComposeScene: PluginComposeScene) {
                 }
             },
     ) {
+        // Reading the host's frame time here is what keeps this draw invalidated once per frame, so
+        // the plugin's own animations keep advancing. It is deliberately not the scene's animation
+        // clock: PluginComposeScene.render owns that, because this scene is also rendered by the MCP
+        // tools on a different clock.
+        @Suppress("UNUSED_EXPRESSION")
+        frameNanoTime
         this.drawIntoCanvas {
-            pluginComposeScene.composeScene.render(it, frameNanoTime)
+            pluginComposeScene.render(it)
         }
     }
 }


### PR DESCRIPTION
Fixes a crash that takes the **whole host process** down while a plugin's UI is being used:

```
Exception in thread "AWT-EventQueue-0" java.lang.IllegalStateException: lineHeight can't be negative (NaN)
  at androidx.compose.ui.text.ParagraphStyleKt.lerp(ParagraphStyle.kt:439)
  at androidx.compose.material3.internal.TextFieldImplKt.DecoratedLabel(TextFieldImpl.kt:331)
  at androidx.compose.material3.OutlinedTextFieldKt.OutlinedTextField(OutlinedTextField.kt:405)
  at <the plugin's screen>
```

## Cause

A nested plugin `ComposeScene` takes its animation clock from whatever `nanoTime` its renderer hands
to `render()` (`BaseComposeScene.skiko.kt:173`). It has **more than one renderer**, and they
disagreed about the epoch:

| Renderer | Frame time | Counts from |
|---|---|---|
| Host window (`PluginScreen`) | `withFrameNanos` | on macOS, skiko's `MetalRedrawer` creation — `Redrawer.update()` defaults to `initialTime.elapsedNow()` |
| MCP tools (screenshot, a11y tree, viewport) | `System.nanoTime()` | boot — ~8.1e14 on a machine up for days |

`PluginScreen` also held `remember(pluginComposeScene) { 0L }`, so the first draw after any re-entry
into composition (a hot reload, a pop-in) rendered the scene at `nanoTime = 0` — a second guaranteed
backwards jump.

From there: `Transition.onFrame` computes `deltaT = frameTimeNanos - startTimeNanos` with no
clamping, a large negative `deltaT` makes an underdamped spring's exponential overflow to infinity,
and `lerp(bodyLarge, bodySmall, ±Infinity)` is `∓Inf + ±Inf` = `NaN`. `ParagraphStyle`'s precondition
then throws, on the AWT event thread, where nothing catches it.

This was reproduced against the repo's real dependency versions with a byte-identical stack trace
(line numbers included). The reproduction was a scratch test and is not part of this PR.

Not the cause, for the record: the host installs no custom `Typography`, so the theory that a style
carried an unspecified `lineHeight` is wrong. Hot reload is only a **trigger** — it forces
`PluginScreen` back through the remembered `0L` — and the same crash is reachable with no reload at
all, from an ordinary MCP `click` or `type` landing while a text field label is animating.

## Fix

`PluginComposeScene` owns the clock. `render(canvas)` always uses `System.nanoTime()`, and every
renderer goes through it — `composeScene.render(` now appears in exactly one place. `PluginScreen`
still reads the host's frame time, but only to invalidate its draw once per host frame.

No plugin-side change is possible or needed: nothing about a labelled `OutlinedTextField` is wrong.

## Testing

`:jetwhale-host:core:mcp:test`, the affected compilations and `spotlessCheck` pass, and the
reproduction no longer throws through the new path.

## Follow-ups found while investigating (not in this PR)

1. **The host has no `WindowExceptionHandler`** (grep: zero hits), which is *why* a plugin render
   exception is fatal. The existing boundary — `PluginScreen` routing into soil's `CatchThrowHost` —
   only catches what the example plugin's "Throw UI error" button throws, because that runs
   synchronously inside `sendPointerEvent`; it is not a guard around the nested `render()`.
   Providing `LocalWindowExceptionHandlerFactory` would turn future plugin-render crashes into
   `PluginScreenErrorFallback` instead of process death.
2. `DefaultPluginHotReloadService` runs `disposePlugin` (which calls `composeScene.close()` and
   mutates a plain `mutableMapOf`) on `Dispatchers.IO` in the full-reload path, racing the render
   loop; the in-place-redefine path correctly uses `Dispatchers.Main`.
3. After an MCP screenshot with an explicit `density`, `applyViewport` never restores the previous
   density.
