### PR TITLE
feat: add the Compose Semantics Inspector plugin

### DIFF
--- a/demo/android/build.gradle.kts
+++ b/demo/android/build.gradle.kts
@@ -23,6 +23,9 @@ android {
 
 dependencies {
     implementation(projects.demo.shared)
+    // Compose Semantics Inspector probe: reaching a live composition is Android-only for now, so it is
+    // wired up here rather than in the shared module.
+    implementation(projects.jetwhalePlugins.semantics.agent)
     implementation(libs.androidxActivityCompose)
     implementation(libs.androidxActivityKtx)
     implementation(libs.androidxCoreKtx)

--- a/demo/android/src/main/kotlin/com/kitakkun/jetwhale/demo/DemoApplication.kt
+++ b/demo/android/src/main/kotlin/com/kitakkun/jetwhale/demo/DemoApplication.kt
@@ -2,10 +2,16 @@ package com.kitakkun.jetwhale.demo
 
 import android.app.Application
 import com.kitakkun.jetwhale.demo.shared.initializeJetWhale
+import com.kitakkun.jetwhale.plugins.semantics.agent.installJetWhaleSemanticsProbe
 
 class DemoApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        // Installed before any activity exists, so the probe sees every Compose root the app
+        // creates — including the separate one a Dialog composes into (the "Compose nodes" tab
+        // opens one). The alternative is JetWhaleSemanticsProbe() inside a composition, which
+        // registers only that composition's own root.
+        installJetWhaleSemanticsProbe(this)
         initializeJetWhale()
     }
 }

--- a/demo/desktop/build.gradle.kts
+++ b/demo/desktop/build.gradle.kts
@@ -17,6 +17,9 @@ compose.desktop {
 dependencies {
     implementation(projects.demo.shared)
     implementation(compose.desktop.currentOs)
+    // Compose Semantics Inspector probe: on desktop it is scoped to a window, so it is wired up here
+    // rather than in the shared module.
+    implementation(projects.jetwhalePlugins.semantics.agent)
 
     // Self-contained local API the demo client calls, so the demo never depends on a public endpoint.
     implementation(libs.ktorServerNetty)

--- a/demo/desktop/src/main/kotlin/com/kitakkun/jetwhale/demo/Main.kt
+++ b/demo/desktop/src/main/kotlin/com/kitakkun/jetwhale/demo/Main.kt
@@ -1,14 +1,20 @@
 package com.kitakkun.jetwhale.demo
 
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.singleWindowApplication
 import com.kitakkun.jetwhale.demo.shared.App
 import com.kitakkun.jetwhale.demo.shared.initializeJetWhale
+import com.kitakkun.jetwhale.plugins.semantics.agent.JetWhaleSemanticsProbe
 
+@OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     initializeJetWhale()
     startDemoApiServer()
 
     singleWindowApplication {
+        // Desktop has no process-wide root callback, so the probe is scoped to this window. Dialogs
+        // and popups rendered inside it are picked up on their own.
+        JetWhaleSemanticsProbe()
         App()
     }
 }

--- a/demo/shared/build.gradle.kts
+++ b/demo/shared/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
             implementation(projects.jetwhalePlugins.nav3.agent)
             implementation(libs.navigation3Runtime)
             implementation(libs.navigation3Ui)
+            implementation(projects.jetwhalePlugins.semantics.agent)
             implementation(libs.ktorClientCio)
         }
 

--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/App.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/App.kt
@@ -49,10 +49,15 @@ fun App() {
                             onClick = { selectedTab = 2 },
                             text = { Text("Nav3 plugin") },
                         )
+                        Tab(
+                            selected = selectedTab == 3,
+                            onClick = { selectedTab = 3 },
+                            text = { Text("Compose nodes") },
+                        )
                         platformExtraTabLabel?.let { label ->
                             Tab(
-                                selected = selectedTab == 3,
-                                onClick = { selectedTab = 3 },
+                                selected = selectedTab == 4,
+                                onClick = { selectedTab = 4 },
                                 text = { Text(label) },
                             )
                         }
@@ -61,6 +66,7 @@ fun App() {
                         0 -> ExampleTestScreen()
                         1 -> NetworkTestScreen()
                         2 -> Nav3TestScreen(nav3BackStack)
+                        3 -> ComposeNodeTestScreen()
                         else -> PlatformExtraTabScreen()
                     }
                 }

--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/ComposeNodeTestScreen.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/ComposeNodeTestScreen.kt
@@ -1,0 +1,144 @@
+package com.kitakkun.jetwhale.demo.shared
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+/**
+ * A screen with one of each kind of semantics node, so the Compose Semantics Inspector plugin has
+ * something worth looking at: labelled and unlabelled controls, an editable field, toggleable and
+ * selectable state, a disabled node, a scrollable list, and a dialog — which composes into a
+ * **separate** Compose root and therefore shows up as a second root in the plugin.
+ */
+@Composable
+fun ComposeNodeTestScreen() {
+    var clicks by remember { mutableStateOf(0) }
+    var input by remember { mutableStateOf("") }
+    var checked by remember { mutableStateOf(false) }
+    var switched by remember { mutableStateOf(true) }
+    var selectedOption by remember { mutableStateOf("Alpha") }
+    var dialogVisible by remember { mutableStateOf(false) }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item {
+            Text(
+                "Capture this screen from the Compose Semantics Inspector plugin.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        item {
+            Button(
+                onClick = { clicks++ },
+                modifier = Modifier.testTag("increment-button"),
+            ) {
+                Text("Clicked $clicks time(s)")
+            }
+        }
+        item {
+            Button(onClick = {}, enabled = false) {
+                Text("Disabled button")
+            }
+        }
+        item {
+            OutlinedTextField(
+                value = input,
+                onValueChange = { input = it },
+                label = { Text("Editable field") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().testTag("demo-text-field"),
+            )
+        }
+        item {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(checked = checked, onCheckedChange = { checked = it }, modifier = Modifier.testTag("demo-checkbox"))
+                Text("Checkbox")
+            }
+        }
+        item {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Switch(checked = switched, onCheckedChange = { switched = it })
+                Text("Switch")
+            }
+        }
+        item {
+            Column {
+                listOf("Alpha", "Beta", "Gamma").forEach { option ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.selectable(
+                            selected = selectedOption == option,
+                            onClick = { selectedOption = option },
+                        ),
+                    ) {
+                        RadioButton(selected = selectedOption == option, onClick = { selectedOption = option })
+                        Text(option)
+                    }
+                }
+            }
+        }
+        item {
+            // A node whose only label is a contentDescription: it has nothing to read on screen,
+            // but an agent can still find and describe it.
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .semantics { contentDescription = "Decorative banner" },
+            ) {}
+        }
+        item {
+            Button(onClick = { dialogVisible = true }, modifier = Modifier.testTag("open-dialog-button")) {
+                Text("Open dialog (a second Compose root)")
+            }
+        }
+        items(SCROLLABLE_ROW_COUNT) { index ->
+            Text("List row #$index", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+
+    if (dialogVisible) {
+        AlertDialog(
+            onDismissRequest = { dialogVisible = false },
+            title = { Text("Dialog") },
+            text = { Text("This dialog is its own Compose root — the plugin lists it separately.") },
+            confirmButton = {
+                TextButton(onClick = { dialogVisible = false }, modifier = Modifier.testTag("dialog-close-button")) {
+                    Text("Close")
+                }
+            },
+        )
+    }
+}
+
+private const val SCROLLABLE_ROW_COUNT = 30

--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/DIModule.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/DIModule.kt
@@ -6,6 +6,7 @@ import com.kitakkun.jetwhale.plugins.nav3.agent.JetWhaleNav3AgentPlugin
 import com.kitakkun.jetwhale.plugins.nav3.agent.Nav3KeyCodec
 import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
 import com.kitakkun.jetwhale.plugins.network.agent.ktor.ktorClientPlugin
+import com.kitakkun.jetwhale.plugins.semantics.agent.JetWhaleSemanticsAgentPlugin
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.HttpTimeout
@@ -19,6 +20,13 @@ object DIModule {
     val nav3AgentPlugin: JetWhaleNav3AgentPlugin<NavKey> by lazy {
         JetWhaleNav3AgentPlugin(Nav3KeyCodec.openPolymorphic(demoNavKeySerializersModule))
     }
+
+    /**
+     * Answers the Compose Semantics Inspector's tree captures. It reads whatever roots a probe has
+     * registered, so a platform where none is installed reports an empty tree — the probe is wired
+     * up per platform, in `demo/android` and `demo/desktop`.
+     */
+    val semanticsAgentPlugin: JetWhaleSemanticsAgentPlugin by lazy { JetWhaleSemanticsAgentPlugin() }
 
     /** A demo Ktor client wired to the Network Inspector so its traffic shows up in the debugger. */
     val httpClient: HttpClient by lazy {

--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
@@ -26,6 +26,7 @@ fun initializeJetWhale() {
             register(DIModule.exampleAgentPlugin)
             register(DIModule.networkAgentPlugin)
             register(DIModule.nav3AgentPlugin)
+            register(DIModule.semanticsAgentPlugin)
         }
     }
 }

--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -79,6 +79,7 @@ export default defineConfig({
         items: [
           { text: 'Network Inspector', link: '/guide/network-inspector' },
           { text: 'Nav3 Navigator', link: '/guide/nav3-navigator' },
+          { text: 'Compose Semantics Inspector', link: '/guide/compose-semantics-inspector' },
           { text: 'MCP Server', link: '/guide/mcp-server' },
           { text: 'Host Settings', link: '/guide/host-settings' },
           { text: 'ADB Auto Port Mapping', link: '/guide/adb-auto-port-mapping' },

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -1,0 +1,280 @@
+# Compose Semantics Inspector
+
+The Compose Semantics Inspector is a built-in JetWhale plugin that reads the **Compose node tree of your
+running app** — every node, its labels, its bounds, and the actions it exposes — and lets you both
+browse it in the host and hand it to an AI agent over [MCP](/guide/mcp-server).
+
+- ⚡ **~14 ms** per capture end-to-end, against ~2.7 s for `android layout` — see
+  [Why not the CLI?](#why-not-the-cli)
+- 🌲 Live tree of the app's Compose nodes, with search and an *interactive only* filter
+- 🎯 Per-node detail: role, text, `contentDescription`, `testTag`, state, bounds in root **and**
+  screen pixels
+- 👆 Run a node's own semantics action — click, long click, set text, scroll, focus, dismiss —
+  from the host or from an AI agent
+- 🪟 Dialogs and popups appear as their own roots, because that is what they are in Compose
+- 🤖 Three MCP tools so an agent can see the screen structurally instead of guessing at pixels
+
+## Why not the CLI?
+
+`android layout` and `adb shell uiautomator dump` both go out to the accessibility framework across
+a process boundary and write a file on the device before anything can read it. This plugin reads the
+semantics tree **inside** the app, on its main thread, and sends it back over the JetWhale
+connection that is already open — so a capture costs about as much as a frame.
+
+Measured on one machine, on the same screen, back to back — a Pixel-class emulator (1080×2400,
+density 2.625) showing the demo app's *Compose nodes* screen, 38–39 elements:
+
+| | median | 
+|---|---|
+| **`com.kitakkun.jetwhale.semantics.getNodeTree`** (host → app → host) | **14 ms** (min 12, p90 15) |
+| ⤷ of which reading the tree on the device | **1 ms** (max 6) |
+| **`com.kitakkun.jetwhale.semantics.findNodes`** | **11 ms** |
+| `adb shell uiautomator dump` + `adb pull` | 1,960 ms |
+| `android layout` (Google's Android CLI) | 2,703 ms |
+
+That is **~190× faster than `android layout`** on this setup — fast enough that an agent can capture
+between every action instead of budgeting for the dump. Treat the ratio as indicative rather than a
+spec: an emulator is slower than a physical device, and a bigger screen means more nodes.
+
+The host shows both numbers live — what the capture cost on the device, and the round trip from the
+host — so a slow capture says where the time went.
+
+### Are the coordinates right?
+
+`bounds` and `tap` are screen pixels, so they have to survive whatever the device does to the
+window. They were checked two ways at once — cross-checked against `android layout`'s reading of the
+same screen, and proved by tapping the reported point and watching the intended node react — across
+the conditions that move a window around:
+
+| Condition | nodes cross-checked | worst disagreement | tap reached the node |
+|---|---|---|---|
+| gesture nav, portrait, density 420 | 19 | 1 px | ✅ |
+| 3-button navigation bar | 18 | 1 px | ✅ |
+| landscape | 10 | 1 px | ✅ |
+| density 320 | 29 | 1 px | ✅ |
+| 800×1280 @ density 320 | 12 | 1 px | ✅ |
+
+The residual 1 px is rounding: this plugin rounds, `android layout` truncates.
+
+Each condition was also re-run with a dialog open, which is the case that actually exercises the
+arithmetic — a dialog is its own window and does **not** start at the screen origin, so a
+window-relative coordinate reported as if it were absolute would be off by the whole offset. In
+landscape that offset reaches `(717, 298)`; the dialog's nodes still agreed to within 1 px, and
+tapping the reported point closed the dialog. Every root reports its own `windowOffset`, so a
+suspicious coordinate can be traced back to the window it came from.
+
+The tree is also richer than what the CLIs return: `android layout` gives a flat list with text,
+`content-desc` and bounds, but no `testTag`, no role and no per-node id, so an agent can only aim by
+label or by pixel. This plugin reports all three, which is what makes
+[`performNodeAction`](#com-kitakkun-jetwhale-compose-performnodeaction) able to address a node
+directly.
+
+## What the tree contains
+
+The tree is the Compose **semantics** tree: the same tree an accessibility service sees, and the one
+that says what is actually clickable. A `Box` that only lays out pixels does not appear on its own;
+a `Button` does, carrying its label and its `OnClick` action.
+
+Two views of it are available, switchable in the host and per MCP call:
+
+| | What you get |
+|---|---|
+| **Merged** (default) | A `Button`'s label is folded into the clickable node — one node per control. This is what accessibility services and `performClick` see, and usually what you want. |
+| **Unmerged** | Every semantics node stays separate, closer to how the UI is written. Useful when you need to see exactly which composable contributed which property. |
+
+## Setup
+
+Add the agent to the app being debugged — one artifact, carrying both the plugin and the probes
+(see [Platform support](#platform-support) for which targets have a probe):
+
+```kotlin
+dependencies {
+    implementation("com.kitakkun.jetwhale:jetwhale-agent-runtime:<version>")
+    implementation("com.kitakkun.jetwhale:jetwhale-compose-semantics-inspector-agent:<version>")
+}
+```
+
+Register the plugin with the agent runtime, and install a probe so it has roots to read.
+
+### Registering the plugin
+
+```kotlin
+import com.kitakkun.jetwhale.agent.runtime.startJetWhale
+import com.kitakkun.jetwhale.plugins.semantics.agent.JetWhaleSemanticsAgentPlugin
+
+startJetWhale {
+    connection { host = "localhost"; port = 5080 }
+    plugins { register(JetWhaleSemanticsAgentPlugin()) }
+}
+```
+
+This part is common code — it compiles on every Compose Multiplatform target. Without a probe the
+plugin still answers, reporting an empty tree and a warning saying so, which the host shows.
+
+### Installing a probe
+
+There are two ways in, and they can be combined — registrations are reference counted per root, so
+neither can pull a root out from under the other.
+
+#### From the Application layer (recommended)
+
+```kotlin
+import com.kitakkun.jetwhale.plugins.semantics.agent.installJetWhaleSemanticsProbe
+
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        installJetWhaleSemanticsProbe(this)
+        startJetWhale { /* … */ }
+    }
+}
+```
+
+Installed from `onCreate()`, before any activity exists, it hooks the callback Compose fires when it
+creates the view backing a composition — so it sees **every** root, including the separate one a
+`Dialog` or a `Popup` composes into. No screen has to change.
+
+Installed later it also scans the resumed activity's window, so roots created before the call are
+not lost — but roots in windows that were already open and are never re-resumed can be.
+
+The install is process-wide and idempotent, and closing the returned handle restores whatever
+callback was there before — so it composes with the Compose test framework rather than displacing
+it.
+
+#### From inside the composition
+
+```kotlin
+import com.kitakkun.jetwhale.plugins.semantics.agent.JetWhaleSemanticsProbe
+
+setContent {
+    JetWhaleSemanticsProbe()
+    App()
+}
+```
+
+Use this when the Application layer is not yours to touch, or when only one screen should be
+readable. It registers **its own** root for as long as it stays composed — a `Dialog` or `Popup`
+composes into a root of its own, so add a call inside those too, or install the Application-level
+probe, which finds them all.
+
+::: warning Debug builds only
+The probe makes your app's UI structure readable, and the actions below make it drivable, over the
+JetWhale connection. Wire both up in debug builds only, exactly as you would the rest of JetWhale.
+:::
+
+## Using the host UI
+
+Open the **Compose Semantics Inspector** tab for a session and press **Refresh**.
+
+- **Auto** re-captures once a second. It is off by default: a capture reads the app's semantics on
+  its main thread, so leaving it on makes the app do that work forever.
+- **Interactive only** keeps the nodes that expose an action, are editable, or scroll — plus their
+  ancestors, so the structure stays readable.
+- **Include invisible** adds nodes that are not laid out or are fully clipped away.
+- The **search box** matches text, `contentDescription`, `testTag`, role and id.
+
+Select a node to see its full semantics on the right, along with a button for every action it
+actually exposes. There is also a **Copy `adb shell input tap`** button for the times you do want to
+drive the app through the input system.
+
+## MCP tools
+
+The plugin contributes three tools to the host's [MCP server](/guide/mcp-server). As with every
+plugin tool, JetWhale injects the `sessionId` parameter and routes the call to the right session.
+
+### `com.kitakkun.jetwhale.semantics.findNodes`
+
+The one to reach for first. Captures the tree and returns the matching nodes as a flat list, each
+carrying the `rootId`/`id` pair that addresses it, screen-pixel `bounds`, and a ready-made `tap`
+point.
+
+Criteria (`text`, `contentDescription`, `testTag`, `role`) are combined with AND and match
+case-insensitively by substring unless `exact` is set. With no criteria at all it lists everything
+interactive on screen — a good way to answer "what can I do here?".
+
+### `com.kitakkun.jetwhale.semantics.getNodeTree`
+
+The whole tree, structure included. Takes `merged`, `includeInvisible`, `maxDepth`,
+`interactiveOnly` and `rootId`. Use it when the layout itself is the question; use `findNodes` when
+you are looking for one element.
+
+### `com.kitakkun.jetwhale.semantics.performNodeAction`
+
+Invokes a node's own semantics action: `Click`, `LongClick`, `SetText`, `InsertText`, `ImeAction`,
+`ScrollBy`, `RequestFocus`, `Dismiss`, `Expand`, `Collapse`.
+
+This runs the action the node itself declared, so it needs no coordinates and cannot land on
+whatever moved into that spot in the meantime — prefer it over `adb shell input tap`. `rootId` is
+optional: without it the node is looked up in the most recent capture.
+
+It is also the more *reliable* route, not just the tidier one: on the emulator used for the
+benchmark above, `adb shell input swipe` did not scroll a `LazyColumn` at all, while
+`ScrollBy` moved it by exactly the requested distance on the first try.
+
+A typical agent loop:
+
+```
+findNodes(testTag: "login-button")     → { "nodes": [{ "rootId": "compose-root-1f2e", "id": 42, … }] }
+performNodeAction(nodeId: 42, action: "Click")
+findNodes()                            → the new screen's interactive nodes
+```
+
+## Platform support
+
+The capture and action layer is written against `SemanticsOwner`, which lives in Compose's
+**common** source set — so it is the same code on every target. What differs is only how a probe
+*finds* an owner, and that is where platform support begins and ends.
+
+| Target | Probe | What you write |
+|---|---|---|
+| **Android** | ✅ | `installJetWhaleSemanticsProbe(application)`, or `JetWhaleSemanticsProbe()` in a composition |
+| **Desktop (JVM)** | ✅ | `JetWhaleSemanticsProbe()` inside your `Window { }` |
+| iOS, JS, Wasm | — | register a `SemanticsOwner` yourself (below) |
+
+Those are the targets the agent artifact ships for — Compose Multiplatform's own set. Linux, mingw
+and macOS are absent: the first two have no `androidx.compose.ui` at all, and macOS needs the whole
+build to opt into Compose's experimental support for it.
+
+Android finds roots process-wide through the callback Compose fires when it creates the view backing
+a composition. Desktop has no such callback, so its probe is scoped to a window and reads
+`ComposeWindow.semanticsOwners` — which is snapshot-backed, so a dialog or popup rendered inside
+that window appears and disappears on its own. A second `Window { }` is a second composition and
+needs its own call.
+
+On a target with no probe, register an owner you already hold and everything else works unchanged:
+
+```kotlin
+import com.kitakkun.jetwhale.plugins.semantics.agent.ComposeNodeSourceRegistry
+import com.kitakkun.jetwhale.plugins.semantics.agent.registerSemanticsOwner
+
+ComposeNodeSourceRegistry.registerSemanticsOwner(
+    owner = mySemanticsOwner,
+    sourceId = "main-window",
+    label = "Main window",
+    density = 2f,
+)
+```
+
+::: tip Which thread reads the tree
+Semantics may only be read on the thread that owns the composition, and the probes get there without
+adding a dependency to your app — a `Handler` on Android, `EventQueue` on desktop. A target without
+a probe falls back to `Dispatchers.Main`, which on desktop would need `kotlinx-coroutines-swing` on
+your classpath; pass your own `ComposeUiThread` to `registerSemanticsOwner` if that does not suit.
+:::
+
+## Troubleshooting
+
+**"The app reported no Compose root."** No probe is installed. Add
+`installJetWhaleSemanticsProbe(application)`, or `JetWhaleSemanticsProbe()` inside your
+composition.
+
+**A dialog's contents are missing.** A dialog is a separate Compose root. The Application-level
+probe finds it; an in-composition probe only registers the root it was called in.
+
+**An action comes back `performed: false`.** The message says why — the node does not expose that
+action, it is disabled, or its handler declined. Capture the tree again and check the node's
+`actions` list; only what is listed there can be invoked.
+
+**Node ids changed between calls.** A node's id is stable while it stays composed, and ids are only
+unique within their root. After anything that recomposes the screen, capture again rather than
+reusing ids.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -204,5 +204,7 @@ sessions, so you can debug several apps or devices at once.
 ## Next steps
 
 - [Network Inspector](/guide/network-inspector) — inspect and mock HTTP traffic
+- [Compose Semantics Inspector](/guide/compose-semantics-inspector) — browse your app's Compose node tree and
+  drive it by node
 - [MCP Server](/guide/mcp-server) — let AI agents drive your app
 - [Developing Plugins](/guide/developing-plugins) — build your own debugging tools

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -166,7 +166,10 @@ your custom debugging features too. See
 write one.
 
 The [Network Inspector](/guide/network-inspector#mcp-tools) ships a full set of plugin tools
-(`com.kitakkun.jetwhale.network.*`) for reading captured traffic and managing mock rules.
+(`com.kitakkun.jetwhale.network.*`) for reading captured traffic and managing mock rules, and the
+[Compose Semantics Inspector](/guide/compose-semantics-inspector#mcp-tools) contributes
+`com.kitakkun.jetwhale.semantics.*` for reading the **debuggee's** Compose node tree and invoking a
+node's own action — the structural counterpart to the coordinate-based `jetwhale.click` below.
 
 ::: tip Sensitive values
 Plugin UIs can hide sensitive content from `jetwhale.screenshot` **and**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,7 @@ androidxDatastoreCoreOkio = { module = "androidx.datastore:datastore-core-okio",
 
 # compose
 jetbrainsComposeRuntime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jetbrainsCompose" }
+jetbrainsComposeUi = { module = "org.jetbrains.compose.ui:ui", version.ref = "jetbrainsCompose" }
 jetbrainsComposePreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "jetbrainsCompose" }
 jetbrainsComposeResources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "jetbrainsCompose" }
 jetbrainsComposeSplitPane = { module = "org.jetbrains.compose.components:components-splitpane", version.ref = "jetbrainsCompose" }

--- a/jetwhale-plugins/semantics/agent/build.gradle.kts
+++ b/jetwhale-plugins/semantics/agent/build.gradle.kts
@@ -1,0 +1,62 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidKotlinMultiplatformLibrary)
+    alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.publish)
+}
+
+// Distinct group so these plugin modules don't share coordinates with the other plugins' modules
+// (which also have leaf names protocol/agent/host) and get substituted during resolution.
+group = "com.kitakkun.jetwhale.plugins.semantics"
+
+// Targets follow Compose Multiplatform's own rather than the `multiplatform` convention's: reading
+// a composition needs `androidx.compose.ui`, which is not published for linux or mingw — and a
+// target Compose does not run on has no node tree to read in the first place. macOS is left out
+// too: Compose rejects it unless the whole build opts into its experimental macOS support.
+kotlin {
+    jvm()
+    jvmToolchain(17)
+
+    js(IR) {
+        browser()
+        nodejs()
+    }
+
+    // Browser only: the test bundle now carries Compose, whose wasm runtime does not load under
+    // Node, so a wasmJs Node test fails before it reaches any assertion.
+    wasmJs {
+        browser()
+    }
+
+    iosArm64()
+    iosSimulatorArm64()
+
+    android {
+        namespace = "com.kitakkun.jetwhale.plugins.semantics.agent"
+        compileSdk = 37
+        minSdk = 23
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            api(projects.jetwhalePlugins.semantics.protocol)
+            api(projects.jetwhaleAgentSdk)
+            implementation(libs.jetbrainsComposeUi)
+            implementation(libs.kotlinxCoroutinesCore)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlinTest)
+        }
+    }
+}
+
+jetwhalePublish {
+    artifactId = "jetwhale-compose-semantics-inspector-agent"
+    name = "JetWhale Compose Semantics Inspector Agent"
+    description = "Reads the Compose semantics tree of a running app for the JetWhale Compose Semantics Inspector."
+}

--- a/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/AndroidComposeUiThread.kt
+++ b/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/AndroidComposeUiThread.kt
@@ -1,0 +1,31 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import android.os.Handler
+import android.os.Looper
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * Runs the block on Android's main thread, without hopping when the caller is already on it.
+ *
+ * A plain `Dispatchers.Main` would always dispatch — costing a frame's worth of latency per capture
+ * — and would pull in `kotlinx-coroutines-android`, which the app may not otherwise need. A bare
+ * `Handler` has neither cost.
+ */
+internal object AndroidComposeUiThread : ComposeUiThread {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    override suspend fun <T> await(block: () -> T): T {
+        if (Looper.myLooper() == Looper.getMainLooper()) return block()
+        return suspendCancellableCoroutine { continuation ->
+            val posted = mainHandler.post {
+                // The caller may have been cancelled while the message sat in the queue; running
+                // the block then would touch the UI for a request nobody is waiting on any more.
+                if (!continuation.isActive) return@post
+                continuation.resumeWith(runCatching(block))
+            }
+            if (!posted) {
+                continuation.resumeWith(Result.failure(IllegalStateException("The main thread's message queue is no longer accepting work.")))
+            }
+        }
+    }
+}

--- a/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/AndroidSemanticsProbe.kt
+++ b/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/AndroidSemanticsProbe.kt
@@ -1,0 +1,237 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.content.ContextWrapper
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.ViewRootForTest
+import java.lang.ref.WeakReference
+import java.util.WeakHashMap
+
+/**
+ * Registers every Compose root in the process with [ComposeNodeSourceRegistry], from the
+ * Application layer — no change to any screen.
+ *
+ * Call it from `Application.onCreate()`, before any activity exists: it hooks the callback Compose
+ * fires when it creates the view backing a composition, so it sees **every** root, including the
+ * separate ones a `Dialog` or a `Popup` gets. Installed later it also scans the resumed activity's
+ * window, so roots created before the call are not lost — but roots in windows that were already
+ * open and are never re-resumed can be.
+ *
+ * The install is process-wide and idempotent: calling it twice returns the same handle. Closing the
+ * returned handle restores whatever callback was installed before, so it composes with the Compose
+ * test framework rather than displacing it.
+ *
+ * @see JetWhaleSemanticsProbe for the in-composition alternative.
+ */
+fun installJetWhaleSemanticsProbe(application: Application): AutoCloseable = AndroidSemanticsProbe.install(application)
+
+/**
+ * Registers the Compose root that hosts this composition for as long as it stays composed.
+ *
+ * Use it when the Application layer is not yours to touch, or when only one screen should be
+ * readable. Call it once inside `setContent { … }`:
+ *
+ * ```kotlin
+ * setContent {
+ *     JetWhaleSemanticsProbe()
+ *     App()
+ * }
+ * ```
+ *
+ * It registers only **its own** root, and a `Dialog` or `Popup` composes into a root of its own —
+ * so add a call inside those too, or install the Application-level probe, which finds them all.
+ *
+ * Safe to combine with [installJetWhaleSemanticsProbe]: registrations are reference counted per
+ * root, so neither install can pull the root out from under the other.
+ */
+@Composable
+fun JetWhaleSemanticsProbe() {
+    val view = LocalView.current
+    DisposableEffect(view) {
+        val registration = (view as? ViewRootForTest)?.let { root ->
+            ComposeNodeSourceRegistry.register(root.toNodeSource())
+        }
+        onDispose { registration?.close() }
+    }
+}
+
+private object AndroidSemanticsProbe {
+    private val lock = Any()
+    private var installation: Installation? = null
+
+    fun install(application: Application): AutoCloseable = synchronized(lock) {
+        installation ?: Installation(application).also { installation = it }
+    }
+
+    fun uninstalled(installation: Installation) = synchronized(lock) {
+        if (this.installation === installation) this.installation = null
+    }
+
+    // Tracking is per view, not per install: the in-composition probe and the Application-level one
+    // must not each attach their own attach-state listener to the same root.
+    private val trackedViews = WeakHashMap<View, ViewTracker>()
+
+    fun track(root: ViewRootForTest) = synchronized(lock) {
+        trackedViews.getOrPut(root.view) {
+            ViewTracker(root).also { tracker ->
+                root.view.addOnAttachStateChangeListener(tracker)
+                // A root discovered by scanning is normally attached already, so its listener would
+                // never fire; register it here instead of waiting for a re-attach that never comes.
+                if (root.view.isAttachedToWindow) tracker.onViewAttachedToWindow(root.view)
+            }
+        }
+        Unit
+    }
+
+    fun untrackAll() = synchronized(lock) {
+        trackedViews.values.toList().forEach { it.dispose() }
+        trackedViews.clear()
+    }
+
+    class Installation(private val application: Application) : AutoCloseable {
+        private val previousCallback = ViewRootForTest.onViewCreatedCallback
+
+        private val viewCreatedCallback: (ViewRootForTest) -> Unit = { root ->
+            // Chained rather than replaced: the Compose test framework uses this same slot, and a
+            // debug build may well be running both.
+            previousCallback?.invoke(root)
+            AndroidSemanticsProbe.track(root)
+        }
+
+        private val activityCallbacks = object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityResumed(activity: Activity) {
+                activity.window?.peekDecorView()?.let(::scanForComposeRoots)
+            }
+
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+            override fun onActivityStarted(activity: Activity) = Unit
+            override fun onActivityPaused(activity: Activity) = Unit
+            override fun onActivityStopped(activity: Activity) = Unit
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+            override fun onActivityDestroyed(activity: Activity) = Unit
+        }
+
+        init {
+            ViewRootForTest.onViewCreatedCallback = viewCreatedCallback
+            application.registerActivityLifecycleCallbacks(activityCallbacks)
+        }
+
+        override fun close() {
+            // Only restore when ours is still the installed one: something installed afterwards
+            // owns the slot now, and overwriting it would silently disable that.
+            if (ViewRootForTest.onViewCreatedCallback === viewCreatedCallback) {
+                ViewRootForTest.onViewCreatedCallback = previousCallback
+            }
+            application.unregisterActivityLifecycleCallbacks(activityCallbacks)
+            AndroidSemanticsProbe.untrackAll()
+            AndroidSemanticsProbe.uninstalled(this)
+        }
+    }
+}
+
+/** Depth-first walk for roots that already existed when the probe was installed. */
+private fun scanForComposeRoots(view: View) {
+    if (view is ViewRootForTest) {
+        AndroidSemanticsProbe.track(view)
+        return
+    }
+    if (view is ViewGroup) {
+        for (index in 0 until view.childCount) scanForComposeRoots(view.getChildAt(index))
+    }
+}
+
+/**
+ * Holds a root's registration in step with its view being attached.
+ *
+ * A detached root has nothing to report, and its activity may be on its way out, so it leaves the
+ * registry — but the tracker stays on the view so a re-attached one (a view pager page coming back)
+ * registers again instead of disappearing for good.
+ */
+private class ViewTracker(root: ViewRootForTest) : View.OnAttachStateChangeListener {
+    private val source = root.toNodeSource()
+
+    // Weak so a tracker left on a view cannot keep it alive; held only so teardown can detach the
+    // listener from the very view it was added to.
+    private val viewRef = WeakReference(root.view)
+
+    @Volatile
+    private var registration: ComposeNodeSourceRegistry.Registration? = null
+
+    override fun onViewAttachedToWindow(v: View) {
+        if (registration == null) registration = ComposeNodeSourceRegistry.register(source)
+    }
+
+    override fun onViewDetachedFromWindow(v: View) {
+        registration?.close()
+        registration = null
+    }
+
+    fun dispose() {
+        registration?.close()
+        registration = null
+        // Detaching matters as much as closing the registration: a listener left behind would
+        // re-register the root on the next attach, after the probe was uninstalled.
+        viewRef.get()?.removeOnAttachStateChangeListener(this)
+    }
+}
+
+/**
+ * Wraps a root as a node source.
+ *
+ * The root is held weakly and re-checked per call: the registry outlives any single screen, and a
+ * strong reference here would keep a destroyed activity's whole view tree alive for as long as the
+ * process runs.
+ */
+private fun ViewRootForTest.toNodeSource(): SemanticsOwnerNodeSource {
+    val rootRef = WeakReference(this)
+
+    // A detached root has nothing readable to report, and reading its semantics can throw, so the
+    // attachment check gates every lookup rather than only the registration.
+    fun attached(): ViewRootForTest? = rootRef.get()?.takeIf { it.view.isAttachedToWindow }
+    return SemanticsOwnerNodeSource(
+        sourceId = "compose-root-${System.identityHashCode(view).toString(16)}",
+        owner = { attached()?.semanticsOwner },
+        label = { rootRef.get()?.view?.describeComposeRoot() ?: "(detached)" },
+        density = { rootRef.get()?.density?.density ?: 1f },
+        windowOffset = { rootRef.get()?.view?.windowOffsetOnScreen() ?: Offset.Zero },
+        uiThread = AndroidComposeUiThread,
+    )
+}
+
+/**
+ * Names the root by the activity it belongs to, and by its window when that is not the activity's
+ * own — which is how a dialog's or a popup's separate root tells itself apart in the host's list.
+ */
+private fun View.describeComposeRoot(): String {
+    val activity = context.findActivity()
+    val activityName = activity?.javaClass?.simpleName ?: context.javaClass.simpleName
+    return if (activity?.window?.peekDecorView() === rootView) {
+        activityName
+    } else {
+        "$activityName / ${rootView.javaClass.simpleName}"
+    }
+}
+
+/**
+ * Distance between this view's window and the screen, so window-relative semantics bounds can be
+ * reported in screen coordinates — the ones `adb shell input tap` takes.
+ */
+private fun View.windowOffsetOnScreen(): Offset {
+    val onScreen = IntArray(2).also(::getLocationOnScreen)
+    val inWindow = IntArray(2).also(::getLocationInWindow)
+    return Offset((onScreen[0] - inWindow[0]).toFloat(), (onScreen[1] - inWindow[1]).toFloat())
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSource.kt
@@ -1,0 +1,33 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+
+/**
+ * One Compose root the agent can read.
+ *
+ * Reaching a live composition is platform-specific — on Android a root is an `AndroidComposeView`
+ * and its semantics may only be touched on the main thread — so the platform integration
+ * (`jetwhale-compose-semantics-inspector-agent-android`) implements this and registers it with
+ * [ComposeNodeSourceRegistry]. The core plugin only ever sees this interface, which is what keeps
+ * it free of a Compose dependency.
+ */
+interface ComposeNodeSource {
+    /**
+     * Identifies this root for the lifetime of its registration; travels to the host as
+     * [ComposeRoot.rootId] and comes back in [PerformNodeAction.rootId].
+     */
+    val sourceId: String
+
+    /**
+     * Reads the semantics tree of this root, or returns `null` when the root currently has nothing
+     * to report (e.g. its view is detached). Implementations are responsible for hopping to
+     * whatever thread their toolkit requires.
+     */
+    suspend fun capture(options: NodeTreeCaptureOptions): ComposeRoot?
+
+    /** Invokes [request]'s action on the node it names within this root. */
+    suspend fun performAction(request: PerformNodeAction): NodeActionResult
+}

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry.kt
@@ -1,0 +1,69 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Process-wide set of the Compose roots the agent can read.
+ *
+ * A process has exactly one composition hierarchy, and roots come and go on their own schedule —
+ * a dialog opens, an activity is recreated — independently of when the debug host connects. So the
+ * registry is a singleton the probe writes to, rather than state threaded through
+ * [JetWhaleSemanticsAgentPlugin]: a root can be registered before the plugin is even activated,
+ * and the plugin reads whatever is present at capture time.
+ *
+ * Registrations are **reference counted per [ComposeNodeSource.sourceId]**. The two ways of
+ * installing a probe overlap by design — an app can install the Application-level one and still
+ * drop the in-composition one into a screen — and either may be torn down first, so a root stays
+ * registered until the last claim on it is closed.
+ */
+object ComposeNodeSourceRegistry {
+    private val entries = MutableStateFlow<List<Entry>>(emptyList())
+
+    /** The registered roots, oldest registration first. */
+    val sources: List<ComposeNodeSource> get() = entries.value.map { it.source }
+
+    /**
+     * Claims [source]'s root and returns a handle releasing that claim. When a source with the same
+     * [ComposeNodeSource.sourceId] is already registered, the existing one keeps serving captures
+     * and this call only adds a claim on it.
+     */
+    fun register(source: ComposeNodeSource): Registration {
+        entries.update { current ->
+            val index = current.indexOfFirst { it.source.sourceId == source.sourceId }
+            if (index < 0) {
+                current + Entry(source, claims = 1)
+            } else {
+                current.toMutableList().apply { this[index] = this[index].withOneMoreClaim() }
+            }
+        }
+        return Registration(source.sourceId)
+    }
+
+    /** Drops every registration. Intended for tests and for tearing down an install. */
+    fun clear() {
+        entries.value = emptyList()
+    }
+
+    private data class Entry(val source: ComposeNodeSource, val claims: Int) {
+        fun withOneMoreClaim(): Entry = copy(claims = claims + 1)
+    }
+
+    /** One claim on a registered root; releasing the last one unregisters it. */
+    class Registration internal constructor(private val sourceId: String) : AutoCloseable {
+        // Closing twice must not release a claim someone else took out in the meantime.
+        private val closed = MutableStateFlow(false)
+
+        override fun close() {
+            if (!closed.compareAndSet(expect = false, update = true)) return
+            entries.update { current ->
+                val index = current.indexOfFirst { it.source.sourceId == sourceId }
+                when {
+                    index < 0 -> current
+                    current[index].claims <= 1 -> current.filterIndexed { i, _ -> i != index }
+                    else -> current.toMutableList().apply { this[index] = this[index].copy(claims = this[index].claims - 1) }
+                }
+            }
+        }
+    }
+}

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ComposeUiThread.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ComposeUiThread.kt
@@ -1,0 +1,26 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Runs a block on the thread that owns a composition.
+ *
+ * Semantics may only be read — and semantics actions may only be invoked — from that thread, while
+ * the agent's message handlers run on the agent's own dispatcher. Which thread that is, and how to
+ * get onto it cheaply, differs per platform, so it is a parameter of [SemanticsOwnerNodeSource]
+ * rather than a hardcoded dispatcher.
+ */
+interface ComposeUiThread {
+    suspend fun <T> await(block: () -> T): T
+}
+
+/**
+ * Hops to `Dispatchers.Main`, the UI thread on every Compose Multiplatform target.
+ *
+ * Android has a cheaper option that skips the dispatch when the caller is already on the main
+ * thread — the Android probe installs it — so this is the default for everything else.
+ */
+object MainDispatcherComposeUiThread : ComposeUiThread {
+    override suspend fun <T> await(block: () -> T): T = withContext(Dispatchers.Main) { block() }
+}

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/JetWhaleSemanticsAgentPlugin.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/JetWhaleSemanticsAgentPlugin.kt
@@ -1,0 +1,100 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import com.kitakkun.jetwhale.agent.sdk.JetWhaleAgentPlugin
+import com.kitakkun.jetwhale.plugins.semantics.protocol.CaptureNodeTree
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessageHandlers
+import com.kitakkun.jetwhale.protocol.messaging.reply
+import kotlinx.coroutines.CancellationException
+import kotlin.time.Clock
+import kotlin.time.TimeSource
+
+/**
+ * Platform-agnostic core of the Compose Semantics Inspector agent plugin.
+ *
+ * It answers two host requests — capture the semantics tree, and invoke one node's action — by
+ * delegating to the [ComposeNodeSource]s registered in [ComposeNodeSourceRegistry]. Register the
+ * plugin with the agent runtime, and install a platform probe so the registry has roots to read:
+ *
+ * ```kotlin
+ * // Android, Application.onCreate()
+ * installJetWhaleSemanticsProbe(this)
+ * startJetWhale {
+ *     plugins { register(JetWhaleSemanticsAgentPlugin()) }
+ * }
+ * ```
+ *
+ * With no probe installed the plugin still answers, reporting an empty tree and a warning saying
+ * so — a connected host then shows why it sees nothing instead of silently showing nothing.
+ */
+class JetWhaleSemanticsAgentPlugin : JetWhaleAgentPlugin() {
+    override val pluginId: String get() = PLUGIN_ID
+    override val pluginVersion: String get() = "1.0.0"
+
+    override fun JetWhaleMessageHandlers.configure() {
+        onRequest { request: CaptureNodeTree ->
+            reply(capture(request.options))
+        }
+        onRequest { request: PerformNodeAction ->
+            reply(performAction(request))
+        }
+    }
+
+    private suspend fun capture(options: NodeTreeCaptureOptions): NodeTreeSnapshot {
+        val started = TimeSource.Monotonic.markNow()
+        val sources = ComposeNodeSourceRegistry.sources
+        val roots = mutableListOf<ComposeRoot>()
+        val warnings = mutableListOf<String>()
+
+        if (sources.isEmpty()) warnings += NO_PROBE_WARNING
+
+        for (source in sources) {
+            try {
+                source.capture(options)?.let(roots::add)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // One unreadable root (a view detached mid-capture, a toolkit-specific failure)
+                // must not cost the caller the roots that did read cleanly.
+                warnings += "${source.sourceId}: failed to capture (${e.describe()})"
+            }
+        }
+
+        return NodeTreeSnapshot(
+            capturedAtMs = Clock.System.now().toEpochMilliseconds(),
+            captureDurationMs = started.elapsedNow().inWholeMilliseconds,
+            options = options,
+            roots = roots,
+            warnings = warnings,
+        )
+    }
+
+    private suspend fun performAction(request: PerformNodeAction): NodeActionResult {
+        val source = ComposeNodeSourceRegistry.sources.firstOrNull { it.sourceId == request.rootId }
+            ?: return NodeActionResult(
+                performed = false,
+                message = "unknown rootId: ${request.rootId} (the root may have been detached; capture the tree again)",
+            )
+        return try {
+            source.performAction(request)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            NodeActionResult(performed = false, message = "action failed: ${e.describe()}")
+        }
+    }
+
+    private fun Throwable.describe(): String = message?.takeIf { it.isNotBlank() } ?: (this::class.simpleName ?: "unknown error")
+
+    companion object {
+        const val PLUGIN_ID: String = "com.kitakkun.jetwhale.semantics"
+
+        internal const val NO_PROBE_WARNING: String =
+            "No Compose root is registered. Install a probe in the app: installJetWhaleSemanticsProbe(application) " +
+                "on Android, or call JetWhaleSemanticsProbe() inside your composition."
+    }
+}

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsActionDispatch.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsActionDispatch.kt
@@ -1,0 +1,99 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import androidx.compose.ui.semantics.AccessibilityAction
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.text.AnnotatedString
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+
+/**
+ * Invokes the semantics action [request] names on this node.
+ *
+ * Going through the node's own action rather than synthesising input is what makes this usable for
+ * driving an app: it needs no window coordinates, cannot land on whatever moved into that spot
+ * meanwhile, and reports back whether the node actually handled it.
+ *
+ * Must be called on the thread that owns the composition.
+ */
+internal fun SemanticsNode.performSemanticsAction(request: PerformNodeAction): NodeActionResult {
+    val config = config
+    if (request.action.requiresEnabled && config.getOrNull(SemanticsProperties.Disabled) != null) {
+        return NodeActionResult(performed = false, message = "the node is disabled")
+    }
+
+    return when (request.action) {
+        NodeAction.Click -> config.invokeAction(SemanticsActions.OnClick) { it() }
+
+        NodeAction.LongClick -> config.invokeAction(SemanticsActions.OnLongClick) { it() }
+
+        NodeAction.SetText -> {
+            val text = request.text ?: return missingText("SetText")
+            // A text field only accepts programmatic edits while it holds focus, exactly as when a
+            // user types into it, so take focus first when the node offers it.
+            config.getOrNull(SemanticsActions.RequestFocus)?.action?.invoke()
+            config.invokeAction(SemanticsActions.SetText) { it(AnnotatedString(text)) }
+        }
+
+        NodeAction.InsertText -> {
+            val text = request.text ?: return missingText("InsertText")
+            config.getOrNull(SemanticsActions.RequestFocus)?.action?.invoke()
+            config.invokeAction(SemanticsActions.InsertTextAtCursor) { it(AnnotatedString(text)) }
+        }
+
+        NodeAction.ImeAction -> config.invokeAction(SemanticsActions.OnImeAction) { it() }
+
+        NodeAction.ScrollBy -> config.invokeAction(SemanticsActions.ScrollBy) { it(request.scrollX, request.scrollY) }
+
+        NodeAction.RequestFocus -> config.invokeAction(SemanticsActions.RequestFocus) { it() }
+
+        NodeAction.Dismiss -> config.invokeAction(SemanticsActions.Dismiss) { it() }
+
+        NodeAction.Expand -> config.invokeAction(SemanticsActions.Expand) { it() }
+
+        NodeAction.Collapse -> config.invokeAction(SemanticsActions.Collapse) { it() }
+    }
+}
+
+/**
+ * Actions a disabled node still answers — focus, dismissal and scrolling stay meaningful — are
+ * excluded, so only the ones a user could not trigger either are rejected up front.
+ */
+private val NodeAction.requiresEnabled: Boolean
+    get() = when (this) {
+        NodeAction.Click,
+        NodeAction.LongClick,
+        NodeAction.SetText,
+        NodeAction.InsertText,
+        NodeAction.ImeAction,
+        NodeAction.Expand,
+        NodeAction.Collapse,
+        -> true
+
+        NodeAction.ScrollBy,
+        NodeAction.RequestFocus,
+        NodeAction.Dismiss,
+        -> false
+    }
+
+private fun <T : Function<Boolean>> SemanticsConfiguration.invokeAction(
+    key: SemanticsPropertyKey<AccessibilityAction<T>>,
+    invoke: (T) -> Boolean,
+): NodeActionResult {
+    // An AccessibilityAction may advertise a label with no handler behind it (a node that says it
+    // is clickable but delegates the click elsewhere), so the handler is what decides.
+    val handler = getOrNull(key)?.action
+        ?: return NodeActionResult(performed = false, message = "the node does not expose ${key.name}")
+    val performed = invoke(handler)
+    return NodeActionResult(
+        performed = performed,
+        message = if (performed) null else "${key.name} ran but reported that it did not handle the request",
+    )
+}
+
+private fun missingText(action: String): NodeActionResult = NodeActionResult(performed = false, message = "$action requires the 'text' argument")

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsOwnerNodeSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsOwnerNodeSource.kt
@@ -1,0 +1,103 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.semantics.getAllSemanticsNodes
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+
+/**
+ * Reads one composition through its [SemanticsOwner].
+ *
+ * Everything here is platform-independent: [SemanticsOwner] and [SemanticsNode] both live in
+ * Compose's common source set. What differs per platform is only how you get hold of an owner —
+ * `AndroidComposeView` on Android, `ComposeWindow.semanticsOwners` on desktop — which is why the
+ * owner arrives as a lambda rather than being looked up here.
+ *
+ * The owner is the narrowest handle that supports the whole job, so a platform that can only reach
+ * a `SemanticsOwner` (desktop does; it never exposes a `RootForTest`) is served by exactly the same
+ * code as one that has more.
+ *
+ * @param owner looked up per call rather than held, so a caller can keep a weak reference and let
+ *   the composition be collected; returning `null` reports the root as currently unreadable.
+ * @param density px per dp of this root, for converting the pixel bounds it reports back to dp.
+ * @param windowOffset where this root's window sits on screen. Node bounds are reported relative to
+ *   the root **and** to the screen, and the screen figure is this offset plus the in-window bounds —
+ *   so a root whose window does not start at the screen origin (a dialog, a popup) must supply it.
+ */
+class SemanticsOwnerNodeSource(
+    override val sourceId: String,
+    private val owner: () -> SemanticsOwner?,
+    private val label: () -> String,
+    private val density: () -> Float,
+    private val windowOffset: () -> Offset = { Offset.Zero },
+    private val uiThread: ComposeUiThread = MainDispatcherComposeUiThread,
+) : ComposeNodeSource {
+
+    override suspend fun capture(options: NodeTreeCaptureOptions): ComposeRoot? = uiThread.await {
+        val owner = owner() ?: return@await null
+        val offset = windowOffset()
+        val semanticsRoot = if (options.merged) owner.rootSemanticsNode else owner.unmergedRootSemanticsNode
+        ComposeRoot(
+            rootId = sourceId,
+            label = label(),
+            density = density(),
+            windowOffsetX = offset.x,
+            windowOffsetY = offset.y,
+            node = semanticsRoot.toComposeNode(
+                options = options,
+                windowOffsetX = offset.x,
+                windowOffsetY = offset.y,
+                depth = 0,
+            ),
+        )
+    }
+
+    override suspend fun performAction(request: PerformNodeAction): NodeActionResult = uiThread.await {
+        val owner = owner()
+            ?: return@await NodeActionResult(performed = false, message = "the root is no longer readable")
+        val node = owner.findNodeById(request.nodeId)
+            ?: return@await NodeActionResult(
+                performed = false,
+                message = "unknown nodeId: ${request.nodeId} (the node may have left the composition; capture the tree again)",
+            )
+        node.performSemanticsAction(request)
+    }
+}
+
+/**
+ * A node id addresses the same layout node in both trees, but a node merged into its parent is only
+ * present in the unmerged one — so a lookup that missed in the merged tree still has somewhere to
+ * look. The merged tree comes first because its config carries the actions a caller saw advertised.
+ */
+private fun SemanticsOwner.findNodeById(id: Int): SemanticsNode? = getAllSemanticsNodes(mergingEnabled = true, skipDeactivatedNodes = true).firstOrNull { it.id == id }
+    ?: getAllSemanticsNodes(mergingEnabled = false, skipDeactivatedNodes = true).firstOrNull { it.id == id }
+
+/**
+ * Registers a [SemanticsOwner] the caller already holds and keeps alive itself.
+ *
+ * The platform probes ([installJetWhaleSemanticsProbe] on Android, [JetWhaleSemanticsProbe] on
+ * either platform) find owners for you; reach for this only on a target with no probe of its own.
+ *
+ * @see SemanticsOwnerNodeSource
+ */
+fun ComposeNodeSourceRegistry.registerSemanticsOwner(
+    owner: SemanticsOwner,
+    sourceId: String,
+    label: String,
+    density: Float,
+    windowOffset: () -> Offset = { Offset.Zero },
+    uiThread: ComposeUiThread = MainDispatcherComposeUiThread,
+): ComposeNodeSourceRegistry.Registration = register(
+    SemanticsOwnerNodeSource(
+        sourceId = sourceId,
+        owner = { owner },
+        label = { label },
+        density = { density },
+        windowOffset = windowOffset,
+        uiThread = uiThread,
+    ),
+)

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsTreeCapture.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsTreeCapture.kt
@@ -1,0 +1,83 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.semantics.AccessibilityAction
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+
+/**
+ * Converts a Compose semantics subtree into the transport model.
+ *
+ * Returns `null` when the node is filtered out — either it is not laid out and [NodeTreeCaptureOptions.includeInvisible]
+ * is off, or it sits past [NodeTreeCaptureOptions.maxDepth]. A node whose own bounds are empty is
+ * still kept when a descendant survived: dropping it would detach that descendant from the tree.
+ */
+internal fun SemanticsNode.toComposeNode(
+    options: NodeTreeCaptureOptions,
+    windowOffsetX: Float,
+    windowOffsetY: Float,
+    depth: Int,
+): ComposeNode? {
+    val maxDepth = options.maxDepth
+    val children = if (maxDepth != null && depth >= maxDepth) {
+        emptyList()
+    } else {
+        children.mapNotNull { it.toComposeNode(options, windowOffsetX, windowOffsetY, depth + 1) }
+    }
+
+    // Visibility is decided on the sanitized bounds, not the raw ones: a NaN coordinate makes
+    // every comparison false, so a raw-bounds check would call the node visible while the bounds
+    // it reports are the zeroed fallback.
+    val bounds = boundsInRoot.toNodeBounds()
+    val visible = layoutInfo.isPlaced && !bounds.isEmpty
+    if (!visible && !options.includeInvisible && children.isEmpty()) return null
+
+    val config = config
+    val editableText = config.getOrNull(SemanticsProperties.EditableText)?.text
+
+    return ComposeNode(
+        id = id,
+        role = config.getOrNull(SemanticsProperties.Role)?.toString(),
+        text = config.getOrNull(SemanticsProperties.Text)
+            ?.joinToString(separator = " ") { it.text }
+            ?.takeIf { it.isNotEmpty() },
+        editableText = editableText,
+        contentDescription = config.getOrNull(SemanticsProperties.ContentDescription)
+            ?.joinToString(separator = " ")
+            ?.takeIf { it.isNotEmpty() },
+        testTag = config.getOrNull(SemanticsProperties.TestTag),
+        stateDescription = config.getOrNull(SemanticsProperties.StateDescription),
+        toggleableState = config.getOrNull(SemanticsProperties.ToggleableState)?.toString(),
+        bounds = bounds,
+        boundsInScreen = boundsInWindow.toNodeBounds(offsetX = windowOffsetX, offsetY = windowOffsetY),
+        actions = config.mapNotNull { (key, value) -> key.name.takeIf { value is AccessibilityAction<*> } },
+        isEnabled = config.getOrNull(SemanticsProperties.Disabled) == null,
+        isClickable = config.getOrNull(SemanticsActions.OnClick) != null,
+        isFocused = config.getOrNull(SemanticsProperties.Focused) == true,
+        isSelected = config.getOrNull(SemanticsProperties.Selected) == true,
+        isEditable = editableText != null || config.getOrNull(SemanticsActions.SetText) != null,
+        isScrollable = config.getOrNull(SemanticsProperties.VerticalScrollAxisRange) != null ||
+            config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange) != null,
+        isVisible = visible,
+        children = children,
+    )
+}
+
+private fun Rect.toNodeBounds(offsetX: Float = 0f, offsetY: Float = 0f): NodeBounds = NodeBounds(
+    left = (left + offsetX).finiteOrZero(),
+    top = (top + offsetY).finiteOrZero(),
+    right = (right + offsetX).finiteOrZero(),
+    bottom = (bottom + offsetY).finiteOrZero(),
+)
+
+/**
+ * Compose reports an unresolved coordinate as `Offset.Unspecified`, i.e. `NaN`. JSON has no NaN, so
+ * one such node would fail the encoding of the **whole** snapshot; reporting the node with empty
+ * bounds instead costs the caller one unusable node rather than the entire tree.
+ */
+private fun Float.finiteOrZero(): Float = if (isFinite()) this else 0f

--- a/jetwhale-plugins/semantics/agent/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistryTest.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistryTest.kt
@@ -1,0 +1,75 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComposeNodeSourceRegistryTest {
+    @BeforeTest
+    @AfterTest
+    fun resetRegistry() {
+        ComposeNodeSourceRegistry.clear()
+    }
+
+    @Test
+    fun `registers a source and unregisters it when its registration is closed`() {
+        val registration = ComposeNodeSourceRegistry.register(FakeSource("root-1"))
+
+        assertEquals(listOf("root-1"), ComposeNodeSourceRegistry.sources.map { it.sourceId })
+
+        registration.close()
+
+        assertEquals(emptyList(), ComposeNodeSourceRegistry.sources.map { it.sourceId })
+    }
+
+    @Test
+    fun `keeps registration order so the newest root is last`() {
+        ComposeNodeSourceRegistry.register(FakeSource("root-1"))
+        ComposeNodeSourceRegistry.register(FakeSource("root-2"))
+
+        assertEquals(listOf("root-1", "root-2"), ComposeNodeSourceRegistry.sources.map { it.sourceId })
+    }
+
+    @Test
+    fun `registering the same root twice reports it once`() {
+        ComposeNodeSourceRegistry.register(FakeSource("root-1"))
+        ComposeNodeSourceRegistry.register(FakeSource("root-1"))
+
+        assertEquals(1, ComposeNodeSourceRegistry.sources.size)
+    }
+
+    @Test
+    fun `a root stays registered until the last claim on it is released`() {
+        // The Application-level probe and the in-composition one can both claim the same root; the
+        // first to be torn down must not take it away from the other.
+        val first = ComposeNodeSourceRegistry.register(FakeSource("root-1"))
+        val second = ComposeNodeSourceRegistry.register(FakeSource("root-1"))
+
+        first.close()
+        assertEquals(1, ComposeNodeSourceRegistry.sources.size)
+
+        second.close()
+        assertEquals(0, ComposeNodeSourceRegistry.sources.size)
+    }
+
+    @Test
+    fun `closing a registration twice does not release someone else's claim`() {
+        val first = ComposeNodeSourceRegistry.register(FakeSource("root-1"))
+        ComposeNodeSourceRegistry.register(FakeSource("root-1"))
+
+        first.close()
+        first.close()
+
+        assertEquals(1, ComposeNodeSourceRegistry.sources.size)
+    }
+
+    private class FakeSource(override val sourceId: String) : ComposeNodeSource {
+        override suspend fun capture(options: NodeTreeCaptureOptions): ComposeRoot? = null
+        override suspend fun performAction(request: PerformNodeAction): NodeActionResult = NodeActionResult(performed = false)
+    }
+}

--- a/jetwhale-plugins/semantics/agent/src/jvmMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/DesktopSemanticsProbe.kt
+++ b/jetwhale-plugins/semantics/agent/src/jvmMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/DesktopSemanticsProbe.kt
@@ -1,0 +1,70 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.window.FrameWindowScope
+
+/**
+ * Registers this window's Compose roots for as long as the call stays composed.
+ *
+ * Desktop has no equivalent of Android's process-wide root callback, so the probe is scoped to a
+ * window and goes inside it:
+ *
+ * ```kotlin
+ * singleWindowApplication {
+ *     JetWhaleSemanticsProbe()
+ *     App()
+ * }
+ * ```
+ *
+ * [ComposeWindow.semanticsOwners] is snapshot-backed, so reading it here re-runs this composable
+ * whenever the window gains or loses a root — a `Dialog` or a `Popup` rendered inside the window
+ * appears and disappears on its own, with no further calls needed. A window of its own (a separate
+ * `Window { }`) is a separate composition and needs its own call.
+ */
+@ExperimentalComposeUiApi
+@Composable
+fun FrameWindowScope.JetWhaleSemanticsProbe() {
+    val window = window
+    val density = LocalDensity.current.density
+    // Snapshotted into a list so the DisposableEffect key compares by content: the collection
+    // itself is the same instance across changes, which would never re-key the effect.
+    val owners = window.semanticsOwners.toList()
+
+    DisposableEffect(window, owners, density) {
+        val registrations = owners.mapIndexed { index, owner ->
+            ComposeNodeSourceRegistry.register(owner.toNodeSource(window, density, index))
+        }
+        onDispose { registrations.forEach(AutoCloseable::close) }
+    }
+}
+
+private fun SemanticsOwner.toNodeSource(window: ComposeWindow, density: Float, index: Int): SemanticsOwnerNodeSource {
+    val title = window.title.ifEmpty { "Compose window" }
+    return SemanticsOwnerNodeSource(
+        sourceId = "compose-root-${System.identityHashCode(this).toString(16)}",
+        owner = { this },
+        // The collection carries no names, so the extra roots — a dialog or popup layer — are
+        // distinguished by position rather than guessed at.
+        label = { if (index == 0) title else "$title / layer $index" },
+        density = { density },
+        windowOffset = { window.composeSurfaceOffsetOnScreen() },
+        uiThread = SwingComposeUiThread,
+    )
+}
+
+/**
+ * Where the window's Compose surface sits on screen, so in-window bounds can be reported in screen
+ * coordinates. Reading it needs the window to be on screen and to be read on the AWT thread — which
+ * is where captures run — and it is treated as unknown rather than fatal when it is not.
+ */
+private fun ComposeWindow.composeSurfaceOffsetOnScreen(): Offset {
+    if (!isShowing) return Offset.Zero
+    val location = runCatching { contentPane.locationOnScreen }.getOrNull() ?: return Offset.Zero
+    return Offset(location.x.toFloat(), location.y.toFloat())
+}

--- a/jetwhale-plugins/semantics/agent/src/jvmMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SwingComposeUiThread.kt
+++ b/jetwhale-plugins/semantics/agent/src/jvmMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SwingComposeUiThread.kt
@@ -1,0 +1,27 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.awt.EventQueue
+
+/**
+ * Runs the block on the AWT event dispatch thread, which owns a Compose Desktop composition, without
+ * hopping when the caller is already on it.
+ *
+ * `Dispatchers.Main` would be the obvious choice but it is not free on desktop: it needs
+ * `kotlinx-coroutines-swing` on the **app's** runtime classpath, and an app that does not happen to
+ * have it fails every capture with "Module with the Main dispatcher is missing" rather than
+ * degrading. `EventQueue` is in the JDK, so this works in any Compose Desktop app.
+ */
+internal object SwingComposeUiThread : ComposeUiThread {
+    override suspend fun <T> await(block: () -> T): T {
+        if (EventQueue.isDispatchThread()) return block()
+        return suspendCancellableCoroutine { continuation ->
+            EventQueue.invokeLater {
+                // The caller may have been cancelled while the event sat in the queue; running the
+                // block then would touch the UI for a request nobody is waiting on any more.
+                if (!continuation.isActive) return@invokeLater
+                continuation.resumeWith(runCatching(block))
+            }
+        }
+    }
+}

--- a/jetwhale-plugins/semantics/host/build.gradle.kts
+++ b/jetwhale-plugins/semantics/host/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    alias(libs.plugins.jvm)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.jetbrainsCompose)
+    // Provides packagePlugin / installPlugin / stageDevPlugin / runJetWhale / runJetWhaleHot (published).
+    alias(libs.plugins.jetwhalePlugin)
+    // In-repo only: adds runJetWhaleLocal, which launches the local :jetwhale-host:app project.
+    alias(libs.plugins.jetwhaleHostLaunch)
+    alias(libs.plugins.publish)
+}
+
+// Distinct group so this module's coordinates don't collide with the other plugins' `host`.
+group = "com.kitakkun.jetwhale.plugins.semantics"
+
+jetwhalePlugin {
+    // Unique name so the packaged plugin jar doesn't collide with the other plugin modules (also
+    // project name "host") in ~/.jetwhale/plugins/ or the dev staging directory.
+    pluginArchiveName.set("jetwhale-compose-semantics-inspector")
+}
+
+dependencies {
+    // Provided by the host at runtime, so compileOnly: these must be neither bundled into the
+    // plugin jar nor listed in its dependency manifest.
+    compileOnly(projects.jetwhaleHostSdk)
+    compileOnly(compose.desktop.currentOs)
+    compileOnly(libs.material3)
+    compileOnly(libs.kotlinxSerializationJson)
+    api(projects.jetwhalePlugins.semantics.protocol)
+
+    testImplementation(projects.jetwhaleHostSdk)
+    testImplementation(libs.kotlinTest)
+    testImplementation(libs.kotlinxSerializationJson)
+    testImplementation(compose.desktop.currentOs)
+    testImplementation(libs.material3)
+}
+
+// The jetwhalePlugin convention publishes the `packageMavenPlugin` jar (the module's classes plus a
+// manifest of its runtime dependencies) as the main artifact; the host's "Install from Maven"
+// feature downloads it and fetches the listed dependencies itself.
+jetwhalePublish {
+    artifactId = "jetwhale-compose-semantics-inspector"
+    name = "JetWhale Compose Semantics Inspector"
+    description = "JetWhale host plugin that browses the Compose node tree of a running app and exposes it over MCP."
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeMcpCommands.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeMcpCommands.kt
@@ -1,0 +1,19 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+// Shared by the Compose Semantics Inspector's MCP command classes (one class per file in this package).
+
+/** Tool names are globally unique across plugins, so they carry the pluginId by convention. */
+internal const val TOOL_PREFIX = "com.kitakkun.jetwhale.semantics"
+
+internal fun errorJson(message: String): String = buildJsonObject { put("error", message) }.toString()
+
+/**
+ * Every tool here reaches into the running app, so a disconnected or unresponsive agent is a normal
+ * outcome rather than a bug: it is reported to the caller as an error payload instead of failing
+ * the MCP server.
+ */
+internal fun agentErrorJson(failure: JetWhaleMessagingException): String = errorJson("the app did not answer: ${failure.message}")

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
@@ -1,0 +1,120 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMessagingHostPlugin
+import com.kitakkun.jetwhale.plugins.semantics.protocol.CaptureNodeTree
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import com.kitakkun.jetwhale.protocol.messaging.request
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.time.TimeSource
+
+// Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
+@Suppress("UNUSED")
+class ComposeSemanticsInspectorPluginFactory : JetWhaleHostPluginFactory {
+    override fun createPlugin(): JetWhaleHostPlugin = ComposeNodeInspectorHostPlugin()
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+private class ComposeNodeInspectorHostPlugin :
+    JetWhaleMessagingHostPlugin(),
+    JetWhaleHostPluginUi,
+    JetWhaleMcpCapablePlugin {
+
+    private var snapshot by mutableStateOf<NodeTreeSnapshot?>(null)
+    private var capturing by mutableStateOf(false)
+    private var errorMessage by mutableStateOf<String?>(null)
+    private var actionStatus by mutableStateOf<String?>(null)
+
+    // The snapshot reports what the capture cost on the device; this is what it cost from here,
+    // transport included. Shown side by side because the point of reading the tree this way rather
+    // than through `adb` is the latency, and the two numbers say where any of it went.
+    private var roundTripMs by mutableStateOf<Long?>(null)
+
+    // A capture reads the app's semantics on its main thread, so overlapping captures would queue
+    // work there rather than finish sooner. Serialising them keeps auto-refresh and MCP calls from
+    // compounding into UI jank in the app being debugged.
+    private val captureLock = Mutex()
+
+    private suspend fun capture(options: NodeTreeCaptureOptions): NodeTreeSnapshot = captureLock.withLock {
+        capturing = true
+        val startedAt = TimeSource.Monotonic.markNow()
+        try {
+            messenger.request(CaptureNodeTree(options)).also {
+                snapshot = it
+                roundTripMs = startedAt.elapsedNow().inWholeMilliseconds
+                errorMessage = null
+            }
+        } finally {
+            capturing = false
+        }
+    }
+
+    private suspend fun performAction(request: PerformNodeAction): NodeActionResult = messenger.request(request)
+
+    // -------------------------------------------------------------------------
+    // JetWhaleHostPluginUi
+    // -------------------------------------------------------------------------
+
+    @Composable
+    override fun Content() {
+        ComposeSemanticsInspectorScreen(
+            snapshot = snapshot,
+            capturing = capturing,
+            roundTripMs = roundTripMs,
+            errorMessage = errorMessage,
+            actionStatus = actionStatus,
+            onCapture = { options ->
+                try {
+                    capture(options)
+                } catch (e: JetWhaleMessagingException) {
+                    errorMessage = "Capture failed: ${e.message}"
+                }
+            },
+            onPerformAction = { request ->
+                pluginScope.launch {
+                    actionStatus = try {
+                        val result = performAction(request)
+                        // Re-read straight away: an action changes the very tree the user is
+                        // looking at, and a stale tree next to a "done" message reads as a failure.
+                        capture(snapshot?.options ?: NodeTreeCaptureOptions())
+                        when {
+                            result.performed -> "${request.action} on #${request.nodeId}: done"
+                            else -> "${request.action} on #${request.nodeId}: ${result.message ?: "not performed"}"
+                        }
+                    } catch (e: JetWhaleMessagingException) {
+                        "${request.action} on #${request.nodeId} failed: ${e.message}"
+                    }
+                }
+            },
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // JetWhaleMcpCapablePlugin
+    // -------------------------------------------------------------------------
+
+    override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
+        GetNodeTreeCommand(capture = ::capture),
+        FindNodesCommand(capture = ::capture),
+        PerformNodeActionCommand(
+            lastSnapshot = { snapshot },
+            capture = ::capture,
+            perform = ::performAction,
+        ),
+    )
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -1,0 +1,559 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.host.sdk.rememberPersistent
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/**
+ * Browser for the Compose node tree of the running app: the tree on the left, the selected node's
+ * semantics and the actions it exposes on the right.
+ *
+ * Captures are pull-based — a capture reads the debuggee's semantics on its main thread, so the app
+ * pays only when someone is looking. Auto-refresh exists for watching a screen change, but is off by
+ * default for the same reason.
+ */
+@Composable
+internal fun ComposeSemanticsInspectorScreen(
+    snapshot: NodeTreeSnapshot?,
+    capturing: Boolean,
+    roundTripMs: Long?,
+    errorMessage: String?,
+    actionStatus: String?,
+    onCapture: suspend (NodeTreeCaptureOptions) -> Unit,
+    onPerformAction: (PerformNodeAction) -> Unit,
+) {
+    var merged by rememberPersistent("merged-tree", default = true)
+    var interactiveOnly by rememberPersistent("interactive-only", default = false)
+    var includeInvisible by rememberPersistent("include-invisible", default = false)
+    var autoRefresh by rememberPersistent("auto-refresh", default = false)
+    val scope = rememberCoroutineScope()
+    var search by remember { mutableStateOf("") }
+    var selectedKey by remember { mutableStateOf<NodeKey?>(null) }
+    val collapsedKeys = remember { mutableStateMapOf<NodeKey, Unit>() }
+
+    val options = NodeTreeCaptureOptions(merged = merged, includeInvisible = includeInvisible, maxDepth = null)
+
+    // Capture once when the screen opens, and again whenever an option changes what would be
+    // captured — an option the user toggled should show its effect without a second click.
+    LaunchedEffect(merged, includeInvisible) {
+        onCapture(options)
+    }
+    LaunchedEffect(autoRefresh, merged, includeInvisible) {
+        if (!autoRefresh) return@LaunchedEffect
+        while (true) {
+            delay(AUTO_REFRESH_INTERVAL_MILLIS)
+            // Awaited, not fired and forgotten: captures are serialised on the app's main thread,
+            // so a fixed-interval loop against a slow app would queue requests faster than they
+            // drain and leave the view showing an ever-older tree.
+            onCapture(options)
+        }
+    }
+
+    val rows = remember(snapshot, search, interactiveOnly, collapsedKeys.keys.toSet()) {
+        buildTreeRows(
+            roots = snapshot?.roots.orEmpty(),
+            collapsedKeys = collapsedKeys.keys.toSet(),
+            predicate = { node ->
+                (!interactiveOnly || node.isInteractive) && node.matchesFreeText(search)
+            },
+        )
+    }
+    val selectedNode = selectedKey?.let { key ->
+        snapshot?.roots?.firstOrNull { it.rootId == key.rootId }?.findNode(key.nodeId)
+    }
+
+    // The host hands the plugin an unpainted scene, so the screen paints its own background;
+    // without it the areas no child covers fall back to white and fight a dark theme.
+    Column(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
+        Toolbar(
+            capturing = capturing,
+            merged = merged,
+            interactiveOnly = interactiveOnly,
+            includeInvisible = includeInvisible,
+            autoRefresh = autoRefresh,
+            search = search,
+            onRefresh = { scope.launch { onCapture(options) } },
+            onMergedChange = { merged = it },
+            onInteractiveOnlyChange = { interactiveOnly = it },
+            onIncludeInvisibleChange = { includeInvisible = it },
+            onAutoRefreshChange = { autoRefresh = it },
+            onSearchChange = { search = it },
+        )
+        StatusLine(
+            snapshot = snapshot,
+            rowCount = rows.count { it is TreeRow.NodeRow },
+            roundTripMs = roundTripMs,
+            errorMessage = errorMessage,
+            actionStatus = actionStatus,
+        )
+        HorizontalDivider()
+        Row(Modifier.fillMaxSize()) {
+            Box(Modifier.weight(0.58f).fillMaxHeight()) {
+                if (rows.isEmpty()) {
+                    EmptyTreeMessage(snapshot = snapshot, search = search, interactiveOnly = interactiveOnly)
+                } else {
+                    TreeList(
+                        rows = rows,
+                        selectedKey = selectedKey,
+                        onSelect = { selectedKey = it },
+                        onToggleExpanded = { key ->
+                            if (collapsedKeys.remove(key) == null) collapsedKeys[key] = Unit
+                        },
+                    )
+                }
+            }
+            VerticalDivider()
+            Box(Modifier.weight(0.42f).fillMaxHeight()) {
+                NodeDetail(
+                    rootId = selectedKey?.rootId,
+                    node = selectedNode,
+                    onPerformAction = onPerformAction,
+                )
+            }
+        }
+    }
+}
+
+private const val AUTO_REFRESH_INTERVAL_MILLIS = 1_000L
+
+@Composable
+private fun Toolbar(
+    capturing: Boolean,
+    merged: Boolean,
+    interactiveOnly: Boolean,
+    includeInvisible: Boolean,
+    autoRefresh: Boolean,
+    search: String,
+    onRefresh: () -> Unit,
+    onMergedChange: (Boolean) -> Unit,
+    onInteractiveOnlyChange: (Boolean) -> Unit,
+    onIncludeInvisibleChange: (Boolean) -> Unit,
+    onAutoRefreshChange: (Boolean) -> Unit,
+    onSearchChange: (String) -> Unit,
+) {
+    FlowRow(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Button(onClick = onRefresh, enabled = !capturing) {
+            Text(if (capturing) "Capturing…" else "Refresh")
+        }
+        LabelledCheckbox("Auto", autoRefresh, onAutoRefreshChange)
+        LabelledCheckbox("Merged", merged, onMergedChange)
+        LabelledCheckbox("Interactive only", interactiveOnly, onInteractiveOnlyChange)
+        LabelledCheckbox("Include invisible", includeInvisible, onIncludeInvisibleChange)
+        OutlinedTextField(
+            value = search,
+            onValueChange = onSearchChange,
+            label = { Text("Search text / tag / role") },
+            singleLine = true,
+            modifier = Modifier.width(260.dp),
+        )
+    }
+}
+
+@Composable
+private fun LabelledCheckbox(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { onCheckedChange(!checked) }) {
+        Checkbox(checked = checked, onCheckedChange = onCheckedChange)
+        Text(label, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun StatusLine(
+    snapshot: NodeTreeSnapshot?,
+    rowCount: Int,
+    roundTripMs: Long?,
+    errorMessage: String?,
+    actionStatus: String?,
+) {
+    Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp)) {
+        val summary = when (snapshot) {
+            null -> "Not captured yet."
+
+            else -> buildString {
+                append("${snapshot.roots.size} root(s) · $rowCount shown of ${snapshot.nodeCount()} · ")
+                append("${snapshot.captureDurationMs} ms on device")
+                roundTripMs?.let { append(" · $it ms round trip") }
+            }
+        }
+        Text(summary, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        snapshot?.warnings?.forEach { warning ->
+            Text(warning, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary)
+        }
+        errorMessage?.let {
+            Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+        }
+        actionStatus?.let {
+            Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+        }
+        Spacer(Modifier.height(6.dp))
+    }
+}
+
+@Composable
+private fun EmptyTreeMessage(snapshot: NodeTreeSnapshot?, search: String, interactiveOnly: Boolean) {
+    val message = when {
+        snapshot == null -> "Press Refresh to capture the app's node tree."
+        snapshot.roots.isEmpty() -> "The app reported no Compose root. Install a probe: installJetWhaleSemanticsProbe(application), or call JetWhaleSemanticsProbe() inside your composition."
+        search.isNotBlank() || interactiveOnly -> "No node matches the current filter."
+        else -> "The app's Compose roots are empty."
+    }
+    Box(Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
+        Text(message, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun TreeList(
+    rows: List<TreeRow>,
+    selectedKey: NodeKey?,
+    onSelect: (NodeKey) -> Unit,
+    onToggleExpanded: (NodeKey) -> Unit,
+) {
+    LazyColumn(Modifier.fillMaxSize()) {
+        items(rows, key = { it.key }) { row ->
+            when (row) {
+                is TreeRow.RootHeader -> RootHeaderRow(row)
+
+                is TreeRow.NodeRow -> NodeRow(
+                    row = row,
+                    selected = selectedKey == NodeKey(row.rootId, row.node.id),
+                    onSelect = { onSelect(NodeKey(row.rootId, row.node.id)) },
+                    onToggleExpanded = { onToggleExpanded(NodeKey(row.rootId, row.node.id)) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RootHeaderRow(row: TreeRow.RootHeader) {
+    Surface(color = MaterialTheme.colorScheme.surfaceVariant, modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = row.root.label,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = "${row.nodeCount} nodes · ×${row.root.density}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun NodeRow(
+    row: TreeRow.NodeRow,
+    selected: Boolean,
+    onSelect: () -> Unit,
+    onToggleExpanded: () -> Unit,
+) {
+    val background = if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface
+    val label = row.node.displayLabel()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(background)
+            .clickable(onClick = onSelect)
+            .padding(start = (8 + row.depth * 14).dp, end = 8.dp, top = 3.dp, bottom = 3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        // A fixed-width slot even for leaves, so labels at the same depth line up rather than
+        // shifting by whether a node happens to have children.
+        Box(Modifier.width(18.dp), contentAlignment = Alignment.Center) {
+            if (row.expandable) {
+                Text(
+                    text = if (row.expanded) "▾" else "▸",
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.clickable(onClick = onToggleExpanded),
+                )
+            }
+        }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (row.node.isVisible) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outline,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f, fill = false),
+        )
+        if (row.node.isInteractive) {
+            Text(
+                text = row.node.actionSummary(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 1,
+            )
+        }
+        // A node with no semantics of its own is already labelled by its id; repeating it here
+        // would render "#12 #12".
+        if (!label.startsWith("#")) {
+            Text(
+                text = "#${row.node.id}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+        }
+    }
+}
+
+private fun ComposeNode.actionSummary(): String = when {
+    isClickable -> "clickable"
+    isEditable -> "editable"
+    isScrollable -> "scrollable"
+    else -> actions.firstOrNull() ?: ""
+}
+
+@Composable
+private fun NodeDetail(
+    rootId: String?,
+    node: ComposeNode?,
+    onPerformAction: (PerformNodeAction) -> Unit,
+) {
+    if (node == null || rootId == null) {
+        Box(Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
+            Text(
+                "Select a node to see its semantics and the actions it exposes.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        return
+    }
+
+    val clipboard = LocalClipboardManager.current
+    var textInput by remember(node.id) { mutableStateOf(node.editableText ?: "") }
+
+    Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(12.dp)) {
+        Text(node.displayLabel(), style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(8.dp))
+
+        PropertyRow("id", node.id.toString())
+        PropertyRow("rootId", rootId)
+        node.role?.let { PropertyRow("role", it) }
+        node.text?.let { PropertyRow("text", it, wrap = true) }
+        node.editableText?.let { PropertyRow("editableText", it, wrap = true) }
+        node.contentDescription?.let { PropertyRow("contentDescription", it, wrap = true) }
+        node.testTag?.let { PropertyRow("testTag", it) }
+        node.stateDescription?.let { PropertyRow("stateDescription", it, wrap = true) }
+        node.toggleableState?.let { PropertyRow("toggleableState", it) }
+        PropertyRow("bounds (root)", node.bounds.formatted())
+        PropertyRow("bounds (screen)", node.boundsInScreen.formatted())
+        PropertyRow(
+            "flags",
+            buildList {
+                if (!node.isEnabled) add("disabled")
+                if (!node.isVisible) add("invisible")
+                if (node.isFocused) add("focused")
+                if (node.isSelected) add("selected")
+                if (node.isClickable) add("clickable")
+                if (node.isEditable) add("editable")
+                if (node.isScrollable) add("scrollable")
+            }.joinToString(", ").ifEmpty { "—" },
+            wrap = true,
+        )
+        PropertyRow("actions", node.actions.joinToString(", ").ifEmpty { "—" }, wrap = true)
+
+        Spacer(Modifier.height(12.dp))
+        HorizontalDivider()
+        Spacer(Modifier.height(12.dp))
+
+        Text("Run an action on the app", style = MaterialTheme.typography.titleSmall)
+        Spacer(Modifier.height(6.dp))
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            ActionButton("Click", node, NodeAction.Click, rootId, onPerformAction)
+            ActionButton("Long click", node, NodeAction.LongClick, rootId, onPerformAction)
+            ActionButton("Focus", node, NodeAction.RequestFocus, rootId, onPerformAction)
+            ActionButton("Dismiss", node, NodeAction.Dismiss, rootId, onPerformAction)
+            ActionButton("Expand", node, NodeAction.Expand, rootId, onPerformAction)
+            ActionButton("Collapse", node, NodeAction.Collapse, rootId, onPerformAction)
+        }
+
+        if (node.actions.contains("SetText")) {
+            Spacer(Modifier.height(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = textInput,
+                    onValueChange = { textInput = it },
+                    label = { Text("Text") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                )
+                Button(
+                    onClick = {
+                        onPerformAction(PerformNodeAction(rootId = rootId, nodeId = node.id, action = NodeAction.SetText, text = textInput))
+                    },
+                ) {
+                    Text("Set text")
+                }
+            }
+        }
+
+        if (node.isScrollable) {
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(
+                    onClick = {
+                        onPerformAction(PerformNodeAction(rootId = rootId, nodeId = node.id, action = NodeAction.ScrollBy, scrollY = SCROLL_STEP_PX))
+                    },
+                ) {
+                    Text("Scroll down")
+                }
+                OutlinedButton(
+                    onClick = {
+                        onPerformAction(PerformNodeAction(rootId = rootId, nodeId = node.id, action = NodeAction.ScrollBy, scrollY = -SCROLL_STEP_PX))
+                    },
+                ) {
+                    Text("Scroll up")
+                }
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+        TextButton(
+            onClick = {
+                clipboard.setText(AnnotatedString(node.adbTapCommand()))
+            },
+            enabled = !node.boundsInScreen.isEmpty,
+        ) {
+            Text("Copy `adb shell input tap` for these bounds")
+        }
+    }
+}
+
+private const val SCROLL_STEP_PX = 400f
+
+private fun ComposeNode.adbTapCommand(): String = "adb shell input tap ${boundsInScreen.centerX.roundToInt()} ${boundsInScreen.centerY.roundToInt()}"
+
+@Composable
+private fun ActionButton(
+    label: String,
+    node: ComposeNode,
+    action: NodeAction,
+    rootId: String,
+    onPerformAction: (PerformNodeAction) -> Unit,
+) {
+    // Only offer what the node actually advertises: a button for an action the node does not expose
+    // would always come back "not exposed", which is noise rather than feedback.
+    val exposed = node.actions.contains(action.semanticsKeyName)
+    if (!exposed) return
+    OutlinedButton(
+        onClick = { onPerformAction(PerformNodeAction(rootId = rootId, nodeId = node.id, action = action)) },
+        enabled = node.isEnabled,
+    ) {
+        Text(label)
+    }
+}
+
+/** The semantics key an action arrives under in [ComposeNode.actions]. */
+private val NodeAction.semanticsKeyName: String
+    get() = when (this) {
+        NodeAction.Click -> "OnClick"
+        NodeAction.LongClick -> "OnLongClick"
+        NodeAction.SetText -> "SetText"
+        NodeAction.InsertText -> "InsertTextAtCursor"
+        NodeAction.ImeAction -> "PerformImeAction"
+        NodeAction.ScrollBy -> "ScrollBy"
+        NodeAction.RequestFocus -> "RequestFocus"
+        NodeAction.Dismiss -> "Dismiss"
+        NodeAction.Expand -> "Expand"
+        NodeAction.Collapse -> "Collapse"
+    }
+
+/**
+ * @param wrap `true` for values worth reading in full at a glance — the action list, the app's own
+ *   strings. The rest stay on one scrollable line so the columns line up and a long id cannot push
+ *   the properties below it off the pane.
+ */
+@Composable
+private fun PropertyRow(label: String, value: String, wrap: Boolean = false) {
+    Row(Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(140.dp),
+        )
+        if (wrap) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                modifier = Modifier.weight(1f),
+            )
+        } else {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                modifier = Modifier.weight(1f).horizontalScroll(rememberScrollState()),
+                maxLines = 1,
+                softWrap = false,
+            )
+        }
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
@@ -1,0 +1,81 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class FindNodesCommand(
+    private val capture: suspend (NodeTreeCaptureOptions) -> NodeTreeSnapshot,
+) : JetWhaleMcpCommand() {
+    override val name = "$TOOL_PREFIX.findNodes"
+    override val description =
+        "Captures the Compose node tree and returns the nodes matching the given criteria as a flat " +
+            "list: {\"nodes\": [...], \"totalMatches\", \"truncated\"}. Each entry carries its \"rootId\" and " +
+            "\"id\", which together address the node in performNodeAction, plus screen-pixel \"bounds\" and a " +
+            "\"tap\" point. Criteria are combined with AND; matching is case-insensitive and by substring " +
+            "unless exact is set. Omit every criterion to list all interactive nodes on screen."
+
+    private val text by stringOrNull("Match the node's text (or a text field's current content).")
+    private val contentDescription by stringOrNull("Match the node's contentDescription.")
+    private val testTag by stringOrNull("Match the node's Modifier.testTag — the most reliable identifier when the app sets one.")
+    private val role by stringOrNull("Match the node's semantics role, e.g. Button, Checkbox, Tab, Image.")
+    private val interactiveOnly by booleanOrNull(
+        "Keep only nodes that expose an action, are editable, or scroll. Defaults to true when no other criterion is given, false otherwise.",
+    )
+    private val exact by booleanOrNull("Compare whole values instead of substrings. Defaults to false.")
+    private val merged by booleanOrNull("Search the merged tree (default true). See getNodeTree.")
+    private val includeInvisible by booleanOrNull("Include nodes that are not laid out or fully clipped away. Defaults to false.")
+    private val limit by intOrNull("Maximum number of nodes to return, in tree order. Returns all matches if omitted.")
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val limit = arguments[limit]
+        if (limit != null && limit <= 0) throw JetWhaleMcpArgumentException("invalid limit: $limit (expected a positive integer)")
+
+        val criteria = NodeQuery(
+            text = arguments[text],
+            contentDescription = arguments[contentDescription],
+            testTag = arguments[testTag],
+            role = arguments[role],
+            exact = arguments[exact] ?: false,
+        )
+        // With no criterion at all, "every node on screen" is never the useful answer; the caller is
+        // asking what there is to operate. An explicit interactiveOnly still wins.
+        val query = criteria.copy(interactiveOnly = arguments[interactiveOnly] ?: criteria.isEmpty)
+
+        val snapshot = try {
+            capture(
+                NodeTreeCaptureOptions(
+                    merged = arguments[merged] ?: true,
+                    includeInvisible = arguments[includeInvisible] ?: false,
+                    maxDepth = null,
+                ),
+            )
+        } catch (e: JetWhaleMessagingException) {
+            return agentErrorJson(e)
+        }
+
+        val matches = snapshot.roots.flatMap { root ->
+            val nodes = root.node?.asSequence().orEmpty()
+            nodes.filter { it.matches(query) }.map { root.rootId to it }.toList()
+        }
+        val page = if (limit == null) matches else matches.take(limit)
+
+        return buildJsonObject {
+            put("nodes", JsonArray(page.map { (rootId, node) -> node.toMcpJson(rootId = rootId, includeChildren = false) }))
+            put("totalMatches", matches.size)
+            put("truncated", page.size < matches.size)
+            if (snapshot.warnings.isNotEmpty()) {
+                put("warnings", JsonArray(snapshot.warnings.map { JsonPrimitive(it) }))
+            }
+        }.toString()
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/GetNodeTreeCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/GetNodeTreeCommand.kt
@@ -1,0 +1,69 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class GetNodeTreeCommand(
+    private val capture: suspend (NodeTreeCaptureOptions) -> NodeTreeSnapshot,
+) : JetWhaleMcpCommand() {
+    override val name = "$TOOL_PREFIX.getNodeTree"
+    override val description =
+        "Captures the Compose node tree of the running app right now and returns it as JSON: " +
+            "{\"capturedAtMs\", \"captureDurationMs\", \"merged\", \"roots\": [{\"rootId\", \"label\", \"density\", \"node\"}]}. " +
+            "Each node carries id, role, text, contentDescription, testTag, its semantics actions, " +
+            "screen-pixel \"bounds\", and a \"tap\" point (the centre, ready for `adb shell input tap`). " +
+            "A dialog or popup appears as its own root. Prefer findNodes when you are looking for a " +
+            "specific element, and performNodeAction over tapping coordinates."
+
+    private val merged by booleanOrNull(
+        "true (default) returns the merged tree an accessibility service sees, where a Button's label is folded into the clickable node. false keeps every semantics node separate.",
+    )
+    private val includeInvisible by booleanOrNull(
+        "Include nodes that are not laid out or fully clipped away. Defaults to false.",
+    )
+    private val maxDepth by intOrNull(
+        "Stop descending past this depth (each root's own node is depth 0). Returns the whole tree if omitted.",
+    )
+    private val interactiveOnly by booleanOrNull(
+        "Keep only nodes that expose an action, are editable, or scroll — plus their ancestors, so the structure is preserved. Defaults to false.",
+    )
+    private val rootId by stringOrNull(
+        "Return only this root. Use it to look at just the dialog on top, for example. Returns every root if omitted.",
+    )
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val snapshot = try {
+            capture(
+                NodeTreeCaptureOptions(
+                    merged = arguments[merged] ?: true,
+                    includeInvisible = arguments[includeInvisible] ?: false,
+                    maxDepth = arguments[maxDepth],
+                ),
+            )
+        } catch (e: JetWhaleMessagingException) {
+            return agentErrorJson(e)
+        }
+
+        val requestedRootId = arguments[rootId]
+        val roots = snapshot.roots.filter { requestedRootId == null || it.rootId == requestedRootId }
+        if (requestedRootId != null && roots.isEmpty()) {
+            throw JetWhaleMcpArgumentException(
+                "unknown rootId: $requestedRootId (known roots: ${snapshot.roots.joinToString { it.rootId }})",
+            )
+        }
+
+        val pruned = if (arguments[interactiveOnly] == true) {
+            roots.map { root -> root.copy(node = root.node?.filterTree { it.isInteractive }) }
+        } else {
+            roots
+        }
+
+        return snapshot.copy(roots = pruned).toMcpJson().toString()
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJson.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJson.kt
@@ -1,0 +1,90 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import kotlin.math.roundToInt
+
+/**
+ * Renders a snapshot for an AI agent.
+ *
+ * Deliberately not the transport model verbatim: absent and default-valued properties are dropped
+ * so a large tree stays readable, and each node carries a ready-made `tap` point, because the whole
+ * reason to read this instead of `adb shell uiautomator dump` is to act on it immediately.
+ * Coordinates are screen pixels.
+ */
+internal fun NodeTreeSnapshot.toMcpJson(): JsonObject = buildJsonObject {
+    put("capturedAtMs", capturedAtMs)
+    put("captureDurationMs", captureDurationMs)
+    put("merged", options.merged)
+    put("roots", JsonArray(roots.map { it.toMcpJson() }))
+    if (warnings.isNotEmpty()) put("warnings", JsonArray(warnings.map { JsonPrimitive(it) }))
+}
+
+internal fun ComposeRoot.toMcpJson(): JsonObject = buildJsonObject {
+    put("rootId", rootId)
+    put("label", label)
+    put("density", density)
+    // Where this root's window sits on screen. Zero for a full-screen activity; non-zero for a
+    // dialog, a popup, or a split-screen window — which is exactly when node coordinates would
+    // drift if they were reported window-relative, so it is worth being able to see it.
+    putJsonObject("windowOffset") {
+        put("x", windowOffsetX.roundToInt())
+        put("y", windowOffsetY.roundToInt())
+    }
+    node?.let { put("node", it.toMcpJson()) }
+}
+
+/**
+ * @param rootId when set, added to the node so a flat result stays addressable by
+ *   `performNodeAction` without the caller having to track which root it came from.
+ */
+internal fun ComposeNode.toMcpJson(rootId: String? = null, includeChildren: Boolean = true): JsonObject = buildJsonObject {
+    put("id", id)
+    rootId?.let { put("rootId", it) }
+    role?.let { put("role", it) }
+    text?.let { put("text", it) }
+    editableText?.let { put("editableText", it) }
+    contentDescription?.let { put("contentDescription", it) }
+    testTag?.let { put("testTag", it) }
+    stateDescription?.let { put("stateDescription", it) }
+    toggleableState?.let { put("toggleableState", it) }
+
+    // Only the surprising side of each flag is emitted: an enabled, visible, unfocused node is the
+    // norm, and spelling that out on every node would triple the payload for no information.
+    if (isClickable) put("clickable", true)
+    if (!isEnabled) put("enabled", false)
+    if (isFocused) put("focused", true)
+    if (isSelected) put("selected", true)
+    if (isEditable) put("editable", true)
+    if (isScrollable) put("scrollable", true)
+    if (!isVisible) put("visible", false)
+
+    if (actions.isNotEmpty()) put("actions", JsonArray(actions.map { JsonPrimitive(it) }))
+
+    putJsonObject("bounds") {
+        put("left", boundsInScreen.left.roundToInt())
+        put("top", boundsInScreen.top.roundToInt())
+        put("right", boundsInScreen.right.roundToInt())
+        put("bottom", boundsInScreen.bottom.roundToInt())
+    }
+    if (!boundsInScreen.isEmpty) {
+        putJsonObject("tap") {
+            put("x", boundsInScreen.centerX.roundToInt())
+            put("y", boundsInScreen.centerY.roundToInt())
+        }
+    }
+
+    if (includeChildren && children.isNotEmpty()) {
+        put("children", JsonArray(children.map { it.toMcpJson(includeChildren = true) }))
+    }
+}
+
+internal fun NodeBounds.formatted(): String = "(${left.roundToInt()}, ${top.roundToInt()}) ${width.roundToInt()}×${height.roundToInt()}"

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTree.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTree.kt
@@ -1,0 +1,98 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+
+/** Identifies one node across the whole snapshot; node ids are only unique within their root. */
+internal data class NodeKey(val rootId: String, val nodeId: Int)
+
+/**
+ * Keeps the nodes [predicate] accepts, plus every ancestor of a kept node.
+ *
+ * Ancestors are kept even when they fail the predicate: a filter that dropped them would reparent
+ * the matches and lose the structure that makes the tree readable in the first place. Returns
+ * `null` when nothing in this subtree matched.
+ */
+internal fun ComposeNode.filterTree(predicate: (ComposeNode) -> Boolean): ComposeNode? {
+    val keptChildren = children.mapNotNull { it.filterTree(predicate) }
+    return when {
+        keptChildren.isNotEmpty() -> copy(children = keptChildren)
+        predicate(this) -> copy(children = emptyList())
+        else -> null
+    }
+}
+
+/** Depth-first walk, this node first. */
+internal fun ComposeNode.asSequence(): Sequence<ComposeNode> = sequence {
+    yield(this@asSequence)
+    children.forEach { yieldAll(it.asSequence()) }
+}
+
+internal fun ComposeRoot.findNode(nodeId: Int): ComposeNode? = node?.asSequence()?.firstOrNull { it.id == nodeId }
+
+/**
+ * The root holding [nodeId], for resolving a node the caller named without saying where. Searched
+ * newest root first: ids are only unique within a root, and the newest window (a dialog over the
+ * screen that opened it) is the one a caller is looking at.
+ */
+internal fun NodeTreeSnapshot.findRootOf(nodeId: Int): ComposeRoot? = roots.lastOrNull { it.findNode(nodeId) != null }
+
+internal fun NodeTreeSnapshot.nodeCount(): Int = roots.sumOf { it.node?.asSequence()?.count() ?: 0 }
+
+/**
+ * `true` when the node offers something to do: an action, editable content, or scrolling.
+ *
+ * This is the filter that answers "what can be operated here" — the question both the tree view's
+ * *interactive only* toggle and an AI agent driving the app are actually asking.
+ */
+internal val ComposeNode.isInteractive: Boolean
+    get() = actions.isNotEmpty() || isClickable || isEditable || isScrollable
+
+/** How a node should read in a list: its own label if it has one, otherwise its role or id. */
+internal fun ComposeNode.displayLabel(): String {
+    val role = role
+    val label = text ?: contentDescription ?: editableText ?: testTag
+    return when {
+        role != null && label != null -> "$role · $label"
+        role != null -> role
+        label != null -> label
+        else -> "#$id"
+    }
+}
+
+/** Matcher shared by the tree view's search box and the `findNodes` MCP tool. */
+internal data class NodeQuery(
+    val text: String? = null,
+    val contentDescription: String? = null,
+    val testTag: String? = null,
+    val role: String? = null,
+    val interactiveOnly: Boolean = false,
+    /** Compare whole values instead of substrings. Substring matching is the default because a
+     *  caller usually knows part of a label, not its exact composition. */
+    val exact: Boolean = false,
+) {
+    val isEmpty: Boolean
+        get() = text == null && contentDescription == null && testTag == null && role == null && !interactiveOnly
+}
+
+internal fun ComposeNode.matches(query: NodeQuery): Boolean {
+    if (query.interactiveOnly && !isInteractive) return false
+    if (!fieldMatches(query.text, listOfNotNull(text, editableText), query.exact)) return false
+    if (!fieldMatches(query.contentDescription, listOfNotNull(contentDescription), query.exact)) return false
+    if (!fieldMatches(query.testTag, listOfNotNull(testTag), query.exact)) return false
+    if (!fieldMatches(query.role, listOfNotNull(role), query.exact)) return false
+    return true
+}
+
+/** A free-text search over everything a node displays, for the tree view's search box. */
+internal fun ComposeNode.matchesFreeText(term: String): Boolean {
+    if (term.isBlank()) return true
+    val haystack = listOfNotNull(text, editableText, contentDescription, testTag, role, id.toString())
+    return haystack.any { it.contains(term, ignoreCase = true) }
+}
+
+private fun fieldMatches(expected: String?, candidates: List<String>, exact: Boolean): Boolean {
+    if (expected == null) return true
+    return candidates.any { if (exact) it.equals(expected, ignoreCase = true) else it.contains(expected, ignoreCase = true) }
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/PerformNodeActionCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/PerformNodeActionCommand.kt
@@ -1,0 +1,86 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.host.sdk.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class PerformNodeActionCommand(
+    private val lastSnapshot: () -> NodeTreeSnapshot?,
+    private val capture: suspend (NodeTreeCaptureOptions) -> NodeTreeSnapshot,
+    private val perform: suspend (PerformNodeAction) -> NodeActionResult,
+) : JetWhaleMcpCommand() {
+    override val name = "$TOOL_PREFIX.performNodeAction"
+    override val description =
+        "Invokes a semantics action on one node of the running app, addressed by the id findNodes or " +
+            "getNodeTree reported. This runs the node's own action rather than synthesising a touch, so it " +
+            "needs no coordinates and cannot land on something that moved in the meantime — prefer it over " +
+            "`adb shell input tap`. Returns {\"performed\", \"rootId\", \"nodeId\", \"action\", \"message\"}; " +
+            "performed=false with a message when the node does not expose the action or declined it. " +
+            "Capture the tree again afterwards to see the result."
+
+    private val nodeId by int("The node's id, as reported by findNodes or getNodeTree.")
+    private val action by enum(
+        "The semantics action to invoke. Click is what a tap would do. SetText/InsertText require text; ScrollBy uses scrollX/scrollY.",
+        NodeAction.entries,
+    )
+    private val rootId by stringOrNull(
+        "The root the node belongs to. Optional: without it the node is looked up in the most recent capture, and the topmost root wins if the id appears in more than one.",
+    )
+    private val text by stringOrNull("The text for SetText or InsertText.")
+    private val scrollX by intOrNull("Horizontal scroll distance in pixels for ScrollBy. Defaults to 0.")
+    private val scrollY by intOrNull("Vertical scroll distance in pixels for ScrollBy. Defaults to 0.")
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val nodeId = arguments[nodeId]
+        val action = arguments[action]
+        val result: NodeActionResult
+        val rootId: String
+        try {
+            rootId = arguments[this.rootId] ?: resolveRootId(nodeId)
+            result = perform(
+                PerformNodeAction(
+                    rootId = rootId,
+                    nodeId = nodeId,
+                    action = action,
+                    text = arguments[text],
+                    scrollX = (arguments[scrollX] ?: 0).toFloat(),
+                    scrollY = (arguments[scrollY] ?: 0).toFloat(),
+                ),
+            )
+        } catch (e: JetWhaleMessagingException) {
+            return agentErrorJson(e)
+        }
+
+        return buildJsonObject {
+            put("performed", result.performed)
+            put("rootId", rootId)
+            put("nodeId", nodeId)
+            put("action", action.name)
+            result.message?.let { put("message", it) }
+        }.toString()
+    }
+
+    /**
+     * The last capture is consulted first so the common flow — findNodes, then act on what it
+     * returned — costs no extra round trip; a fresh capture is only taken when that misses, which
+     * also covers a caller acting on an id it obtained some other way.
+     */
+    private suspend fun resolveRootId(nodeId: Int): String {
+        lastSnapshot()?.findRootOf(nodeId)?.let { return it.rootId }
+        val snapshot = capture(NodeTreeCaptureOptions(merged = true, includeInvisible = true, maxDepth = null))
+        snapshot.findRootOf(nodeId)?.let { return it.rootId }
+        throw JetWhaleMcpArgumentException(
+            "unknown nodeId: $nodeId (it is in none of the ${snapshot.roots.size} current roots; capture the tree again and use a fresh id)",
+        )
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/TreeRow.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/TreeRow.kt
@@ -1,0 +1,63 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
+
+/** One line of the tree view. */
+internal sealed interface TreeRow {
+    val key: String
+
+    data class RootHeader(val root: ComposeRoot, val nodeCount: Int) : TreeRow {
+        override val key: String get() = "root:${root.rootId}"
+    }
+
+    data class NodeRow(
+        val rootId: String,
+        val node: ComposeNode,
+        val depth: Int,
+        val expandable: Boolean,
+        val expanded: Boolean,
+    ) : TreeRow {
+        override val key: String get() = "node:$rootId:${node.id}"
+    }
+}
+
+/**
+ * Flattens the roots into the rows the tree view draws.
+ *
+ * Filtering happens before flattening so a match keeps its ancestors and stays where it belongs in
+ * the tree; collapsing happens during it, so a collapsed node's subtree costs nothing to skip. A
+ * root with no surviving node still gets its header — "this window has nothing matching" is
+ * information, and silently dropping the root would read as the window being gone.
+ */
+internal fun buildTreeRows(
+    roots: List<ComposeRoot>,
+    collapsedKeys: Set<NodeKey>,
+    predicate: (ComposeNode) -> Boolean,
+): List<TreeRow> = buildList {
+    for (root in roots) {
+        val filtered = root.node?.filterTree(predicate)
+        add(TreeRow.RootHeader(root, nodeCount = filtered?.asSequence()?.count() ?: 0))
+        if (filtered != null) appendNodeRows(root.rootId, filtered, depth = 0, collapsedKeys = collapsedKeys)
+    }
+}
+
+private fun MutableList<TreeRow>.appendNodeRows(
+    rootId: String,
+    node: ComposeNode,
+    depth: Int,
+    collapsedKeys: Set<NodeKey>,
+) {
+    val expanded = NodeKey(rootId, node.id) !in collapsedKeys
+    add(
+        TreeRow.NodeRow(
+            rootId = rootId,
+            node = node,
+            depth = depth,
+            expandable = node.children.isNotEmpty(),
+            expanded = expanded,
+        ),
+    )
+    if (!expanded) return
+    node.children.forEach { appendNodeRows(rootId, it, depth + 1, collapsedKeys) }
+}

--- a/jetwhale-plugins/semantics/host/src/main/resources/META-INF/jetwhale/plugin-manifest.json
+++ b/jetwhale-plugins/semantics/host/src/main/resources/META-INF/jetwhale/plugin-manifest.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../../../../../../../../../schemas/plugin-manifest.schema.json",
+  "plugins": [
+    {
+      "pluginId": "com.kitakkun.jetwhale.semantics",
+      "pluginName": "Compose Semantics Inspector",
+      "version": "1.0.0",
+      "factoryClass": "com.kitakkun.jetwhale.plugins.semantics.host.ComposeSemanticsInspectorPluginFactory",
+      "agentVersionRange": {
+        "min": "1.0.0",
+        "max": "1.0.0"
+      },
+      "icon": {
+        "activePath": "icons/node_tree_filled.svg",
+        "inactivePath": "icons/node_tree_outlined.svg"
+      }
+    }
+  ]
+}

--- a/jetwhale-plugins/semantics/host/src/main/resources/icons/node_tree_filled.svg
+++ b/jetwhale-plugins/semantics/host/src/main/resources/icons/node_tree_filled.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"></path></svg>

--- a/jetwhale-plugins/semantics/host/src/main/resources/icons/node_tree_outlined.svg
+++ b/jetwhale-plugins/semantics/host/src/main/resources/icons/node_tree_outlined.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z" fill-opacity="0.6"></path></svg>

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeFixtures.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeFixtures.kt
@@ -1,0 +1,54 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+
+internal fun node(
+    id: Int,
+    role: String? = null,
+    text: String? = null,
+    contentDescription: String? = null,
+    testTag: String? = null,
+    actions: List<String> = emptyList(),
+    isClickable: Boolean = false,
+    isEditable: Boolean = false,
+    isScrollable: Boolean = false,
+    isEnabled: Boolean = true,
+    isVisible: Boolean = true,
+    bounds: NodeBounds = NodeBounds(0f, 0f, 100f, 40f),
+    children: List<ComposeNode> = emptyList(),
+): ComposeNode = ComposeNode(
+    id = id,
+    role = role,
+    text = text,
+    contentDescription = contentDescription,
+    testTag = testTag,
+    bounds = bounds,
+    boundsInScreen = bounds,
+    actions = actions,
+    isEnabled = isEnabled,
+    isClickable = isClickable,
+    isEditable = isEditable,
+    isScrollable = isScrollable,
+    isVisible = isVisible,
+    children = children,
+)
+
+internal fun root(rootId: String, label: String = rootId, node: ComposeNode?): ComposeRoot = ComposeRoot(
+    rootId = rootId,
+    label = label,
+    density = 2f,
+    windowOffsetX = 0f,
+    windowOffsetY = 0f,
+    node = node,
+)
+
+internal fun snapshot(vararg roots: ComposeRoot): NodeTreeSnapshot = NodeTreeSnapshot(
+    capturedAtMs = 0,
+    captureDurationMs = 1,
+    options = NodeTreeCaptureOptions(),
+    roots = roots.toList(),
+)

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJsonTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJsonTest.kt
@@ -1,0 +1,95 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NodeMcpJsonTest {
+    @Test
+    fun `emits the identifying semantics and a ready-made tap point`() {
+        val json = node(
+            id = 7,
+            role = "Button",
+            text = "Send",
+            testTag = "send-button",
+            actions = listOf("OnClick"),
+            isClickable = true,
+            bounds = NodeBounds(10f, 20f, 110f, 60f),
+        ).toMcpJson()
+
+        assertEquals(7, json["id"]?.jsonPrimitive?.content?.toInt())
+        assertEquals("Button", json["role"]?.jsonPrimitive?.content)
+        assertEquals("Send", json["text"]?.jsonPrimitive?.content)
+        assertEquals("send-button", json["testTag"]?.jsonPrimitive?.content)
+        assertEquals(listOf("OnClick"), json["actions"]?.jsonArray?.map { it.jsonPrimitive.content })
+        assertEquals(10, json["bounds"]?.jsonObject?.get("left")?.jsonPrimitive?.content?.toInt())
+        assertEquals(60, json["tap"]?.jsonObject?.get("x")?.jsonPrimitive?.content?.toInt())
+        assertEquals(40, json["tap"]?.jsonObject?.get("y")?.jsonPrimitive?.content?.toInt())
+    }
+
+    @Test
+    fun `omits the unsurprising side of every flag so a large tree stays readable`() {
+        val json = node(id = 1, text = "label").toMcpJson()
+
+        assertNull(json["clickable"])
+        assertNull(json["enabled"])
+        assertNull(json["focused"])
+        assertNull(json["visible"])
+        assertNull(json["actions"])
+        assertNull(json["role"])
+    }
+
+    @Test
+    fun `spells out a disabled or invisible node, which is the surprising case`() {
+        val json = node(id = 1, isEnabled = false, isVisible = false).toMcpJson()
+
+        assertFalse(json["enabled"]!!.jsonPrimitive.content.toBoolean())
+        assertFalse(json["visible"]!!.jsonPrimitive.content.toBoolean())
+    }
+
+    @Test
+    fun `omits the tap point for a node with no area to tap`() {
+        val json = node(id = 1, bounds = NodeBounds(0f, 0f, 0f, 0f)).toMcpJson()
+
+        assertNull(json["tap"])
+    }
+
+    @Test
+    fun `carries rootId on a flat result so the node stays addressable`() {
+        val json = node(id = 1, children = listOf(node(id = 2))).toMcpJson(rootId = "window", includeChildren = false)
+
+        assertEquals("window", json["rootId"]?.jsonPrimitive?.content)
+        assertNull(json["children"])
+    }
+
+    @Test
+    fun `renders a snapshot with its roots and only reports warnings when there are any`() {
+        val json = snapshot(root("window", label = "MainActivity", node = node(id = 1))).toMcpJson()
+
+        assertEquals(1, json["roots"]?.jsonArray?.size)
+        val root = json["roots"]!!.jsonArray.single().jsonObject
+        assertEquals("window", root["rootId"]?.jsonPrimitive?.content)
+        assertEquals("MainActivity", root["label"]?.jsonPrimitive?.content)
+        assertTrue(root["node"] is JsonObject)
+        assertNull(json["warnings"])
+    }
+
+    @Test
+    fun `reports where a root's window sits on screen`() {
+        // A dialog's window is not at the screen origin, which is the case where node coordinates
+        // would drift if they were reported window-relative — so the offset is worth surfacing.
+        val dialog = root("dialog", node = node(id = 1)).copy(windowOffsetX = 120.4f, windowOffsetY = 926.6f)
+
+        val offset = snapshot(dialog).toMcpJson()["roots"]!!.jsonArray.single().jsonObject["windowOffset"]!!.jsonObject
+
+        assertEquals(120, offset["x"]?.jsonPrimitive?.content?.toInt())
+        assertEquals(927, offset["y"]?.jsonPrimitive?.content?.toInt())
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTreeTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTreeTest.kt
@@ -1,0 +1,130 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NodeTreeTest {
+    @Test
+    fun `filterTree keeps a match together with its ancestors`() {
+        val tree = node(
+            id = 1,
+            children = listOf(
+                node(id = 2, children = listOf(node(id = 3, testTag = "target"))),
+                node(id = 4),
+            ),
+        )
+
+        val filtered = tree.filterTree { it.testTag == "target" }
+
+        // The ancestors 1 and 2 do not match themselves, but dropping them would reparent the
+        // match and lose where it sits in the tree.
+        assertEquals(listOf(1, 2, 3), filtered?.asSequence()?.map { it.id }?.toList())
+    }
+
+    @Test
+    fun `filterTree returns null when nothing in the subtree matches`() {
+        val tree = node(id = 1, children = listOf(node(id = 2)))
+
+        assertNull(tree.filterTree { it.testTag == "absent" })
+    }
+
+    @Test
+    fun `filterTree drops the children of a node kept only on its own merit`() {
+        val tree = node(id = 1, testTag = "target", children = listOf(node(id = 2)))
+
+        assertEquals(listOf(1), tree.filterTree { it.testTag == "target" }?.asSequence()?.map { it.id }?.toList())
+    }
+
+    @Test
+    fun `asSequence walks depth-first with the node itself first`() {
+        val tree = node(
+            id = 1,
+            children = listOf(
+                node(id = 2, children = listOf(node(id = 3))),
+                node(id = 4),
+            ),
+        )
+
+        assertEquals(listOf(1, 2, 3, 4), tree.asSequence().map { it.id }.toList())
+    }
+
+    @Test
+    fun `findRootOf prefers the newest root when an id appears in more than one`() {
+        // Ids are only unique within a root, so a dialog can reuse the id of a node underneath it.
+        val snapshot = snapshot(
+            root("window", node = node(id = 7, text = "behind")),
+            root("dialog", node = node(id = 7, text = "in front")),
+        )
+
+        assertEquals("dialog", snapshot.findRootOf(nodeId = 7)?.rootId)
+    }
+
+    @Test
+    fun `findRootOf returns null for an unknown id`() {
+        assertNull(snapshot(root("window", node = node(id = 1))).findRootOf(nodeId = 99))
+    }
+
+    @Test
+    fun `nodeCount counts every node across every root`() {
+        val snapshot = snapshot(
+            root("a", node = node(id = 1, children = listOf(node(id = 2)))),
+            root("b", node = node(id = 3)),
+            root("c", node = null),
+        )
+
+        assertEquals(3, snapshot.nodeCount())
+    }
+
+    @Test
+    fun `isInteractive covers actions, editing and scrolling`() {
+        assertTrue(node(id = 1, actions = listOf("OnClick"), isClickable = true).isInteractive)
+        assertTrue(node(id = 2, isEditable = true).isInteractive)
+        assertTrue(node(id = 3, isScrollable = true).isInteractive)
+        assertFalse(node(id = 4, text = "just a label").isInteractive)
+    }
+
+    @Test
+    fun `matches combines criteria with AND and compares case-insensitively by substring`() {
+        val target = node(id = 1, role = "Button", text = "Send message", testTag = "send-button", isClickable = true, actions = listOf("OnClick"))
+
+        assertTrue(target.matches(NodeQuery(text = "send", role = "button")))
+        assertTrue(target.matches(NodeQuery(testTag = "SEND-BUTTON")))
+        assertFalse(target.matches(NodeQuery(text = "send", role = "checkbox")))
+    }
+
+    @Test
+    fun `matches compares whole values when exact is set`() {
+        val target = node(id = 1, text = "Send message")
+
+        assertFalse(target.matches(NodeQuery(text = "Send", exact = true)))
+        assertTrue(target.matches(NodeQuery(text = "send message", exact = true)))
+    }
+
+    @Test
+    fun `matches rejects a non-interactive node when interactiveOnly is set`() {
+        assertFalse(node(id = 1, text = "label").matches(NodeQuery(interactiveOnly = true)))
+        assertTrue(node(id = 2, text = "label", isClickable = true).matches(NodeQuery(interactiveOnly = true)))
+    }
+
+    @Test
+    fun `matchesFreeText searches every label the node displays`() {
+        val target = node(id = 42, role = "Tab", contentDescription = "Profile picture")
+
+        assertTrue(target.matchesFreeText("profile"))
+        assertTrue(target.matchesFreeText("tab"))
+        assertTrue(target.matchesFreeText("42"))
+        assertTrue(target.matchesFreeText("   "))
+        assertFalse(target.matchesFreeText("absent"))
+    }
+
+    @Test
+    fun `displayLabel prefers the node's own label and falls back to role then id`() {
+        assertEquals("Button · Send", node(id = 1, role = "Button", text = "Send").displayLabel())
+        assertEquals("Send", node(id = 1, text = "Send").displayLabel())
+        assertEquals("Button", node(id = 1, role = "Button").displayLabel())
+        assertEquals("#1", node(id = 1).displayLabel())
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/TreeRowTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/TreeRowTest.kt
@@ -1,0 +1,63 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TreeRowTest {
+    @Test
+    fun `emits a header per root followed by its nodes, indented by depth`() {
+        val rows = buildTreeRows(
+            roots = listOf(root("window", label = "MainActivity", node = node(id = 1, children = listOf(node(id = 2))))),
+            collapsedKeys = emptySet(),
+            predicate = { true },
+        )
+
+        assertEquals(3, rows.size)
+        val header = rows[0] as TreeRow.RootHeader
+        assertEquals("MainActivity", header.root.label)
+        assertEquals(2, header.nodeCount)
+        assertEquals(0, (rows[1] as TreeRow.NodeRow).depth)
+        assertEquals(1, (rows[2] as TreeRow.NodeRow).depth)
+    }
+
+    @Test
+    fun `a collapsed node hides its subtree but stays visible itself`() {
+        val rows = buildTreeRows(
+            roots = listOf(root("window", node = node(id = 1, children = listOf(node(id = 2, children = listOf(node(id = 3))))))),
+            collapsedKeys = setOf(NodeKey("window", 2)),
+            predicate = { true },
+        )
+
+        assertEquals(listOf(1, 2), rows.filterIsInstance<TreeRow.NodeRow>().map { it.node.id })
+        assertTrue(rows.filterIsInstance<TreeRow.NodeRow>().single { it.node.id == 2 }.expandable)
+    }
+
+    @Test
+    fun `a root whose nodes are all filtered out still gets its header`() {
+        // "This window has nothing matching" is information; dropping the root would read as the
+        // window having gone away.
+        val rows = buildTreeRows(
+            roots = listOf(root("window", node = node(id = 1, text = "hello"))),
+            collapsedKeys = emptySet(),
+            predicate = { it.text == "absent" },
+        )
+
+        assertEquals(1, rows.size)
+        assertEquals(0, (rows.single() as TreeRow.RootHeader).nodeCount)
+    }
+
+    @Test
+    fun `row keys are unique across roots that reuse node ids`() {
+        val rows = buildTreeRows(
+            roots = listOf(
+                root("window", node = node(id = 1)),
+                root("dialog", node = node(id = 1)),
+            ),
+            collapsedKeys = emptySet(),
+            predicate = { true },
+        )
+
+        assertEquals(rows.size, rows.map { it.key }.distinct().size)
+    }
+}

--- a/jetwhale-plugins/semantics/protocol/build.gradle.kts
+++ b/jetwhale-plugins/semantics/protocol/build.gradle.kts
@@ -1,0 +1,27 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
+plugins {
+    alias(libs.plugins.multiplatform)
+    alias(libs.plugins.kotlinxSerialization)
+    alias(libs.plugins.publish)
+}
+
+// Distinct group so this module's coordinates don't collide with the other plugins' `protocol`.
+group = "com.kitakkun.jetwhale.plugins.semantics"
+
+kotlin {
+    android.namespace = "com.kitakkun.jetwhale.plugins.semantics.protocol"
+}
+
+dependencies {
+    commonMainApi(projects.jetwhaleProtocol.core)
+    commonMainImplementation(libs.kotlinxSerializationJson)
+}
+
+jetwhalePublish {
+    artifactId = "jetwhale-compose-semantics-inspector-protocol"
+    name = "JetWhale Compose Semantics Inspector Protocol"
+    description = "Transport-agnostic protocol types shared by the JetWhale Compose Semantics Inspector agent and host."
+}

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNodeMessages.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNodeMessages.kt
@@ -1,0 +1,42 @@
+package com.kitakkun.jetwhale.plugins.semantics.protocol
+
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleRequest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// -- Requests: host -> agent (debuggee) --------------------------------------
+
+/**
+ * Captures the Compose semantics tree of every root the agent knows about.
+ *
+ * The host asks on demand (a refresh, an MCP tool call) rather than the agent streaming changes:
+ * a capture is cheap and reading the tree only when someone looks at it keeps the debuggee's main
+ * thread free the rest of the time.
+ */
+@SerialName("compose/capture_node_tree")
+@Serializable
+data class CaptureNodeTree(
+    val options: NodeTreeCaptureOptions = NodeTreeCaptureOptions(),
+) : JetWhaleRequest<NodeTreeSnapshot>
+
+/**
+ * Invokes a semantics action on one node, addressed by the [rootId]/[nodeId] pair a
+ * [NodeTreeSnapshot] reported.
+ *
+ * This runs the node's own action, so it works regardless of where the window sits on screen and
+ * without going through the input system — which is what makes it usable for driving an app from
+ * an AI agent.
+ */
+@SerialName("compose/perform_node_action")
+@Serializable
+data class PerformNodeAction(
+    val rootId: String,
+    val nodeId: Int,
+    val action: NodeAction,
+    /** Text for [NodeAction.SetText] / [NodeAction.InsertText]; ignored otherwise. */
+    val text: String? = null,
+    /** Horizontal scroll distance in pixels for [NodeAction.ScrollBy]; ignored otherwise. */
+    val scrollX: Float = 0f,
+    /** Vertical scroll distance in pixels for [NodeAction.ScrollBy]; ignored otherwise. */
+    val scrollY: Float = 0f,
+) : JetWhaleRequest<NodeActionResult>

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeModels.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeModels.kt
@@ -1,0 +1,159 @@
+package com.kitakkun.jetwhale.plugins.semantics.protocol
+
+import kotlinx.serialization.Serializable
+
+/**
+ * What to include when capturing the node tree.
+ *
+ * The captured tree is the Compose **semantics** tree: the tree that carries the labels, roles and
+ * actions a node exposes, and therefore the one that says what is actually clickable. Nodes that
+ * only lay out pixels (a `Box` with no semantics of its own) do not appear on their own.
+ */
+@Serializable
+data class NodeTreeCaptureOptions(
+    /**
+     * `true` captures the merged tree — the one accessibility services see, where a `Button`'s
+     * label is folded into the clickable node. `false` captures the unmerged tree, which keeps
+     * every semantics node separate (closer to how the UI is written).
+     */
+    val merged: Boolean = true,
+    /** Include nodes whose bounds are empty (not laid out, or fully clipped away). */
+    val includeInvisible: Boolean = false,
+    /** Stop descending past this depth (the root is depth 0). `null` captures the whole tree. */
+    val maxDepth: Int? = null,
+)
+
+/** One capture of every Compose root known to the agent. */
+@Serializable
+data class NodeTreeSnapshot(
+    /** When the capture was taken, in epoch milliseconds on the device. */
+    val capturedAtMs: Long,
+    /** How long the capture itself took on the device, in milliseconds. */
+    val captureDurationMs: Long,
+    /** Echoes the options the capture ran with, so a consumer can tell merged from unmerged. */
+    val options: NodeTreeCaptureOptions,
+    /** One entry per Compose root (window), in registration order — the newest window is last. */
+    val roots: List<ComposeRoot>,
+    /**
+     * Roots that could not be captured, e.g. because their view was detached mid-capture. Reported
+     * rather than thrown: a partial tree is still useful.
+     */
+    val warnings: List<String> = emptyList(),
+)
+
+/**
+ * A single Compose root — one composition backed by one platform view. A dialog or a popup gets its
+ * own root, so a snapshot normally has more than one entry while a dialog is open.
+ */
+@Serializable
+data class ComposeRoot(
+    /** Stable while the root stays attached; address nodes with it in [PerformNodeAction]. */
+    val rootId: String,
+    /** Human-readable origin, e.g. `MainActivity` or `PopupWindow`. */
+    val label: String,
+    /** Device density (px per dp) of this root, for converting the pixel bounds below to dp. */
+    val density: Float,
+    /**
+     * Where this root's window sits on screen, in pixels. Node bounds are reported in both root and
+     * screen coordinates, so this is only needed to reason about the window itself.
+     */
+    val windowOffsetX: Float,
+    val windowOffsetY: Float,
+    /** The root semantics node, or `null` when the root has no content yet. */
+    val node: ComposeNode?,
+)
+
+/** One node of the Compose semantics tree. */
+@Serializable
+data class ComposeNode(
+    /** Semantics id, unique within its root and stable while the node stays composed. */
+    val id: Int,
+    /** Semantics role (`Button`, `Checkbox`, `Tab`, ...), when the node declares one. */
+    val role: String? = null,
+    /** Concatenated `Text` semantics of the node. */
+    val text: String? = null,
+    /** Current content of an editable node (a text field). */
+    val editableText: String? = null,
+    val contentDescription: String? = null,
+    /** `Modifier.testTag` value — the most reliable way to address a node from a test or an agent. */
+    val testTag: String? = null,
+    val stateDescription: String? = null,
+    /** `On`, `Off` or `Indeterminate` for a toggleable node. */
+    val toggleableState: String? = null,
+    /** Bounds in this root's coordinate space, in pixels. */
+    val bounds: NodeBounds,
+    /**
+     * Bounds in screen coordinates, in pixels — the ones to feed to `adb shell input tap`. Prefer
+     * [PerformNodeAction] where possible: it invokes the node's own semantics action and does not
+     * depend on the window still being where it was when the snapshot was taken.
+     */
+    val boundsInScreen: NodeBounds,
+    /** Names of the semantics actions this node exposes, e.g. `OnClick`, `SetText`, `ScrollBy`. */
+    val actions: List<String> = emptyList(),
+    val isEnabled: Boolean = true,
+    val isClickable: Boolean = false,
+    val isFocused: Boolean = false,
+    val isSelected: Boolean = false,
+    val isEditable: Boolean = false,
+    val isScrollable: Boolean = false,
+    /** `false` when the node has empty bounds or is hidden from accessibility. */
+    val isVisible: Boolean = true,
+    val children: List<ComposeNode> = emptyList(),
+)
+
+/** A rectangle in pixels. */
+@Serializable
+data class NodeBounds(
+    val left: Float,
+    val top: Float,
+    val right: Float,
+    val bottom: Float,
+) {
+    val width: Float get() = right - left
+    val height: Float get() = bottom - top
+    val centerX: Float get() = (left + right) / 2f
+    val centerY: Float get() = (top + bottom) / 2f
+
+    /** `true` when the rectangle encloses no pixels, i.e. the node is not laid out or fully clipped. */
+    val isEmpty: Boolean get() = width <= 0f || height <= 0f
+}
+
+/** A semantics action that [PerformNodeAction] can invoke on a node. */
+@Serializable
+enum class NodeAction {
+    /** Invokes `SemanticsActions.OnClick` — what a tap on the node would do. */
+    Click,
+
+    /** Invokes `SemanticsActions.OnLongClick`. */
+    LongClick,
+
+    /** Replaces an editable node's content via `SemanticsActions.SetText`. Requires `text`. */
+    SetText,
+
+    /** Appends to an editable node's content via `SemanticsActions.InsertTextAtCursor`. Requires `text`. */
+    InsertText,
+
+    /** Submits an editable node via `SemanticsActions.OnImeAction`. */
+    ImeAction,
+
+    /** Scrolls a scrollable node by `scrollX`/`scrollY` pixels via `SemanticsActions.ScrollBy`. */
+    ScrollBy,
+
+    /** Gives the node keyboard focus via `SemanticsActions.RequestFocus`. */
+    RequestFocus,
+
+    /** Dismisses the node (a dialog, a snackbar) via `SemanticsActions.Dismiss`. */
+    Dismiss,
+
+    Expand,
+    Collapse,
+}
+
+/** Outcome of a [PerformNodeAction]. */
+@Serializable
+data class NodeActionResult(
+    /** `true` only when the node's action ran and reported success. */
+    val performed: Boolean,
+    /** Why the action did not run, or a note about what did run. */
+    val message: String? = null,
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,6 +55,10 @@ include(":jetwhale-plugins:nav3:protocol")
 include(":jetwhale-plugins:nav3:agent")
 include(":jetwhale-plugins:nav3:host")
 
+include(":jetwhale-plugins:semantics:protocol")
+include(":jetwhale-plugins:semantics:agent")
+include(":jetwhale-plugins:semantics:host")
+
 include(":test-annotations")
 
 include(":tools:qa-agent")


### PR DESCRIPTION
Reads the Compose semantics tree of the app being debugged — the tree that says what is
actually clickable — and both browses it in the host and serves it to an AI agent over MCP.

The motivation is latency: `android layout` and `adb shell uiautomator dump` cross a process
boundary and write a file on the device before anything can read it, which is too slow to sit
in an agent's loop. This reads the tree *inside* the app and returns it over the connection
that is already open.

## What it adds

| Module | |
|---|---|
| `semantics/protocol` | node and root models, and the two host-to-agent requests |
| `semantics/agent` | the plugin, the registry of readable roots, capture and action against a `SemanticsOwner`, and root discovery per platform |
| `semantics/host` | the tree browser and three MCP tools |

Two ways to install a probe, which can be combined (registrations are reference counted per
root):

```kotlin
// Android — Application.onCreate(); finds every root in the process, dialogs included
installJetWhaleSemanticsProbe(application)

// Android or desktop — inside a composition / a Window { }
JetWhaleSemanticsProbe()
```

MCP tools: `findNodes`, `getNodeTree`, and `performNodeAction`, which invokes a node's own
semantics action rather than synthesising input — so it needs no coordinates and cannot land
on whatever moved into that spot meanwhile.

## Verified

Emulator (1080x2400, density 2.625) and Compose Desktop, same screen, back to back:

| | median |
|---|---|
| `getNodeTree` (host to app and back) | **14 ms** (1 ms on device) |
| `adb shell uiautomator dump` + `pull` | 1,960 ms |
| `android layout` | 2,703 ms |

Coordinates were checked two ways at once — cross-checked against `android layout`'s reading
of the same screen, and proved by tapping the reported point and watching the intended node
react — under gesture nav, a 3-button nav bar, landscape, density 320 and 800x1280@320. Worst
disagreement 1 px in every condition (rounding: this plugin rounds, `android layout`
truncates). Each condition was re-run with a dialog open, which is the case that exercises the
window-offset arithmetic: a dialog is its own window and does not start at the screen origin —
in landscape that offset reaches (717, 298).

30 unit tests; the new ones are mutation-checked.

## Platform support

Android and desktop have probes. iOS/JS/Wasm compile and can register a `SemanticsOwner`
manually, but have no probe of their own — reaching a live composition has no public API there
yet. The agent artifact ships for Compose Multiplatform's target set; linux and mingw have no
`androidx.compose.ui`, and macOS would need the whole build to opt into Compose's experimental
support for it.

## Not covered

- Physical devices, notched displays and split-screen were not tested (emulator only).
- The tree is the **semantics** tree, not a composition tree carrying composable names. The
  docs say so plainly.
- No Compose UI test for the host screen yet; it was verified by driving it over MCP.
- `ComposeWindow.semanticsOwners`, which the desktop probe reads, is `@ExperimentalComposeUiApi`.

