### PR TITLE
fix(mcp): scope a capture's viewport to the capture

### DIFF
--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeTool.kt
@@ -15,8 +15,8 @@ import com.kitakkun.jetwhale.host.mcp.errorResult
 import com.kitakkun.jetwhale.host.mcp.jsonContent
 import com.kitakkun.jetwhale.host.mcp.stringProperty
 import com.kitakkun.jetwhale.host.mcp.viewport.McpViewport
-import com.kitakkun.jetwhale.host.mcp.viewport.applyViewport
 import com.kitakkun.jetwhale.host.mcp.viewport.isValidForViewport
+import com.kitakkun.jetwhale.host.mcp.viewport.withScopedViewport
 import com.kitakkun.jetwhale.host.model.PluginComposeScene
 import com.kitakkun.jetwhale.host.model.PluginComposeSceneService
 import dev.zacsweers.metro.AppScope
@@ -71,7 +71,8 @@ class GetAccessibilityTreeMcpTool(
  * elements by name/role and calculate precise click coordinates from [NodeInfo.bounds].
  *
  * Must be called on the UI thread (Dispatchers.Main): it applies the viewport, renders, and flips
- * the capture flag, all of which mutate the ComposeScene.
+ * the capture flag, all of which mutate the ComposeScene. Both mutations are scoped to the capture
+ * — the scene is put back on the viewport it had before returning.
  *
  * The tree carries the same strings the screenshot shows, so it is captured under
  * [com.kitakkun.jetwhale.host.sdk.LocalIsMcpCapture] exactly like a screenshot is —
@@ -85,26 +86,27 @@ fun captureAccessibilityTree(scene: PluginComposeScene): String {
         ?: scene.windowInfoUpdater.currentIntSize.takeIf { it.isValidForViewport() }
         ?: IntSize(1280, 720)
     val viewport = McpViewport(size = size, density = scene.composeScene.density)
-    applyViewport(scene, viewport)
 
-    // Raised only for this off-screen render; being on the UI thread, no interactive frame can
-    // observe the raised state.
-    scene.isMcpCapture.value = true
-    val nodes = try {
-        // render() only flushes snapshot apply notifications at its end (before draw), so a write
-        // made right before it is not yet observed by the scene's recomposer and the frame would be
-        // drawn with the stale value. Flush explicitly here so the flag-flip recomposition is applied
-        // within this render pass.
-        Snapshot.sendApplyNotifications()
-        scene.render(Canvas(ImageBitmap(size.width, size.height)))
-        // Read the semantics while the flag is still raised: lowering it first would leave the tree
-        // one recomposition away from the values that were actually rendered.
-        scene.semanticsOwners.map { it.rootSemanticsNode }.flatMap { traverseSemanticsTree(it) }
-    } finally {
-        scene.isMcpCapture.value = false
-        // Flush the restore so the next interactive render observes capture=false immediately rather
-        // than lagging a frame behind.
-        Snapshot.sendApplyNotifications()
+    val nodes = withScopedViewport(scene, viewport) {
+        // Raised only for this off-screen render; being on the UI thread, no interactive frame can
+        // observe the raised state.
+        scene.isMcpCapture.value = true
+        try {
+            // render() only flushes snapshot apply notifications at its end (before draw), so a write
+            // made right before it is not yet observed by the scene's recomposer and the frame would be
+            // drawn with the stale value. Flush explicitly here so the flag-flip recomposition is applied
+            // within this render pass.
+            Snapshot.sendApplyNotifications()
+            scene.render(Canvas(ImageBitmap(size.width, size.height)))
+            // Read the semantics while the flag is still raised: lowering it first would leave the tree
+            // one recomposition away from the values that were actually rendered.
+            scene.semanticsOwners.map { it.rootSemanticsNode }.flatMap { traverseSemanticsTree(it) }
+        } finally {
+            scene.isMcpCapture.value = false
+            // Flush the restore so the next interactive render observes capture=false immediately rather
+            // than lagging a frame behind.
+            Snapshot.sendApplyNotifications()
+        }
     }
     return Json.encodeToString(AccessibilityTreeResult(nodes))
 }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotTool.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotTool.kt
@@ -16,8 +16,8 @@ import com.kitakkun.jetwhale.host.mcp.jsonInt
 import com.kitakkun.jetwhale.host.mcp.numberProperty
 import com.kitakkun.jetwhale.host.mcp.stringProperty
 import com.kitakkun.jetwhale.host.mcp.viewport.McpViewport
-import com.kitakkun.jetwhale.host.mcp.viewport.applyViewport
 import com.kitakkun.jetwhale.host.mcp.viewport.isValidForViewport
+import com.kitakkun.jetwhale.host.mcp.viewport.withScopedViewport
 import com.kitakkun.jetwhale.host.model.PluginComposeScene
 import com.kitakkun.jetwhale.host.model.PluginComposeSceneService
 import dev.zacsweers.metro.AppScope
@@ -47,13 +47,19 @@ class ScreenshotMcpTool(
                     mapOf(
                         "pluginId" to stringProperty("The plugin ID."),
                         "sessionId" to stringProperty("The session ID."),
-                        "width" to numberProperty("Image width in pixels. Defaults to the current UI width (fallback: 1280)."),
-                        "height" to numberProperty("Image height in pixels. Defaults to the current UI height (fallback: 720)."),
+                        "width" to numberProperty(
+                            "Image width in pixels. Defaults to the current UI width (fallback: 1280). " +
+                                "Scoped to this capture; the scene keeps the size it was showing at.",
+                        ),
+                        "height" to numberProperty(
+                            "Image height in pixels. Defaults to the current UI height (fallback: 720). " +
+                                "Scoped to this capture; the scene keeps the size it was showing at.",
+                        ),
                         "density" to numberProperty(
                             "Pixel density to render at, e.g. 2 for HiDPI. Defaults to the scene's own density, " +
                                 "which follows the host window. Pin it to keep pixel geometry identical across " +
-                                "machines. Like width/height, this is applied to the live scene, so the host window " +
-                                "keeps rendering at it until the window next resizes.",
+                                "machines. Like width/height, it is scoped to this capture; the scene keeps the " +
+                                "density it was showing at.",
                         ),
                     ),
                 ),
@@ -73,9 +79,9 @@ class ScreenshotMcpTool(
             invalidDensityMessage(requestedDensity)?.let { return@addTool errorResult(it) }
 
             val scene = pluginComposeSceneService.getOrCreatePluginScene(pluginId, sessionId)
-            val (viewport, pngBytes) = withContext(Dispatchers.Main) {
+            val pngBytes = withContext(Dispatchers.Main) {
                 val viewport = resolveViewport(scene, requestedWidth, requestedHeight, requestedDensity)
-                viewport to captureScreenshot(scene, viewport)
+                captureScreenshot(scene, viewport)
             }
             val base64 = Base64.getEncoder().encodeToString(pngBytes)
             CallToolResult(content = listOf(ImageContent(data = base64, mimeType = "image/png")))
@@ -86,7 +92,9 @@ class ScreenshotMcpTool(
 /**
  * Renders the plugin's ComposeScene to an in-memory PNG image.
  *
- * Must be called on the UI thread (Dispatchers.Main), as it mutates the ComposeScene.
+ * Must be called on the UI thread (Dispatchers.Main), as it mutates the ComposeScene. [viewport] is
+ * scoped to the capture: the scene is put back on the viewport it had before returning, so the
+ * on-screen plugin UI is unaffected and later captures do not inherit this one's size or density.
  *
  * @param scene  The plugin ComposeScene to render.
  * @param viewport Output viewport (size + density) to render with.
@@ -97,25 +105,25 @@ fun captureScreenshot(
     scene: PluginComposeScene,
     viewport: McpViewport,
 ): ByteArray {
-    applyViewport(scene, viewport)
-
     val imageBitmap = ImageBitmap(viewport.size.width, viewport.size.height)
     val composeCanvas = Canvas(imageBitmap)
-    // Raised only for this off-screen render; being on the UI thread, no interactive frame can
-    // observe the raised state.
-    scene.isMcpCapture.value = true
-    try {
-        // render() only flushes snapshot apply notifications at its end (before draw), so a write
-        // made right before it is not yet observed by the scene's recomposer and the frame would be
-        // drawn with the stale value. Flush explicitly here so the flag-flip recomposition is applied
-        // within this render pass.
-        Snapshot.sendApplyNotifications()
-        scene.render(composeCanvas)
-    } finally {
-        scene.isMcpCapture.value = false
-        // Flush the restore so the next interactive render observes capture=false immediately rather
-        // than lagging a frame behind.
-        Snapshot.sendApplyNotifications()
+    withScopedViewport(scene, viewport) {
+        // Raised only for this off-screen render; being on the UI thread, no interactive frame can
+        // observe the raised state.
+        scene.isMcpCapture.value = true
+        try {
+            // render() only flushes snapshot apply notifications at its end (before draw), so a write
+            // made right before it is not yet observed by the scene's recomposer and the frame would be
+            // drawn with the stale value. Flush explicitly here so the flag-flip recomposition is applied
+            // within this render pass.
+            Snapshot.sendApplyNotifications()
+            scene.render(composeCanvas)
+        } finally {
+            scene.isMcpCapture.value = false
+            // Flush the restore so the next interactive render observes capture=false immediately rather
+            // than lagging a frame behind.
+            Snapshot.sendApplyNotifications()
+        }
     }
 
     return SkiaImage.makeFromBitmap(imageBitmap.asSkiaBitmap())

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/viewport/McpViewportUtils.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/viewport/McpViewportUtils.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.mcp.viewport
 
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.ImageBitmap
@@ -47,4 +48,68 @@ internal fun applyViewport(scene: PluginComposeScene, viewport: McpViewport) {
         DpSize(viewport.size.width.toDp(), viewport.size.height.toDp())
     }
     scene.windowInfoUpdater.updateWindowSize(intSize = viewport.size, dpSize = dpSize)
+}
+
+/**
+ * Applies [viewport] for the duration of [block], then puts the scene back on the size, density and
+ * window info it had.
+ *
+ * The scene is the live, on-screen one and the interactive renderer only pushes its own size and
+ * density when the host window resizes, so a viewport left applied here would keep the visible
+ * plugin UI rendering at it and every later capture would inherit it.
+ *
+ * Must be called on the UI thread (Dispatchers.Main).
+ */
+internal fun <T> withScopedViewport(
+    scene: PluginComposeScene,
+    viewport: McpViewport,
+    block: () -> T,
+): T {
+    val previous = readSceneViewportState(scene)
+    applyViewport(scene, viewport)
+    try {
+        return block()
+    } finally {
+        restoreSceneViewportState(scene, previous)
+    }
+}
+
+/**
+ * The scene state [applyViewport] overwrites.
+ *
+ * [composeSceneSize] is nullable because a ComposeScene may have no size of its own, which means
+ * "measure against the window instead of a fixed constraint" — a state worth putting back verbatim.
+ */
+private class SceneViewportState(
+    val composeSceneSize: IntSize?,
+    val density: Density,
+    val windowIntSize: IntSize,
+    val windowDpSize: DpSize,
+)
+
+/** Null when the scene cannot be read, i.e. it is being disposed and has nothing left to restore. */
+@OptIn(InternalComposeUiApi::class)
+private fun readSceneViewportState(scene: PluginComposeScene): SceneViewportState? = runCatching {
+    SceneViewportState(
+        composeSceneSize = scene.composeScene.size,
+        density = scene.composeScene.density,
+        windowIntSize = scene.windowInfoUpdater.currentIntSize,
+        windowDpSize = scene.windowInfoUpdater.currentDpSize,
+    )
+}.getOrNull()
+
+@OptIn(InternalComposeUiApi::class)
+private fun restoreSceneViewportState(scene: PluginComposeScene, state: SceneViewportState?) {
+    if (state == null) return
+    try {
+        scene.composeScene.density = state.density
+        scene.composeScene.size = state.composeSceneSize
+    } catch (_: IllegalStateException) {
+        // May happen during dispose/close; ignore to avoid crashing MCP calls.
+    }
+    scene.windowInfoUpdater.updateWindowSize(intSize = state.windowIntSize, dpSize = state.windowDpSize)
+    // The scene density and the window info override are snapshot state. Flush the restore so the
+    // next interactive render observes the original viewport immediately rather than lagging a
+    // frame behind on the capture's one.
+    Snapshot.sendApplyNotifications()
 }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/AccessibilityTreeToolTest.kt
@@ -7,7 +7,12 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.host.mcp.viewport.McpViewport
+import com.kitakkun.jetwhale.host.model.PluginComposeScene
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -63,6 +68,40 @@ class AccessibilityTreeToolTest {
         assertEquals(0f, target.bounds.top)
         assertEquals(200f, target.bounds.right)
         assertEquals(200f, target.bounds.bottom)
+    }
+
+    @Test
+    fun `captureAccessibilityTree leaves the window info it had`() {
+        val scene = createTestScene()
+        scene.composeScene.size = IntSize(320, 240)
+
+        captureAccessibilityTree(scene)
+
+        // The tree is captured at the scene's own size, but the window info is a separate piece of
+        // state that the tool must not repoint at it.
+        assertEquals(IntSize(TEST_SCENE_WIDTH, TEST_SCENE_HEIGHT), scene.windowInfoUpdater.currentIntSize)
+        assertEquals(DpSize(TEST_SCENE_WIDTH.dp, TEST_SCENE_HEIGHT.dp), scene.windowInfoUpdater.currentDpSize)
+    }
+
+    @Test
+    fun `bounds are unchanged by a screenshot taken at another density`() {
+        val scene = createTestScene {
+            Box(modifier = Modifier.size(100.dp).semantics { contentDescription = "bounded" })
+        }
+        scene.composeScene.density = Density(1f)
+        renderTestScene(scene)
+        val before = boundsOf(scene, "bounded")
+
+        captureScreenshot(scene, McpViewport(size = IntSize(400, 300), density = Density(2f)))
+
+        assertEquals(before, boundsOf(scene, "bounded"), "A screenshot's density must not move later bounds")
+    }
+
+    private fun boundsOf(scene: PluginComposeScene, contentDescription: String): BoundsInfo {
+        val result = Json.decodeFromString<AccessibilityTreeResult>(captureAccessibilityTree(scene))
+        val node = result.nodes.flatMap { collectAllNodes(it) }.find { it.contentDescription == contentDescription }
+        assertNotNull(node, "Expected a node with contentDescription '$contentDescription'")
+        return node.bounds
     }
 
     private fun collectAllNodes(node: NodeInfo): List<NodeInfo> = listOf(node) + node.children.flatMap { collectAllNodes(it) }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotToolTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.host.mcp.viewport.McpViewport
@@ -85,6 +86,49 @@ class ScreenshotToolTest {
         // Sample the center of each box
         assertEquals(Color.Red, pixels[25, 25], "Expected red at center of left box")
         assertEquals(Color.Blue, pixels[75, 25], "Expected blue at center of right box")
+    }
+
+    @Test
+    fun `captureScreenshot leaves the scene on the size and density it had`() {
+        val scene = createTestScene()
+        scene.composeScene.size = IntSize(320, 240)
+        scene.composeScene.density = Density(density = 1.5f, fontScale = 1.25f)
+
+        captureScreenshot(scene, McpViewport(size = IntSize(800, 600), density = Density(3f)))
+
+        assertEquals(IntSize(320, 240), scene.composeScene.size, "Capture size must not outlive the capture")
+        assertEquals(Density(density = 1.5f, fontScale = 1.25f), scene.composeScene.density, "Capture density must not outlive the capture")
+    }
+
+    @Test
+    fun `captureScreenshot leaves the window info it had`() {
+        val scene = createTestScene()
+        scene.composeScene.size = IntSize(320, 240)
+        applyViewport(scene, McpViewport(size = IntSize(320, 240), density = Density(1f)))
+
+        captureScreenshot(scene, McpViewport(size = IntSize(800, 600), density = Density(3f)))
+
+        assertEquals(IntSize(320, 240), scene.windowInfoUpdater.currentIntSize)
+        assertEquals(DpSize(320.dp, 240.dp), scene.windowInfoUpdater.currentDpSize)
+    }
+
+    @Test
+    fun `the frame drawn after a capture uses the scene's own density`() {
+        // A 50dp box covers 50px at density 1 and 150px at density 3, so the pixel it lands on
+        // says which density the interactive frame was laid out at.
+        val scene = createTestScene {
+            Box(modifier = Modifier.size(50.dp).background(Color.Red))
+        }
+        scene.composeScene.density = Density(1f)
+
+        captureScreenshot(scene, McpViewport(size = IntSize(200, 200), density = Density(3f)))
+
+        val imageBitmap = ImageBitmap(200, 200)
+        scene.composeScene.size = IntSize(200, 200)
+        scene.composeScene.render(Canvas(imageBitmap), System.nanoTime())
+        val pixels = imageBitmap.toPixelMap()
+        assertEquals(Color.Red, pixels[25, 25], "Expected the box to still cover 50px")
+        assertEquals(Color.Transparent, pixels[100, 100], "Expected the box not to have grown to the capture's density")
     }
 
     @Test

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/TestSceneFactory.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/TestSceneFactory.kt
@@ -69,7 +69,14 @@ private class TestPlatformContext(
         override fun onLayoutChange(semanticsOwner: SemanticsOwner, semanticsNodeId: Int) = Unit
     }
 
-    override val currentIntSize: IntSize get() = IntSize(TEST_SCENE_WIDTH, TEST_SCENE_HEIGHT)
-    override val currentDpSize: DpSize get() = DpSize(TEST_SCENE_WIDTH.dp, TEST_SCENE_HEIGHT.dp)
-    override fun updateWindowSize(intSize: IntSize, dpSize: DpSize) {}
+    // Recorded rather than fixed, so a test can tell whether a tool put the window info back.
+    override var currentIntSize: IntSize = IntSize(TEST_SCENE_WIDTH, TEST_SCENE_HEIGHT)
+        private set
+    override var currentDpSize: DpSize = DpSize(TEST_SCENE_WIDTH.dp, TEST_SCENE_HEIGHT.dp)
+        private set
+
+    override fun updateWindowSize(intSize: IntSize, dpSize: DpSize) {
+        currentIntSize = intSize
+        currentDpSize = dpSize
+    }
 }

--- a/plugins/jetwhale/skills/plugin-qa/SKILL.md
+++ b/plugins/jetwhale/skills/plugin-qa/SKILL.md
@@ -279,9 +279,10 @@ Always `Read` the screenshot afterwards. A screenshot you never open verifies no
 - A pixel landmark is therefore only portable if you **pin the density**: `screenshot` takes a
   `density` argument — pass `2` and the geometry is identical on any machine. Omit it to inherit
   whatever the window is at. Values that are not finite and > 0 are rejected.
-- Passing `width`/`height`/`density` **mutates the live scene** — they are applied to the very scene
-  the host window is showing, and it keeps rendering that way until the window next resizes. Omit
-  them to capture as-is unless a fixed viewport is the point.
+- `width`/`height`/`density` are **scoped to the capture** — the scene is put back on the viewport
+  it was showing at before the tool returns, so the on-screen UI is untouched and the next
+  screenshot does not inherit them. Still omit them to capture as-is unless a fixed viewport is the
+  point.
 - Prefer asserting **relationships** — "the left pane grew", "the divider stopped moving" — over
   absolute pixel values.
 


### PR DESCRIPTION
`jetwhale.screenshot` applied the caller's `width`/`height`/`density` straight onto the live
plugin scene and never put it back. The interactive renderer only pushes the scene's own size
and density when the host window resizes, so one capture at another density left the **visible**
plugin UI rendering at it until the next resize — and every later capture inherited it, which
made captures irreproducible.

`withScopedViewport` snapshots the scene size, density and window info, applies the viewport,
and restores it in a `finally`. The restore is followed by `Snapshot.sendApplyNotifications()`
— both the scene density and the window-info override are snapshot state — so the next
interactive frame does not lag a frame behind on the capture's viewport.

`getAccessibilityTree` goes through the same path. It never changed the density (it derives its
viewport from the scene's own), but it did repoint the window info, so it is scoped too.

`ensureSceneRendered`, used by click/drag/scroll/type, is deliberately left alone: it re-applies
the scene's own size and density rather than a caller's, so it cannot carry a wrong viewport
into the live UI, and scoping it would mean restoring window info around pointer dispatch.

The `width`/`height`/`density` schema descriptions no longer tell agents the values stick; the
plugin-qa skill is corrected to match.

## Verified

`./gradlew :jetwhale-host:core:mcp:test` — 142 tests, 0 failures. Disabling the restore fails
exactly the five new tests, split across what they pin:

- `captureScreenshot leaves the scene on the size and density it had`
- `captureScreenshot leaves the window info it had`
- `the frame drawn after a capture uses the scene's own density`
- `captureAccessibilityTree leaves the window info it had`
- `bounds are unchanged by a screenshot taken at another density`

Not covered by a test: the `Snapshot.sendApplyNotifications()` in the restore. A test asserting
the post-restore recomposition timing proved flaky — `render` already flushes at its start and
`GlobalSnapshotManager` flushes on its own dispatcher — so it was replaced by the deterministic
drawn-pixel check above. The flush stays as defence, matching the existing `isMcpCapture`
pattern.
