### PR TITLE
docs: cover the host window, QA agent, and other undocumented surface

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -77,6 +77,7 @@ export default defineConfig({
       {
         text: 'Guide',
         items: [
+          { text: 'The Host Window', link: '/guide/host-window' },
           { text: 'Network Inspector', link: '/guide/network-inspector' },
           { text: 'Nav3 Navigator', link: '/guide/nav3-navigator' },
           { text: 'Compose Semantics Inspector', link: '/guide/compose-semantics-inspector' },
@@ -89,6 +90,7 @@ export default defineConfig({
         text: 'Plugin Development',
         items: [
           { text: 'Developing Plugins', link: '/guide/developing-plugins' },
+          { text: 'QA Agent', link: '/guide/qa-agent' },
         ],
       },
       {

--- a/docs/guide/adb-auto-port-mapping.md
+++ b/docs/guide/adb-auto-port-mapping.md
@@ -12,7 +12,8 @@ manual `adb reverse` commands needed.
 ## Enabling it
 
 It is **on by default** — Android debugging needs no setup. The toggle lives under
-**ADB support** in the JetWhale host's settings if you want to turn it off.
+[**Settings → Connection → ADB Support**](/guide/host-settings#adb-support) if you want to turn it
+off.
 
 While enabled, the host:
 
@@ -59,7 +60,8 @@ If you'd rather manage the forwarding yourself, turn the setting off and run:
 adb reverse tcp:<serverPort> tcp:<serverPort>
 ```
 
-after each device connection, using the ports shown in **Settings → Server** (repeat for the wss
+after each device connection, using the port shown in
+[**Settings → Connection → Debug Server**](/guide/host-settings#debug-server) (repeat for the wss
 port if the agent connects over wss).
 
 ::: tip Non-Android platforms

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -1,6 +1,6 @@
 # Compose Semantics Inspector
 
-The Compose Semantics Inspector is a built-in JetWhale plugin that reads the **Compose node tree of your
+The Compose Semantics Inspector is an official JetWhale plugin that reads the **Compose node tree of your
 running app** — every node, its labels, its bounds, and the actions it exposes — and lets you both
 browse it in the host and hand it to an AI agent over [MCP](/guide/mcp-server).
 
@@ -66,7 +66,7 @@ suspicious coordinate can be traced back to the window it came from.
 The tree is also richer than what the CLIs return: `android layout` gives a flat list with text,
 `content-desc` and bounds, but no `testTag`, no role and no per-node id, so an agent can only aim by
 label or by pixel. This plugin reports all three, which is what makes
-[`performNodeAction`](#com-kitakkun-jetwhale-compose-performnodeaction) able to address a node
+[`performNodeAction`](#com-kitakkun-jetwhale-semantics-performnodeaction) able to address a node
 directly.
 
 ## What the tree contains
@@ -83,6 +83,22 @@ Two views of it are available, switchable in the host and per MCP call:
 | **Unmerged** | Every semantics node stays separate, closer to how the UI is written. Useful when you need to see exactly which composable contributed which property. |
 
 ## Setup
+
+### Install the host plugin
+
+The Compose Semantics Inspector is **not** in the host's official catalog yet, so install it by
+coordinates: **Settings → Plugins → Add Plugins → Install from Maven**, repository *Maven Central*,
+and
+
+```
+com.kitakkun.jetwhale:jetwhale-compose-semantics-inspector:<version>
+```
+
+where `<version>` is your host's version (shown under **Settings → General → Application**). Pasting
+that whole line into the dialog's **Paste coordinates** field fills the rest in for you. See
+[Host Settings → Plugins](/guide/host-settings#plugins) for the other install routes.
+
+### Add the agent to your app
 
 Add the agent to the app being debugged — one artifact, carrying both the plugin and the probes
 (see [Platform support](#platform-support) for which targets have a probe):

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -9,12 +9,19 @@ The `com.kitakkun.jetwhale.host` plugin gives your plugin's module these tasks:
 
 | Task                     | What it does                                                                                          |
 |--------------------------|------------------------------------------------------------------------------------------------------|
-| `packagePlugin`          | Builds the distributable plugin fat-jar (the artifact you drop into `~/.jetwhale/plugins/`).          |
-| `installPlugin`          | Copies the packaged fat-jar into `~/.jetwhale/plugins/`.                                              |
+| `packagePlugin`          | Builds the distributable plugin fat-jar (the artifact you drop into `~/.jetwhale/plugins/`). Hooked to `assemble`, so a plain `./gradlew build` already produces it. |
+| `installPlugin`          | Copies the packaged fat-jar into `~/.jetwhale/plugins/` — your real installation, not the [sandbox](#isolated-sandbox-environment). |
 | `stageDevPlugin`         | Stages the packaged fat-jar into a private dev directory the host watches for hot reload.             |
 | `packageMavenPlugin`     | Builds the publishable plugin jar (see [Publishing your plugin to Maven](#publishing-your-plugin-to-maven)). |
+| `generatePluginDependencyManifest` | Writes the runtime dependency list `packageMavenPlugin` embeds. Runs as part of it. |
+| `downloadJetWhaleHost`   | Downloads the released host uber jar for `hostVersion`. Runs as part of `runJetWhale`.                |
 | `runJetWhale`            | Downloads a released JetWhale host for your OS and launches it with your plugin loaded.|
 | `runJetWhaleHot`         | Like `runJetWhale`, but runs the host on the JetBrains Runtime so structural changes hot-reload in place (see [Limitations](#limitations)), and auto re-stages your plugin in the background — the whole hot-reload loop in one command. |
+| `runJetWhaleQaAgent`     | Runs a headless debuggee your plugin can render against, driven over HTTP — see [QA Agent](/guide/qa-agent). |
+
+`runJetWhale` and `runJetWhaleHot` launch the host on a **Java 21** toolchain (`runJetWhaleHot`
+additionally requires the JetBrains vendor), independently of the toolchain your plugin module
+itself compiles with.
 
 ## Set up
 
@@ -61,6 +68,17 @@ jetwhalePlugin {
 }
 ```
 
+The extension has exactly three properties:
+
+| Property | Default | What it does |
+|----------|---------|--------------|
+| `hostVersion` | none | The released host version `runJetWhale` / `runJetWhaleHot` download and launch. Required unless you pass `-PjetwhaleHostJar`. |
+| `pluginArchiveName` | the project name | Base name of the packaged jars. Set it when several plugin modules in one build are all called `host`, so their jars do not collide in `~/.jetwhale/plugins/` or the staging directory. |
+| `qaAgentVersion` | falls back to `hostVersion` | Version of the [QA agent](/guide/qa-agent) `runJetWhaleQaAgent` resolves. |
+
+The two packaging tasks write `<pluginArchiveName>-<version>-jetwhale-plugin.jar` and
+`<pluginArchiveName>-<version>-jetwhale-maven-plugin.jar` into `build/libs/`.
+
 ::: warning Kotlin version compatibility
 The host loads your plugin jar into its own runtime, which ships a fixed Kotlin stdlib and Compose
 runtime. Kotlin is **not forward-compatible**: a plugin compiled with a newer Kotlin than the host's
@@ -92,6 +110,7 @@ complete, working example:
 
   ```json
   {
+    "$schema": "https://raw.githubusercontent.com/kitakkun/JetWhale/main/schemas/plugin-manifest.schema.json",
     "plugins": [
       {
         "pluginId": "com.example.myplugin",
@@ -102,6 +121,32 @@ complete, working example:
     ]
   }
   ```
+
+The manifest is **hand-written** — the Gradle plugin ships whatever is in your resources rather than
+generating it. Pointing `"$schema"` at the published JSON Schema gives you completion and validation
+in the IDE.
+
+#### Manifest reference
+
+| Field | Required | Default | Meaning |
+|-------|----------|---------|---------|
+| `pluginId` | ✅ | — | Unique id. The **agent** plugin's `pluginId` must match it for the two to be paired. |
+| `pluginName` | ✅ | — | Display name in the plugin drawer. |
+| `version` | ✅ | — | Your plugin's version. |
+| `factoryClass` | ✅ | — | Fully-qualified `JetWhaleHostPluginFactory` the host instantiates. Needs a public no-arg constructor. |
+| `requiresAgent` | | `true` | `false` makes the plugin [host-only](#host-only-plugins-no-agent-no-messaging): no agent counterpart, no messaging, instantiated for every active session. |
+| `agentVersionRange` | | none | `{ "min": …, "max": … }`, both **inclusive** and both nullable. An agent plugin whose `pluginVersion` falls outside the range is reported back to the agent as *incompatible* and never paired. Omit the object to accept any agent version. |
+| `icon` | | none | `{ "activePath": …, "inactivePath": … }` — see below. |
+
+#### Icons
+
+`activePath` and `inactivePath` are resource paths **relative to the jar root** (e.g.
+`"icons/widget_filled.svg"`), loaded with your plugin's own classloader. `activePath` is used when
+the plugin is selected and enabled, `inactivePath` otherwise; a path that does not resolve falls back
+silently to JetWhale's default puzzle-piece icons.
+
+Both must be **SVG** — a PNG will not render — and they are drawn as Material `Icon`s, i.e. tinted
+with the drawer's content color. Author monochrome shapes, not multi-color artwork.
 
 #### Multiple plugins in one module
 
@@ -174,6 +219,11 @@ pass `timeout` to `request`
 to override the default per call (e.g. `request(SlowOp, timeout = 30.seconds)`). Implement `JetWhaleHostPluginUi`
 (`@Composable Content()`) to render a UI; plugins that don't are **headless** (e.g. MCP-only).
 
+::: tip `onDispose()` is public
+`onCreate()` is `protected`, but `onDispose()` is `public open` — override it without a `protected`
+modifier or it will not compile.
+:::
+
 **The host plugin's `messenger` is a plain, always-connected property.** A host plugin instance
 lives exactly as long as its session's connection, so `messenger` is valid from `onCreate()` through
 `onDispose()` and may be used anywhere — UI callbacks, MCP tool handlers, background jobs. Because
@@ -187,7 +237,13 @@ instance is disposed, so nothing can outlive the plugin. State that must survive
 **On the agent** the `messenger` property is **connection-independent** (it outlives any single
 connection), so app code may send at any time and choose the offline behavior per call: `trySend`
 drops, `sendOrQueue` buffers, `sendOrFail` throws. Buffering is opt-in — override
-`offlineEventBufferCapacity` (bounded, drops oldest when full).
+`offlineEventBufferCapacity`, which defaults to **`0`** (so `sendOrQueue` behaves like `trySend`
+until you raise it) and drops the oldest entry once full.
+
+Two rules the buffer does not bend: **requests are never buffered** (`request` throws
+`JetWhaleConnectionClosedException` while disconnected, whatever the capacity), and ordering is only
+guaranteed *within* a policy — a `trySend` issued while queued events are still draining can overtake
+them. Pick one policy per logical stream.
 
 **Commands vs queries.** `request` returns the reply value (`val r: Pong = request(Ping)`); when you
 issue a command and only need it to succeed, just discard the result (`request(SetMockRules(rules))`).
@@ -228,9 +284,10 @@ override suspend fun onPrepare() {
 
 By convention only **one** side of a plugin pair actively `request`s during preparation (the other
 answers from its handlers): two sides that both block on each other's handlers while preparing would
-deadlock until the timeout. `onPrepare` is bounded by `prepareTimeoutMillis` — on timeout (or
-failure) the runtime logs a warning (visible in the host log) and opens handler dispatch anyway, so
-the plugin proceeds degraded rather than hanging.
+deadlock until the timeout. `onPrepare` is bounded by `prepareTimeoutMillis` (a `protected open val`
+on both sides, **10 000 ms** by default) — on timeout (or failure) the runtime logs a warning
+(visible in the host log) and opens handler dispatch anyway, so the plugin proceeds degraded rather
+than hanging.
 
 Note that there is no preparation-only message lane: a handler registered in `configure` is callable
 by the other side for the **whole session**, not just while preparing. Design prepare-time exchanges
@@ -290,6 +347,11 @@ Things to know:
   caller mistakes — it is rendered as an `{"error": ...}` payload instead of failing the server.
 - **Messaging works from tool handlers.** `messenger` is valid for the whole instance lifetime, so
   a command can `request` the agent directly.
+- **Declare parameters as properties, never inside `execute`.** The list is read once, and declaring
+  one afterwards — or declaring the same name twice — throws with a message saying so.
+- **`mcpCommands` is read once** per plugin instance activation and treated as static from then on.
+- Every declarator takes an optional `name` to override the wire name, for when the property cannot
+  be called what the parameter should be called (`by stringOrNull("…", name = "name")`).
 - The MCP APIs are marked `@ExperimentalJetWhaleApi` and may change between releases.
 
 ### Structured parameters
@@ -308,7 +370,8 @@ description, so it cannot drift from the model. A payload that doesn't fit the t
 `JetWhaleMcpArgumentException` naming the parameter.
 
 Document individual properties with `@McpDescription`; the text lands in the schema next to the
-field it describes:
+field it describes. It reaches your classpath transitively through the host SDK, so there is no extra
+dependency to declare:
 
 ```kotlin
 @Serializable
@@ -319,6 +382,11 @@ data class MockMatcher(
     val urlPattern: String,
 )
 ```
+
+`@McpDescription` also applies to a whole `@Serializable` **class**, where it becomes that object's
+schema description; a property's own annotation wins over the one inherited from its type. It is
+deliberately not usable on a value parameter's use-site target — writing it on a constructor
+parameter without a target is what makes it survive into the serial descriptor.
 
 A sealed hierarchy is advertised as a `oneOf` over its subclasses, each pinning the class
 discriminator (`"type"` by default, or whatever `@JsonClassDiscriminator` sets) to a `const` — the
@@ -371,6 +439,30 @@ Read it (`LocalJetWhaleDarkTheme.current`) to pick theme-appropriate colors inst
 `isSystemInDarkTheme()`, which reflects the OS setting and can disagree with the host's own Theme
 option.
 
+### Theming: you already match the host
+
+The host wraps your `Content()` in **its own** `MaterialTheme` before calling it, so plain
+`MaterialTheme.colorScheme` / `MaterialTheme.typography` inside your plugin already resolve to the
+host's applied scheme. Do not install a theme of your own unless you deliberately want to look
+different — that is why `material3` is a `compileOnly` dependency and why plugins get visual
+consistency for free.
+
+The SDK ships **no component library** — no shared Composables, icons, scaffolds or spacing tokens.
+Build your UI from Compose and Material 3 directly. Your composition is kept for the lifetime of the
+plugin instance, so it survives switching to another plugin tab and back.
+
+::: warning What the host SDK does *not* give a plugin
+There is no settings/preferences API (render your own controls inside `Content()` and persist them
+with [storage](#persistent-storage)), no logging API (use `println` or your own logging library —
+the host's log viewer captures stdout/stderr), and no way to read the session's app/device metadata.
+A plugin never learns its own session id; if you need facts about the app, `request` them from your
+agent counterpart.
+
+Members annotated `@InternalJetWhaleHostApi` (`bindMessenger`, `dispatchCreate`, …) show up in
+autocomplete because the runtime calls them across module boundaries. Never call them — the opt-in is
+an error, not a warning.
+:::
+
 ## Persistent storage
 
 Every host plugin instance gets a persistent key-value store via the protected `storage` property,
@@ -395,7 +487,12 @@ class MyPlugin : JetWhaleMessagingHostPlugin() {
 ```
 
 The API is suspend/`Flow` based: `put` / `get` / `getFlow` / `contains` / `remove` / `clear`, plus
-`keysFlow` to observe the stored key set.
+`keysFlow` to observe the stored key set. Each has an explicit-`KSerializer` overload alongside the
+reified one, for types whose serializer you resolve yourself.
+
+The key `__jetwhale_storage_version` is **reserved** — writing it throws, and it never shows up in
+`keysFlow` or `contains`. `clear()` wipes the store and re-stamps the current `storageVersion`, so a
+cleared store is not mistaken for legacy data by the migration below.
 
 ### Compose helper: `rememberPersistent`
 
@@ -409,6 +506,14 @@ fun DraftField() {
     OutlinedTextField(value = draft, onValueChange = { draft = it })
 }
 ```
+
+Two behaviours to design around: the state **starts at `default`** and is replaced asynchronously
+once the stored value has been read, so the first frame shows the default; and writes are **debounced
+by 300 ms**, so a value typed and immediately followed by a crash may not have reached disk. There is
+also an overload taking an explicit `KSerializer`.
+
+From UI code that has no plugin reference, `LocalJetWhalePluginStorage.current` gives the same
+`pluginId`-scoped store as the `storage` property (it is `null` outside a host-managed scene).
 
 ### Migrating stored data
 
@@ -455,10 +560,16 @@ state; for changes it can't apply that way it recreates the plugin from a fresh 
 `runJetWhale`, `runJetWhaleHot` and the in-repo `runJetWhaleLocal` run the host against an
 **isolated, per-project sandbox** at
 `build/jetwhale-sandbox/` instead of your real `~/.jetwhale/`. Everything the host persists — installed
-plugins, settings, per-plugin data, TLS material and the plugin trust registry — lives there, so trying
-a plugin never reads or mutates your actual JetWhale installation. The sandbox starts empty: only your
-dev plugin is loaded (dev-directory plugins are trusted implicitly, so there is no trust prompt to
-click through), and there are no leftover plugins or settings from previous work.
+plugins (`plugins/`, with Maven-installed dependencies under `plugins/libs/`), settings, per-plugin
+data (`plugin-data/`), TLS material (`ssl/`) and the plugin trust registry
+(`trusted-plugins.json`) — lives there, so trying a plugin never reads or mutates your actual JetWhale
+installation. The sandbox starts empty: only your dev plugin is loaded (dev-directory plugins are
+trusted implicitly, so there is no trust prompt to click through), and there are no leftover plugins
+or settings from previous work.
+
+Two system properties do this, both set for you by the launch tasks: `jetwhale.appDataDir` redirects
+the app data root, and `jetwhale.devPluginsDir` names the watched staging directory. Note that
+`installPlugin` is **not** affected — it deliberately targets your real `~/.jetwhale/plugins/`.
 
 The sandbox lives under `build/`, so it **persists across re-launches** of the same project — test data
 you set up survives the next `runJetWhale`. Running `./gradlew :myPlugin:clean` wipes it for a
@@ -498,8 +609,21 @@ yourself from a second terminal:
 > in one terminal and `stageDevPlugin -t` in another.
 
 `runJetWhale` downloads the runnable host uber jar for `hostVersion` and the current
-OS/architecture from the GitHub release (cached under `~/.jetwhale/dev-host/`) — no manual install of
-JetWhale needed. Pass `-PjetwhaleHostJar=<path>` to launch a locally built host uber jar instead.
+OS/architecture from the GitHub release — no manual install of JetWhale needed. Pass
+`-PjetwhaleHostJar=<path>` to launch a locally built host uber jar instead, which skips the download
+entirely.
+
+The download is cached under `~/.jetwhale/dev-host/<version>/` and reused. A released version is only
+fetched once; a `-SNAPSHOT` `hostVersion` is re-checked against the release asset's ETag on every
+launch, so you pick up a newer snapshot without clearing anything by hand. The supported matrix is
+macOS / Linux / Windows on `arm64` or `x64`; anything else fails with an explicit
+*Unsupported OS/architecture* message.
+
+### Testing against a real session
+
+A plugin screen has nothing to render without a connected debuggee. `runJetWhaleQaAgent` starts a
+headless one and gives you an HTTP control API to push messages at your plugin — see
+[QA Agent](/guide/qa-agent).
 
 ### Limitations
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -79,6 +79,13 @@ fun initializeJetWhale() {
 }
 ```
 
+::: warning Always set `port`
+The agent's `connection { }` defaults are `host = "localhost"` and **`port = 8080`**, while the
+host's debug server listens on **5080**. The defaults deliberately do not match, so set `port`
+explicitly to whichever port the host reports in
+[Settings → Connection → Debug Server](/guide/host-settings#debug-server).
+:::
+
 Where to call it, per platform:
 
 - **Android** — in `Application.onCreate()`
@@ -89,8 +96,56 @@ Where to call it, per platform:
 The [demo apps](https://github.com/kitakkun/JetWhale/tree/main/demo) show a complete multiplatform
 setup with a shared `initializeJetWhale()` function.
 
-An optional `logging { }` block controls agent-side logging
-(`enabled = true`, `logLevel = LogLevel.WARN` by default).
+### Logging
+
+An optional `logging { }` block controls agent-side logging:
+
+```kotlin
+startJetWhale {
+    connection { /* ... */ }
+    logging {
+        enabled = true                      // default
+        logLevel = LogLevel.WARN            // default
+        ktorLogLevel = KtorLogLevel.NONE    // default
+    }
+}
+```
+
+- **`logLevel`** is a minimum threshold over `LogLevel.VERBOSE`, `DEBUG`, `INFO`, `WARN`, `ERROR`,
+  `ASSERT`. Nothing is logged at `ASSERT`, so setting it silences the agent entirely.
+- **`ktorLogLevel`** gates the underlying Ktor client's own HTTP logging: `NONE` (default), `HEADERS`,
+  `BODY`, `ALL`. Raise it only when diagnosing the connection itself — it is noisy.
+
+There is no custom-logger hook, and the configuration is process-global: with several concurrent
+sessions, the last `startJetWhale` call wins.
+
+### Stopping a session
+
+`startJetWhale` returns a **`JetWhaleSession`** handle:
+
+```kotlin
+val session = startJetWhale { /* ... */ }
+// later
+session.stop()
+```
+
+`stop()` tears the reconnect loop down and drops the plugins. It is **terminal** — a stopped session
+cannot be revived, and repeated calls are ignored. To connect again, call `startJetWhale` a second
+time with **fresh plugin instances** (a plugin is bound to the session it was registered with).
+Teardown is asynchronous: `stop()` returns as soon as it is scheduled, and the host observes the
+disconnect shortly after. Holding the handle is optional — most apps start one session for the
+process lifetime and never stop it.
+
+### Reconnecting
+
+The agent retries **forever**. After a failed connection or negotiation it drops the plugins'
+peers, waits, and tries again with a linear backoff that grows by one second per attempt and is
+capped at five (1s, 2s, 3s, 4s, 5s, 5s, …); the counter resets on the first success. None of this is
+configurable, and there is no connection-state API to poll — start the host before the app, or just
+leave the app running until the host comes up.
+
+A disconnect is **not** a deactivation: registered plugins stay activated across it, so an agent
+plugin that buffers events keeps buffering for the next connection.
 
 ### Session metadata
 
@@ -115,11 +170,31 @@ startJetWhale {
 }
 ```
 
+How much is resolved for you differs sharply by platform — Android and iOS fill in everything,
+desktop and web mostly do not:
+
+| Platform | `appName` | `deviceId` | `deviceName` |
+|----------|-----------|------------|--------------|
+| **Android** | the application label | `Settings.Secure.ANDROID_ID` | `Build.MODEL` |
+| **iOS** | `CFBundleDisplayName` / `CFBundleName` | `identifierForVendor` | the device name |
+| **macOS (native)** | `CFBundleDisplayName` / `CFBundleName` | — | the host's localized name |
+| **Desktop (JVM)** | — | — | the `os.name` system property |
+| **Linux / Windows (native)** | — | — | the machine's host name |
+| **Web (JS / WasmJS)** | — | — | `"Web Browser"` |
+
+A dash means nothing is resolved and the field stays empty unless you set it in `app { }`. On
+desktop and web in particular, setting `appName` is what makes a session readable in the host's
+[device / app selector](/guide/host-window#choosing-a-session).
+
+An `appIconPng` whose base64 form exceeds the 32KB cap is dropped with a warning — which is visible,
+since `WARN` is the default log level.
+
 ## Secure connections (wss)
 
 By default the agent connects over plain **ws** (port **5080**). The host can additionally serve
 **secure WebSocket (wss)** on port **5443**, backed by a locally-issued CA — see
-[Host Settings → Server](/guide/host-settings#server) for generating and activating a certificate.
+[Host Settings → SSL certificates](/guide/host-settings#ssl-certificates) for generating and
+activating a certificate.
 
 To make the agent connect over wss, add an `ssl { }` block to `connection { }`. As soon as at least
 one trusted certificate is configured, the connection switches from ws to wss:
@@ -134,7 +209,7 @@ startJetWhale {
             // Option A: fetch and pin the host's active CA automatically (trust-on-first-use).
             trustServerCertificate()
 
-            // Option B: pin a CA you exported from the host's Server settings.
+            // Option B: pin a CA you exported from the host's SSL Certificate settings.
             // trustCertificate(pem = "-----BEGIN CERTIFICATE-----\n...")
         }
     }
@@ -158,8 +233,9 @@ startJetWhale {
   pins the subsequent wss session). Over ADB port forwarding (the usual case) the download never
   leaves the machine, so it is as trustworthy as the ADB link. If the CA cannot be fetched over
   either channel, the connection falls back to plain ws.
-- **`trustCertificate(pem)`** — pins a CA PEM you exported yourself from the host's Server settings
-  (**Show Details → Copy to Clipboard**). Prefer this on an untrusted LAN, where strict pinning
+- **`trustCertificate(pem)`** — pins a CA PEM you exported yourself from the host's
+  [SSL Certificate](/guide/host-settings#ssl-certificates) settings (**Show Details → Copy to
+  Clipboard**). Prefer this on an untrusted LAN, where strict pinning
   matters.
 
 ### Per-platform pinning support
@@ -201,8 +277,37 @@ falls back to `https` over the wss port, no App Transport Security exception for
 Launch your app — it appears as a new session in the host. JetWhale supports multiple simultaneous
 sessions, so you can debug several apps or devices at once.
 
+## Published artifacts
+
+Everything is published to Maven Central under the group **`com.kitakkun.jetwhale`**, all at the same
+version as the host release they belong to.
+
+| Artifact | Where it goes |
+|----------|---------------|
+| `jetwhale-agent-runtime` | The app being debugged. Brings `jetwhale-agent-sdk` and `jetwhale-protocol-core` with it, so you rarely need to name those. |
+| `jetwhale-agent-sdk` | Only when a module writes agent plugins without depending on the runtime. |
+| `jetwhale-protocol-core` | The shared module of a plugin pair, for `JetWhaleEvent` / `JetWhaleRequest`. |
+| `jetwhale-annotations` | `@McpDescription`. Reaches both SDKs transitively; rarely named directly. |
+| `jetwhale-host-sdk` | A host plugin module, as `compileOnly` — see [Developing Plugins](/guide/developing-plugins). |
+| `jetwhale-gradle-plugin` | Applied as the `com.kitakkun.jetwhale.host` Gradle plugin id. |
+| `jetwhale-qa-agent` | Run, not depended on — see [QA Agent](/guide/qa-agent). |
+| `jetwhale-network-inspector`, `-agent`, `-agent-ktor`, `-agent-okhttp`, `-protocol` | [Network Inspector](/guide/network-inspector). |
+| `jetwhale-nav3-navigator`, `jetwhale-nav3-agent`, `jetwhale-nav3-protocol` | [Nav3 Navigator](/guide/nav3-navigator). |
+| `jetwhale-compose-semantics-inspector`, `-agent`, `-protocol` | [Compose Semantics Inspector](/guide/compose-semantics-inspector). |
+
+The `-navigator` / `-inspector` artifacts (no suffix) are the **host** plugin jars — you install
+those into the host rather than into your app; see [Host Settings → Plugins](/guide/host-settings#plugins).
+
+::: warning Published Kotlin Multiplatform targets
+The multiplatform artifacts ship `jvm`, `android`, `js(IR)`, `wasmJs`, `iosArm64`,
+`iosSimulatorArm64`, `macosArm64`, `mingwX64`, `linuxX64` and `linuxArm64`. There is **no `iosX64`
+and no `macosX64`**, so an Intel Mac (and the Intel iOS simulator) cannot resolve them; and there are
+no watchOS/tvOS targets.
+:::
+
 ## Next steps
 
+- [The Host Window](/guide/host-window) — find your way around the debugger UI
 - [Network Inspector](/guide/network-inspector) — inspect and mock HTTP traffic
 - [Compose Semantics Inspector](/guide/compose-semantics-inspector) — browse your app's Compose node tree and
   drive it by node

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -1,6 +1,16 @@
 # Host Settings
 
-The JetWhale host's behavior is configured from its **Settings** screen.
+The JetWhale host's behavior is configured from its **Settings** screen, opened from the gear icon in
+the [drawer](/guide/host-window#the-rest-of-the-drawer).
+
+Settings are organized into four **sections**, each holding one or more **pages**:
+
+| Section | Pages |
+|---------|-------|
+| **General** | [Appearance](#appearance), [Application](#application) |
+| **Connection** | [Debug Server](#debug-server), [SSL Certificate](#ssl-certificates), [ADB Support](#adb-support) |
+| **AI Agents** | [MCP Server](#mcp-server), [Permissions](#mcp-permissions) |
+| **Plugins** | [Installed Plugins](#plugins), [Add Plugins](#plugins), [Security](#plugin-trust) |
 
 ::: tip Window size and position
 The host remembers its window size and position across launches automatically (when the window is
@@ -10,8 +20,6 @@ configure.
 
 ## General
 
-The **Settings → General** screen groups the host-wide options:
-
 ### Appearance
 
 | Setting | Description |
@@ -19,88 +27,48 @@ The **Settings → General** screen groups the host-wide options:
 | **Language** | UI language of the host: **English** or **Japanese**. |
 | **Theme** | Color scheme: `builtin:dynamic`, `builtin:light`, or `builtin:dark`. |
 
-### Maintenance
+### Application
 
-- **Application data directory** — shows the host's app-data path (normally `~/.jetwhale/`) with a
+Everything about *this install* of the host.
+
+**Maintenance**
+
+- **Application Data Directory** — shows the host's app-data path (normally `~/.jetwhale/`) with a
   shortcut to open it in your file manager.
-- **View application logs** — opens the built-in log viewer.
+- **View Application Logs** — opens the built-in [log viewer](/guide/host-window#the-log-viewer).
 
-### Updates
+**Updates**
 
-- **Current version** — the running host version.
-- **Check for updates on startup** — toggle the automatic update check.
-- **Check for updates** — check immediately; when an update is found you can install it or open the
-  download page.
+- **Current Version** — the running host version.
+- **Check for updates on startup (notify only)** — toggle the automatic check. Updates are never
+  applied automatically.
+- **Check for Updates** — check immediately. When one is found you can **Install and Relaunch** (on
+  the platforms that support in-app updates) or **Open Download Page**.
 
-## ADB support
+## Connection
 
-The **Settings → Connection → ADB support** page carries the Android port forwarding, plus where
-the host found the tool it needs for it:
+### Debug Server
 
-| Setting | Default | Description |
-|---------|---------|-------------|
-| **ADB auto port mapping** | on | Automatically runs `adb reverse` for Android devices as they connect. Inactive on machines without `adb`. See [ADB Auto Port Mapping](/guide/adb-auto-port-mapping). |
-
-- **adb executable path** — shows where JetWhale found `adb` (see
-  [How adb is found](/guide/adb-auto-port-mapping#how-adb-is-found)), or that it is unavailable.
-
-## Server
-
-The **Settings → Server** screen configures the debug WebSocket server and its TLS certificates.
+The **Settings → Connection → Debug Server** page configures the WebSocket server debuggee apps
+connect to.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| **Debug server port** | `5080` | The plain **ws** port debuggee apps connect to. Must match the `port` in your app's `startJetWhale { connection { ... } }` block. |
-| **wss port** | `5443` | The **secure WebSocket (wss)** port, served alongside plain ws when a certificate is active. Point the agent's `port` at this when it connects over `ssl { }`. |
-| **MCP server port** | `7080` | Port of the built-in [MCP server](/guide/mcp-server) for AI agents. |
+| **Debug Server Port** | `5080` | The plain **ws** port. Must match the `port` in your app's `startJetWhale { connection { ... } }` block. |
 
-The server status line shows the running ports, e.g. *Running on port 5080 (WSS: 5443)* when wss is
-active.
+Editing the port reveals an **Apply** button, which confirms before restarting the server —
+restarting disconnects every session.
 
-The **MCP Server** section also offers copy-ready connection snippets — a `claude mcp add` command
-and a JSON config block, both carrying the port the MCP server is currently running on — plus a link
-to the [MCP Server](/guide/mcp-server) guide.
+The status line above it shows the running ports, e.g. *Running on port 5080 (WSS: 5443)* when wss is
+active, and offers **Retry** if the server failed to bind.
 
-The **MCP Server** section also carries **Permissions** — a checkbox tree deciding what an AI
-agent may do, from read-only observation through to restarting the debug server. See
-[MCP Server → Permissions](/guide/mcp-server#permissions).
-
-Changing the MCP server port here restarts the MCP server immediately. An agent changing it through
-`jetwhale.updateSettings` only persists the value — restarting would drop the agent's own
-connection — so that change takes effect on the next host start.
-
-### Overriding the ports at startup
-
-Each port can also be chosen on the command line, which is handy when several hosts have to run side
-by side (for example one per checkout of the app you are debugging) and would otherwise fight over
-the same defaults:
-
-| Option | Overrides |
-|--------|-----------|
-| `--server-port <port>` | **Debug server port** |
-| `--wss-port <port>` | **wss port** |
-| `--mcp-server-port <port>` | **MCP server port** |
-
-An option that is not passed keeps using the saved setting. `--wss-port` only picks the port: wss is
-still served only when it is enabled in the settings.
-
-An override applies to that launch only and is never written back, but for as long as it is in force
-it *is* the port the host reports — the **Settings → Server** screen shows it, so the screen and the
-running server never disagree. Changing a port on that screen afterwards wins: the new value is saved
-and the override for that port is retired for the rest of the session.
-
-Pass them to the [runnable uber jar](/guide/getting-started):
-
-```bash
-java -jar jetwhale-host-<version>-<osArch>.jar --server-port 5081 --mcp-server-port 7081
-```
-
-When you launch the host from a plugin project with
-[`runJetWhale`](/guide/developing-plugins) (or `runJetWhaleHot`), pass them with `--args`:
-
-```bash
-./gradlew :myPlugin:runJetWhale --args="--server-port 5081 --mcp-server-port 7081"
-```
+::: tip The wss port has no field of its own
+The **secure WebSocket (wss)** port (default `5443`) and whether the wss connector is exposed at all
+are not editable on this screen. They are set at launch with [`--wss-port`](#overriding-the-ports-at-startup),
+or by an AI agent through `jetwhale.updateSettings` (`wssPort` / `wssEnabled`). In practice you only
+need to generate a certificate under [SSL Certificate](#ssl-certificates) and point the agent's
+`port` at 5443.
+:::
 
 ### SSL certificates
 
@@ -143,12 +111,53 @@ unaffected.
   certificate **at generation time**. If your machine's IP changes, **regenerate the certificate**
   so LAN clients still pass hostname verification.
 
+### ADB support
+
+The **Settings → Connection → ADB Support** page carries the Android port forwarding, plus where
+the host found the tool it needs for it:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Automatically wire ADB port to host PC port** | on | Runs `adb reverse` for Android devices as they connect. Inactive on machines without `adb`. See [ADB Auto Port Mapping](/guide/adb-auto-port-mapping). |
+
+Under **Health Check**, **ADB Executable Path** shows where JetWhale found `adb` (see
+[How adb is found](/guide/adb-auto-port-mapping#how-adb-is-found)), or *ADB command not found*.
+
+## AI Agents
+
+### MCP Server
+
+The **Settings → AI Agents → MCP Server** page configures the built-in
+[MCP server](/guide/mcp-server) for AI agents.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **MCP Server Port** | `7080` | Port the MCP server's SSE endpoint listens on, bound to localhost. |
+
+Below it are copy-ready connection snippets — a `claude mcp add` command and a JSON config block,
+both carrying the port the MCP server is *currently* running on — plus **Open setup guide**, which
+links to the [MCP Server](/guide/mcp-server) page.
+
+Changing the MCP server port here restarts the MCP server immediately (after a confirmation). An
+agent changing it through `jetwhale.updateSettings` only persists the value — restarting would drop
+the agent's own connection — so that change takes effect on the next host start.
+
+### MCP Permissions
+
+The **Settings → AI Agents → Permissions** page is a checkbox tree deciding what an AI agent may do,
+from read-only observation through to restarting the debug server. See
+[MCP Server → Permissions](/guide/mcp-server#permissions).
+
 ## Plugins
+
+The **Installed Plugins** page lists what is loaded; **Add Plugins** is where new ones come from and
+**Security** holds the trust settings below.
 
 Installed plugins live in `~/.jetwhale/plugins/`. There are three ways to install one:
 
-- **Official Plugins** — one-click install for officially published plugins (e.g. the Network
-  Inspector), no coordinates needed. The artifact version matching the running host is fetched
+- **Official Plugins** — one-click install from the official catalog, no coordinates needed. The
+  catalog currently holds the [Network Inspector](/guide/network-inspector) and the
+  [Nav3 Navigator](/guide/nav3-navigator). The artifact version matching the running host is fetched
   from Maven Central, falling back to the matching snapshot build when the release is not
   published yet (snapshot hosts fetch their matching snapshot directly).
 - **Install from Maven** — enter the plugin's `group:artifact:version` and pick a repository
@@ -218,4 +227,56 @@ signing back off, because deleting the key requires credential-store access — 
 What stays outside scope is an attacker who can already reach the credential store, or who runs code
 as you and modifies JetWhale itself; protecting against full control of your user account is not a
 goal of this mechanism.
+:::
+
+## Command-line options
+
+### Overriding the ports at startup
+
+Each port can also be chosen on the command line, which is handy when several hosts have to run side
+by side (for example one per checkout of the app you are debugging) and would otherwise fight over
+the same defaults:
+
+| Option | Overrides |
+|--------|-----------|
+| `--server-port <port>` | **Debug Server Port** |
+| `--wss-port <port>` | **wss port** |
+| `--mcp-server-port <port>` | **MCP Server Port** |
+
+An option that is not passed keeps using the saved setting. `--wss-port` only picks the port: wss is
+still served only when it is enabled in the settings.
+
+An override applies to that launch only and is never written back, but for as long as it is in force
+it *is* the port the host reports — the settings screen shows it, so the screen and the running
+server never disagree. Changing a port on that screen afterwards wins: the new value is saved and the
+override for that port is retired for the rest of the session.
+
+Pass them to the [runnable uber jar](/guide/getting-started):
+
+```bash
+java -jar jetwhale-host-<version>-<osArch>.jar --server-port 5081 --mcp-server-port 7081
+```
+
+When you launch the host from a plugin project with
+[`runJetWhale`](/guide/developing-plugins) (or `runJetWhaleHot`), pass them with `--args`:
+
+```bash
+./gradlew :myPlugin:runJetWhale --args="--server-port 5081 --mcp-server-port 7081"
+```
+
+### Other options
+
+| Option | Default | What it does |
+|--------|---------|--------------|
+| `--plugin-dir <path>` | — | Load plugins from an additional directory, on top of `~/.jetwhale/plugins/`. **Repeatable.** |
+| `--log-level <level>` | `WARN` | Minimum level the host's own logging emits: `DEBUG`, `INFO`, `WARN` or `ERROR`. Raise it when diagnosing a plugin that will not load, then read the result in the [log viewer](/guide/host-window#the-log-viewer). |
+| `--mcp-allow-all-permissions` | off | Allows every MCP tool for that process only — see [MCP Server → Lifting every permission for one launch](/guide/mcp-server#lifting-every-permission-for-one-launch). |
+
+Ports are validated at parse time (they must be in `1..65535`), so a typo is reported immediately
+rather than as a bind failure later. Unrecognized arguments are ignored.
+
+::: tip Plugin developers use a sandbox, not `~/.jetwhale`
+`runJetWhale` / `runJetWhaleHot` also set `-Djetwhale.appDataDir` and `-Djetwhale.devPluginsDir`, so
+the whole app-data directory described on this page is redirected into a per-project sandbox. See
+[Developing Plugins → Isolated sandbox environment](/guide/developing-plugins#isolated-sandbox-environment).
 :::

--- a/docs/guide/host-window.md
+++ b/docs/guide/host-window.md
@@ -1,0 +1,92 @@
+# The Host Window
+
+The JetWhale host is one window: a **drawer** down the left side that picks *what you are debugging*
+and *which tool you are looking at*, and the selected plugin's own UI filling the rest.
+
+Everything below is the host itself — the plugins it shows are documented on their own pages
+([Network Inspector](/guide/network-inspector), [Nav3 Navigator](/guide/nav3-navigator),
+[Compose Semantics Inspector](/guide/compose-semantics-inspector)).
+
+## The drawer
+
+The drawer can be **collapsed** to a narrow icon rail with the **✕** button at its top left, and
+expanded again with the unfold button on the rail. Collapsed, it keeps the same entries as icons —
+the device picker, the plugin list, the MCP tools button, Settings, and Info.
+
+::: tip Window size and position
+The host remembers its window size and position across launches (while the window is in its normal
+floating state; maximized/fullscreen is not persisted). There is nothing to configure.
+:::
+
+## Choosing a session
+
+Sessions are picked with **two dropdowns**, because one host commonly holds several apps from the
+same device:
+
+1. **Select Device** — one entry per device, keyed by the `deviceId` the agent reported. Sessions
+   that share a device are grouped under it.
+2. **Select App** — the apps connected from that device. It only appears once the device has more
+   than one app (or one is already selected). Picking a device automatically selects its first app,
+   so a session is always active.
+
+Each entry carries a small lock icon for how its transport is secured — see
+[Session security indicator](/guide/what-is-jetwhale#session-security-indicator). When nothing is
+connected the device row reads *No session available*.
+
+When a session goes away the host says so (*&lt;app&gt; disconnected*, or *N sessions disconnected*
+when several drop at once, e.g. after a debug-server restart).
+
+## The plugin list
+
+Below the session selector, the installed plugins are grouped into three collapsible sections. The
+grouping is computed against the **selected session**, so it changes as you switch apps:
+
+| Section | What lands there |
+|---------|------------------|
+| **Enabled Plugins** | Enabled in settings **and** available for this session. |
+| **Disabled Plugins** | Available for this session, but switched off. |
+| **Unavailable Plugins** | No session is selected, or the session's agent never advertised this plugin id. Host-only plugins (`"requiresAgent": false`) are available for every active session and never land here. |
+
+Click a plugin to open it. Each row also has an overflow (**⋮**) menu:
+
+- **Disable** / **Enable** — the same toggle as `jetwhale.setPluginEnabled` over
+  [MCP](/guide/mcp-server), applied host-wide rather than per session.
+- **Pop out** — moves the plugin into a window of its own. The main window shows *This plugin is
+  popped out* with a **Bring back to main window** button, and the drawer entry's menu switches to
+  **Bring back**. Popping out is how you watch two plugins (or the same plugin on two sessions) side
+  by side.
+
+If no plugins are installed at all, the drawer says so and — when some jars failed to load — offers a
+shortcut to the plugin settings screen. See
+[Host Settings → Plugins](/guide/host-settings#plugins) for installing them.
+
+### MCP badges
+
+A plugin that contributes [MCP tools](/guide/mcp-server#plugin-provided-tools) carries an **MCP**
+badge on its drawer row. Clicking the badge opens the
+[MCP tools browser](/guide/mcp-server#the-mcp-tools-browser) already filtered to that plugin.
+
+While an AI agent is actually calling one of that plugin's tools, the badge and the whole row take an
+accent-colored rotating ring, so the plugin being driven is unmistakable even if the label has
+scrolled out of view. A banner at the top of the drawer reports the connection itself — *AI agent
+connected*, and *AI agent is operating* while a call is in flight.
+
+## The rest of the drawer
+
+| Entry | What it opens |
+|-------|---------------|
+| **Browse MCP tools** (wrench icon, top of the drawer) | The [MCP tools browser](/guide/mcp-server#the-mcp-tools-browser), unfiltered — so the tools an agent can reach are visible without first finding a plugin that publishes some. |
+| **Settings** (gear icon, top of the drawer) | [Host Settings](/guide/host-settings). |
+| **Info** (bottom of the collapsed rail) | The about panel: version, project links, and **OSS Licenses** — the full list of open-source components the host ships. |
+
+When a newer release is available, a banner appears above the content with a **View in Settings**
+shortcut. Updates are never applied automatically — see
+[Host Settings → Application](/guide/host-settings#application).
+
+## The log viewer
+
+**Settings → General → Application → View Application Logs** opens the host's own captured
+stdout/stderr in a separate window: filter by substring, toggle auto-scroll, and clear the buffer.
+This is the **host's** log, not the debugged app's — it is where a plugin jar that failed to load,
+or a server that failed to bind, reports itself. The same buffer backs the `jetwhale.getLogs` and
+`jetwhale.clearLogs` [MCP tools](/guide/mcp-server#host-tools).

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -12,8 +12,8 @@ can inspect and drive your debugging sessions. The built-in tools come in two fa
 
 ## Connecting an AI agent
 
-The server speaks MCP over **SSE**, listening on port **7080** by default (configurable in
-**Settings**):
+The server speaks MCP over **SSE**, bound to **localhost** on port **7080** by default (configurable
+in **Settings → AI Agents → MCP Server**):
 
 - `GET http://localhost:7080/sse` — the SSE stream
 - `POST http://localhost:7080/message?sessionId=...` — client-to-server messages
@@ -24,9 +24,18 @@ For example, to register it with Claude Code:
 claude mcp add --transport sse jetwhale http://localhost:7080/sse
 ```
 
-The host's **Settings → AI Agents → MCP Server** section shows this command — and an equivalent JSON
+The host's **Settings → AI Agents → MCP Server** page shows this command — and an equivalent JSON
 config block for other MCP clients — already filled in with the port the server is actually running
 on, ready to copy.
+
+::: tip Two different things called `sessionId`
+The `sessionId` in the `/message` query string is the **MCP transport** session — one per SSE
+connection, minted by the MCP library. It has nothing to do with the JetWhale **debug** session ids
+that `jetwhale.listSessions` returns and the tools below take as arguments.
+:::
+
+The tool list is computed **when a client connects** and never changes for that connection, so a
+plugin enabled (or a permission re-allowed) mid-session only shows up after the client reconnects.
 
 ## Plugin UI tools
 
@@ -44,6 +53,48 @@ on, ready to copy.
 Because a single host can debug multiple apps at once — each with several plugins — every tool that
 targets a plugin UI takes required `sessionId` **and** `pluginId` parameters: call
 `jetwhale.listSessions` first, then `jetwhale.listPlugins` to pick the plugin.
+
+### Parameters
+
+Beyond that pair, each tool takes:
+
+| Tool | Parameter | Required | Default | Meaning |
+|------|-----------|----------|---------|---------|
+| `screenshot` | `width`, `height` | no | the UI's current size (fallback 1280×720) | Render at a different size for this capture only. Must be supplied **together**. |
+| | `density` | no | the scene's own density | e.g. `2` for HiDPI. Must be finite and greater than 0. |
+| `click` | `x`, `y` | yes | — | Pixels from the plugin UI's left/top edge. |
+| `type` | `text` | no | — | Printable characters to type. |
+| | `specialKey` | no | — | A key name instead of text. **Exactly one** of `text` / `specialKey` must be given. |
+| `scroll` | `x`, `y` | yes | — | Where to scroll. |
+| | `deltaX` | no | `0` | Positive scrolls right, negative left. |
+| | `deltaY` | no | `0` | Positive scrolls down, negative up. |
+| `drag` | `startX`, `startY`, `endX`, `endY` | yes | — | The gesture's endpoints, in pixels. |
+| | `steps` | no | `10` | Intermediate move events between them. |
+
+`specialKey` accepts (case-insensitively): `ENTER`, `BACKSPACE`, `DELETE`, `TAB`, `ESCAPE`, `UP`,
+`DOWN`, `LEFT`, `RIGHT`, `HOME`, `END`, `PAGE_UP`, `PAGE_DOWN`. There are no modifier parameters.
+
+Two implementation details worth knowing when a call does not do what you expect:
+
+- **`jetwhale.click` is not a raw pointer event.** It finds the deepest clickable node containing the
+  point and invokes its `OnClick` semantics action, so a point with nothing clickable under it comes
+  back as *No clickable element found*, rather than silently doing nothing.
+- **`jetwhale.type`'s `text` goes to the first editable node in the scene**, not to whatever has
+  focus. Use `specialKey` (or a click first) when the target matters. A special key is dispatched as
+  a real key-down/key-up pair.
+- `jetwhale.drag` is for drag-and-drop gestures; use `jetwhale.scroll` to scroll a list.
+
+`jetwhale.getAccessibilityTree` returns each node's `id`, `role`, `text`, `contentDescription`,
+`bounds` (relative to the plugin UI's root) and the `isClickable` / `isEnabled` / `isFocused` /
+`isSelected` / `isChecked` / `isEditable` flags, nested by `children`. Both it and
+`jetwhale.screenshot` raise the plugin's `LocalIsMcpCapture`, so
+[redaction](#plugin-provided-tools) applies to either.
+
+::: tip Reading the *app's* UI, not the plugin's
+These tools read the **host window's** Compose UI. To read the debugged app's own Compose tree — and
+to invoke a node's action there rather than aiming at pixels — use the
+[Compose Semantics Inspector](/guide/compose-semantics-inspector#mcp-tools).
+:::
 
 ## Host tools
 
@@ -69,7 +120,49 @@ and what the window is showing.
 | `jetwhale.navigate` | Switches the main window to another screen, selecting the session and plugin as it goes |
 
 `jetwhale.getLogs` reads the **host's** log, not the debuggee app's — use it to diagnose JetWhale
-itself, for example a plugin jar that failed to load.
+itself, for example a plugin jar that failed to load. It takes `limit` (default 200, maximum 1000),
+`level` and `contains` (a case-insensitive substring), and answers oldest-first with the matched and
+total counts. Individual messages longer than 2000 characters are truncated.
+
+`level` is `INFO` or `ERROR` — the buffer is the host's captured **stdout** and **stderr**, which is
+all the distinction there is. That is unrelated to the `--log-level` startup option, which decides
+how much the host writes to stdout in the first place.
+
+### `jetwhale.updateSettings`
+
+Every argument is optional; only the ones you supply are touched.
+
+| Argument | Type | What it changes |
+|----------|------|-----------------|
+| `serverPort` | integer | The plain **ws** debug server port. |
+| `wssPort` | integer | The **wss** port. |
+| `wssEnabled` | boolean | Whether the wss connector is exposed at all. |
+| `mcpServerPort` | integer | This server's port. Persisted only — see the warning below. |
+| `adbAutoPortMappingEnabled` | boolean | [ADB auto port mapping](/guide/adb-auto-port-mapping). |
+| `checkForUpdatesOnStartup` | boolean | The startup update check. |
+| `persistData` | boolean | Whether captured debug data survives a host restart. |
+| `restartDebugServer` | boolean | Whether to restart the debug server now. Defaults to `true` when any of `serverPort`, `wssPort`, `wssEnabled` or `adbAutoPortMappingEnabled` changed. |
+
+Ports are validated (`1..65535`) before anything is written, and a call that supplies no settings at
+all is rejected. The result reports exactly which keys were applied, whether the debug server was
+restarted, and notes explaining any deferred effect.
+
+### `jetwhale.navigate`
+
+| Argument | Required | Accepted values |
+|----------|----------|-----------------|
+| `destination` | yes | `HOME`, `PLUGIN`, `SETTINGS`, `INFO`, `LOG_VIEWER` |
+| `pluginId` | for `PLUGIN` | An installed, **enabled** plugin id. |
+| `sessionId` | no | Only for `PLUGIN`; defaults to the session already selected in the drawer. |
+| `settingsSection` | no | Only for `SETTINGS`: `GENERAL`, `SERVER`, `AI_AGENTS`, `PLUGINS`. Defaults to `GENERAL`. |
+
+Navigating to `PLUGIN` also selects that session in the drawer, which is what a subsequent
+`jetwhale.screenshot` of the same plugin will show. The call waits up to two seconds for the window
+to confirm, and reports `applied: false` with a reason if it does not.
+
+`jetwhale.getStatus` can report destinations the tool cannot request — `DISABLED_PLUGIN`, `LICENSES`
+and `MCP_TOOLS`. The tools browser in particular exists so a *person* can watch what an agent is
+doing, so an agent has no reason to send itself there.
 
 ::: warning Destructive host tools
 `jetwhale.restartDebugServer` — and `jetwhale.updateSettings` when it changes a ws/wss setting —
@@ -169,7 +262,10 @@ The [Network Inspector](/guide/network-inspector#mcp-tools) ships a full set of 
 (`com.kitakkun.jetwhale.network.*`) for reading captured traffic and managing mock rules, and the
 [Compose Semantics Inspector](/guide/compose-semantics-inspector#mcp-tools) contributes
 `com.kitakkun.jetwhale.semantics.*` for reading the **debuggee's** Compose node tree and invoking a
-node's own action — the structural counterpart to the coordinate-based `jetwhale.click` below.
+node's own action — the structural counterpart to the coordinate-based `jetwhale.click` above.
+
+A plugin's `mcpCommands` list is read **once per plugin instance activation** and treated as static
+for that instance's lifetime, so a list that changes at runtime is not picked up.
 
 ::: tip Sensitive values
 Plugin UIs can hide sensitive content from `jetwhale.screenshot` **and**
@@ -178,6 +274,31 @@ because the semantics tree carries the same strings the pixels do. The Network I
 [redaction rules](/guide/network-inspector#redacting-sensitive-values) support an `MCP_ONLY` scope
 that keeps values visible to you but hidden from AI agents.
 :::
+
+## The MCP tools browser
+
+The host has its own view of what agents can do and what they have done. Open it from the **wrench
+icon** at the top of the [drawer](/guide/host-window#the-rest-of-the-drawer), or from the **MCP
+badge** on a plugin's drawer row — which lands you already filtered to that plugin.
+
+Two filter rows across the top narrow everything below by **Plugin** and by **Session**. Each is a
+multi-select: pick as many values as you like from the dropdown (it stays open so you can add
+several), and remove one by clicking its chip. With nothing picked the filter reads *All*. A label at
+the right says *MCP available*, or *MCP executing* while a call is running.
+
+**Tools** — a searchable list of every tool in scope on the left (search matches the tool name, its
+description, and the plugin name), and the selected tool's detail on the right: its short and fully
+qualified names, the plugin that publishes it, its description, and each parameter with its type,
+whether it is **required**, and its description. A trailing badge counts how many times that tool has
+been called; while an agent is calling it, the badge takes an accent fill and a rotating ring.
+
+**History** — every call made in the current scope, newest first: the tool, the time of day, and
+whether it succeeded. Selecting one shows the arguments it was called with and the response it
+returned. Each section has an inline copy button, and **Copy details** takes the whole record — a
+right-click on a history row offers the same four copy actions.
+
+This is the fastest way to answer "what did the agent actually send, and what did it get back?" when
+a plugin behaves unexpectedly under automation.
 
 ::: warning The MCP port is unauthenticated
 The SSE endpoint has no authentication, so **any process on the machine** can reach it — and it is

--- a/docs/guide/nav3-navigator.md
+++ b/docs/guide/nav3-navigator.md
@@ -8,6 +8,12 @@ MCP.
 It is generic: it knows nothing about your screens. Everything it can show and construct is derived
 from the serializers your app **already** gives `rememberNavBackStack`.
 
+## Install the host plugin
+
+The Nav3 Navigator is in the host's **official catalog**: open **Settings → Plugins → Add Plugins →
+Official Plugins** and install it with one click — no coordinates needed. See
+[Host Settings → Plugins](/guide/host-settings#plugins) for the other install routes.
+
 ## Add it to your app
 
 The agent side is a normal dependency of the app being debugged:

--- a/docs/guide/network-inspector.md
+++ b/docs/guide/network-inspector.md
@@ -1,6 +1,6 @@
 # Network Inspector
 
-The Network Inspector is a built-in JetWhale plugin for inspecting the HTTP traffic of your app —
+The Network Inspector is an official JetWhale plugin for inspecting the HTTP traffic of your app —
 and for **mocking responses** without touching your backend.
 
 - 📡 Live view of HTTP transactions (request/response headers, bodies, timing)
@@ -14,6 +14,15 @@ and for **mocking responses** without touching your backend.
 It works with **Ktor** and **OkHttp** clients.
 
 ## Setup
+
+### Install the host plugin
+
+The Network Inspector is in the host's **official catalog**, so no coordinates are needed: open
+**Settings → Plugins → Add Plugins → Official Plugins** and install it with one click. The version
+matching your host is fetched automatically. See
+[Host Settings → Plugins](/guide/host-settings#plugins) for the other install routes.
+
+### Add the agent to your app
 
 Add the core agent plus the adapter for your HTTP client to the app being debugged:
 
@@ -106,6 +115,14 @@ transaction appears live as your app makes requests. Select a transaction to ins
 and response — headers, bodies (with a dedicated JSON view), and status. Use **copy** on a
 transaction to share it or reproduce the request elsewhere.
 
+The host keeps the **latest 500 transactions** per session; older ones are dropped as new traffic
+arrives. Use **clear** (or `com.kitakkun.jetwhale.network.clearTransactions`) before reproducing an
+issue so what you capture afterwards is only what the reproduction produced.
+
+Traffic captured while the host is away is **not** lost: the agent buffers up to **256** events
+(dropping the oldest past that) and flushes them on reconnect, so requests fired before you opened
+the host still show up.
+
 ## Redacting sensitive values
 
 Captured traffic often contains secrets — `Authorization` headers, session cookies, tokens in query
@@ -141,7 +158,34 @@ Without a `redaction` argument no rules apply and captured data is forwarded ver
 The Mocks view lets you define **mock rules** on the host and push them to the running app: when
 mocking is enabled, requests matching a rule get the mocked response instead of hitting the
 network. This is handy for reproducing error states, empty lists, or slow-path payloads without a
-test backend. Toggle mocking on/off at any time from the host — no app restart needed.
+test backend. Toggle **Mocking enabled** on/off at any time from the host — no app restart needed.
+
+### What a rule looks like
+
+**Add rule** opens an editor with these fields. The same shape is what the
+[MCP tools](#mcp-tools) take, so a rule written by hand and one written by an AI agent are
+interchangeable.
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| **Name** | empty | Human-readable label, shown in the list. |
+| **enabled** | on | Whether the rule takes effect. Rules can be parked without deleting them. |
+| **Method** | any | HTTP method to match, compared case-insensitively. Blank matches any method. |
+| **URL pattern** | — | The pattern, interpreted per the match type. |
+| **match type** | `CONTAINS` | `CONTAINS` (substring), `EXACT` (whole URL), or `REGEX` (a regex that must match somewhere in the URL). An invalid regex simply never matches. |
+| **Status** | `200` | Status code of the mocked response. |
+| **Content-Type** | none | Convenience field for the header of the same name. |
+| **Response body** | empty | The body to return. |
+| **Delay ms** | `0` | Artificial delay before the mocked response is delivered. |
+
+The **first enabled rule that matches** wins, so order the list from most specific to most general.
+Matching is identical in every adapter, because they share one implementation.
+
+::: tip The app owns the mock config
+The mock rules and the enabled flag live on the **agent**, not the host — they survive a host
+restart, and the host fetches them back when it reconnects. That is also why a rule you add applies
+immediately without restarting the app.
+:::
 
 ## MCP tools
 
@@ -150,15 +194,29 @@ an AI agent can read captured traffic and manage mock rules for a session:
 
 | Tool | What it does |
 |------|--------------|
-| `com.kitakkun.jetwhale.network.listTransactions` | Lists captured HTTP transactions |
-| `com.kitakkun.jetwhale.network.getTransaction` | Returns one transaction in full (headers, bodies, timing) |
+| `com.kitakkun.jetwhale.network.listTransactions` | Lists captured HTTP transactions, filterable |
+| `com.kitakkun.jetwhale.network.getTransaction` | Returns one transaction in full (headers, bodies, timing) — takes `txId` from `listTransactions` |
 | `com.kitakkun.jetwhale.network.clearTransactions` | Clears the captured transaction list |
 | `com.kitakkun.jetwhale.network.getMockConfig` | Returns the current mock rules and whether mocking is enabled |
-| `com.kitakkun.jetwhale.network.addMockRule` | Adds a mock rule |
-| `com.kitakkun.jetwhale.network.removeMockRule` | Removes a mock rule |
+| `com.kitakkun.jetwhale.network.addMockRule` | Adds one mock rule from flat arguments |
+| `com.kitakkun.jetwhale.network.removeMockRule` | Removes the rule with a given `id` |
+| `com.kitakkun.jetwhale.network.setMockRules` | Replaces the **whole** rule list in one call |
 | `com.kitakkun.jetwhale.network.setMockingEnabled` | Turns mocking on or off |
 
 Like every MCP tool, they take a required `sessionId` (from `jetwhale.listSessions`).
+
+`listTransactions` narrows a busy capture rather than dumping it: `limit`, `afterTxId` (everything
+recorded after a transaction you already have — the cheap way to poll), `sinceTimestampMs` /
+`untilTimestampMs`, `urlContains` and `method`.
+
+`addMockRule` takes the rule's fields flat (`urlPattern`, `matchType`, `method`, `name`,
+`statusCode`, `body`, `headers`, `contentType`, `delayMs`), appends one enabled rule with a generated
+id, and returns it. `contentType` is a convenience that only fills in a `Content-Type` header when
+`headers` did not already set one.
+
+`setMockRules` instead takes a JSON list of complete rules and **replaces** the whole set — the tool
+to reach for when setting up a scenario, editing a rule (reuse its `id`), or disabling one
+(`enabled: false`) rather than deleting it.
 
 [Redaction rules](#redacting-sensitive-values) apply to MCP output as well: values redacted with
 `RedactionScope.MCP_ONLY` are hidden from these tools' results **and** from `jetwhale.screenshot`

--- a/docs/guide/qa-agent.md
+++ b/docs/guide/qa-agent.md
@@ -1,0 +1,105 @@
+# QA Agent <Badge type="warning" text="experimental" />
+
+Testing a host plugin means having a **connected session** for it to render against — the plugin
+screen is empty without one. A demo app is a poor stand-in: it only fires the requests its buttons
+are wired to, and a GUI app cannot be driven from a script at all.
+
+The **JetWhale QA agent** is a headless debuggee for exactly this. It connects to the host as an
+ordinary debug session and exposes a small HTTP **control API** you drive from a terminal, a test, or
+an AI agent — so your plugin's host UI can be exercised end to end without writing an app.
+
+It is **plugin-agnostic**: you name the plugin ids it should impersonate, and `/send` / `/request`
+carry arbitrary messages to their host counterparts over the messaging layer's raw lane. There is no
+compile-time dependency on the plugin under test, so it works for plugins living outside this
+repository.
+
+## Running it
+
+The [`com.kitakkun.jetwhale.host`](/guide/developing-plugins) Gradle plugin adds a
+`runJetWhaleQaAgent` task to your plugin module. It resolves
+`com.kitakkun.jetwhale:jetwhale-qa-agent` at `jetwhalePlugin.qaAgentVersion`, falling back to
+`hostVersion`:
+
+```shell
+# Terminal 1 — the host with your plugin loaded
+./gradlew :myPlugin:runJetWhaleHot
+
+# Terminal 2 — a headless session for it to render
+./gradlew :myPlugin:runJetWhaleQaAgent
+```
+
+Pass the agent's own options with `-PjetwhaleQaAgentArgs` (space-separated):
+
+```shell
+./gradlew :myPlugin:runJetWhaleQaAgent \
+  -PjetwhaleQaAgentArgs="--plugin com.example.myplugin --port 5080"
+```
+
+| Option | Default | What it does |
+|--------|---------|--------------|
+| `--app <name>` | one app named `qa-agent` | Connect as an app of this name, as its own session. **Repeatable** — one process can hold several apps under one device, which is how the host groups them. Names must be unique. |
+| `--plugin <id>[@<version>]` | none | Register a raw-messaging plugin under this id so `/send` and `/request` can drive its host counterpart. Registered for **every** app. Repeatable; the version defaults to `1.0.0`. |
+| `--host <name>` | `localhost` | The JetWhale host to connect to. |
+| `--port <n>` | `5443` | The host's debug port. The agent trusts the host's active CA automatically, so the default is the **wss** port; pass `--port 5080` to use plain ws. |
+| `--control-port <n>` | `7100` | Port for the agent's own control API. |
+| `--help`, `-h` | — | Print the usage text and exit. |
+
+::: warning Address the control API as `127.0.0.1`
+It binds loopback IPv4 only. `localhost` may resolve to `::1` first and be refused.
+:::
+
+## The control API
+
+| Route | Body | What it does |
+|-------|------|--------------|
+| `GET /health` | — | `{status, ready, apps:{<name>:{connected, ready}}}`. **Poll this before sending anything**: the control API answers long before the debug session is up, and a send in that window is silently dropped. |
+| `GET /plugins` | — | Per registered plugin id: `{version, activated, ready, apps:{…}}`. `activated: false` means the host has that plugin **disabled**, so waiting will not help. |
+| `POST /send` | `{app?, pluginId, messageType, payload, policy?}` | Sends a fire-and-forget event. `policy` is `DROP` (default), `QUEUE` or `FAIL`. Answers `{sent, hint?}` — `hint` says *why* a `false` happened. |
+| `POST /request` | `{app?, pluginId, messageType, payload, timeoutMs?}` | Sends a request and waits for the host's reply: `{durationMs, reply}`. |
+| `POST /fire` | `{app?, url, method?, headers?, body?, contentType?}` | Issues a real HTTP request through an instrumented client, so the [Network Inspector](/guide/network-inspector) captures it. Answers `{status, durationMs, bodyPreview}`. |
+| `POST /disconnect` | `{app?}` | Gives one app's session up while the process keeps running — this is how the host's disconnect handling gets exercised. Terminal for that app. |
+| `POST /shutdown` | — | Stops the process. |
+
+`app` is optional while only one app is running; with several, a call that does not name one is
+rejected rather than guessed at. `messageType` is the **serial name** of the message class — the
+value `@SerialName` sets, or the fully-qualified class name by default.
+
+```shell
+curl -s 127.0.0.1:7100/health
+
+curl -s 127.0.0.1:7100/send -H 'Content-Type: application/json' -d '{
+  "pluginId": "com.example.myplugin",
+  "messageType": "com.example.myplugin.protocol.ItemAdded",
+  "payload": {"id": 1, "label": "hello"}
+}'
+```
+
+A host handler that fails, times out or was never registered comes back as
+`{"error": "..."}` with HTTP 200 — that is a legitimate QA finding about your plugin, not a
+control-API error, so it is reported as data.
+
+`/fire` is the one plugin-specific convenience: it needs no `--plugin`, because the Network
+Inspector's agent is always registered.
+
+::: warning Sending only
+The impersonated plugin exposes the messenger's raw lane, which is a send-side surface: inbound
+handlers resolve their serializer from a reified type parameter, so there is no catch-all shape to
+register. A host plugin that **requests the agent** — for example one that fetches state in
+`onPrepare()` — cannot be answered from the QA agent, and will see that request time out.
+:::
+
+## Driving the plugin's UI too
+
+The QA agent gives your plugin a session; the host's [MCP server](/guide/mcp-server) gives you its
+UI. Together they close the loop: `POST /send` to put your plugin into a state, then
+`jetwhale.screenshot` / `jetwhale.getAccessibilityTree` to check what it rendered and
+`jetwhale.click` / `jetwhale.type` to drive it.
+
+For automated runs where nobody is there to tick a permission checkbox, start the host with
+[`--mcp-allow-all-permissions`](/guide/mcp-server#lifting-every-permission-for-one-launch).
+
+## Inside this repository
+
+In-repo plugin modules get `runJetWhaleQaAgentLocal` as well, added by the internal
+`jetwhale-host-launch` convention. It runs the QA agent straight from the local `:tools:qa-agent`
+project instead of resolving a published artifact, and reads the same `-PjetwhaleQaAgentArgs`.

--- a/docs/guide/qa-agent.md
+++ b/docs/guide/qa-agent.md
@@ -52,7 +52,7 @@ It binds loopback IPv4 only. `localhost` may resolve to `::1` first and be refus
 
 | Route | Body | What it does |
 |-------|------|--------------|
-| `GET /health` | — | `{status, ready, apps:{<name>:{connected, ready}}}`. **Poll this before sending anything**: the control API answers long before the debug session is up, and a send in that window is silently dropped. |
+| `GET /health` | — | `{status, ready, apps:{<name>:{connected, ready}}}`. **Poll this before sending anything**: the control API answers long before the debug session is up, and a send in that window is dropped — `/send` reports it as `sent: false` with a `hint`, but nothing retries it for you. |
 | `GET /plugins` | — | Per registered plugin id: `{version, activated, ready, apps:{…}}`. `activated: false` means the host has that plugin **disabled**, so waiting will not help. |
 | `POST /send` | `{app?, pluginId, messageType, payload, policy?}` | Sends a fire-and-forget event. `policy` is `DROP` (default), `QUEUE` or `FAIL`. Answers `{sent, hint?}` — `hint` says *why* a `false` happened. |
 | `POST /request` | `{app?, pluginId, messageType, payload, timeoutMs?}` | Sends a request and waits for the host's reply: `{durationMs, reply}`. |

--- a/docs/guide/what-is-jetwhale.md
+++ b/docs/guide/what-is-jetwhale.md
@@ -53,5 +53,6 @@ Each session in the host shows a lock indicator for how its transport is secured
 ## Next steps
 
 - [Getting Started](/guide/getting-started) — install the host and integrate the agent into your app
+- [The Host Window](/guide/host-window) — sessions, the plugin drawer, and popping a plugin out
 - [Network Inspector](/guide/network-inspector) — inspect and mock HTTP traffic
 - [Developing Plugins](/guide/developing-plugins) — build your own debugging tools

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -49,7 +49,7 @@ stable — changing one breaks compatibility with older implementations — so t
 
 | Step | Agent → host | Host → agent |
 |------|--------------|--------------|
-| Protocol version | `negotiation/agent/protocol_version` | `negotiation/host/protocol_version_response/accept` or `.../reject` |
+| Protocol version | `negotiation/agent/protocol_version` | `negotiation/host/protocol_version_response/accept` or `negotiation/host/protocol_version_response/reject` |
 | Session | `negotiation/agent/session` | `negotiation/host/accept_session` |
 | Capabilities | `negotiation/agent/capabilities` | `negotiation/host/capabilities_response` |
 | Plugins | `negotiation/agent/available_plugins` | `negotiation/host/available_plugins_response` |

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -2,7 +2,13 @@
 
 This page describes the communication protocol used between the JetWhale debugger (host) and the
 debuggee application. The protocol is defined in the
-[`jetwhale-protocol`](https://github.com/kitakkun/JetWhale/tree/main/jetwhale-protocol) module.
+[`jetwhale-protocol`](https://github.com/kitakkun/JetWhale/tree/main/jetwhale-protocol) module,
+published as `com.kitakkun.jetwhale:jetwhale-protocol-core`.
+
+Messages travel as JSON over one WebSocket connection (plain **ws**, or **wss** when the agent
+configures a trusted certificate — see
+[Secure connections](/guide/getting-started#secure-connections-wss)). Every message carries a stable
+`type` discriminator; the current **protocol version is 2**.
 
 ## Two Phases Before Starting a Debugging Session
 
@@ -36,6 +42,30 @@ The negotiation phase consists of the following steps:
 5. **Debugging Session Start**: Once all the above negotiations are complete, the debugging session
    is ready to start.
 
+### Message catalog
+
+Each step is one request from the agent and one response from the host. The `type` discriminators are
+stable — changing one breaks compatibility with older implementations — so they are worth naming:
+
+| Step | Agent → host | Host → agent |
+|------|--------------|--------------|
+| Protocol version | `negotiation/agent/protocol_version` | `negotiation/host/protocol_version_response/accept` or `.../reject` |
+| Session | `negotiation/agent/session` | `negotiation/host/accept_session` |
+| Capabilities | `negotiation/agent/capabilities` | `negotiation/host/capabilities_response` |
+| Plugins | `negotiation/agent/available_plugins` | `negotiation/host/available_plugins_response` |
+
+A **reject** carries a human-readable `reason` and the versions the host does support. The session
+response carries the assigned `sessionId`, which the agent may send back in a later
+`negotiation/agent/session` to resume. The plugin response splits the agent's list into
+`availablePlugins` (paired, and enabled on the host) and `incompatiblePlugins` (the plugin exists on
+both sides, but the agent's `pluginVersion` falls outside the host plugin manifest's
+[`agentVersionRange`](/guide/developing-plugins#manifest-reference)); a plugin the host does not have
+at all is simply absent from both.
+
+Capabilities are exchanged as a plain `Map<String, String>` in both directions. Nothing consumes them
+yet — the step exists so future versions can negotiate optional features without another protocol
+version bump.
+
 ## Debugging Session
 
 During the debugging session, plugin messages travel as **plugin frames**, carried symmetrically in
@@ -50,3 +80,24 @@ is one of:
 Frames are addressed by plugin id and routed to that plugin's messaging peer on the receiving side.
 Notifications and requests are dispatched in arrival order; replies bypass the queue so a handler
 awaiting a reply is never blocked behind other traffic.
+
+On the wire a frame is one of `frame/notification`, `frame/request`, `frame/reply/success` or
+`frame/reply/failure`. A notification and a request both carry a `messageType` — the serial name of
+the concrete payload class — plus the payload as a serialized string; a request adds a
+`correlationId`, which the reply echoes back as `inReplyTo`. A reply needs no `messageType`, because
+the requester already knows the reply type from the request's `JetWhaleRequest<R>` declaration.
+
+Plugin frames are carried inside `event/agent/plugin_frame` and `event/host/plugin_frame`.
+
+### Plugin activation
+
+The host additionally sends two events of its own:
+
+| Message | Meaning |
+|---------|---------|
+| `event/host/plugin_activated` | The host enabled this plugin id for the session. The agent plugin's `onActivate()` runs, then `onPrepare()` for the current connection. |
+| `event/host/plugin_deactivated` | The host disabled it. The agent plugin's `onDeactivate()` runs. |
+
+Both carry only the `pluginId`. A **disconnect is not a deactivation**: the agent plugin stays
+activated across a reconnect, so one that buffers events keeps buffering. See
+[Developing Plugins](/guide/developing-plugins) for the lifecycle callbacks these drive.


### PR DESCRIPTION
Surveys the shipped surface area against `docs/` and fills the gaps.

## New pages

- `host-window.md` — the drawer, session selection, plugin enable/disable and pop-out, MCP badges, and the log viewer. The host window itself had no documentation.
- `qa-agent.md` — `jetwhale-qa-agent` is a published artifact with Gradle tasks and an HTTP control API, but had no coverage at all.

## Corrections

- `host-settings.md` described the old four-tab layout; the UI now has four sections over ten pages, and the wss port it listed as an editable Server field has no UI control.
- Fixed a broken anchor in `compose-semantics-inspector.md`.

## Additions

- The agent `connection` default is `localhost:8080` while the host listens on 5080 — a trap that was never stated. Also logging, stopping a session, reconnection behaviour, and the published artifact list.
- Parameter reference for the plugin UI MCP tools; argument tables for `updateSettings` / `navigate` / `getLogs`; the MCP tools browser.
- Network Inspector: mock-rule reference, `setMockRules`, `listTransactions` filters, the transaction cap and the offline buffer.
- `developing-plugins.md`: task table, extension properties, manifest and icon reference, storage details, and what the SDK deliberately does not provide.
- `protocol.md`: protocol version, message catalog, frame type names, plugin activation events.
- Host plugin install sections for the network, nav3, and semantics pages.

`jetwhale-bom` is deliberately left undocumented: it is not in `settings.gradle.kts`, its directory holds only stale build output, and one of the three artifacts its old POM manages no longer exists.

VitePress link checking passes.