### PR TITLE
feat(host): add a headless launch mode

### DIFF
--- a/.claude/skills/plugin-qa/SKILL.md
+++ b/.claude/skills/plugin-qa/SKILL.md
@@ -31,6 +31,29 @@ share this machine.
 `:jetwhale-host:app:run` also works and skips the plugin staging, but it uses the developer's real
 `~/.jetwhale` instead of a sandbox. Prefer `runJetWhaleLocal`.
 
+## Launch without a window (CI, or a machine with no display)
+
+Add `--headless` to either launcher. The agent WebSocket server, the MCP server, plugin instances
+and adb auto-wiring all come up as usual; only the window is skipped, so every MCP tool that works
+against a plugin's UI — screenshot, accessibility tree, click, drag, scroll, type — works unchanged.
+
+```bash
+./gradlew :jetwhale-plugins:<plugin>:host:runJetWhaleLocal \
+  --args="--headless --server-port 5081 --wss-port 5444 --mcp-server-port 7081 --mcp-allow-all-permissions"
+
+# Or, without staging a plugin (`-PjetwhaleAppDataDir` keeps it out of the real ~/.jetwhale):
+./gradlew :jetwhale-host:app:runHeadless -PjetwhaleAppDataDir=/tmp/jetwhale-ci \
+  --args="--server-port 5081 --wss-port 5444 --mcp-server-port 7081 --mcp-allow-all-permissions"
+```
+
+A headless run prints `JetWhale headless: ready` on stdout once both listeners are bound — wait for
+that line rather than sleeping. Unlike a windowed run, it **exits 1** if a port is taken, so the
+"two hosts silently fighting over one port" failure surfaces immediately.
+
+What is not there: `jetwhale.navigate` reports `applied: false` (there is no window to navigate),
+and nothing enables a plugin for you — either reuse an app-data dir where it is already enabled, or
+call `jetwhale.setPluginEnabled` over MCP first.
+
 ## Run the QA agent from this build
 
 ```bash

--- a/jetwhale-host/app/build.gradle.kts
+++ b/jetwhale-host/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.process.CommandLineArgumentProvider
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
@@ -93,6 +94,29 @@ tasks.withType<org.gradle.jvm.tasks.Jar>().matching { it.name.contains("UberJar"
 
 compose.resources {
     packageOfResClass = "com.kitakkun.jetwhale.host"
+}
+
+// Headless launch, for CI and agent-driven QA: the same entry point and the same DI graph as the
+// windowed `run` task, minus the window. Host options go through `--args`, e.g.
+// `--args="--server-port 5081 --wss-port 5444 --mcp-server-port 7081 --mcp-allow-all-permissions"`.
+tasks.register<JavaExec>("runHeadless") {
+    group = "application"
+    description = "Runs the JetWhale host with no GUI window — agent WebSocket server, MCP server, plugins and adb auto-wiring only."
+
+    mainClass.set("com.kitakkun.jetwhale.host.MainKt")
+    classpath = sourceSets.main.get().runtimeClasspath
+
+    // Prepended, so a caller's `--args` cannot end up before the flag that selects this mode.
+    argumentProviders.add(CommandLineArgumentProvider { listOf("--headless") })
+
+    // A CI run must not share the developer's `~/.jetwhale`: `-PjetwhaleAppDataDir=<path>` gives it
+    // its own settings, plugin jars and trust registry.
+    val appDataDir = providers.gradleProperty("jetwhaleAppDataDir")
+    jvmArgumentProviders.add(
+        CommandLineArgumentProvider {
+            appDataDir.map { listOf("-Djetwhale.appDataDir=$it") }.getOrElse(emptyList())
+        },
+    )
 }
 
 val aboutLibrariesDir = layout.buildDirectory.dir("generated/aboutlibraries")

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.painterResource
 import java.awt.Taskbar
 import javax.imageio.ImageIO
+import kotlin.system.exitProcess
 
 /**
  * Applies the application name and icon at runtime so they are correct even when the host is
@@ -56,9 +57,16 @@ private val DefaultWindowSize = DpSize(1280.dp, 800.dp)
 
 @OptIn(FlowPreview::class)
 fun main(args: Array<String>) = runBlocking {
-    configureAppMetadata()
-
     val cliOptions = CommandLineArgumentsParser().parse(args)
+
+    if (cliOptions.headless) {
+        // AWT reads this once, when its first class is loaded, so it has to be set before anything
+        // else here touches AWT. A headless run has no window to attach to, and a CI machine has no
+        // display for AWT to find.
+        System.setProperty("java.awt.headless", "true")
+    } else {
+        configureAppMetadata()
+    }
 
     val appGraph: JetWhaleAppGraph = createGraphFactory<JetWhaleAppGraph.Factory>()
         .create(
@@ -70,6 +78,11 @@ fun main(args: Array<String>) = runBlocking {
     appGraph.logCaptureService.startCapture()
 
     appGraph.applicationLifecycleOwner.initialize()
+
+    if (cliOptions.headless) {
+        // Serves until signalled; the window and everything that drives it stays uncreated.
+        exitProcess(appGraph.headlessHostRunner.run())
+    }
 
     val persistedWindowState = appGraph.windowStateRepository.loadWindowState()
     val initialWindowSize = persistedWindowState

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsParser.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsParser.kt
@@ -8,6 +8,8 @@ data class JetWhaleCliOptions(
     val logLevel: JetWhaleLogLevel,
     val serverPortOverrides: ServerPortOverrides,
     val mcpPermissionOverride: McpPermissionOverride,
+    /** Runs the servers with no window, for CI and agent-driven QA. See [com.kitakkun.jetwhale.host.headless.HeadlessHostRunner]. */
+    val headless: Boolean,
 )
 
 enum class JetWhaleLogLevel {
@@ -25,6 +27,7 @@ class CommandLineArgumentsParser {
         var wssPort: Int? = null
         var mcpServerPort: Int? = null
         var mcpAllowAllPermissions = false
+        var headless = false
 
         val iterator = args.iterator()
 
@@ -60,6 +63,8 @@ class CommandLineArgumentsParser {
 
                 "--mcp-allow-all-permissions" -> mcpAllowAllPermissions = true
 
+                "--headless" -> headless = true
+
                 else -> {
                     // Ignore unknown arguments
                 }
@@ -75,6 +80,7 @@ class CommandLineArgumentsParser {
                 mcpServerPort = mcpServerPort,
             ),
             mcpPermissionOverride = McpPermissionOverride(allowAll = mcpAllowAllPermissions),
+            headless = headless,
         )
     }
 

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
@@ -5,6 +5,7 @@ import com.kitakkun.jetwhale.host.BuildConfig
 import com.kitakkun.jetwhale.host.architecture.ScreenContext
 import com.kitakkun.jetwhale.host.drawer.McpToolsScreenContext
 import com.kitakkun.jetwhale.host.drawer.ToolingScaffoldScreenContext
+import com.kitakkun.jetwhale.host.headless.HeadlessHostRunner
 import com.kitakkun.jetwhale.host.mcp.McpServerService
 import com.kitakkun.jetwhale.host.model.AppearanceSettingsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
@@ -38,6 +39,7 @@ import soil.query.SwrClientPlus
 @DependencyGraph(AppScope::class)
 interface JetWhaleAppGraph : ScreenContext {
     val applicationLifecycleOwner: ApplicationLifecycleOwner
+    val headlessHostRunner: HeadlessHostRunner
     val mcpServerService: McpServerService
     val swrClient: SwrClientPlus
 

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/headless/HeadlessHostRunner.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/headless/HeadlessHostRunner.kt
@@ -1,0 +1,155 @@
+package com.kitakkun.jetwhale.host.headless
+
+import com.kitakkun.jetwhale.host.ApplicationLifecycleOwner
+import com.kitakkun.jetwhale.host.mcp.McpServerService
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
+import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
+import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.McpServerStatus
+import com.kitakkun.jetwhale.host.model.PluginComposeSceneService
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+
+/** Exit code reported when a listener could not be brought up. */
+private const val EXIT_CODE_STARTUP_FAILED = 1
+
+/** How long to wait for both listeners to report a bound port before giving up on the run. */
+private const val STARTUP_TIMEOUT_MILLIS = 60_000L
+
+/** How long a signalled process may spend releasing its ports and adb port mappings. */
+private const val SHUTDOWN_TIMEOUT_MILLIS = 10_000L
+
+/** Prefix every readiness line carries, so a CI script can wait on it without parsing log output. */
+private const val READINESS_PREFIX = "JetWhale headless:"
+
+/**
+ * Runs the host with no window: the agent WebSocket server, the MCP server, plugin instances and
+ * adb auto-wiring, but no composition.
+ *
+ * The servers themselves are started by [ApplicationLifecycleOwner] and need no window. This adds
+ * back only what the composition would otherwise be responsible for in a windowed run:
+ * - disposing plugin compose scenes as sessions and plugins go away (`JetWhaleApp` does this from
+ *   the composition, which never runs here), and
+ * - keeping the process alive until it is asked to stop.
+ *
+ * It also reports the ports it actually bound, and fails the run if it could not bind them: a
+ * second host on the same ports leaves the first one serving and the second one silently useless,
+ * which is invisible without a window to look at.
+ */
+@Inject
+@SingleIn(AppScope::class)
+class HeadlessHostRunner(
+    private val applicationLifecycleOwner: ApplicationLifecycleOwner,
+    private val debugWebSocketServer: DebugWebSocketServer,
+    private val mcpServerService: McpServerService,
+    private val enabledPluginsRepository: EnabledPluginsRepository,
+    private val pluginComposeSceneService: PluginComposeSceneService,
+) {
+    /**
+     * Suspends until the host is asked to shut down, and returns the process exit code.
+     *
+     * [ApplicationLifecycleOwner.initialize] must already have been called: this waits for the
+     * listeners it starts.
+     */
+    suspend fun run(): Int = coroutineScope {
+        installShutdownHook()
+
+        val sceneHousekeepingJob = launch { disposeScenesForDepartedSessions() }
+
+        val startup = withTimeoutOrNull(STARTUP_TIMEOUT_MILLIS) { awaitListeners() }
+            ?: ListenerStartup.Failed("A listener did not report a bound port within $STARTUP_TIMEOUT_MILLIS ms.")
+
+        if (startup is ListenerStartup.Failed) {
+            System.err.println("$READINESS_PREFIX startup failed — ${startup.reason}")
+            sceneHousekeepingJob.cancel()
+            shutdownAndAwait()
+            return@coroutineScope EXIT_CODE_STARTUP_FAILED
+        }
+
+        println("$READINESS_PREFIX ready")
+
+        applicationLifecycleOwner.applicationStateFlow.first { it == ApplicationLifecycleOwner.ApplicationState.STOPPED }
+        sceneHousekeepingJob.cancel()
+        0
+    }
+
+    private sealed interface ListenerStartup {
+        data object Ready : ListenerStartup
+        data class Failed(val reason: String) : ListenerStartup
+    }
+
+    /** Waits for both listeners, reporting the ports they bound or why they could not bind them. */
+    private suspend fun awaitListeners(): ListenerStartup {
+        val webSocketStatus = debugWebSocketServer.statusFlow
+            .first { it is DebugWebSocketServerStatus.Started || it is DebugWebSocketServerStatus.Error }
+        if (webSocketStatus is DebugWebSocketServerStatus.Error) {
+            return ListenerStartup.Failed("agent WebSocket server: ${webSocketStatus.message}")
+        }
+        val started = webSocketStatus as DebugWebSocketServerStatus.Started
+        println("$READINESS_PREFIX agent ws://${started.host}:${started.port}" + (started.wssPort?.let { " wss port $it" } ?: ""))
+
+        val mcpStatus = mcpServerService.statusFlow
+            .first { it is McpServerStatus.Running || it is McpServerStatus.Error }
+        if (mcpStatus is McpServerStatus.Error) {
+            return ListenerStartup.Failed("MCP server: ${mcpStatus.message}")
+        }
+        val running = mcpStatus as McpServerStatus.Running
+        println("$READINESS_PREFIX mcp http://${running.host}:${running.port}/sse")
+
+        return ListenerStartup.Ready
+    }
+
+    /**
+     * Closes plugin compose scenes whose session, server or plugin has gone away.
+     *
+     * Scenes are created on demand by the MCP tools even with no window, so without this a headless
+     * run keeps composing plugin code for sessions that have already disconnected.
+     */
+    private suspend fun disposeScenesForDepartedSessions(): Unit = coroutineScope {
+        launch {
+            debugWebSocketServer.sessionClosedFlow.collect { sessionId ->
+                pluginComposeSceneService.disposePluginSceneForSession(sessionId)
+            }
+        }
+        launch {
+            debugWebSocketServer.serverStoppedFlow.collect {
+                pluginComposeSceneService.disposeAllPluginScenes()
+            }
+        }
+        launch {
+            enabledPluginsRepository.disabledPluginIdFlow.collect { pluginId ->
+                pluginComposeSceneService.disposePluginScenesForPlugin(pluginId)
+            }
+        }
+    }
+
+    /**
+     * Makes SIGINT/SIGTERM a graceful stop. Without it the JVM dies with its ports still bound from
+     * the OS's point of view and its adb port mappings still installed on attached devices.
+     */
+    private fun installShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                applicationLifecycleOwner.shutdown()
+                runBlocking { awaitStopped() }
+            },
+        )
+    }
+
+    private suspend fun shutdownAndAwait() {
+        applicationLifecycleOwner.shutdown()
+        awaitStopped()
+    }
+
+    private suspend fun awaitStopped() {
+        withTimeoutOrNull(SHUTDOWN_TIMEOUT_MILLIS) {
+            applicationLifecycleOwner.applicationStateFlow.first { it == ApplicationLifecycleOwner.ApplicationState.STOPPED }
+        }
+    }
+}

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsResolverTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsResolverTest.kt
@@ -6,6 +6,8 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class CommandLineArgumentsResolverTest {
     @Test
@@ -115,6 +117,21 @@ class CommandLineArgumentsResolverTest {
         val options = CommandLineArgumentsParser().parse(arrayOf("--mcp-allow-all-permissions"))
 
         assertEquals(McpPermissionOverride(allowAll = true), options.mcpPermissionOverride)
+    }
+
+    @Test
+    fun `a launch is windowed unless the headless flag is passed`() {
+        val options = CommandLineArgumentsParser().parse(arrayOf("--server-port", "5081"))
+
+        assertFalse(options.headless)
+    }
+
+    @Test
+    fun `the headless flag takes no value and runs the servers without a window`() {
+        val options = CommandLineArgumentsParser().parse(arrayOf("--headless", "--server-port", "5081"))
+
+        assertTrue(options.headless)
+        assertEquals(5081, options.serverPortOverrides.serverPort)
     }
 
     @Test


### PR DESCRIPTION
Runs the host without opening the Compose Desktop window, so CI and agent-driven QA can use the agent WebSocket server, the MCP server, and plugin instances without a display.

Host plugins do not need a window: plugin state lives in the plugin instance and is fed by wire message handlers, and plugin Compose scenes are created lazily and rendered on demand by the MCP tools that need them.

`--headless` sets `java.awt.headless` before AWT loads, skips the application window, awaits both listeners and reports their bound ports, and installs a graceful stop on SIGTERM/SIGINT. Failing to bind a port exits non-zero rather than leaving a host running that cannot serve.

Adds a `runHeadless` Gradle task, with `-PjetwhaleAppDataDir` for an isolated app-data root.

```
./gradlew :jetwhale-host:app:runHeadless -PjetwhaleAppDataDir=/tmp/jetwhale-ci \
  --args="--server-port 5081 --wss-port 5444 --mcp-server-port 7081 --mcp-allow-all-permissions"
```

## Verified

The QA agent connects and `/health` reports `ready`; `jetwhale.screenshot` returns a real PNG; the accessibility tree reflects live recomposed state after firing traffic; `jetwhale.click` selects a row and swaps the detail pane. Port collision fails fast with `Address already in use`. `:jetwhale-host:app:test` passes.

## Known limits

- `jetwhale.navigate` cannot work headless — it drives the main window's back stack, so it always fails its confirmation wait.
- A fresh app-data dir enables no plugins (`DefaultEnabledPluginsRepository` defaults to an empty set); use `jetwhale.setPluginEnabled` or reuse a configured app-data dir.
- Scene density stays at 1.0 since no window reports one. MCP tools pass explicit sizes, so layout is deterministic rather than HiDPI-matched.
- Trust approval for new jars remains a settings-UI action; headless loads already-trusted jars plus the dev-plugins dir.

`docs/guide/` is not updated here — the docs branch was written in parallel and deliberately left `--headless` out as unmerged work. Worth adding once this lands.

---

## Benchmarked: this is a capability change, not a speed-up

Measured on an M-series Mac against the Network Inspector, driving MCP over SSE directly. Two launch
layers were timed separately so Gradle overhead could be isolated; distinct port sets per mode with a
bind probe before every run; one seeded app-data template cloned per run; runs interleaved with run 0
discarded as warm-up.

**Cold start to serving** (direct JVM, ms to first successful MCP call, n=7):

```
headless  1328 1393 1420 1425 1441 1452 1520   median 1425
windowed  1632 1690 1698 1705 1724 1761 1896   median 1705
```

280 ms (16%), distributions do not overlap. Via `./gradlew` with a warm daemon and the configuration
cache reused, ~710 ms of Gradle overhead lands on both modes equally and the saving survives intact:
2421 ms → 2131 ms.

**End-to-end QA scenario** (launch → connect → enable → fire 8 requests → screenshot → tree → click
→ verify → stop, n=5): 8520 ms → 8169 ms, **4.1%**. Nearly all of it is the startup delta, and most
of that is handed straight back — see below.

Per-call medians:

| call | headless | windowed |
|---|---|---|
| `screenshot`, viewport and density pinned | 129 ms | 129 ms |
| `screenshot`, as-is | 71 ms | 115 ms |
| `getAccessibilityTree` | 9 ms | 7 ms |
| `click` | 8 ms | 8 ms |
| traffic → visible in the tree | **523 ms** | **147 ms** |
| `setPluginEnabled` | 2039 ms | 2015 ms |

**Rendering Compose headless is not slower — it is identical.** With viewport and density pinned the
two modes rasterise within 1 ms. The as-is gap is density, not mode: both PNGs are 1280×720, but
headless renders at density 1.0 while the Retina window renders at 2.0.

**Concurrency is not the win.** Three windowed hosts parallelise fine on a machine with a display —
three windows opened and all nine scenarios passed. Headless parallel beats windowed parallel by ~10%
at the median (8505/8609/8839 vs 9451/9584/15899 ms); its only real advantage is spread, windowed
producing one run where all three scenarios slowed to ~15.7 s.

**Resources are the solid gain**: peak RSS 445 MB vs 525 MB, user CPU 6.5 s vs 8.6 s — ~15% memory
and ~25% CPU, which compounds when fanning out.

### What this means

Judged as a speed-up for interactive QA on a developer's Mac, this does not pay for its complexity.
The 16% startup number should not be quoted on its own: the end-to-end gain is 4%, and 376 ms of the
351 ms saved is given back by slower state→UI propagation — a plugin that fires more state updates
would come out behind.

What justifies the feature is that windowed mode does not exist without a display. A windowed host
launched with `-Djava.awt.headless=true` dies with `java.awt.HeadlessException` and exits 1. On CI
there is no alternative to compare against.

### Two findings worth acting on separately

- **Density differs by mode, and that is a QA hazard**: the same row sits at y=165 headless and
  y=330 windowed. Coordinates must be read from the accessibility tree per mode, never carried
  across. Worth a documentation note.
- **State→UI propagation is 3.5× slower headless** (523 ms vs 147 ms, consistent across all runs).
  Unexplained; worth its own investigation.

Unrelated to this PR but found on the way: `setPluginEnabled` costs ~2.0 s in *both* modes — 25% of
the whole scenario — dominated by the plugin's `onPrepare` `network/get_mock_config` request timing
out against the QA agent, which is send-only by design.
