### PR TITLE
feat(host): add the Compose Semantics Inspector to the official plugin catalog

### DIFF
--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -86,16 +86,9 @@ Two views of it are available, switchable in the host and per MCP call:
 
 ### Install the host plugin
 
-The Compose Semantics Inspector is **not** in the host's official catalog yet, so install it by
-coordinates: **Settings → Plugins → Add Plugins → Install from Maven**, repository *Maven Central*,
-and
-
-```
-com.kitakkun.jetwhale:jetwhale-compose-semantics-inspector:<version>
-```
-
-where `<version>` is your host's version (shown under **Settings → General → Application**). Pasting
-that whole line into the dialog's **Paste coordinates** field fills the rest in for you. See
+The Compose Semantics Inspector is in the host's **official catalog**, so no coordinates are needed:
+open **Settings → Plugins → Add Plugins → Official Plugins** and install it with one click. The
+version matching your host is fetched automatically. See
 [Host Settings → Plugins](/guide/host-settings#plugins) for the other install routes.
 
 ### Add the agent to your app

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -156,10 +156,11 @@ The **Installed Plugins** page lists what is loaded; **Add Plugins** is where ne
 Installed plugins live in `~/.jetwhale/plugins/`. There are three ways to install one:
 
 - **Official Plugins** — one-click install from the official catalog, no coordinates needed. The
-  catalog currently holds the [Network Inspector](/guide/network-inspector) and the
-  [Nav3 Navigator](/guide/nav3-navigator). The artifact version matching the running host is fetched
-  from Maven Central, falling back to the matching snapshot build when the release is not
-  published yet (snapshot hosts fetch their matching snapshot directly).
+  catalog currently holds the [Network Inspector](/guide/network-inspector), the
+  [Nav3 Navigator](/guide/nav3-navigator) and the
+  [Compose Semantics Inspector](/guide/compose-semantics-inspector). The artifact version matching
+  the running host is fetched from Maven Central, falling back to the matching snapshot build when
+  the release is not published yet (snapshot hosts fetch their matching snapshot directly).
 - **Install from Maven** — enter the plugin's `group:artifact:version` and pick a repository
   preset (Maven Central, Central Snapshots, Google, JitPack) or a custom URL. Pasting a plain
   coordinate line (optionally with `@https://your.repo/url`), a Gradle dependency line, or a Maven

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/OfficialPluginCatalog.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/OfficialPluginCatalog.kt
@@ -59,5 +59,11 @@ object OfficialPluginCatalog {
             description = "Inspect and drive the Navigation 3 back stack of connected debug sessions.",
             artifactId = "jetwhale-nav3-navigator",
         ),
+        OfficialPlugin(
+            pluginId = "com.kitakkun.jetwhale.semantics",
+            displayName = "Compose Semantics Inspector",
+            description = "Browse and drive the Compose node tree of connected debug sessions.",
+            artifactId = "jetwhale-compose-semantics-inspector",
+        ),
     )
 }


### PR DESCRIPTION
## Summary

The Compose Semantics Inspector host plugin is published to Maven Central as `com.kitakkun.jetwhale:jetwhale-compose-semantics-inspector`, but it was never listed in `OfficialPluginCatalog` — so the only way to install it was to paste coordinates into **Install from Maven**.

This adds the catalog entry, which makes it installable from the app in one click.

## Changes

- `OfficialPluginCatalog` — new `OfficialPlugin` entry (`pluginId = com.kitakkun.jetwhale.semantics`, `artifactId = jetwhale-compose-semantics-inspector`). It surfaces in two places at once, since both read the same catalog:
  - **Settings → Plugins → Add Plugins → Official Plugins**, one-click install.
  - The `jetwhale.installOfficialPlugin` MCP tool, which by design only accepts catalog entries.
- Docs — the Compose Semantics Inspector setup section now describes the one-click route instead of the manual coordinates, and the catalog list in Host Settings mentions it.

No publishing changes were needed: the module already configures `jetwhalePublish`, and `installCandidatesFor` falls back to the matching `-SNAPSHOT` for host versions whose plugin release is not out yet.

## Testing

- `./gradlew :jetwhale-host:core:model:test :jetwhale-host:core:mcp:test :jetwhale-host:feature:settings:compileKotlin`