### PR TITLE
docs: correct the iOS and web platform support of the semantics plugin

### DIFF
--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -238,7 +238,7 @@ The capture and action layer is written against `SemanticsOwner`, which lives in
 |---|---|---|
 | **Android** | ✅ | `installJetWhaleSemanticsProbe(application)`, or `JetWhaleSemanticsProbe()` in a composition |
 | **Desktop (JVM)** | ✅ | `JetWhaleSemanticsProbe()` inside your `Window { }` |
-| iOS, JS, Wasm | — | register a `SemanticsOwner` yourself (below) |
+| iOS, JS, Wasm | — | not yet reachable — see [iOS and web](#ios-and-web) |
 
 Those are the targets the agent artifact ships for — Compose Multiplatform's own set. Linux, mingw
 and macOS are absent: the first two have no `androidx.compose.ui` at all, and macOS needs the whole
@@ -250,7 +250,25 @@ a composition. Desktop has no such callback, so its probe is scoped to a window 
 that window appears and disappears on its own. A second `Window { }` is a second composition and
 needs its own call.
 
-On a target with no probe, register an owner you already hold and everything else works unchanged:
+### iOS and web
+
+There is no probe on iOS, JS or Wasm because Compose Multiplatform currently hands out no
+`SemanticsOwner` on those targets — not to a probe, and not to your own code either.
+
+`ComposeUIViewController`, `ComposeUIView` and `ComposeViewport` build their `ComposeScene`
+internally. `PlatformContext.SemanticsOwnerListener` is the seam that would deliver the owners, but
+it is only consulted for a scene the caller constructs, so an app cannot supply one. Nor is there a
+route from inside the composition: `SemanticsNode.root` is public, but reaching a `SemanticsNode`
+needs an owner to begin with.
+
+Desktop was in the same position until Compose Multiplatform 1.10 exposed
+`ComposeWindow.semanticsOwners`; iOS and web have no equivalent yet. The plugin's capture and action
+layer is already common code, so a probe for both targets is a small addition once an owner can be
+reached.
+
+Until then, `registerSemanticsOwner` is the seam to use for any host you build yourself on top of
+`ComposeScene` — including `ImageComposeScene`, whose `semanticsOwners` *is* available on these
+targets:
 
 ```kotlin
 import com.kitakkun.jetwhale.plugins.semantics.agent.ComposeNodeSourceRegistry
@@ -275,7 +293,7 @@ your classpath; pass your own `ComposeUiThread` to `registerSemanticsOwner` if t
 
 **"The app reported no Compose root."** No probe is installed. Add
 `installJetWhaleSemanticsProbe(application)`, or `JetWhaleSemanticsProbe()` inside your
-composition.
+composition. On iOS, JS and Wasm this is expected — see [iOS and web](#ios-and-web).
 
 **A dialog's contents are missing.** A dialog is a separate Compose root. The Application-level
 probe finds it; an in-composition probe only registers the root it was called in.

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -238,7 +238,7 @@ The capture and action layer is written against `SemanticsOwner`, which lives in
 |---|---|---|
 | **Android** | ✅ | `installJetWhaleSemanticsProbe(application)`, or `JetWhaleSemanticsProbe()` in a composition |
 | **Desktop (JVM)** | ✅ | `JetWhaleSemanticsProbe()` inside your `Window { }` |
-| iOS, JS, Wasm | — | not yet reachable — see [iOS and web](#ios-and-web) |
+| iOS, JS, Wasm | — | the standard entry points expose no owner — see [iOS and web](#ios-and-web) |
 
 Those are the targets the agent artifact ships for — Compose Multiplatform's own set. Linux, mingw
 and macOS are absent: the first two have no `androidx.compose.ui` at all, and macOS needs the whole
@@ -252,8 +252,8 @@ needs its own call.
 
 ### iOS and web
 
-There is no probe on iOS, JS or Wasm because Compose Multiplatform currently hands out no
-`SemanticsOwner` on those targets — not to a probe, and not to your own code either.
+There is no probe on iOS, JS or Wasm because Compose Multiplatform hands out no `SemanticsOwner` for
+the scene your app actually shows — not to a probe, and not to your own code either.
 
 `ComposeUIViewController`, `ComposeUIView` and `ComposeViewport` build their `ComposeScene`
 internally. `PlatformContext.SemanticsOwnerListener` is the seam that would deliver the owners, but

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsOwnerNodeSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsOwnerNodeSource.kt
@@ -79,8 +79,9 @@ private fun SemanticsOwner.findNodeById(id: Int): SemanticsNode? = getAllSemanti
 /**
  * Registers a [SemanticsOwner] the caller already holds and keeps alive itself.
  *
- * The platform probes ([installJetWhaleSemanticsProbe] on Android, [JetWhaleSemanticsProbe] on
- * either platform) find owners for you; reach for this only on a target with no probe of its own.
+ * The Android and desktop probes find owners for you; reach for this when you host a `ComposeScene`
+ * yourself and so already hold one. iOS and web have no probe because Compose Multiplatform exposes
+ * no owner for their entry points — see the Compose Semantics Inspector guide.
  *
  * @see SemanticsOwnerNodeSource
  */


### PR DESCRIPTION
## What

Rewrites the **Platform support** section of the Compose Semantics Inspector guide, and the matching
`registerSemanticsOwner` KDoc, so they describe what iOS and web can actually do today.

## Why

The guide told readers that on iOS, JS and Wasm they should "register a `SemanticsOwner` yourself".
That is not actionable: on those targets there is no way for an app to obtain one.

Verified against the public ABI of `org.jetbrains.compose.ui:ui` 1.11.1 and 1.12.0-beta02
(`klib dump-abi` on `ui-iosarm64` and `ui-wasm-js`):

- `ComposeUIViewController`, `ComposeUIView` and `ComposeViewport` construct their `ComposeScene`
  internally. `PlatformContext.SemanticsOwnerListener` and `PlatformContext.RootForTestListener` are
  the right shape, but they are only consulted for a scene the caller constructs, so an app cannot
  supply either.
- There is no route from inside the composition either. `SemanticsNode.root: RootForTest?` is
  public, but reaching a `SemanticsNode` needs an owner to begin with, and `DelegatableNode` exposes
  `requireDensity()` / `requireLayoutCoordinates()` but nothing that reaches the owner.
- `SkikoComposeUiTest` builds its own scene, so it cannot attach to one the app already created.

Desktop was in the same position until Compose Multiplatform 1.10 exposed
`ComposeWindow.semanticsOwners` (CMP-8824, compose-multiplatform-core#2358, whose stated motivation
is letting external tools examine the UI structure). iOS and web have no equivalent yet.

## What changed

- `docs/guide/compose-semantics-inspector.md` — the support table now points iOS/JS/Wasm at a new
  **iOS and web** section that explains what is blocked and why. `registerSemanticsOwner` is
  repositioned as the seam for a host you build on `ComposeScene` yourself, including
  `ImageComposeScene`, whose `semanticsOwners` *is* available on these targets. The
  "no Compose root" troubleshooting entry now says this is expected there.
- `SemanticsOwnerNodeSource.kt` — the `registerSemanticsOwner` KDoc says the same thing, and drops
  two KDoc links that never resolved from `commonMain` because they name platform-only declarations.

Documentation and comments only; no behaviour change.

## Follow-up

A probe for both targets is a small addition to the existing common capture layer once an owner can
be reached, so the next step is an upstream request for the iOS/web counterpart of
`ComposeWindow.semanticsOwners`. Not filed yet.