### PR TITLE
docs: document headless mode

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -19,6 +19,10 @@ The `com.kitakkun.jetwhale.host` plugin gives your plugin's module these tasks:
 | `runJetWhaleHot`         | Like `runJetWhale`, but runs the host on the JetBrains Runtime so structural changes hot-reload in place (see [Limitations](#limitations)), and auto re-stages your plugin in the background — the whole hot-reload loop in one command. |
 | `runJetWhaleQaAgent`     | Runs a headless debuggee your plugin can render against, driven over HTTP — see [QA Agent](/guide/qa-agent). |
 
+Pass `--args="--headless"` to `runJetWhale` to launch the host without its window, which is how a
+plugin is exercised on a machine with no display — see
+[Headless mode](/guide/host-settings#headless-mode).
+
 `runJetWhale` and `runJetWhaleHot` launch the host on a **Java 21** toolchain (`runJetWhaleHot`
 additionally requires the JetBrains vendor), independently of the toolchain your plugin module
 itself compiles with.

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -279,9 +279,9 @@ rather than as a bind failure later. Unrecognized arguments are ignored.
 
 ### Headless mode
 
-`--headless` runs the host without opening its window. The agent WebSocket server, the MCP server
-and plugin instances all come up as usual, so a CI job or an AI agent can drive plugins on a machine
-with no display.
+`--headless` runs the host without opening its window. The debug server, the MCP server and plugin
+instances all come up as usual, so a CI job or an AI agent can drive plugins on a machine with no
+display.
 
 ```bash
 ./gradlew :myPlugin:runJetWhale \

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -272,9 +272,47 @@ When you launch the host from a plugin project with
 | `--plugin-dir <path>` | — | Load plugins from an additional directory, on top of `~/.jetwhale/plugins/`. **Repeatable.** |
 | `--log-level <level>` | `WARN` | Minimum level the host's own logging emits: `DEBUG`, `INFO`, `WARN` or `ERROR`. Raise it when diagnosing a plugin that will not load, then read the result in the [log viewer](/guide/host-window#the-log-viewer). |
 | `--mcp-allow-all-permissions` | off | Allows every MCP tool for that process only — see [MCP Server → Lifting every permission for one launch](/guide/mcp-server#lifting-every-permission-for-one-launch). |
+| `--headless` | off | Runs without the application window — see [Headless mode](#headless-mode) below. |
 
 Ports are validated at parse time (they must be in `1..65535`), so a typo is reported immediately
 rather than as a bind failure later. Unrecognized arguments are ignored.
+
+### Headless mode
+
+`--headless` runs the host without opening its window. The agent WebSocket server, the MCP server
+and plugin instances all come up as usual, so a CI job or an AI agent can drive plugins on a machine
+with no display.
+
+```bash
+./gradlew :myPlugin:runJetWhale \
+  --args="--headless --server-port 5081 --wss-port 5444 --mcp-server-port 7081"
+```
+
+The host prints the ports it bound and then `JetWhale headless: ready`; wait for that line before
+connecting. If a port cannot be bound the process exits non-zero rather than staying up unable to
+serve. `SIGTERM` and `SIGINT` stop it gracefully.
+
+Plugins do not need a window to work. Plugin state is fed by the messages their agent sends, and a
+plugin's Compose scene is created on demand by whichever MCP tool asks for it, so
+[`screenshot`](/guide/mcp-server) and the interaction tools render exactly as they do with a window.
+
+Three differences are worth knowing before you script against it:
+
+- **`jetwhale.navigate` does not work.** It moves the main window's back stack, so with no window it
+  always reports `applied: false` after its confirmation timeout. Tools that address a plugin
+  directly are unaffected.
+- **Coordinates differ from a windowed run.** With no window reporting a density, scenes render at
+  density 1.0, so the same element sits at different coordinates than it would on a HiDPI display.
+  Always read coordinates from `jetwhale.accessibilityTree` in the same run rather than carrying
+  them over from a windowed session.
+- **A fresh app-data directory enables no plugins.** Enable them with `jetwhale.setPluginEnabled`
+  over MCP, or point `-Djetwhale.appDataDir` at a directory where they already are. Approving a new
+  plugin jar's signature is still a settings-UI action, so headless runs load already-trusted jars
+  and the dev-plugins directory.
+
+Headless is a little lighter than a windowed run — it starts a few hundred milliseconds sooner and
+uses roughly 15% less memory — but that is not the reason to use it. Use it because a windowed host
+cannot start at all where there is no display.
 
 ::: tip Plugin developers use a sandbox, not `~/.jetwhale`
 `runJetWhale` / `runJetWhaleHot` also set `-Djetwhale.appDataDir` and `-Djetwhale.devPluginsDir`, so


### PR DESCRIPTION
`--headless` shipped in #219 without documentation. The docs pass that covered the rest of the host (#218) was written while the feature was still an unmerged branch and deliberately left it out; now that it is on `main`, `docs/` does not mention it anywhere.

Adds a **Headless mode** section to the host's command-line options covering:

- what still runs (agent WebSocket server, MCP server, plugin instances) and why plugins do not need a window — state is fed by agent messages, and a plugin's Compose scene is created on demand by whichever MCP tool asks for it
- the `JetWhale headless: ready` line to wait for, and the non-zero exit when a port cannot be bound
- the three ways a headless run differs from a windowed one:
  - `jetwhale.navigate` cannot work — it moves the main window's back stack
  - scenes render at density 1.0, so coordinates must be read from `jetwhale.accessibilityTree` in the same run rather than carried over from a windowed session
  - a fresh app-data directory enables no plugins, and jar trust approval is still a settings-UI action

It also says plainly that the performance difference is not the reason to use it — the reason is that a windowed host cannot start where there is no display.

Cross-linked from the plugin task table in `developing-plugins.md`.

VitePress builds clean.

### Not covered here

`plugins/jetwhale/skills/plugin-qa/SKILL.md` — the skill distributed to plugin authors — does not mention headless host runs either. The in-repo `.claude/skills/plugin-qa/SKILL.md` does, having been updated alongside #219. Worth deciding separately whether the distributed skill should teach it.