### PR TITLE
chore(deps): bump androidx.datastore to 1.3.0-alpha10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ navigation3 = "1.1.1"
 lifecycle = "2.11.0"
 soil = "1.0.0-alpha15"
 
-androidxDatastore = "1.2.1"
+androidxDatastore = "1.3.0-alpha10"
 metro = "1.3.2"
 mokkery = "3.4.2"
 ktor = "3.5.1"


### PR DESCRIPTION
Fixes the intermittent CI failure on `main`, and makes #209 unnecessary.

## The bug

`androidx.datastore 1.2.1` serves a stale value to any `dataStore.data` collection whose initial read overlaps a write:

1. The writer calls `incrementAndGetVersion()` **before** writing the file (`DataStoreImpl.kt:372` → `:373`).
2. A collection starting concurrently samples that post-increment version, fails `tryLock`, reads the file **unlocked** — getting pre-write content — and stamps it with the new version (`:388-392`).
3. `data`'s `dropWhile { it is Data && it.version <= startState.version }` (`:105`) then discards the writer's own cache update, because it carries the same version.
4. `SingleProcessCoordinator.updateNotifications` is an empty `flow {}` (`:36`), so nothing re-reads.

**No data is lost** — the write lands. The collection just serves a stale value until the next write to that file or a restart.

This is what fails `DefaultDebuggerSettingsRepositoryTest > picking a port after launch retires its override`, the only test in that class that writes *after* constructing the repository and then asserts on a flow. Granting the assertion 20 extra seconds recovers 0 of 15 stalls, so it is not an under-sized timeout.

## The fix in 1.3.0

The writer still increments before writing — deliberately, and now with a comment saying so, since the alternative would let a crash leave readers skipping a version forever. What changed is the **reader's** version stamp: the no-lock path is handed the version cached *before* the lock attempt (`readDataAndUpdateCache` captures `cachedVersion` from `inMemoryCache.currentState` and passes it down; `readDataOrHandleCorruption` returns `getVersion.invoke(locked)`). Pre-write content therefore carries an *older* version, and the writer's update is no longer dropped.

`dropWhile` and `SingleProcessCoordinator` are unchanged between the two versions, so the fix is exactly this and nothing else.

## Measurements

The failing scenario, replayed in-process, 2000 iterations per version, run alternately (baseline → bumped → bumped → baseline) so machine drift cannot explain the result:

| version | failures | rate |
|---|---|---|
| 1.2.1 | 26/1000, 19/1000 → **45/2000** | 2.25% |
| 1.3.0-alpha10 | 0/1000, 0/1000 → **0/2000** | 0% |

The final control run on 1.2.1 still reproduced 19/1000, so the machine was not simply quiet during the bumped runs.

`:jetwhale-host:core:data:test` and `:jetwhale-host:app:test` pass.

## Impact of the bump

- Artifact set is identical; **no new transitive dependencies**.
- One third-party change: **okio 3.9.1 → 3.17.0**, via `datastore-core-okio`.
- No API the host uses changed — `PreferenceDataStoreFactory.createWithPath`, `DataStoreFactory.create`, `OkioStorage`, `ReplaceFileCorruptionHandler` and `OkioSerializer` all keep their signatures and defaults.
- No DataStore deprecation warnings introduced.

## On shipping a pre-release version

There is no 1.3.0 stable. The line has been in alpha since November 2025 with no beta announced, so waiting is not a plan.

The risk is contained: DataStore is an `implementation` dependency of `jetwhale-host` only, and **no published JetWhale artifact depends on it**, so the pre-release version never reaches a consumer's classpath. If a later alpha regresses this, the flaky test that motivated the bump is itself the detector — CI goes red immediately.

## Supersedes #209

#209 worked around the bug in application code: a single shared `dataStore.data` collection plus a `CompletableDeferred` gate ordering writes after the initial read. It is no longer needed. It was also incomplete — the gate is per instance, but `DefaultDebuggerSettingsRepository` and `DefaultMcpPermissionsRepository` share the same store file (`debugger_settings.preferences_pb`, both under `@DebuggerSettingsDataStoreQualifier`), so an MCP-permissions write could still poison the repository #209 fixed.