### PR TITLE
fix(discovery): try every candidate before backing off

### DIFF
--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.cancellation.CancellationException
 
 internal class DefaultJetWhaleMessagingService(
@@ -28,22 +29,15 @@ internal class DefaultJetWhaleMessagingService(
         keepAwakeJob?.cancel()
         keepAwakeJob = coroutineScope.launch {
             while (isActive) {
-                var attempted: ResolvedEndpoint? = null
-                try {
-                    // Asked per attempt rather than once up front: an address that only becomes
-                    // correct later is reached without restarting the session.
-                    val resolved = resolver.resolve()
-                    attempted = resolved
-                    openConnection(resolved.host, resolved.port)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Throwable) {
-                    reportFailure(attempted, e)
-                    pluginService.disconnectAll()
-                    retryCount++
-                    val delayMillis = (retryCount * RETRY_DELAY_INCREMENT_MILLIS).coerceAtMost(MAX_RECONNECT_DELAY_MILLIS)
-                    delay(delayMillis)
-                }
+                // Resolved per round rather than once up front: an address that only becomes correct
+                // later is reached without restarting the session.
+                val failures = tryEachCandidate(resolver.resolve())
+                // Only once the whole round is spent: a reachable host further down the list should
+                // not be kept waiting by the backoff owed to the ones before it.
+                reportRoundFailed(failures)
+                pluginService.disconnectAll()
+                retryCount++
+                delay((retryCount * RETRY_DELAY_INCREMENT_MILLIS).coerceAtMost(MAX_RECONNECT_DELAY_MILLIS))
             }
         }
     }
@@ -68,24 +62,61 @@ internal class DefaultJetWhaleMessagingService(
     }
 
     /**
-     * Reports why an attempt failed. The socket client rethrows without logging, so this is the only
-     * place a refused host, a wrong port or a failed TLS handshake becomes visible — and at the
-     * default WARN level, the only sign the agent is doing anything at all.
+     * Works down [candidates] until one connects, and returns why each of them did not.
      *
-     * The same cause repeats on every retry, so it is reported once and again only when it changes,
-     * or when a connection succeeded in between.
+     * Returns only once the list is spent — a connection that succeeds keeps this suspended for as
+     * long as it lasts, and the candidates after it are never dialled.
      */
-    private fun reportFailure(attempted: ResolvedEndpoint?, cause: Throwable) {
-        val where = attempted?.toString() ?: "the JetWhale host"
-        val message = "Could not connect to $where: $cause"
-        if (message == lastReportedFailure) return
-        lastReportedFailure = message
-        JetWhaleLogger.w("$message. Retrying with backoff until it succeeds.")
+    private suspend fun tryEachCandidate(candidates: List<ResolvedEndpoint>): List<CandidateFailure> {
+        val failures = mutableListOf<CandidateFailure>()
+        for (candidate in candidates) {
+            try {
+                // The cap covers establishment only — never the session that follows, which is meant
+                // to last. Establishment is the CA fetch, the TLS handshake, the upgrade and the
+                // negotiation together, measured at over six seconds on a physical device over Wi-Fi,
+                // so the cap is loose. Its job is only to stop a candidate that swallows packets — a
+                // firewall that drops rather than refuses — from holding up the ones behind it.
+                val connection = withTimeoutOrNull(CANDIDATE_TIMEOUT_MILLIS) {
+                    socketClient.openConnection(candidate.host, candidate.port)
+                }
+                if (connection == null) {
+                    failures += CandidateFailure(candidate, "timed out after ${CANDIDATE_TIMEOUT_MILLIS}ms")
+                    JetWhaleLogger.d("Gave up on $candidate after ${CANDIDATE_TIMEOUT_MILLIS}ms")
+                } else {
+                    // Suspends for as long as the connection lasts. Once it ends, the next round starts
+                    // from the top of the list so a preferred candidate gets its turn back.
+                    serveConnection(connection)
+                    return failures
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                failures += CandidateFailure(candidate, e.toString())
+                JetWhaleLogger.d("Could not connect to $candidate", e)
+            }
+        }
+        return failures
     }
 
-    private suspend fun openConnection(host: String, port: Int) {
-        val connection = socketClient.openConnection(host, port)
+    /**
+     * Reports a round in which nothing accepted a connection. The socket client rethrows without
+     * logging, so this is the only place a refused host, a wrong port or a failed TLS handshake
+     * becomes visible — and at the default WARN level, the only sign the agent is doing anything.
+     *
+     * One line per round rather than one per candidate, so the same set of failures repeating is a
+     * repeating message and stays suppressed until something about it changes.
+     */
+    private fun reportRoundFailed(failures: List<CandidateFailure>) {
+        if (failures.isEmpty()) return
+        val listed = failures.joinToString { "${it.endpoint} (${it.reason})" }
+        val message = "No JetWhale host accepted a connection. Tried ${failures.size}: $listed"
+        if (message == lastReportedFailure) return
+        lastReportedFailure = message
+        JetWhaleLogger.w("$message. Retrying with backoff until one does.")
+    }
 
+    /** Runs an established connection until it ends. */
+    private suspend fun serveConnection(connection: JetWhaleConnection) {
         retryCount = 0
         lastReportedFailure = null
 
@@ -113,8 +144,12 @@ internal class DefaultJetWhaleMessagingService(
         }
     }
 
+    /** Why one candidate did not take the connection, kept so the round can report itself as a whole. */
+    private data class CandidateFailure(val endpoint: ResolvedEndpoint, val reason: String)
+
     companion object {
         private const val RETRY_DELAY_INCREMENT_MILLIS = 1000L
         private const val MAX_RECONNECT_DELAY_MILLIS = 5000L
+        private const val CANDIDATE_TIMEOUT_MILLIS = 15_000L
     }
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 internal class DefaultJetWhaleMessagingService(
     private val socketClient: JetWhaleSocketClient,
@@ -29,10 +31,10 @@ internal class DefaultJetWhaleMessagingService(
         keepAwakeJob?.cancel()
         keepAwakeJob = coroutineScope.launch {
             while (isActive) {
-                // A round that connected costs no delay, however many candidates were refused before
-                // the one that worked: backoff is owed by a round where nothing accepted at all.
+                // A round that served a session costs no delay, however many candidates were refused
+                // before the one that worked: backoff is owed by a round where nothing accepted.
                 val outcome = runRound(resolver)
-                if (outcome is RoundResult.Connected) continue
+                if (outcome is RoundResult.Served) continue
 
                 reportRoundFailed((outcome as RoundResult.Failed).summary)
                 pluginService.disconnectAll()
@@ -100,8 +102,19 @@ internal class DefaultJetWhaleMessagingService(
                 } else {
                     // Suspends for as long as the connection lasts. Once it ends, the next round starts
                     // from the top of the list so a preferred candidate gets its turn back.
+                    val startedAt = TimeSource.Monotonic.markNow()
                     serveConnection(connection)
-                    return RoundResult.Connected
+                    val lasted = startedAt.elapsedNow()
+                    // A session that ends the moment it starts has not really worked — a host that
+                    // accepts the upgrade and then drops it has been seen — and reconnecting with no
+                    // delay would spin. Only a session that held counts as a round that was served.
+                    if (lasted >= MIN_SESSION_TO_COUNT) {
+                        retryCount = 0
+                        lastReportedFailure = null
+                        return RoundResult.Served
+                    }
+                    failures += CandidateFailure(candidate, "closed after $lasted")
+                    JetWhaleLogger.d("$candidate closed the session after $lasted")
                 }
             } catch (e: CancellationException) {
                 throw e
@@ -130,9 +143,6 @@ internal class DefaultJetWhaleMessagingService(
 
     /** Runs an established connection until it ends. */
     private suspend fun serveConnection(connection: JetWhaleConnection) {
-        retryCount = 0
-        lastReportedFailure = null
-
         pluginService.startConnection(
             scope = coroutineScope,
             sendFrame = { frame ->
@@ -160,9 +170,16 @@ internal class DefaultJetWhaleMessagingService(
     /** Why one candidate did not take the connection, kept so the round can report itself as a whole. */
     private data class CandidateFailure(val endpoint: ResolvedEndpoint, val reason: String)
 
-    /** How a round ended. Only a round where nothing connected owes a backoff. */
+    /**
+     * How a round ended, decided once it has. Both cases are reached with nothing connected — a served
+     * round reports a session that ran and has since ended — so this says what the round achieved,
+     * not what the connection is doing now.
+     */
     private sealed interface RoundResult {
-        data object Connected : RoundResult
+        /** A session ran and held. Nothing is owed: the next round starts at once. */
+        data object Served : RoundResult
+
+        /** Nothing took the connection, so the round is reported and a backoff follows. */
         data class Failed(val summary: String) : RoundResult
     }
 
@@ -170,5 +187,11 @@ internal class DefaultJetWhaleMessagingService(
         private const val RETRY_DELAY_INCREMENT_MILLIS = 1000L
         private const val MAX_RECONNECT_DELAY_MILLIS = 5000L
         private const val CANDIDATE_TIMEOUT_MILLIS = 30_000L
+
+        /**
+         * How long a session has to hold before it counts as having worked. Establishment alone takes
+         * seconds, so anything ending inside this window ended on the host's side straight away.
+         */
+        private val MIN_SESSION_TO_COUNT = 2.seconds
     }
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
@@ -73,9 +73,10 @@ internal class DefaultJetWhaleMessagingService(
             try {
                 // The cap covers establishment only — never the session that follows, which is meant
                 // to last. Establishment is the CA fetch, the TLS handshake, the upgrade and the
-                // negotiation together, measured at over six seconds on a physical device over Wi-Fi,
-                // so the cap is loose. Its job is only to stop a candidate that swallows packets — a
-                // firewall that drops rather than refuses — from holding up the ones behind it.
+                // negotiation together, and that has been measured at 13s on a physical device over
+                // Wi-Fi, half of it spent in the CA fetch's plain-channel probe. The cap is therefore
+                // generous: its job is to bound a candidate that swallows packets — a firewall that
+                // drops rather than refuses — not to be tight.
                 val connection = withTimeoutOrNull(CANDIDATE_TIMEOUT_MILLIS) {
                     socketClient.openConnection(candidate.host, candidate.port)
                 }
@@ -150,6 +151,6 @@ internal class DefaultJetWhaleMessagingService(
     companion object {
         private const val RETRY_DELAY_INCREMENT_MILLIS = 1000L
         private const val MAX_RECONNECT_DELAY_MILLIS = 5000L
-        private const val CANDIDATE_TIMEOUT_MILLIS = 15_000L
+        private const val CANDIDATE_TIMEOUT_MILLIS = 30_000L
     }
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
@@ -29,12 +29,12 @@ internal class DefaultJetWhaleMessagingService(
         keepAwakeJob?.cancel()
         keepAwakeJob = coroutineScope.launch {
             while (isActive) {
-                // Resolved per round rather than once up front: an address that only becomes correct
-                // later is reached without restarting the session.
-                val failures = tryEachCandidate(resolver.resolve())
-                // Only once the whole round is spent: a reachable host further down the list should
-                // not be kept waiting by the backoff owed to the ones before it.
-                reportRoundFailed(failures)
+                // A round that connected costs no delay, however many candidates were refused before
+                // the one that worked: backoff is owed by a round where nothing accepted at all.
+                val outcome = runRound(resolver)
+                if (outcome is RoundResult.Connected) continue
+
+                reportRoundFailed((outcome as RoundResult.Failed).summary)
                 pluginService.disconnectAll()
                 retryCount++
                 delay((retryCount * RETRY_DELAY_INCREMENT_MILLIS).coerceAtMost(MAX_RECONNECT_DELAY_MILLIS))
@@ -62,12 +62,26 @@ internal class DefaultJetWhaleMessagingService(
     }
 
     /**
-     * Works down [candidates] until one connects, and returns why each of them did not.
+     * Resolves the candidates and works down them until one connects.
      *
-     * Returns only once the list is spent — a connection that succeeds keeps this suspended for as
-     * long as it lasts, and the candidates after it are never dialled.
+     * A connection that succeeds keeps this suspended for as long as it lasts, and the candidates
+     * after it are never dialled; the ones refused before it are not the round's verdict.
      */
-    private suspend fun tryEachCandidate(candidates: List<ResolvedEndpoint>): List<CandidateFailure> {
+    private suspend fun runRound(resolver: EndpointResolver): RoundResult {
+        val candidates = try {
+            // Resolved per round rather than once up front: an address that only becomes correct
+            // later is reached without restarting the session.
+            resolver.resolve()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // Resolution is not supposed to throw — discovery reports its own failures and falls back
+            // — but letting one escape would end the loop and the session with it.
+            JetWhaleLogger.d("Working out where to connect failed", e)
+            return RoundResult.Failed("Could not work out where to connect: $e")
+        }
+        if (candidates.isEmpty()) return RoundResult.Failed("No address to connect to.")
+
         val failures = mutableListOf<CandidateFailure>()
         for (candidate in candidates) {
             try {
@@ -87,7 +101,7 @@ internal class DefaultJetWhaleMessagingService(
                     // Suspends for as long as the connection lasts. Once it ends, the next round starts
                     // from the top of the list so a preferred candidate gets its turn back.
                     serveConnection(connection)
-                    return failures
+                    return RoundResult.Connected
                 }
             } catch (e: CancellationException) {
                 throw e
@@ -96,7 +110,8 @@ internal class DefaultJetWhaleMessagingService(
                 JetWhaleLogger.d("Could not connect to $candidate", e)
             }
         }
-        return failures
+        val listed = failures.joinToString { "${it.endpoint} (${it.reason})" }
+        return RoundResult.Failed("No JetWhale host accepted a connection. Tried ${failures.size}: $listed")
     }
 
     /**
@@ -107,13 +122,10 @@ internal class DefaultJetWhaleMessagingService(
      * One line per round rather than one per candidate, so the same set of failures repeating is a
      * repeating message and stays suppressed until something about it changes.
      */
-    private fun reportRoundFailed(failures: List<CandidateFailure>) {
-        if (failures.isEmpty()) return
-        val listed = failures.joinToString { "${it.endpoint} (${it.reason})" }
-        val message = "No JetWhale host accepted a connection. Tried ${failures.size}: $listed"
-        if (message == lastReportedFailure) return
-        lastReportedFailure = message
-        JetWhaleLogger.w("$message. Retrying with backoff until one does.")
+    private fun reportRoundFailed(summary: String) {
+        if (summary == lastReportedFailure) return
+        lastReportedFailure = summary
+        JetWhaleLogger.w("$summary. Retrying with backoff until one does.")
     }
 
     /** Runs an established connection until it ends. */
@@ -147,6 +159,12 @@ internal class DefaultJetWhaleMessagingService(
 
     /** Why one candidate did not take the connection, kept so the round can report itself as a whole. */
     private data class CandidateFailure(val endpoint: ResolvedEndpoint, val reason: String)
+
+    /** How a round ended. Only a round where nothing connected owes a backoff. */
+    private sealed interface RoundResult {
+        data object Connected : RoundResult
+        data class Failed(val summary: String) : RoundResult
+    }
 
     companion object {
         private const val RETRY_DELAY_INCREMENT_MILLIS = 1000L

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/EndpointResolver.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/EndpointResolver.kt
@@ -6,16 +6,18 @@ internal data class ResolvedEndpoint(val host: String, val port: Int) {
 }
 
 /**
- * Supplies the address for the next connection attempt.
+ * Supplies the addresses worth trying, best first.
  *
- * Asked before every attempt rather than once per session, so an address that only becomes correct
- * later is still reached without restarting the session.
+ * Asked before every round of attempts rather than once per session, so an address that only becomes
+ * correct later is still reached without restarting the session. Returning a list rather than one
+ * address is what lets a host that answers discovery but refuses connections be passed over: the
+ * caller works down the list and only gives up once every entry has been tried.
  */
 internal fun interface EndpointResolver {
-    suspend fun resolve(): ResolvedEndpoint
+    suspend fun resolve(): List<ResolvedEndpoint>
 }
 
 /** Resolves to the same literal address every time. */
 internal class FixedEndpointResolver(private val endpoint: ResolvedEndpoint) : EndpointResolver {
-    override suspend fun resolve(): ResolvedEndpoint = endpoint
+    override suspend fun resolve(): List<ResolvedEndpoint> = listOf(endpoint)
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
@@ -56,25 +56,30 @@ internal expect suspend fun browseJetWhaleServices(timeoutMillis: Long): Discove
 internal data class SelectedHost(val service: DiscoveredService, val port: Int)
 
 /**
- * Picks the host to connect to among [services], or null when none can serve this agent.
+ * Every host among [services] this agent could use, in the order they were browsed.
  *
  * A host qualifies only when it satisfies every configured filter **and** advertises the port for the
  * scheme the connection will use. The scheme comes from the `ssl {}` block alone, so an ssl-configured
  * agent cannot use a host that advertises no wss port: dialling `wss://` at its plain-ws port would
- * fail every handshake. Such a host is skipped rather than chosen, leaving the next match a chance.
+ * fail every handshake. Such a host is dropped rather than dialled.
+ *
+ * All of them are returned, not just the first: browse order is arbitrary and a host that answers mDNS
+ * may still refuse a connection, so the caller tries them in turn.
  */
-internal fun selectHost(services: List<DiscoveredService>, discovery: HostDiscoveryConfig): SelectedHost? = services.asSequence()
+internal fun selectHosts(services: List<DiscoveredService>, discovery: HostDiscoveryConfig): List<SelectedHost> = services
     .filter { it.matches(discovery) }
     .mapNotNull { service -> service.portFor(discovery.useWss)?.let { SelectedHost(service, it) } }
-    .firstOrNull()
 
 /**
- * Browses for a JetWhale host over mDNS, standing [fallback] in whenever a browse yields none that
- * this agent can use.
+ * Browses for JetWhale hosts over mDNS and offers every usable one, with [fallback] last.
  *
  * Browsing on every call is the point: a host started after the app, or one that came back on a
  * different port, is only reached by looking again. That makes the outcome repetitive by nature, so
  * the resolver remembers what it last reported and stays quiet while nothing changes.
+ *
+ * [fallback] is offered even when hosts were found. Answering mDNS says a host is advertising, not
+ * that it will accept a connection — a firewall between them is invisible to the browse — so the
+ * configured address stays available behind the discovered ones.
  */
 internal class MdnsEndpointResolver(
     val discovery: HostDiscoveryConfig,
@@ -82,32 +87,32 @@ internal class MdnsEndpointResolver(
 ) : EndpointResolver {
     private var lastReported: String? = null
 
-    override suspend fun resolve(): ResolvedEndpoint {
+    override suspend fun resolve(): List<ResolvedEndpoint> {
         val result = browseJetWhaleServices(HOST_DISCOVERY_TIMEOUT_MILLIS)
-        return when (result) {
+        val discovered = when (result) {
             is DiscoveryResult.Unavailable -> {
-                report("mDNS host discovery is unavailable because ${result.reason}; using $fallback", warn = true)
-                fallback
+                report("mDNS host discovery is unavailable because ${result.reason}; using $fallback")
+                emptyList()
             }
 
             is DiscoveryResult.Browsed -> {
-                val selected = selectHost(result.services, discovery)
-                if (selected == null) {
-                    report(noHostMessage(result.services), warn = true)
-                    fallback
-                } else {
-                    val ambiguous = !discovery.hasFilter && result.services.size > 1
-                    report(chosenMessage(selected, result.services, ambiguous), warn = ambiguous)
-                    ResolvedEndpoint(selected.service.address, selected.port)
-                }
+                val usable = selectHosts(result.services, discovery)
+                report(if (usable.isEmpty()) noHostMessage(result.services) else foundMessage(usable))
+                usable.map { ResolvedEndpoint(it.service.address, it.port) }
             }
         }
+        return discovered + fallback
     }
 
-    private fun report(message: String, warn: Boolean) {
+    private fun report(message: String) {
         if (message == lastReported) return
         lastReported = message
-        if (warn) JetWhaleLogger.w(message) else JetWhaleLogger.i(message)
+        JetWhaleLogger.i(message)
+    }
+
+    private fun foundMessage(usable: List<SelectedHost>): String {
+        val listed = usable.joinToString { "${it.service.displayName()} at ${it.service.address}:${it.port}" }
+        return "Discovered ${usable.size} JetWhale host(s) over mDNS: $listed. Falling back to $fallback if none accepts a connection."
     }
 
     private fun noHostMessage(services: List<DiscoveredService>): String {
@@ -121,16 +126,6 @@ internal class MdnsEndpointResolver(
         val listed = matched.joinToString { it.displayName() }
         return "mDNS host discovery matched ${matched.size} host(s) ($listed) but none advertised a $scheme port; using $fallback. " +
             "A host advertises its wss port only while wss is enabled in its settings."
-    }
-
-    private fun chosenMessage(selected: SelectedHost, services: List<DiscoveredService>, ambiguous: Boolean): String {
-        val chosen = "Discovered JetWhale host over mDNS: ${selected.service.displayName()} at ${selected.service.address}:${selected.port}"
-        // With no filter, first-match is ambiguous when several hosts advertise; make that visible
-        // instead of silently picking one.
-        if (!ambiguous) return chosen
-        val listed = services.joinToString { "${it.displayName()}@${it.address}" }
-        return "$chosen — but ${services.size} hosts advertised and no filter was set. Discovered: $listed. " +
-            "Narrow with discovered(fallback) { allowHostName(...) } or allowAddress(...)."
     }
 }
 

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
@@ -101,7 +101,9 @@ internal class MdnsEndpointResolver(
                 usable.map { ResolvedEndpoint(it.service.address, it.port) }
             }
         }
-        return discovered + fallback
+        // Deduplicated, order kept: the fallback may well be an address that was also advertised, and
+        // dialling the same endpoint twice in a round only spends the establishment budget twice.
+        return (discovered + fallback).distinct()
     }
 
     private fun report(message: String) {

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
@@ -12,7 +12,7 @@ class ConnectionEndpointTest {
 
     private fun fixedEndpoint(
         configure: JetWhaleConnectionConfigurationScope.() -> Unit,
-    ): ResolvedEndpoint = runBlocking { assertIs<FixedEndpointResolver>(connection(configure)).resolve() }
+    ): ResolvedEndpoint = runBlocking { assertIs<FixedEndpointResolver>(connection(configure)).resolve().single() }
 
     private fun mdns(
         configure: JetWhaleConnectionConfigurationScope.() -> Unit,

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
@@ -5,9 +5,11 @@ import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggeeEvent
 import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggerEvent
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import java.util.Collections
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -18,8 +20,14 @@ private const val RESOLUTION_TIMEOUT_MILLIS = 10_000L
 /** Comfortably under the shortest backoff (1s), so waiting one out would blow this window. */
 private const val BACKOFF_FREE_WINDOW_MILLIS = 800L
 
+/** Comfortably over the two seconds a session has to last before it counts as having worked. */
+private const val HELD_SESSION_MILLIS = 2_500L
+
 /** Records every address dialled, and refuses all of them except those named in [reachable]. */
-private class RecordingSocketClient(private val reachable: Set<ResolvedEndpoint> = emptySet()) : JetWhaleSocketClient {
+private class RecordingSocketClient(
+    private val reachable: Set<ResolvedEndpoint> = emptySet(),
+    private val closeImmediately: Boolean = false,
+) : JetWhaleSocketClient {
     val attempts: MutableList<ResolvedEndpoint> = Collections.synchronizedList(mutableListOf())
     val attemptCount: Channel<ResolvedEndpoint> = Channel(Channel.UNLIMITED)
     val connected: CompletableDeferred<ResolvedEndpoint> = CompletableDeferred()
@@ -35,6 +43,8 @@ private class RecordingSocketClient(private val reachable: Set<ResolvedEndpoint>
         if (endpoint !in reachable) throw IllegalStateException("unreachable")
         connected.complete(endpoint)
         debuggerEvents = Channel(Channel.UNLIMITED)
+        // A closed event flow ends the session as soon as the service starts collecting it.
+        if (closeImmediately) debuggerEvents.close()
         return JetWhaleConnection(
             negotiationResult = ClientSessionNegotiationResult.Success(availablePluginIds = emptyList()),
             debuggerEventFlow = debuggerEvents.receiveAsFlow(),
@@ -97,8 +107,8 @@ class MessagingServiceResolutionTest {
     }
 
     @Test
-    fun `a session that ends reconnects without waiting out a backoff`() = runBlocking {
-        // Refusals before the candidate that worked are not the round's verdict, so an ended session
+    fun `a session that held reconnects without waiting out a backoff`() = runBlocking {
+        // Refusals before the candidate that worked are not the round's verdict, so a session that ran
         // is not treated as a failed round: it reconnects at once, as it did before candidates were
         // tried in turn.
         val refused = ResolvedEndpoint("refused", 1)
@@ -109,7 +119,9 @@ class MessagingServiceResolutionTest {
         try {
             withTimeout(RESOLUTION_TIMEOUT_MILLIS) {
                 socketClient.connected.await()
-                // End the session; a backoff-free reconnect dials the whole round again promptly.
+                // Long enough that the session counts as having worked rather than as a host dropping
+                // it straight away, which is a failed round and does owe a backoff.
+                delay(HELD_SESSION_MILLIS)
                 socketClient.closeConnection()
                 withTimeout(BACKOFF_FREE_WINDOW_MILLIS) {
                     while (socketClient.attempts.size < 4) socketClient.attemptCount.receive()
@@ -120,6 +132,28 @@ class MessagingServiceResolutionTest {
         }
 
         assertEquals(listOf(refused, reachable, refused, reachable), socketClient.attempts.take(4))
+    }
+
+    @Test
+    fun `a host that accepts and drops straight away does not spin the loop`() = runBlocking {
+        // Seen for real: a host whose websocket handler threw after the upgrade, accepting and closing
+        // each time. Reconnecting with no delay would dial it as fast as it can close.
+        val flapping = ResolvedEndpoint("flapping", 1)
+        val socketClient = RecordingSocketClient(reachable = setOf(flapping), closeImmediately = true)
+        val service = service(socketClient, ScriptedEndpointResolver(listOf(listOf(flapping))))
+
+        try {
+            withTimeout(RESOLUTION_TIMEOUT_MILLIS) {
+                socketClient.attemptCount.receive()
+                socketClient.attemptCount.receive()
+            }
+            // A backoff was owed between them, so a third cannot arrive inside the window a
+            // delay-free loop would have filled with hundreds.
+            val third = withTimeoutOrNull(BACKOFF_FREE_WINDOW_MILLIS) { socketClient.attemptCount.receive() }
+            assertEquals(null, third, "expected the loop to be backing off, got another attempt")
+        } finally {
+            service.stopService()
+        }
     }
 
     @Test

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
@@ -2,7 +2,10 @@ package com.kitakkun.jetwhale.agent.runtime
 
 import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
 import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggeeEvent
+import com.kitakkun.jetwhale.protocol.core.JetWhaleDebuggerEvent
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.util.Collections
@@ -12,27 +15,39 @@ import kotlin.test.assertTrue
 
 private const val RESOLUTION_TIMEOUT_MILLIS = 10_000L
 
-/** A socket client that never connects, so the service keeps retrying and keeps re-resolving. */
-private class UnreachableSocketClient : JetWhaleSocketClient {
-    val attemptedEndpoints: MutableList<ResolvedEndpoint> = Collections.synchronizedList(mutableListOf())
-    val secondAttempt: CompletableDeferred<Unit> = CompletableDeferred()
+/** Records every address dialled, and refuses all of them except those named in [reachable]. */
+private class RecordingSocketClient(private val reachable: Set<ResolvedEndpoint> = emptySet()) : JetWhaleSocketClient {
+    val attempts: MutableList<ResolvedEndpoint> = Collections.synchronizedList(mutableListOf())
+    val attemptCount: Channel<ResolvedEndpoint> = Channel(Channel.UNLIMITED)
+    val connected: CompletableDeferred<ResolvedEndpoint> = CompletableDeferred()
+
+    private var debuggerEvents: Channel<JetWhaleDebuggerEvent> = Channel(Channel.UNLIMITED)
 
     override suspend fun sendDebuggeeEvent(event: JetWhaleDebuggeeEvent) = Unit
 
     override suspend fun openConnection(host: String, port: Int): JetWhaleConnection {
-        attemptedEndpoints.add(ResolvedEndpoint(host, port))
-        if (attemptedEndpoints.size >= 2) secondAttempt.complete(Unit)
-        throw IllegalStateException("unreachable")
+        val endpoint = ResolvedEndpoint(host, port)
+        attempts.add(endpoint)
+        attemptCount.send(endpoint)
+        if (endpoint !in reachable) throw IllegalStateException("unreachable")
+        connected.complete(endpoint)
+        debuggerEvents = Channel(Channel.UNLIMITED)
+        return JetWhaleConnection(
+            negotiationResult = ClientSessionNegotiationResult.Success(availablePluginIds = emptyList()),
+            debuggerEventFlow = debuggerEvents.receiveAsFlow(),
+        )
     }
 
-    override suspend fun closeConnection() = Unit
+    override suspend fun closeConnection() {
+        debuggerEvents.close()
+    }
 }
 
-/** Hands out each address in turn, standing on the last one once they run out. */
-private class ScriptedEndpointResolver(private val script: List<ResolvedEndpoint>) : EndpointResolver {
+/** Hands out each candidate list in turn, standing on the last once they run out. */
+private class ScriptedEndpointResolver(private val rounds: List<List<ResolvedEndpoint>>) : EndpointResolver {
     private var index = 0
 
-    override suspend fun resolve(): ResolvedEndpoint = script[minOf(index++, script.lastIndex)]
+    override suspend fun resolve(): List<ResolvedEndpoint> = rounds[minOf(index++, rounds.lastIndex)]
 }
 
 @OptIn(InternalJetWhaleApi::class)
@@ -43,43 +58,65 @@ class MessagingServiceResolutionTest {
     ).also { it.startService(resolver) }
 
     @Test
-    fun `the address is resolved again for every connection attempt`() = runBlocking {
-        val socketClient = UnreachableSocketClient()
-        val resolver = ScriptedEndpointResolver(listOf(ResolvedEndpoint("first", 1), ResolvedEndpoint("second", 2)))
-        val service = service(socketClient, resolver)
+    fun `a candidate that refuses is passed over for the next one in the same round`() = runBlocking {
+        // The point of the whole list: a host that answers discovery but refuses connections must not
+        // strand the session. Both are dialled before any backoff is owed.
+        val unreachable = ResolvedEndpoint("unreachable", 1)
+        val reachable = ResolvedEndpoint("reachable", 2)
+        val socketClient = RecordingSocketClient(reachable = setOf(reachable))
+        val service = service(socketClient, ScriptedEndpointResolver(listOf(listOf(unreachable, reachable))))
 
         try {
-            // Wait for the second *attempt*, not the second resolution: resolve() returns before the
-            // address it produced has been dialled, so waiting on the resolver would leave a window
-            // where only one attempt has been recorded.
-            withTimeout(RESOLUTION_TIMEOUT_MILLIS) { socketClient.secondAttempt.await() }
+            withTimeout(RESOLUTION_TIMEOUT_MILLIS) { socketClient.connected.await() }
         } finally {
             service.stopService()
         }
 
-        // A resolver consulted once per session would have produced "first" twice.
-        assertTrue(socketClient.attemptedEndpoints.size >= 2, "expected a retry, got ${socketClient.attemptedEndpoints}")
-        assertEquals(ResolvedEndpoint("first", 1), socketClient.attemptedEndpoints[0])
-        assertEquals(ResolvedEndpoint("second", 2), socketClient.attemptedEndpoints[1])
+        assertEquals(listOf(unreachable, reachable), socketClient.attempts.take(2))
     }
 
     @Test
-    fun `an address that only becomes reachable later is still dialled`() = runBlocking {
-        // The host was not up at startup, so the first resolution yields the unreachable fallback and a
-        // later one yields the host that has since appeared. Without per-attempt resolution the session
-        // would stay pinned to the fallback for good.
-        val socketClient = UnreachableSocketClient()
+    fun `the fallback is reached when the discovered candidate refuses`() = runBlocking {
+        // Resolving once per round is not enough on its own: before the chain, a discovered host that
+        // refused was re-picked every round and the configured fallback was never dialled at all.
+        val discovered = ResolvedEndpoint("192.168.3.26", 5443)
+        val fallback = ResolvedEndpoint("localhost", 5443)
+        val socketClient = RecordingSocketClient(reachable = setOf(fallback))
+        val service = service(socketClient, ScriptedEndpointResolver(listOf(listOf(discovered, fallback))))
+
+        try {
+            withTimeout(RESOLUTION_TIMEOUT_MILLIS) { socketClient.connected.await() }
+        } finally {
+            service.stopService()
+        }
+
+        assertEquals(fallback, socketClient.connected.getCompleted())
+    }
+
+    @Test
+    fun `a spent round is resolved again rather than retried as it was`() = runBlocking {
+        // A host started after the app is only reached by browsing again, so each round asks the
+        // resolver afresh instead of reusing what the last one produced.
+        val socketClient = RecordingSocketClient()
         val resolver = ScriptedEndpointResolver(
-            listOf(ResolvedEndpoint("localhost", 5443), ResolvedEndpoint("192.168.3.26", 5443)),
+            listOf(
+                listOf(ResolvedEndpoint("first-round", 1)),
+                listOf(ResolvedEndpoint("second-round", 2)),
+            ),
         )
         val service = service(socketClient, resolver)
 
         try {
-            withTimeout(RESOLUTION_TIMEOUT_MILLIS) { socketClient.secondAttempt.await() }
+            withTimeout(RESOLUTION_TIMEOUT_MILLIS) {
+                socketClient.attemptCount.receive()
+                socketClient.attemptCount.receive()
+            }
         } finally {
             service.stopService()
         }
 
-        assertEquals(ResolvedEndpoint("192.168.3.26", 5443), socketClient.attemptedEndpoints[1])
+        assertTrue(socketClient.attempts.size >= 2, "expected a second round, got ${socketClient.attempts}")
+        assertEquals(ResolvedEndpoint("first-round", 1), socketClient.attempts[0])
+        assertEquals(ResolvedEndpoint("second-round", 2), socketClient.attempts[1])
     }
 }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
@@ -15,6 +15,9 @@ import kotlin.test.assertTrue
 
 private const val RESOLUTION_TIMEOUT_MILLIS = 10_000L
 
+/** Comfortably under the shortest backoff (1s), so waiting one out would blow this window. */
+private const val BACKOFF_FREE_WINDOW_MILLIS = 800L
+
 /** Records every address dialled, and refuses all of them except those named in [reachable]. */
 private class RecordingSocketClient(private val reachable: Set<ResolvedEndpoint> = emptySet()) : JetWhaleSocketClient {
     val attempts: MutableList<ResolvedEndpoint> = Collections.synchronizedList(mutableListOf())
@@ -91,6 +94,56 @@ class MessagingServiceResolutionTest {
         }
 
         assertEquals(fallback, socketClient.connected.getCompleted())
+    }
+
+    @Test
+    fun `a session that ends reconnects without waiting out a backoff`() = runBlocking {
+        // Refusals before the candidate that worked are not the round's verdict, so an ended session
+        // is not treated as a failed round: it reconnects at once, as it did before candidates were
+        // tried in turn.
+        val refused = ResolvedEndpoint("refused", 1)
+        val reachable = ResolvedEndpoint("reachable", 2)
+        val socketClient = RecordingSocketClient(reachable = setOf(reachable))
+        val service = service(socketClient, ScriptedEndpointResolver(listOf(listOf(refused, reachable))))
+
+        try {
+            withTimeout(RESOLUTION_TIMEOUT_MILLIS) {
+                socketClient.connected.await()
+                // End the session; a backoff-free reconnect dials the whole round again promptly.
+                socketClient.closeConnection()
+                withTimeout(BACKOFF_FREE_WINDOW_MILLIS) {
+                    while (socketClient.attempts.size < 4) socketClient.attemptCount.receive()
+                }
+            }
+        } finally {
+            service.stopService()
+        }
+
+        assertEquals(listOf(refused, reachable, refused, reachable), socketClient.attempts.take(4))
+    }
+
+    @Test
+    fun `a resolver that throws is a failed round, not the end of the session`() = runBlocking {
+        val reachable = ResolvedEndpoint("reachable", 1)
+        val socketClient = RecordingSocketClient(reachable = setOf(reachable))
+        var firstCall = true
+        val service = service(socketClient) {
+            // Resolution is not supposed to throw, but one escaping used to take the loop down with
+            // it, leaving the agent silently dead for the life of the process.
+            if (firstCall) {
+                firstCall = false
+                throw IllegalStateException("resolver blew up")
+            }
+            listOf(reachable)
+        }
+
+        try {
+            withTimeout(RESOLUTION_TIMEOUT_MILLIS) { socketClient.connected.await() }
+        } finally {
+            service.stopService()
+        }
+
+        assertEquals(reachable, socketClient.connected.getCompleted())
     }
 
     @Test

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/SelectHostTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/SelectHostTest.kt
@@ -29,63 +29,73 @@ class SelectHostTest {
 
     @Test
     fun `no advertised host means nothing to select`() {
-        assertNull(selectHost(emptyList(), discovery()))
+        assertEquals(emptyList(), selectHosts(emptyList(), discovery()))
     }
 
     @Test
     fun `a plain connection takes the advertised ws port`() {
-        assertEquals(5080, selectHost(listOf(bothPorts), discovery(useWss = false))?.port)
+        assertEquals(5080, selectHosts(listOf(bothPorts), discovery(useWss = false)).firstOrNull()?.port)
     }
 
     @Test
     fun `an ssl connection takes the advertised wss port`() {
-        assertEquals(5443, selectHost(listOf(bothPorts), discovery(useWss = true))?.port)
+        assertEquals(5443, selectHosts(listOf(bothPorts), discovery(useWss = true)).firstOrNull()?.port)
     }
 
     @Test
     fun `an ssl connection skips a host that advertises no wss port`() {
         // Dialling wss at the plain-ws port would fail every handshake, so the host is not a candidate
         // at all rather than a candidate reached on the wrong port.
-        assertNull(selectHost(listOf(plainOnly), discovery(useWss = true)))
+        assertEquals(emptyList(), selectHosts(listOf(plainOnly), discovery(useWss = true)))
     }
 
     @Test
     fun `an ssl connection passes over a plain host to reach one that serves wss`() {
-        val selected = selectHost(listOf(plainOnly, bothPorts), discovery(useWss = true))
+        val selected = selectHosts(listOf(plainOnly, bothPorts), discovery(useWss = true))
 
-        assertEquals("192.168.3.27", selected?.service?.address)
-        assertEquals(5443, selected?.port)
+        assertEquals(1, selected.size)
+        assertEquals("192.168.3.27", selected.single().service.address)
+        assertEquals(5443, selected.single().port)
+    }
+
+    @Test
+    fun `every usable host is offered, in browse order`() {
+        // Answering mDNS is not the same as accepting a connection, so the caller gets them all and
+        // works down the list rather than being handed one and stranded if it refuses.
+        val selected = selectHosts(listOf(plainOnly, bothPorts), discovery(useWss = false))
+
+        assertEquals(listOf("192.168.3.26", "192.168.3.27"), selected.map { it.service.address })
     }
 
     @Test
     fun `hostName is matched case-insensitively`() {
-        assertEquals("192.168.3.26", selectHost(listOf(plainOnly, bothPorts), discovery(hostNames = listOf("PLAIN-HOST")))?.service?.address)
+        assertEquals("192.168.3.26", selectHosts(listOf(plainOnly, bothPorts), discovery(hostNames = listOf("PLAIN-HOST"))).firstOrNull()?.service?.address)
     }
 
     @Test
     fun `a hostName that matches nothing selects nothing`() {
-        assertNull(selectHost(listOf(plainOnly, bothPorts), discovery(hostNames = listOf("absent-host"))))
+        assertEquals(emptyList(), selectHosts(listOf(plainOnly, bothPorts), discovery(hostNames = listOf("absent-host"))))
     }
 
     @Test
     fun `the hostName allowlist admits a host matching any of its entries`() {
         val allowed = discovery(hostNames = listOf("absent-host", "secure-host"))
 
-        assertEquals("192.168.3.27", selectHost(listOf(plainOnly, bothPorts), allowed)?.service?.address)
+        assertEquals("192.168.3.27", selectHosts(listOf(plainOnly, bothPorts), allowed).firstOrNull()?.service?.address)
     }
 
     @Test
     fun `the address allowlist admits only hosts resolving to one of its entries`() {
-        assertEquals("192.168.3.27", selectHost(listOf(plainOnly, bothPorts), discovery(addresses = listOf("192.168.3.27")))?.service?.address)
-        assertNull(selectHost(listOf(plainOnly, bothPorts), discovery(addresses = listOf("10.0.0.1"))))
+        assertEquals("192.168.3.27", selectHosts(listOf(plainOnly, bothPorts), discovery(addresses = listOf("192.168.3.27"))).firstOrNull()?.service?.address)
+        assertEquals(emptyList(), selectHosts(listOf(plainOnly, bothPorts), discovery(addresses = listOf("10.0.0.1"))))
     }
 
     @Test
     fun `hostName and address must both match when both are set`() {
-        assertNull(selectHost(listOf(plainOnly), discovery(hostNames = listOf("plain-host"), addresses = listOf("10.0.0.1"))))
+        assertEquals(emptyList(), selectHosts(listOf(plainOnly), discovery(hostNames = listOf("plain-host"), addresses = listOf("10.0.0.1"))))
         assertEquals(
             "192.168.3.26",
-            selectHost(listOf(plainOnly), discovery(hostNames = listOf("plain-host"), addresses = listOf("192.168.3.26")))?.service?.address,
+            selectHosts(listOf(plainOnly), discovery(hostNames = listOf("plain-host"), addresses = listOf("192.168.3.26"))).firstOrNull()?.service?.address,
         )
     }
 
@@ -99,6 +109,6 @@ class SelectHostTest {
             wssPort = null,
         )
 
-        assertEquals("192.168.3.28", selectHost(listOf(unnamed), discovery(hostNames = listOf("fallback-name")))?.service?.address)
+        assertEquals("192.168.3.28", selectHosts(listOf(unnamed), discovery(hostNames = listOf("fallback-name"))).firstOrNull()?.service?.address)
     }
 }


### PR DESCRIPTION
## Motivation

Falling back covered a browse that found nothing, and nothing else. Two gaps followed from that.

**A host that was found and then refused the connection was never given up on.** Each round re-picked
it, so the configured address was never dialled at all. An app carrying
`discovered(fallback = fixed("localhost", 5443))` could see a host on the LAN and never reach the
emulator's localhost behind it — the fallback was there, and unreachable.

**Only the first advertised host was ever tried.** `selectHost` took the head of the browse result and
kept no memory of it failing, so a firewalled host at the front of an arbitrary, platform-dependent
order stranded the session for good.

Both are the same missing behaviour: nothing moved on when a connection attempt failed.

## What changed

`EndpointResolver.resolve()` returns a list rather than an address. `MdnsEndpointResolver` offers every
usable host it browsed, with the fallback last — answering mDNS says a host is advertising, not that it
will accept a connection, so the configured address stays available behind the discovered ones.

The connect loop works down that list and backs off once the whole round is spent, not once per
candidate: a reachable host further down should not have to wait out the delay owed to the ones before
it. Each round resolves afresh, so a host that starts later is still picked up — the per-round
resolution from #146 is unchanged.

Establishment is capped at 30s so a candidate that drops packets rather than refusing cannot hold up
the ones behind it. The cap covers establishment only, never the session that follows. It is generous
on purpose: verifying on a physical Pixel measured 13s from discovery to an established session, over
half of it inside the CA fetch's plain-channel probe.

Failures are reported once per round rather than once per candidate, so a repeating set of failures
stays a repeating message and the existing suppression keeps working; individual attempts drop to
debug. The "several hosts advertised, using the first" warning is gone — with the whole list tried in
turn, several hosts is no longer an ambiguity anyone has to resolve.

No public API change: every type here is internal, and the `connection { }` DSL is untouched.

## Tests

`MessagingServiceResolutionTest` drives the loop with a scripted resolver and a socket client that
accepts only named addresses:

- a candidate that refuses is passed over for the next one **in the same round**
- **the fallback is reached when the discovered candidate refuses** — the regression test for the first
  gap above, a result the previous code could not produce
- a spent round is resolved again rather than retried as it was

`SelectHostTest` gains the case that every usable host is offered, in browse order.

## Verification

`:jetwhale-agent-runtime:jvmTest`, `:jetwhale-host:core:data:test`, `compileKotlinIosArm64`,
`compileKotlinMacosArm64`, `compileKotlinJs`, `compileKotlinWasmJs`, `compileKotlinLinuxX64`,
`compileKotlinMingwX64`, `checkKotlinAbi`, `:demo:shared:compileKotlinJvm` and `spotlessCheck` pass
locally.

Exercised end to end against a headless host with the demo's fallback pointed at an unreachable
address, so a connection could only come from discovery:

| Platform | Result |
|----------|--------|
| Android, physical Pixel 6 Pro | `Discovered 1 JetWhale host(s) over mDNS: … at 192.168.3.9:5443` → `WebSocket session established`; host logged the negotiation |
| iOS, physical device | connects |

## Follow-up

The CA fetch probes `http://<host>:<port>` before `https://`, which on a LAN connection always fails
first. It costs ~6.5s of the 13s establishment measured above and writes three stack traces into the
host log per connection. Worth its own change.
