### PR TITLE
Follow the plugin an AI agent operates

### DIFF
--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -9,7 +9,7 @@ Settings are organized into four **sections**, each holding one or more **pages*
 |---------|-------|
 | **General** | [Appearance](#appearance), [Application](#application) |
 | **Connection** | [Debug Server](#debug-server), [SSL Certificate](#ssl-certificates), [ADB Support](#adb-support) |
-| **AI Agents** | [MCP Server](#mcp-server), [Permissions](#mcp-permissions) |
+| **AI Agents** | [MCP Server](#mcp-server), [Permissions](#mcp-permissions), [Activity](#ai-activity) |
 | **Plugins** | [Installed Plugins](#plugins), [Add Plugins](#plugins), [Security](#plugin-trust) |
 
 ::: tip Window size and position
@@ -147,6 +147,20 @@ the agent's own connection — so that change takes effect on the next host star
 The **Settings → AI Agents → Permissions** page is a checkbox tree deciding what an AI agent may do,
 from read-only observation through to restarting the debug server. See
 [MCP Server → Permissions](/guide/mcp-server#permissions).
+
+### AI Activity
+
+The **Settings → AI Agents → Activity** page decides how the host window behaves while an agent is
+working.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Follow the plugin an AI agent operates** | On | While an agent drives a plugin over MCP, the main window switches to that plugin so you can watch it work. |
+
+Only a tool call that names a plugin moves the window; host-level calls (navigation, settings,
+status) leave it alone, and so does a plugin already popped out into its own window — it is visible
+where it is. While the window is following, a banner above the plugin names the tool running and
+offers **Stop following**, which turns the setting off without a trip back to this page.
 
 ## Plugins
 

--- a/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
@@ -32,6 +32,8 @@
     <string name="disable">無効化</string>
     <string name="ai_agent_connected">AI エージェント接続中</string>
     <string name="ai_agent_operating">AI エージェントが操作中</string>
+    <string name="following_ai_operation">AI エージェントに追従中 — %1$s</string>
+    <string name="stop_following_ai_operation">追従をやめる</string>
     <string name="plugin_exposes_mcp_tools">AI エージェントに MCP tools を公開中</string>
     <string name="mcp_tool_executing">MCP実行中</string>
     <string name="mcp_tools_available">MCP利用可能</string>

--- a/jetwhale-host/app/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values/strings.xml
@@ -32,6 +32,8 @@
     <string name="disable">Disable</string>
     <string name="ai_agent_connected">AI agent connected</string>
     <string name="ai_agent_operating">AI agent is operating</string>
+    <string name="following_ai_operation">Following the AI agent — %1$s</string>
+    <string name="stop_following_ai_operation">Stop following</string>
     <string name="plugin_exposes_mcp_tools">Exposes MCP tools to AI agents</string>
     <string name="mcp_tool_executing">MCP executing</string>
     <string name="mcp_tools_available">MCP available</string>

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -78,6 +78,12 @@ fun JetWhaleApp() {
         }
     }
 
+    // Started from the window rather than at app start: it drives the navigation this window owns,
+    // and a headless run has nothing to point anywhere.
+    LaunchedEffect(Unit) {
+        appGraph.followAiOperationService.followAiOperations()
+    }
+
     LaunchedEffect(Unit) {
         // dispose plugin scenes when the debug websocket server is stopped, as all plugin sessions will be closed
         appGraph.debugWebSocketServer.serverStoppedFlow.collect {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/component/AiOperationLatch.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/component/AiOperationLatch.kt
@@ -1,0 +1,36 @@
+package com.kitakkun.jetwhale.host.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
+
+/** How long an MCP tool call keeps showing after it completes. */
+private val AI_OPERATION_INDICATOR_LINGER = 1500.milliseconds
+
+/**
+ * Whether an AI agent should read as operating right now, given [startedCount] from
+ * [com.kitakkun.jetwhale.host.model.McpActivity].
+ *
+ * A tool call can start and finish faster than the UI samples the running-invocation list, so
+ * watching that list drops fast calls entirely. This latches "operating" on whenever [startedCount]
+ * changes and holds it briefly instead: a fast call still registers, and a burst reads as one
+ * continuous operation because each new call restarts the hold. Keying the effect on the monotonic
+ * counter means a skipped intermediate value still re-fires, since the value differs across frames.
+ */
+@Composable
+fun rememberAiOperating(startedCount: Long): Boolean {
+    var operating by remember { mutableStateOf(false) }
+    LaunchedEffect(startedCount) {
+        if (startedCount > 0L) {
+            operating = true
+            delay(AI_OPERATION_INDICATOR_LINGER)
+            operating = false
+        }
+    }
+    return operating
+}

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/component/FollowingAiOperationBanner.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/component/FollowingAiOperationBanner.kt
@@ -1,0 +1,87 @@
+package com.kitakkun.jetwhale.host.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SmartToy
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.host.Res
+import com.kitakkun.jetwhale.host.following_ai_operation
+import com.kitakkun.jetwhale.host.stop_following_ai_operation
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Says that the window moved on its own, and offers the switch that stops it.
+ *
+ * It sits above the content rather than over it — a following window is showing a plugin the user
+ * wants to watch, and a floating snackbar would cover exactly the thing it is announcing. Expanding
+ * the banner pushes the plugin down instead, so nothing is hidden.
+ */
+@Composable
+fun FollowingAiOperationBanner(
+    visible: Boolean,
+    toolName: String,
+    onClickStopFollowing: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = expandVertically() + fadeIn(),
+        exit = shrinkVertically() + fadeOut(),
+        modifier = modifier,
+    ) {
+        Surface(color = MaterialTheme.colorScheme.primaryContainer) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.SmartToy,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                )
+                Text(
+                    // The tool name is what the agent is doing right now; the plugin it targets is
+                    // already on screen, so naming it here would only repeat what the user sees.
+                    text = stringResource(Res.string.following_ai_operation, toolName),
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = onClickStopFollowing) {
+                    Text(stringResource(Res.string.stop_following_ai_operation))
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun FollowingAiOperationBannerPreview() {
+    FollowingAiOperationBanner(
+        visible = true,
+        toolName = "jetwhale.click",
+        onClickStopFollowing = {},
+    )
+}

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
@@ -11,6 +11,7 @@ import com.kitakkun.jetwhale.host.model.AppearanceSettingsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
 import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
 import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.FollowAiOperationService
 import com.kitakkun.jetwhale.host.model.HostNavigationService
 import com.kitakkun.jetwhale.host.model.HostVersionInfo
 import com.kitakkun.jetwhale.host.model.LogCaptureService
@@ -53,6 +54,7 @@ interface JetWhaleAppGraph : ScreenContext {
     val appearanceSettingsSubscriptionKey: AppearanceSettingsSubscriptionKey
     val debugWebSocketServer: DebugWebSocketServer
     val hostNavigationService: HostNavigationService
+    val followAiOperationService: FollowAiOperationService
     val pluginComposeSceneService: PluginComposeSceneService
     val pluginInstanceService: PluginInstanceService
     val pluginHotReloadService: PluginHotReloadService

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/AiActivityIndicatorView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/AiActivityIndicatorView.kt
@@ -260,7 +260,11 @@ fun CompactAiActivityIndicatorView(
 @Composable
 private fun AiActivityIndicatorConnectedPreview() {
     AiActivityIndicatorView(
-        uiState = AiActivityUiState(isAgentConnected = true, operatingToolName = null),
+        uiState = AiActivityUiState(
+            isAgentConnected = true,
+            operatingToolName = null,
+            isFollowingOperation = false,
+        ),
     )
 }
 
@@ -268,6 +272,10 @@ private fun AiActivityIndicatorConnectedPreview() {
 @Composable
 private fun AiActivityIndicatorOperatingPreview() {
     AiActivityIndicatorView(
-        uiState = AiActivityUiState(isAgentConnected = true, operatingToolName = "jetwhale.click"),
+        uiState = AiActivityUiState(
+            isAgentConnected = true,
+            operatingToolName = "jetwhale.click",
+            isFollowingOperation = true,
+        ),
     )
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/JetWhaleToolingScaffold.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/JetWhaleToolingScaffold.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.host.drawer
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -15,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.host.component.FollowingAiOperationBanner
 import com.kitakkun.jetwhale.host.component.ToolingDrawer
 import com.kitakkun.jetwhale.host.model.DebugSession
 import kotlinx.collections.immutable.persistentListOf
@@ -34,6 +36,7 @@ fun ToolingScaffold(
     onClickBringBack: (DrawerPluginItemUiState) -> Unit,
     onSelectSession: (DebugSession) -> Unit,
     onSetPluginEnabled: (pluginId: String, enabled: Boolean) -> Unit,
+    onClickStopFollowingAiOperation: () -> Unit,
     snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
@@ -62,16 +65,25 @@ fun ToolingScaffold(
                 )
             },
             content = {
-                // The drawer is not a Scaffold, so the snackbar is overlaid on the content area
-                // only: messages stay clear of the drawer and of any popped-out plugin window.
-                Box(modifier = Modifier.fillMaxSize()) {
-                    content()
-                    SnackbarHost(
-                        hostState = snackbarHostState,
-                        modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            .padding(16.dp),
+                Column(modifier = Modifier.fillMaxSize()) {
+                    // Above the content, not over it: the plugin below is the thing the follow just
+                    // brought into view, so an overlay would cover what it announces.
+                    FollowingAiOperationBanner(
+                        visible = uiState.aiActivity.isFollowingOperation,
+                        toolName = uiState.aiActivity.operatingToolName.orEmpty(),
+                        onClickStopFollowing = onClickStopFollowingAiOperation,
                     )
+                    // The drawer is not a Scaffold, so the snackbar is overlaid on the content area
+                    // only: messages stay clear of the drawer and of any popped-out plugin window.
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        content()
+                        SnackbarHost(
+                            hostState = snackbarHostState,
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(16.dp),
+                        )
+                    }
                 }
             },
             modifier = modifier,
@@ -102,6 +114,7 @@ private fun ToolingScaffoldPreview() {
         isPoppedOut = { false },
         onClickBringBack = {},
         onSetPluginEnabled = { _, _ -> },
+        onClickStopFollowingAiOperation = {},
         snackbarHostState = remember { SnackbarHostState() },
     ) {
         Text("Hello, World!")

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -54,6 +54,22 @@ internal fun closedSessions(
     return previouslyConnected.filterNot { it.id in stillConnected }
 }
 
+/**
+ * Whether following this call is something the user would see happen in the main window.
+ *
+ * Mirrors what [com.kitakkun.jetwhale.host.model.FollowAiOperationService] decides, so the banner
+ * announces a move rather than merely an agent being busy. A call that named no session is followed
+ * against the drawer's own selection, which is where [selectedSessionId] comes in.
+ */
+internal fun McpToolInvocation?.movesTheWindow(
+    selectedSessionId: String,
+    isPluginPoppedOut: (pluginId: String, sessionId: String) -> Boolean,
+): Boolean {
+    val pluginId = this?.pluginId ?: return false
+    val sessionId = this.sessionId ?: selectedSessionId
+    return !isPluginPoppedOut(pluginId, sessionId)
+}
+
 @Composable
 context(presenterContext: ToolingScaffoldPresenterContext)
 fun toolingScaffoldPresenter(
@@ -65,6 +81,7 @@ fun toolingScaffoldPresenter(
     mcpActivity: McpActivity,
     mcpCapablePlugins: McpCapablePlugins,
     followAiOperationEnabled: Boolean,
+    isPluginPoppedOut: (pluginId: String, sessionId: String) -> Boolean,
 ): ToolingScaffoldUiState {
     var selectedSessionId by retain { mutableStateOf("") }
     var selectedPluginId by retain { mutableStateOf("") }
@@ -160,8 +177,9 @@ fun toolingScaffoldPresenter(
         aiActivity = AiActivityUiState(
             isAgentConnected = mcpActivity.hasConnectedClient,
             operatingToolName = activeInvocation?.toolName,
-            // Only a call that names a plugin moves the window, so only that one is announced.
-            isFollowingOperation = followAiOperationEnabled && activeInvocation?.pluginId != null,
+            // Announce only what the window actually does: a call that names no plugin never moves
+            // it, and a plugin popped out into its own window is watched there, not here.
+            isFollowingOperation = followAiOperationEnabled && activeInvocation.movesTheWindow(selectedSessionId, isPluginPoppedOut),
         ),
     )
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.setValue
 import com.kitakkun.jetwhale.host.architecture.ActionEffect
 import com.kitakkun.jetwhale.host.architecture.MutationErrorEffect
 import com.kitakkun.jetwhale.host.architecture.ScreenChannel
+import com.kitakkun.jetwhale.host.component.rememberAiOperating
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.McpActivity
 import com.kitakkun.jetwhale.host.model.McpCapablePlugins
@@ -20,17 +21,15 @@ import com.kitakkun.jetwhale.host.model.PluginMetaData
 import com.kitakkun.jetwhale.host.model.SetPluginEnabledParams
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.delay
 import soil.query.compose.rememberMutation
-import kotlin.time.Duration.Companion.milliseconds
-
-/** How long an MCP tool call keeps showing after it completes. */
-private val AI_OPERATION_INDICATOR_LINGER = 1500.milliseconds
 
 sealed interface ToolingScaffoldScreenAction {
     data class SelectSession(val session: DebugSession) : ToolingScaffoldScreenAction
     data class UpdateSelectedPlugin(val pluginId: String) : ToolingScaffoldScreenAction
     data class SetPluginEnabled(val pluginId: String, val enabled: Boolean) : ToolingScaffoldScreenAction
+
+    /** Turns the follow mode off from the banner it puts on screen, without a trip to the settings. */
+    data object StopFollowingAiOperation : ToolingScaffoldScreenAction
 }
 
 sealed interface ToolingScaffoldScreenActionResult {
@@ -65,6 +64,7 @@ fun toolingScaffoldPresenter(
     hasFailedJars: Boolean,
     mcpActivity: McpActivity,
     mcpCapablePlugins: McpCapablePlugins,
+    followAiOperationEnabled: Boolean,
 ): ToolingScaffoldUiState {
     var selectedSessionId by retain { mutableStateOf("") }
     var selectedPluginId by retain { mutableStateOf("") }
@@ -72,22 +72,11 @@ fun toolingScaffoldPresenter(
         derivedStateOf { debugSessions.firstOrNull { it.id == selectedSessionId } }
     }
 
-    // A tool call can start and finish faster than the UI samples runningInvocations, so watching
-    // that list drops fast calls entirely. Latch "operating" on whenever startedCount changes and
-    // hold it briefly instead: a fast call still registers, and a burst reads as one continuous
-    // operation because each new call restarts the hold. Keying the effect on the monotonic counter
-    // means a skipped intermediate value still re-fires, since the value differs across frames.
-    var operating by remember { mutableStateOf(false) }
-    LaunchedEffect(mcpActivity.startedCount) {
-        if (mcpActivity.startedCount > 0L) {
-            operating = true
-            delay(AI_OPERATION_INDICATOR_LINGER)
-            operating = false
-        }
-    }
+    val operating = rememberAiOperating(mcpActivity.startedCount)
     val activeInvocation = mcpActivity.lastStartedInvocation?.takeIf { operating }
 
     val setPluginEnabledMutation = rememberMutation(presenterContext.setPluginEnabledMutationKey)
+    val followAiOperationMutation = rememberMutation(presenterContext.followAiOperationMutationKey)
 
     val plugins by remember(loadedPlugins, selectedSession, enabledPluginIds, mcpCapablePlugins, activeInvocation) {
         derivedStateOf {
@@ -151,6 +140,10 @@ fun toolingScaffoldPresenter(
             is ToolingScaffoldScreenAction.SetPluginEnabled -> {
                 setPluginEnabledMutation.mutateAsync(SetPluginEnabledParams(action.pluginId, action.enabled))
             }
+
+            ToolingScaffoldScreenAction.StopFollowingAiOperation -> {
+                followAiOperationMutation.mutateAsync(false)
+            }
         }
     }
 
@@ -167,6 +160,8 @@ fun toolingScaffoldPresenter(
         aiActivity = AiActivityUiState(
             isAgentConnected = mcpActivity.hasConnectedClient,
             operatingToolName = activeInvocation?.toolName,
+            // Only a call that names a plugin moves the window, so only that one is announced.
+            isFollowingOperation = followAiOperationEnabled && activeInvocation?.pluginId != null,
         ),
     )
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -79,6 +79,7 @@ fun ToolingScaffoldRoot(
                     mcpActivity = mcpActivity,
                     mcpCapablePlugins = mcpCapablePlugins,
                     followAiOperationEnabled = debuggerSettings.followAiOperationEnabled,
+                    isPluginPoppedOut = isPoppedOut,
                 )
             }
 

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -45,123 +45,134 @@ fun ToolingScaffoldRoot(
         state5 = rememberSubscription(screenContext.mcpActivitySubscriptionKey),
         state6 = rememberSubscription(screenContext.mcpCapablePluginsSubscriptionKey),
     ) { loadedPlugins, debugSessions, enabledPluginIds, failedJars, mcpActivity, mcpCapablePlugins ->
-        val screenChannel = rememberScreenChannel<ToolingScaffoldScreenAction, ToolingScaffoldScreenActionResult>()
-        val snackbarHostState = remember { SnackbarHostState() }
-        ActionResultEffect(screenChannel) { result ->
-            when (result) {
-                is ToolingScaffoldScreenActionResult.SessionClosed -> {
-                    // A single disconnect names the session; a simultaneous batch (the server
-                    // stopping, say) is collapsed into a count so the queue stays short enough to
-                    // read. showSnackbar suspends until dismissed, which serializes the queue.
-                    val closedSessions = result.closedSessions
-                    val message = closedSessions.singleOrNull()
-                        ?.let { getString(Res.string.session_disconnected_message, it.deviceAndAppDisplayName) }
-                        ?: getString(Res.string.sessions_disconnected_message, closedSessions.size)
-                    snackbarHostState.showSnackbar(message = message, duration = SnackbarDuration.Short)
+        // Nested rather than a seventh state: the boundary above is already at the arity it
+        // provides, and the settings read here are backed by an eagerly-started store, so the extra
+        // level resolves in the same frame.
+        SoilDataBoundary(
+            state = rememberSubscription(screenContext.settingsSubscriptionKey),
+        ) { debuggerSettings ->
+            val screenChannel = rememberScreenChannel<ToolingScaffoldScreenAction, ToolingScaffoldScreenActionResult>()
+            val snackbarHostState = remember { SnackbarHostState() }
+            ActionResultEffect(screenChannel) { result ->
+                when (result) {
+                    is ToolingScaffoldScreenActionResult.SessionClosed -> {
+                        // A single disconnect names the session; a simultaneous batch (the server
+                        // stopping, say) is collapsed into a count so the queue stays short enough to
+                        // read. showSnackbar suspends until dismissed, which serializes the queue.
+                        val closedSessions = result.closedSessions
+                        val message = closedSessions.singleOrNull()
+                            ?.let { getString(Res.string.session_disconnected_message, it.deviceAndAppDisplayName) }
+                            ?: getString(Res.string.sessions_disconnected_message, closedSessions.size)
+                        snackbarHostState.showSnackbar(message = message, duration = SnackbarDuration.Short)
+                    }
+
+                    is ToolingScaffoldScreenActionResult.SetPluginEnabledFailed -> Unit
                 }
-
-                is ToolingScaffoldScreenActionResult.SetPluginEnabledFailed -> Unit
             }
-        }
-        val uiState = context(screenContext.presenterContext) {
-            toolingScaffoldPresenter(
-                screenChannel = screenChannel,
-                loadedPlugins = loadedPlugins,
-                debugSessions = debugSessions,
-                enabledPluginIds = enabledPluginIds,
-                hasFailedJars = failedJars.isNotEmpty(),
-                mcpActivity = mcpActivity,
-                mcpCapablePlugins = mcpCapablePlugins,
-            )
-        }
+            val uiState = context(screenContext.presenterContext) {
+                toolingScaffoldPresenter(
+                    screenChannel = screenChannel,
+                    loadedPlugins = loadedPlugins,
+                    debugSessions = debugSessions,
+                    enabledPluginIds = enabledPluginIds,
+                    hasFailedJars = failedJars.isNotEmpty(),
+                    mcpActivity = mcpActivity,
+                    mcpCapablePlugins = mcpCapablePlugins,
+                    followAiOperationEnabled = debuggerSettings.followAiOperationEnabled,
+                )
+            }
 
-        // When the active/selected session changes, notify the host so that an open plugin
-        // screen can follow the newly-selected session instead of lingering on the old one.
-        LaunchedEffect(uiState.selectedSessionId) {
-            val selectedSession = uiState.selectedSession ?: return@LaunchedEffect
-            onSelectedSessionChange(selectedSession)
-        }
+            // When the active/selected session changes, notify the host so that an open plugin
+            // screen can follow the newly-selected session instead of lingering on the old one.
+            LaunchedEffect(uiState.selectedSessionId) {
+                val selectedSession = uiState.selectedSession ?: return@LaunchedEffect
+                onSelectedSessionChange(selectedSession)
+            }
 
-        // Publish the drawer's selection so a caller outside the composition (the MCP server) can
-        // read what the window is pointed at; the destination itself is published by JetWhaleApp.
-        LaunchedEffect(uiState.selectedSessionId, uiState.selectedPluginId) {
-            screenContext.hostNavigationService.updateSelection(
-                selectedSessionId = uiState.selectedSessionId.takeIf { it.isNotEmpty() },
-                selectedPluginId = uiState.selectedPluginId.takeIf { it.isNotEmpty() },
-            )
-        }
+            // Publish the drawer's selection so a caller outside the composition (the MCP server) can
+            // read what the window is pointed at; the destination itself is published by JetWhaleApp.
+            LaunchedEffect(uiState.selectedSessionId, uiState.selectedPluginId) {
+                screenContext.hostNavigationService.updateSelection(
+                    selectedSessionId = uiState.selectedSessionId.takeIf { it.isNotEmpty() },
+                    selectedPluginId = uiState.selectedPluginId.takeIf { it.isNotEmpty() },
+                )
+            }
 
-        // The collector below outlives every recomposition, so it must not close over the sessions
-        // and ui state of the composition that started it.
-        val currentSessions by rememberUpdatedState(debugSessions)
-        val currentUiState by rememberUpdatedState(uiState)
+            // The collector below outlives every recomposition, so it must not close over the sessions
+            // and ui state of the composition that started it.
+            val currentSessions by rememberUpdatedState(debugSessions)
+            val currentUiState by rememberUpdatedState(uiState)
 
-        // The single collector of navigation requests: only here are both the screen channel and
-        // the navigation callbacks in scope, and the request channel delivers each request once.
-        LaunchedEffect(screenChannel) {
-            screenContext.hostNavigationService.requests.collect { request ->
-                when (request) {
-                    HostNavigationRequest.Home -> onNavigateHome()
+            // The single collector of navigation requests: only here are both the screen channel and
+            // the navigation callbacks in scope, and the request channel delivers each request once.
+            LaunchedEffect(screenChannel) {
+                screenContext.hostNavigationService.requests.collect { request ->
+                    when (request) {
+                        HostNavigationRequest.Home -> onNavigateHome()
 
-                    HostNavigationRequest.Info -> onClickInfo()
+                        HostNavigationRequest.Info -> onClickInfo()
 
-                    HostNavigationRequest.LogViewer -> onNavigateLogViewer()
+                        HostNavigationRequest.LogViewer -> onNavigateLogViewer()
 
-                    is HostNavigationRequest.Settings -> onNavigateSettings(request.section.toPage())
+                        is HostNavigationRequest.Settings -> onNavigateSettings(request.section.toPage())
 
-                    is HostNavigationRequest.Plugin -> {
-                        // Only a request that named no session falls back to the drawer's selection.
-                        // A named session that has gone away since the request was validated must
-                        // drop the request rather than navigate to some other app.
-                        val targetSession = when (val requestedSessionId = request.sessionId) {
-                            null -> currentUiState.selectedSession
-                            else -> currentSessions.firstOrNull { it.id == requestedSessionId }
-                        } ?: return@collect
-                        // Drive the same path a drawer click takes, so an MCP-driven navigation and a
-                        // click are indistinguishable downstream.
-                        if (targetSession.id != currentUiState.selectedSessionId) {
-                            screenChannel.send(ToolingScaffoldScreenAction.SelectSession(targetSession))
+                        is HostNavigationRequest.Plugin -> {
+                            // Only a request that named no session falls back to the drawer's selection.
+                            // A named session that has gone away since the request was validated must
+                            // drop the request rather than navigate to some other app.
+                            val targetSession = when (val requestedSessionId = request.sessionId) {
+                                null -> currentUiState.selectedSession
+                                else -> currentSessions.firstOrNull { it.id == requestedSessionId }
+                            } ?: return@collect
+                            // Drive the same path a drawer click takes, so an MCP-driven navigation and a
+                            // click are indistinguishable downstream.
+                            if (targetSession.id != currentUiState.selectedSessionId) {
+                                screenChannel.send(ToolingScaffoldScreenAction.SelectSession(targetSession))
+                            }
+                            screenChannel.send(ToolingScaffoldScreenAction.UpdateSelectedPlugin(request.pluginId))
+                            onClickPlugin(request.pluginId, targetSession.id)
                         }
-                        screenChannel.send(ToolingScaffoldScreenAction.UpdateSelectedPlugin(request.pluginId))
-                        onClickPlugin(request.pluginId, targetSession.id)
                     }
                 }
             }
-        }
 
-        ToolingScaffold(
-            uiState = uiState,
-            onClickSettings = onClickSettings,
-            onClickPluginSettings = onClickPluginSettings,
-            onClickInfo = onClickInfo,
-            onClickPlugin = {
-                val selectedSession = uiState.selectedSession ?: return@ToolingScaffold
-                screenChannel.send(ToolingScaffoldScreenAction.UpdateSelectedPlugin(it))
-                onClickPlugin(it, selectedSession.id)
-            },
-            // The browser tolerates a missing session, so the badge stays usable while no session
-            // is selected: it simply opens with the session filter on "All".
-            onOpenMcpTools = { onOpenMcpTools(it, uiState.selectedSession?.id) },
-            onOpenAllMcpTools = { onOpenMcpTools(null, null) },
-            onClickPopout = {
-                val selectedSession = uiState.selectedSession ?: return@ToolingScaffold
-                onClickPopout(it.id, it.name, selectedSession.id)
-            },
-            isPoppedOut = { pluginId ->
-                val selectedSession = uiState.selectedSession ?: return@ToolingScaffold false
-                isPoppedOut(pluginId, selectedSession.id)
-            },
-            onClickBringBack = {
-                val selectedSession = uiState.selectedSession ?: return@ToolingScaffold
-                screenChannel.send(ToolingScaffoldScreenAction.UpdateSelectedPlugin(it.id))
-                onClickBringBack(it.id, selectedSession.id)
-            },
-            onSelectSession = { screenChannel.send(ToolingScaffoldScreenAction.SelectSession(it)) },
-            onSetPluginEnabled = { pluginId, enabled ->
-                screenChannel.send(ToolingScaffoldScreenAction.SetPluginEnabled(pluginId, enabled))
-            },
-            snackbarHostState = snackbarHostState,
-            content = content,
-        )
+            ToolingScaffold(
+                uiState = uiState,
+                onClickSettings = onClickSettings,
+                onClickPluginSettings = onClickPluginSettings,
+                onClickInfo = onClickInfo,
+                onClickPlugin = {
+                    val selectedSession = uiState.selectedSession ?: return@ToolingScaffold
+                    screenChannel.send(ToolingScaffoldScreenAction.UpdateSelectedPlugin(it))
+                    onClickPlugin(it, selectedSession.id)
+                },
+                // The browser tolerates a missing session, so the badge stays usable while no session
+                // is selected: it simply opens with the session filter on "All".
+                onOpenMcpTools = { onOpenMcpTools(it, uiState.selectedSession?.id) },
+                onOpenAllMcpTools = { onOpenMcpTools(null, null) },
+                onClickPopout = {
+                    val selectedSession = uiState.selectedSession ?: return@ToolingScaffold
+                    onClickPopout(it.id, it.name, selectedSession.id)
+                },
+                isPoppedOut = { pluginId ->
+                    val selectedSession = uiState.selectedSession ?: return@ToolingScaffold false
+                    isPoppedOut(pluginId, selectedSession.id)
+                },
+                onClickBringBack = {
+                    val selectedSession = uiState.selectedSession ?: return@ToolingScaffold
+                    screenChannel.send(ToolingScaffoldScreenAction.UpdateSelectedPlugin(it.id))
+                    onClickBringBack(it.id, selectedSession.id)
+                },
+                onSelectSession = { screenChannel.send(ToolingScaffoldScreenAction.SelectSession(it)) },
+                onSetPluginEnabled = { pluginId, enabled ->
+                    screenChannel.send(ToolingScaffoldScreenAction.SetPluginEnabled(pluginId, enabled))
+                },
+                onClickStopFollowingAiOperation = {
+                    screenChannel.send(ToolingScaffoldScreenAction.StopFollowingAiOperation)
+                },
+                snackbarHostState = snackbarHostState,
+                content = content,
+            )
+        }
     }
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldScreenContext.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldScreenContext.kt
@@ -5,11 +5,13 @@ import com.kitakkun.jetwhale.host.architecture.ScreenContext
 import com.kitakkun.jetwhale.host.model.DebugSessionsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.EnabledPluginsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.FailedPluginJarPathsSubscriptionKey
+import com.kitakkun.jetwhale.host.model.FollowAiOperationMutationKey
 import com.kitakkun.jetwhale.host.model.HostNavigationService
 import com.kitakkun.jetwhale.host.model.LoadedPluginsMetaDataSubscriptionKey
 import com.kitakkun.jetwhale.host.model.McpActivitySubscriptionKey
 import com.kitakkun.jetwhale.host.model.McpCapablePluginsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.SetPluginEnabledMutationKey
+import com.kitakkun.jetwhale.host.model.SettingsSubscriptionKey
 import dev.zacsweers.metro.Inject
 
 /**
@@ -18,6 +20,7 @@ import dev.zacsweers.metro.Inject
 @Inject
 class ToolingScaffoldPresenterContext(
     val setPluginEnabledMutationKey: SetPluginEnabledMutationKey,
+    val followAiOperationMutationKey: FollowAiOperationMutationKey,
 ) : PresenterContext
 
 /**
@@ -32,6 +35,7 @@ class ToolingScaffoldScreenContext(
     val failedPluginJarPathsSubscriptionKey: FailedPluginJarPathsSubscriptionKey,
     val mcpActivitySubscriptionKey: McpActivitySubscriptionKey,
     val mcpCapablePluginsSubscriptionKey: McpCapablePluginsSubscriptionKey,
+    val settingsSubscriptionKey: SettingsSubscriptionKey,
     val hostNavigationService: HostNavigationService,
     val presenterContext: ToolingScaffoldPresenterContext,
 ) : ScreenContext

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldUiState.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldUiState.kt
@@ -12,11 +12,20 @@ import kotlinx.collections.immutable.ImmutableList
 data class AiActivityUiState(
     val isAgentConnected: Boolean,
     val operatingToolName: String?,
+    /**
+     * Whether the window is following the operation on screen right now — the mode is on and the
+     * call in flight names a plugin. Only then is there a movement to announce and offer to stop.
+     */
+    val isFollowingOperation: Boolean,
 ) {
     val isOperating: Boolean get() = operatingToolName != null
 
     companion object {
-        val Idle = AiActivityUiState(isAgentConnected = false, operatingToolName = null)
+        val Idle = AiActivityUiState(
+            isAgentConnected = false,
+            operatingToolName = null,
+            isFollowingOperation = false,
+        )
     }
 }
 

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/drawer/FollowBannerVisibilityTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/drawer/FollowBannerVisibilityTest.kt
@@ -1,0 +1,83 @@
+package com.kitakkun.jetwhale.host.drawer
+
+import com.kitakkun.jetwhale.host.model.McpToolInvocation
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The banner claims the window is following an agent, so it may only appear when the window really
+ * moves. These pin it to the same cases `FollowAiOperationService` acts on.
+ */
+class FollowBannerVisibilityTest {
+
+    private val nothingPoppedOut: (String, String) -> Boolean = { _, _ -> false }
+
+    private fun invocation(pluginId: String?, sessionId: String?) = McpToolInvocation(
+        id = 1,
+        toolName = "jetwhale.click",
+        pluginId = pluginId,
+        sessionId = sessionId,
+        arguments = persistentListOf(),
+    )
+
+    @Test
+    fun `a call driving a plugin moves the window`() {
+        val moves = invocation(pluginId = "plugin-1", sessionId = "session-1")
+            .movesTheWindow(selectedSessionId = "session-1", isPluginPoppedOut = nothingPoppedOut)
+
+        assertTrue(moves)
+    }
+
+    @Test
+    fun `no call in flight moves nothing`() {
+        assertFalse(null.movesTheWindow(selectedSessionId = "session-1", isPluginPoppedOut = nothingPoppedOut))
+    }
+
+    @Test
+    fun `a host call naming no plugin moves nothing`() {
+        val moves = invocation(pluginId = null, sessionId = "session-1")
+            .movesTheWindow(selectedSessionId = "session-1", isPluginPoppedOut = nothingPoppedOut)
+
+        assertFalse(moves)
+    }
+
+    @Test
+    fun `a plugin popped out for that session is watched in its own window`() {
+        val moves = invocation(pluginId = "plugin-1", sessionId = "session-1")
+            .movesTheWindow(
+                selectedSessionId = "session-1",
+                isPluginPoppedOut = { pluginId, sessionId -> pluginId == "plugin-1" && sessionId == "session-1" },
+            )
+
+        assertFalse(moves)
+    }
+
+    @Test
+    fun `the same plugin popped out for another session still moves the window`() {
+        val moves = invocation(pluginId = "plugin-1", sessionId = "session-2")
+            .movesTheWindow(
+                selectedSessionId = "session-1",
+                isPluginPoppedOut = { pluginId, sessionId -> pluginId == "plugin-1" && sessionId == "session-1" },
+            )
+
+        assertTrue(moves)
+    }
+
+    @Test
+    fun `a call naming no session is judged against the drawer's selection`() {
+        val poppedOutInSelectedSession: (String, String) -> Boolean = { pluginId, sessionId ->
+            pluginId == "plugin-1" && sessionId == "session-1"
+        }
+
+        assertFalse(
+            invocation(pluginId = "plugin-1", sessionId = null)
+                .movesTheWindow(selectedSessionId = "session-1", isPluginPoppedOut = poppedOutInSelectedSession),
+        )
+        assertTrue(
+            invocation(pluginId = "plugin-1", sessionId = null)
+                .movesTheWindow(selectedSessionId = "session-2", isPluginPoppedOut = poppedOutInSelectedSession),
+        )
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultFollowAiOperationService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultFollowAiOperationService.kt
@@ -1,0 +1,67 @@
+package com.kitakkun.jetwhale.host.data.navigation
+
+import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.FollowAiOperationService
+import com.kitakkun.jetwhale.host.model.HostDestination
+import com.kitakkun.jetwhale.host.model.HostDestinationKind
+import com.kitakkun.jetwhale.host.model.HostNavigationRequest
+import com.kitakkun.jetwhale.host.model.HostNavigationService
+import com.kitakkun.jetwhale.host.model.McpActivityRepository
+import com.kitakkun.jetwhale.host.model.McpToolInvocation
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.mapNotNull
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultFollowAiOperationService(
+    private val mcpActivityRepository: McpActivityRepository,
+    private val debuggerSettingsRepository: DebuggerSettingsRepository,
+    private val hostNavigationService: HostNavigationService,
+) : FollowAiOperationService {
+
+    override suspend fun followAiOperations() {
+        // lastStartedInvocation rather than runningInvocations: a call can finish before this
+        // collector is resumed, and a window that missed it would sit on the wrong plugin for the
+        // rest of the run. Every started call carries a fresh id, so keying distinctness on the id
+        // follows each new call exactly once while leaving the completion updates alone.
+        mcpActivityRepository.activityFlow
+            .mapNotNull { it.lastStartedInvocation }
+            .distinctUntilChangedBy { it.id }
+            .collect { invocation -> follow(invocation) }
+    }
+
+    private suspend fun follow(invocation: McpToolInvocation) {
+        // Read per call, not once: turning the mode off has to stop the next call from moving the
+        // window, without restarting the collector.
+        if (!debuggerSettingsRepository.followAiOperationEnabledFlow.value) return
+        // Host tools (navigation, settings, status) name no plugin, and there is nothing to follow.
+        val pluginId = invocation.pluginId ?: return
+
+        val currentView = hostNavigationService.currentView.value
+        // Null until the window reports its first destination; navigating then is still right,
+        // because the request waits in the channel until the window is there to take it.
+        if (currentView != null && currentView.destination.alreadyShows(invocation, pluginId)) return
+
+        hostNavigationService.navigate(HostNavigationRequest.Plugin(pluginId, invocation.sessionId))
+    }
+}
+
+/**
+ * Whether the operated plugin is on screen already, either as the main window's destination or in a
+ * window of its own. Following in that case would only take the main window off whatever else the
+ * user had put there.
+ *
+ * A call that names no session is followed against whatever session the drawer has selected, so it
+ * counts as shown wherever that plugin is shown.
+ */
+private fun HostDestination.alreadyShows(invocation: McpToolInvocation, pluginId: String): Boolean {
+    val matchesSession = { sessionId: String? -> invocation.sessionId == null || invocation.sessionId == sessionId }
+    val poppedOut = poppedOutPlugins.any { it.pluginId == pluginId && matchesSession(it.sessionId) }
+    val onScreen = kind == HostDestinationKind.PLUGIN && this.pluginId == pluginId && matchesSession(this.sessionId)
+    return poppedOut || onScreen
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepository.kt
@@ -90,6 +90,13 @@ class DefaultDebuggerSettingsRepository(
             started = SharingStarted.Eagerly,
             initialValue = DEFAULT_WSS_ENABLED,
         )
+    override val followAiOperationEnabledFlow = dataStore.data
+        .map { it[KEY_FOLLOW_AI_OPERATION_ENABLED] ?: DEFAULT_FOLLOW_AI_OPERATION_ENABLED }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.Eagerly,
+            initialValue = DEFAULT_FOLLOW_AI_OPERATION_ENABLED,
+        )
 
     override suspend fun readAdbAutoPortMappingEnabled(): Boolean = dataStore.data.first()[KEY_ADB_AUTO_PORT_MAPPING_ENABLED] ?: DEFAULT_ADB_AUTO_PORT_MAPPING_ENABLED
 
@@ -148,6 +155,12 @@ class DefaultDebuggerSettingsRepository(
         }
     }
 
+    override suspend fun updateFollowAiOperationEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_FOLLOW_AI_OPERATION_ENABLED] = enabled
+        }
+    }
+
     /** Lets a launch override win over the stored value this flow carries. */
     private fun Flow<Int>.overriddenBy(selectOverride: (ServerPortOverrides) -> Int?): Flow<Int> = combine(portOverrides) { storedPort, overrides -> selectOverride(overrides) ?: storedPort }
 
@@ -173,6 +186,13 @@ class DefaultDebuggerSettingsRepository(
         private val KEY_MCP_SERVER_PORT = intPreferencesKey("mcp_server_port")
         private val KEY_WSS_PORT = intPreferencesKey("wss_port")
         private val KEY_WSS_ENABLED = booleanPreferencesKey("wss_enabled")
+        private val KEY_FOLLOW_AI_OPERATION_ENABLED = booleanPreferencesKey("follow_ai_operation_enabled")
+
+        /**
+         * On by default: an agent driving a plugin the window is not showing is exactly the case
+         * this exists for, and someone who would rather stay put can say so in the settings.
+         */
+        private const val DEFAULT_FOLLOW_AI_OPERATION_ENABLED = true
         private const val DEFAULT_SERVER_PORT = 5080
         private const val DEFAULT_MCP_SERVER_PORT = 7080
         private const val DEFAULT_WSS_PORT = 5443

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultFollowAiOperationMutationKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultFollowAiOperationMutationKey.kt
@@ -1,0 +1,23 @@
+package com.kitakkun.jetwhale.host.data.settings
+
+import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.FollowAiOperationMutationKey
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
+import soil.query.MutationId
+import soil.query.MutationKey
+import soil.query.buildMutationKey
+
+@ContributesBinding(AppScope::class, binding<FollowAiOperationMutationKey>())
+@Inject
+class DefaultFollowAiOperationMutationKey(
+    private val settingsRepository: DebuggerSettingsRepository,
+) : FollowAiOperationMutationKey,
+    MutationKey<Unit, Boolean> by buildMutationKey(
+        id = MutationId("followAiOperation"),
+        mutate = { enabled: Boolean ->
+            settingsRepository.updateFollowAiOperationEnabled(enabled)
+        },
+    )

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultSettingsSubscriptionKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultSettingsSubscriptionKey.kt
@@ -27,7 +27,8 @@ class DefaultSettingsSubscriptionKey(
             defaultDebuggerSettingsRepository.mcpServerPortFlow,
             defaultDebuggerSettingsRepository.wssPortFlow,
             defaultDebuggerSettingsRepository.wssEnabledFlow,
-        ) { adbAutoPortMappingEnabled, checkForUpdatesOnStartup, persistData, serverPort, mcpServerPort, wssPort, wssEnabled ->
+            defaultDebuggerSettingsRepository.followAiOperationEnabledFlow,
+        ) { adbAutoPortMappingEnabled, checkForUpdatesOnStartup, persistData, serverPort, mcpServerPort, wssPort, wssEnabled, followAiOperationEnabled ->
             DebuggerBehaviorSettings(
                 adbAutoPortMappingEnabled = adbAutoPortMappingEnabled,
                 checkForUpdatesOnStartup = checkForUpdatesOnStartup,
@@ -36,14 +37,15 @@ class DefaultSettingsSubscriptionKey(
                 mcpServerPort = mcpServerPort,
                 wssPort = wssPort,
                 wssEnabled = wssEnabled,
+                followAiOperationEnabled = followAiOperationEnabled,
             )
         }
     },
 )
 
-/** Seven-flow overload of [combine], which kotlinx.coroutines only provides up to five flows. */
+/** Eight-flow overload of [combine], which kotlinx.coroutines only provides up to five flows. */
 @Suppress("UNCHECKED_CAST")
-private inline fun <reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, R> combine(
+private inline fun <reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, R> combine(
     flow1: Flow<T1>,
     flow2: Flow<T2>,
     flow3: Flow<T3>,
@@ -51,8 +53,9 @@ private inline fun <reified T1, reified T2, reified T3, reified T4, reified T5, 
     flow5: Flow<T5>,
     flow6: Flow<T6>,
     flow7: Flow<T7>,
-    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7) -> R,
-): Flow<R> = combine(flow1, flow2, flow3, flow4, flow5, flow6, flow7) { args: Array<*> ->
+    flow8: Flow<T8>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
+): Flow<R> = combine(flow1, flow2, flow3, flow4, flow5, flow6, flow7, flow8) { args: Array<*> ->
     transform(
         args[0] as T1,
         args[1] as T2,
@@ -61,5 +64,6 @@ private inline fun <reified T1, reified T2, reified T3, reified T4, reified T5, 
         args[4] as T5,
         args[5] as T6,
         args[6] as T7,
+        args[7] as T8,
     )
 }

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultFollowAiOperationServiceTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultFollowAiOperationServiceTest.kt
@@ -1,0 +1,154 @@
+package com.kitakkun.jetwhale.host.data.navigation
+
+import com.kitakkun.jetwhale.host.data.server.DefaultMcpActivityRepository
+import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.HostDestination
+import com.kitakkun.jetwhale.host.model.HostDestinationKind
+import com.kitakkun.jetwhale.host.model.HostNavigationRequest
+import com.kitakkun.jetwhale.host.model.PoppedOutPlugin
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DefaultFollowAiOperationServiceTest {
+
+    private val activityRepository = DefaultMcpActivityRepository()
+    private val navigationService = DefaultHostNavigationService()
+    private val followEnabled = MutableStateFlow(true)
+    private val settingsRepository = mock<DebuggerSettingsRepository>(MockMode.autoUnit) {
+        every { followAiOperationEnabledFlow } returns this@DefaultFollowAiOperationServiceTest.followEnabled
+    }
+
+    private val service = DefaultFollowAiOperationService(
+        mcpActivityRepository = activityRepository,
+        debuggerSettingsRepository = settingsRepository,
+        hostNavigationService = navigationService,
+    )
+
+    private fun CoroutineScope.startFollowing(): Job = launch { service.followAiOperations() }
+
+    /** Starts a tool call the way `McpToolRegistrar` does when it wraps a handler. */
+    private fun startCall(toolName: String, pluginId: String?, sessionId: String?) {
+        activityRepository.toolInvocationStarted(
+            toolName = toolName,
+            pluginId = pluginId,
+            sessionId = sessionId,
+            arguments = emptyMap(),
+        )
+    }
+
+    private suspend fun awaitRequest(): HostNavigationRequest? = withTimeout(5_000) { navigationService.requests.first() }
+
+    /**
+     * A navigation that never comes can only be observed by waiting for one, so this waits long
+     * enough that a request the service was going to send would have arrived by now.
+     */
+    private suspend fun awaitNoRequest(): HostNavigationRequest? = withTimeoutOrNull(300) { navigationService.requests.first() }
+
+    @Test
+    fun `a plugin tool call points the window at that plugin`() = runBlocking {
+        val following = startFollowing()
+
+        startCall("jetwhale.click", pluginId = "plugin-1", sessionId = "session-1")
+
+        assertEquals(HostNavigationRequest.Plugin("plugin-1", "session-1"), awaitRequest())
+        following.cancel()
+    }
+
+    @Test
+    fun `nothing is followed while the mode is off`() = runBlocking {
+        followEnabled.value = false
+        val following = startFollowing()
+
+        startCall("jetwhale.click", pluginId = "plugin-1", sessionId = "session-1")
+
+        assertNull(awaitNoRequest())
+        following.cancel()
+    }
+
+    @Test
+    fun `turning the mode back on follows the next call`() = runBlocking {
+        followEnabled.value = false
+        val following = startFollowing()
+        startCall("jetwhale.click", pluginId = "plugin-1", sessionId = "session-1")
+        assertNull(awaitNoRequest())
+
+        followEnabled.value = true
+        startCall("jetwhale.click", pluginId = "plugin-2", sessionId = "session-1")
+
+        assertEquals(HostNavigationRequest.Plugin("plugin-2", "session-1"), awaitRequest())
+        following.cancel()
+    }
+
+    @Test
+    fun `a call that names no plugin is not followed`() = runBlocking {
+        val following = startFollowing()
+
+        startCall("jetwhale.host_status", pluginId = null, sessionId = "session-1")
+
+        assertNull(awaitNoRequest())
+        following.cancel()
+    }
+
+    @Test
+    fun `the plugin already on screen is not navigated to again`() = runBlocking {
+        navigationService.updateDestination(
+            HostDestination(
+                kind = HostDestinationKind.PLUGIN,
+                pluginId = "plugin-1",
+                sessionId = "session-1",
+            ),
+        )
+        val following = startFollowing()
+
+        startCall("jetwhale.click", pluginId = "plugin-1", sessionId = "session-1")
+
+        assertNull(awaitNoRequest())
+        following.cancel()
+    }
+
+    @Test
+    fun `the same plugin in another session is still followed`() = runBlocking {
+        navigationService.updateDestination(
+            HostDestination(
+                kind = HostDestinationKind.PLUGIN,
+                pluginId = "plugin-1",
+                sessionId = "session-1",
+            ),
+        )
+        val following = startFollowing()
+
+        startCall("jetwhale.click", pluginId = "plugin-1", sessionId = "session-2")
+
+        assertEquals(HostNavigationRequest.Plugin("plugin-1", "session-2"), awaitRequest())
+        following.cancel()
+    }
+
+    @Test
+    fun `a plugin popped out into its own window is left where it is`() = runBlocking {
+        navigationService.updateDestination(
+            HostDestination(
+                kind = HostDestinationKind.HOME,
+                poppedOutPlugins = listOf(PoppedOutPlugin("plugin-1", "session-1")),
+            ),
+        )
+        val following = startFollowing()
+
+        startCall("jetwhale.click", pluginId = "plugin-1", sessionId = "session-1")
+
+        assertNull(awaitNoRequest())
+        following.cancel()
+    }
+}

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultDebuggerSettingsRepositoryTest.kt
@@ -61,6 +61,17 @@ class DefaultDebuggerSettingsRepositoryTest {
     }
 
     @Test
+    fun `following ai operations is on until it is turned off`() = runBlocking {
+        val dataStore = newDataStore()
+
+        assertEmits(true, DefaultDebuggerSettingsRepository(dataStore, noOverrides).followAiOperationEnabledFlow)
+
+        DefaultDebuggerSettingsRepository(dataStore, noOverrides).updateFollowAiOperationEnabled(false)
+
+        assertEmits(false, DefaultDebuggerSettingsRepository(dataStore, noOverrides).followAiOperationEnabledFlow)
+    }
+
+    @Test
     fun `launch overrides win over the stored ports`() = runBlocking {
         val dataStore = newDataStore()
         DefaultDebuggerSettingsRepository(dataStore, noOverrides).run {

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerBehaviorSettings.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerBehaviorSettings.kt
@@ -8,4 +8,5 @@ data class DebuggerBehaviorSettings(
     val mcpServerPort: Int,
     val wssPort: Int,
     val wssEnabled: Boolean,
+    val followAiOperationEnabled: Boolean,
 )

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerSettingsRepository.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/DebuggerSettingsRepository.kt
@@ -10,6 +10,7 @@ interface DebuggerSettingsRepository {
     val mcpServerPortFlow: StateFlow<Int>
     val wssPortFlow: StateFlow<Int>
     val wssEnabledFlow: StateFlow<Boolean>
+    val followAiOperationEnabledFlow: StateFlow<Boolean>
 
     /**
      * The stored values, awaiting the initial read rather than reporting the default while it is
@@ -30,4 +31,5 @@ interface DebuggerSettingsRepository {
     suspend fun updateMcpServerPort(port: Int)
     suspend fun updateWssPort(port: Int)
     suspend fun updateWssEnabled(enabled: Boolean)
+    suspend fun updateFollowAiOperationEnabled(enabled: Boolean)
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/FollowAiOperationMutationKey.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/FollowAiOperationMutationKey.kt
@@ -1,0 +1,8 @@
+package com.kitakkun.jetwhale.host.model
+
+import soil.query.MutationKey
+
+/**
+ * Persists whether the main window follows the plugin an AI agent is operating.
+ */
+interface FollowAiOperationMutationKey : MutationKey<Unit, Boolean>

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/FollowAiOperationService.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/FollowAiOperationService.kt
@@ -1,0 +1,18 @@
+package com.kitakkun.jetwhale.host.model
+
+/**
+ * Points the main window at whatever plugin an AI agent is currently operating, so a person can
+ * watch the agent work instead of reconstructing it from the drawer's activity indicator.
+ *
+ * The follow only ever moves the main window: a plugin already popped out into its own window is
+ * visible as it is, and dragging the main window onto it would take the user off whatever they were
+ * looking at for no gain.
+ */
+interface FollowAiOperationService {
+    /**
+     * Follows agent operations for as long as this call is active, requesting navigation through
+     * [HostNavigationService] as tool calls arrive. Suspends forever; collect exactly once, from the
+     * window that owns the navigation, since [HostNavigationService.requests] has a single collector.
+     */
+    suspend fun followAiOperations()
+}

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -4,6 +4,9 @@
     <string name="settings_section_ai_agents">AIエージェント</string>
     <string name="settings_page_application">アプリケーション</string>
     <string name="settings_page_add_plugins">プラグインの追加</string>
+    <string name="settings_page_ai_activity">アクティビティ</string>
+    <string name="follow_ai_operation">AI エージェントが操作したプラグインに追従する</string>
+    <string name="follow_ai_operation_description">AI エージェントが MCP 経由でプラグインを操作している間、メインウィンドウがそのプラグインに切り替わり、作業の様子を追えます。すでにポップアウトして別ウィンドウで開いているプラグインはそのままです。</string>
     <string name="general">一般</string>
     <string name="server">サーバー</string>
     <string name="plugins">プラグイン</string>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
@@ -4,6 +4,9 @@
     <string name="settings_section_ai_agents">AI Agents</string>
     <string name="settings_page_application">Application</string>
     <string name="settings_page_add_plugins">Add Plugins</string>
+    <string name="settings_page_ai_activity">Activity</string>
+    <string name="follow_ai_operation">Follow the plugin an AI agent operates</string>
+    <string name="follow_ai_operation_description">While an AI agent drives a plugin over MCP, the main window switches to that plugin so you can watch it work. A plugin already popped out into its own window is left where it is.</string>
     <string name="general">General</string>
     <string name="server">Server</string>
     <string name="plugins">Plugins</string>

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenContext.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenContext.kt
@@ -11,6 +11,7 @@ import com.kitakkun.jetwhale.host.model.CheckForUpdatesOnStartupMutationKey
 import com.kitakkun.jetwhale.host.model.DeleteSslCertificateMutationKey
 import com.kitakkun.jetwhale.host.model.DiagnosticsQueryKey
 import com.kitakkun.jetwhale.host.model.FailedPluginJarPathsSubscriptionKey
+import com.kitakkun.jetwhale.host.model.FollowAiOperationMutationKey
 import com.kitakkun.jetwhale.host.model.GenerateSslCertificateMutationKey
 import com.kitakkun.jetwhale.host.model.HostVersionInfo
 import com.kitakkun.jetwhale.host.model.LoadedPluginsMetaDataSubscriptionKey
@@ -62,6 +63,7 @@ class SettingsPresenterContext(
     val updateCheckMutationKey: UpdateCheckMutationKey,
     val updateInstallMutationKey: UpdateInstallMutationKey,
     val checkForUpdatesOnStartupMutationKey: CheckForUpdatesOnStartupMutationKey,
+    val followAiOperationMutationKey: FollowAiOperationMutationKey,
     val hostVersionInfo: HostVersionInfo,
     val generateSslCertificateMutationKey: GenerateSslCertificateMutationKey,
     val activateSslCertificateMutationKey: ActivateSslCertificateMutationKey,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenMenu.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/SettingsScreenMenu.kt
@@ -76,6 +76,9 @@ enum class SettingsScreenPage(
     /** What a connected agent may then do. A separate question, and a page that keeps growing. */
     McpPermissions(SettingsScreenSection.AiAgents, Res.string.mcp_permission_title, SettingsScreenPageOwner.Server),
 
+    /** How the host itself behaves while an agent works — following its operations, for now. */
+    AiActivity(SettingsScreenSection.AiAgents, Res.string.settings_page_ai_activity, SettingsScreenPageOwner.General),
+
     InstalledPlugins(SettingsScreenSection.Plugins, Res.string.installed_plugins, SettingsScreenPageOwner.Plugin),
 
     /** Every way a plugin gets in: the official catalog, a local jar, or Maven coordinates. */

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreen.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreen.kt
@@ -47,11 +47,14 @@ import com.kitakkun.jetwhale.host.settings.component.SettingOptionView
 import com.kitakkun.jetwhale.host.settings.component.SettingsItemRow
 import com.kitakkun.jetwhale.host.settings.component.SwitchSettingsItemView
 import com.kitakkun.jetwhale.host.settings.current_version
+import com.kitakkun.jetwhale.host.settings.follow_ai_operation
+import com.kitakkun.jetwhale.host.settings.follow_ai_operation_description
 import com.kitakkun.jetwhale.host.settings.health_check
 import com.kitakkun.jetwhale.host.settings.install_update
 import com.kitakkun.jetwhale.host.settings.language_option
 import com.kitakkun.jetwhale.host.settings.maintenance
 import com.kitakkun.jetwhale.host.settings.open_download_page
+import com.kitakkun.jetwhale.host.settings.settings_page_ai_activity
 import com.kitakkun.jetwhale.host.settings.theme_option
 import com.kitakkun.jetwhale.host.settings.update_available
 import com.kitakkun.jetwhale.host.settings.update_available_hint
@@ -74,6 +77,7 @@ fun GeneralSettingsScreen(
     onClickOpenLogViewer: () -> Unit,
     onClickCheckForUpdates: () -> Unit,
     onCheckForUpdatesOnStartupChange: (Boolean) -> Unit,
+    onFollowAiOperationChange: (Boolean) -> Unit,
     onClickInstallUpdate: () -> Unit,
     onClickOpenDownloadPage: (url: String) -> Unit,
 ) {
@@ -111,6 +115,22 @@ fun GeneralSettingsScreen(
                         label = stringResource(Res.string.automatically_wire_adb_transport),
                         isChecked = uiState.automaticallyWireADBTransport,
                         onCheckedChange = onAutomaticallyWireADBTransportChange,
+                    )
+                }
+            }
+        }
+        if (page == SettingsScreenPage.AiActivity) {
+            item {
+                SettingOptionView(stringResource(Res.string.settings_page_ai_activity)) {
+                    SwitchSettingsItemView(
+                        label = stringResource(Res.string.follow_ai_operation),
+                        isChecked = uiState.followAiOperation,
+                        onCheckedChange = onFollowAiOperationChange,
+                    )
+                    Text(
+                        text = stringResource(Res.string.follow_ai_operation_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
@@ -282,6 +302,7 @@ private fun GeneralSettingsScreenPreview() {
             adbPath = "/path/to/adb",
             currentVersion = "1.0.0-alpha08",
             checkForUpdatesOnStartup = true,
+            followAiOperation = true,
             isCheckingForUpdates = false,
             updateCheckResult = null,
             updateCheckError = null,
@@ -294,6 +315,7 @@ private fun GeneralSettingsScreenPreview() {
         onClickOpenLogViewer = {},
         onClickCheckForUpdates = {},
         onCheckForUpdatesOnStartupChange = {},
+        onFollowAiOperationChange = {},
         onClickInstallUpdate = {},
         onClickOpenDownloadPage = {},
     )

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenAction.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenAction.kt
@@ -10,5 +10,6 @@ sealed interface GeneralSettingsScreenAction {
     data class ColorSchemeSelected(val colorSchemeId: JetWhaleColorSchemeId) : GeneralSettingsScreenAction
     data object CheckForUpdates : GeneralSettingsScreenAction
     data class ChangeCheckForUpdatesOnStartup(val enabled: Boolean) : GeneralSettingsScreenAction
+    data class ChangeFollowAiOperation(val enabled: Boolean) : GeneralSettingsScreenAction
     data object InstallUpdate : GeneralSettingsScreenAction
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenPresenter.kt
@@ -23,6 +23,7 @@ fun generalSettingsScreenPresenter(
     val updateCheckMutation = rememberMutation(presenterContext.updateCheckMutationKey)
     val updateInstallMutation = rememberMutation(presenterContext.updateInstallMutationKey)
     val checkForUpdatesOnStartupMutation = rememberMutation(presenterContext.checkForUpdatesOnStartupMutationKey)
+    val followAiOperationMutation = rememberMutation(presenterContext.followAiOperationMutationKey)
 
     ActionEffect(screenChannel) { action ->
         when (action) {
@@ -52,6 +53,10 @@ fun generalSettingsScreenPresenter(
             is GeneralSettingsScreenAction.ChangeCheckForUpdatesOnStartup -> {
                 checkForUpdatesOnStartupMutation.mutateAsync(action.enabled)
             }
+
+            is GeneralSettingsScreenAction.ChangeFollowAiOperation -> {
+                followAiOperationMutation.mutateAsync(action.enabled)
+            }
         }
     }
 
@@ -64,6 +69,7 @@ fun generalSettingsScreenPresenter(
         adbPath = diagnostics.adbPath,
         currentVersion = presenterContext.hostVersionInfo.version,
         checkForUpdatesOnStartup = debuggerBehaviorSettings.checkForUpdatesOnStartup,
+        followAiOperation = debuggerBehaviorSettings.followAiOperationEnabled,
         isCheckingForUpdates = updateCheckMutation.isPending,
         updateCheckResult = updateCheckMutation.data,
         updateCheckError = updateCheckMutation.error?.message,

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenRoot.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenRoot.kt
@@ -60,6 +60,9 @@ fun GeneralSettingsScreenRoot(
             onCheckForUpdatesOnStartupChange = {
                 screenChannel.send(GeneralSettingsScreenAction.ChangeCheckForUpdatesOnStartup(it))
             },
+            onFollowAiOperationChange = {
+                screenChannel.send(GeneralSettingsScreenAction.ChangeFollowAiOperation(it))
+            },
             onClickInstallUpdate = {
                 screenChannel.send(GeneralSettingsScreenAction.InstallUpdate)
             },

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenUiState.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/general/GeneralSettingsScreenUiState.kt
@@ -14,6 +14,7 @@ data class GeneralSettingsScreenUiState(
     val adbPath: String,
     val currentVersion: String,
     val checkForUpdatesOnStartup: Boolean,
+    val followAiOperation: Boolean,
     val isCheckingForUpdates: Boolean,
     val updateCheckResult: UpdateCheckResult?,
     val updateCheckError: String?,


### PR DESCRIPTION
## What

While an AI agent drives a plugin over MCP, the main host window now switches to that plugin, so the agent's work can be watched rather than reconstructed from the drawer's activity indicator.

Until now the only sign was the sweeping border on the drawer item — the window kept showing whatever was last opened, and following the agent meant clicking after it.

## How

`FollowAiOperationService` watches `McpActivityRepository` and, for a tool call that names a plugin, asks `HostNavigationService` to open it. That is the channel the MCP server's own navigation tools already use, so a followed navigation and a drawer click are indistinguishable downstream.

The window is left alone when:

- the mode is off (read per call, so turning it off bites the next call immediately)
- the call names no plugin — host tools (navigation, settings, status)
- the plugin is already the main window's destination for that session
- the plugin is popped out into a window of its own; it is visible where it is

## Stopping it

A banner above the content names the tool currently running and offers **Stop following**, which turns the mode off in place. It expands above the plugin rather than floating over it — a snackbar at the bottom would cover exactly what the follow just brought into view.

The setting itself lives in a new **Settings → AI Agents → Activity** page, on by default.

## Tests

- `DefaultFollowAiOperationServiceTest` — the followed case plus each of the four cases that must not move the window, and that re-enabling the mode picks up the next call
- `DefaultDebuggerSettingsRepositoryTest` — the new preference defaults on and persists off