### PR TITLE
feat(agent): add plainLoopback, the one endpoint that ignores ssl

### DIFF
--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
@@ -7,10 +7,11 @@ import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 fun initializeJetWhale() {
     startJetWhale {
         connection {
-            // Zero-config discovery of the host over mDNS for physical LAN devices. When no host is
-            // advertised (or the platform lacks mDNS), the connection falls back to the fixed endpoint,
-            // keeping "localhost" working for emulators/simulators and ADB-forwarded devices.
-            endpoint = discovered(fallback = fixed("localhost", 5443))
+            // Zero-config discovery of the host over mDNS for physical LAN devices, which reach it
+            // over wss. Everything that can only reach loopback — emulators, simulators, ADB-forwarded
+            // devices, and the browser, which cannot pin a local CA at all — falls back to the plain
+            // ws port. One configuration, every target.
+            endpoint = discovered(fallback = plainLoopback(5080))
             ssl {
                 // Fetches the host's active CA over the plain channel (via ADB forwarding) and pins
                 // the wss connection to it, so the app never has to hardcode a CA certificate.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -205,8 +205,8 @@ startJetWhale {
     connection {
         // Browse the LAN for the host advertised as `_jetwhale._tcp` and connect to it. The fallback
         // applies when nothing is discovered in time (or the platform lacks mDNS), which keeps
-        // emulators/simulators and ADB-forwarded devices working over localhost.
-        endpoint = discovered(fallback = fixed("localhost", 5443))
+        // emulators/simulators, ADB-forwarded devices and browsers working over loopback.
+        endpoint = discovered(fallback = plainLoopback(5080))
 
         ssl { trustServerCertificate() }
     }
@@ -228,6 +228,24 @@ host counts as a candidate only if it advertises the port for that scheme — an
 matching host is skipped that way, the log says so by name, since the host being there but serving
 the wrong scheme looks nothing like the host being absent.
 
+### `plainLoopback` for targets that cannot do wss
+
+`plainLoopback(port)` is the one endpoint that ignores `ssl { }` and connects in the clear. It takes
+no host: plain text is safe here only because loopback never leaves the machine, and a signature that
+cannot name anything else cannot be aimed at the network by mistake. The host serves its plain-ws port
+on loopback alone for the same reason.
+
+It exists because **a browser cannot use wss with JetWhale at all**. TLS trust belongs to the browser,
+so `trustServerCertificate()` has nothing to pin with — and the CA endpoint is a different origin with
+no CORS headers, so the certificate cannot even be read. `ws://localhost` has neither problem.
+
+As a fallback it also covers emulators, simulators and ADB-forwarded devices, so the single
+configuration above serves every target: physical devices discover the host over wss, everything else
+takes loopback in the clear.
+
+Use `fixed("localhost", 5443)` instead when you do want wss over loopback — an ADB-forwarded device
+pinning the CA fetched over the same link, for instance.
+
 ### Narrowing discovery
 
 When several JetWhale hosts run on the same network, first-match is ambiguous (the agent logs a
@@ -235,7 +253,7 @@ warning listing all discovered hosts). Narrow the selection with a filter block:
 
 ```kotlin
 connection {
-    endpoint = discovered(fallback = fixed("localhost", 5443)) {
+    endpoint = discovered(fallback = plainLoopback(5080)) {
         // Accept only a host advertising this machine hostname (exact, case-insensitive).
         allowHostName("my-macbook")
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -248,8 +248,8 @@ pinning the CA fetched over the same link, for instance.
 
 ### Narrowing discovery
 
-When several JetWhale hosts run on the same network, first-match is ambiguous (the agent logs a
-warning listing all discovered hosts). Narrow the selection with a filter block:
+Every advertised host the agent can use is a candidate, tried in turn until one accepts. When several
+run on the same network and you want a particular one, say which:
 
 ```kotlin
 connection {
@@ -257,8 +257,8 @@ connection {
         // Accept only a host advertising this machine hostname (exact, case-insensitive).
         allowHostName("my-macbook")
 
-        // ...and/or only hosts resolving to specific IPs, e.g. to pin discovery to your build
-        // machine — which may answer on both Wi-Fi and Ethernet.
+        // ...and/or only hosts resolving to specific IPs — your build machine, say, which may
+        // answer on both Wi-Fi and Ethernet.
         allowAddress("192.168.3.26")
         allowAddress("192.168.3.27")
     }
@@ -276,15 +276,29 @@ Both are **repeatable allowlists**: calling one twice widens it rather than repl
 value. An empty allowlist means "no restriction on this", so a host must match every allowlist that
 has entries — name **and** address when both are set, either entry within each.
 
-Discovery is best-effort: if no matching host is found within a few seconds — or on a platform
-without mDNS support (**JS/Wasm, Linux, Windows**) — the agent logs a warning and falls back to the
-endpoint passed as `fallback`.
+::: warning These filters choose, they do not authenticate
+mDNS advertisements are unauthenticated. Anyone on the network can advertise `_jetwhale._tcp` with
+any `hostName` TXT record they like, so `allowHostName("my-macbook")` does not establish that the
+host answering *is* your MacBook — it only stops the agent picking a different one that is honest
+about its name.
 
-Falling back is **per attempt, not permanent**. The agent browses again before every connection
-attempt, so [the usual reconnect promise](#reconnecting) still holds with discovery enabled: start the
-app first and the host later, and the next browse picks it up. The same applies when a host restarts
-on a different port. Warnings are not repeated while the outcome stays the same, so an unreachable
-host does not flood the log.
+Authentication is the certificate's job. `trustCertificate(pem = "...")` with a CA you exported from
+the host completes a handshake only with a host holding the matching key; `trustServerCertificate()`
+takes the CA from whoever answered, which is trust-on-first-use and no stronger than the network it
+runs over. See [Which one to use](#which-one-to-use).
+:::
+
+`fallback` is offered **after** the discovered hosts, not only when none were found: answering mDNS
+says a host is advertising, not that it will accept a connection. The whole list is worked through in
+turn, and only once every entry has refused does the agent wait and start again.
+
+That next round browses afresh, so [the usual reconnect promise](#reconnecting) still holds with
+discovery enabled: start the app first and the host later, and the next browse picks it up. The same
+applies when a host restarts on a different port. A failed round is reported once and not repeated
+while the outcome stays the same, so an unreachable host does not flood the log.
+
+On a platform without mDNS support (**JS/Wasm, Linux, Windows**) there is nothing to browse, and the
+agent goes straight to `fallback`.
 
 | Platform | Discovery backend |
 |----------|-------------------|

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -54,9 +54,9 @@ connect to.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| **Debug Server Port** | `5080` | The plain **ws** port. Must match the `port` in your app's `startJetWhale { connection { ... } }` block. |
+| **Debug Server Port** | `5080` | The plain **ws** port. Must match the port your app dials in `startJetWhale { connection { endpoint = ... } }`, unless it discovers the host — discovery reads the port from what the host advertises. |
 | **Enable WSS** | on | Whether the secure **wss** connector is exposed at all. |
-| **WSS Port** | `5443` | The **wss** port. Must match the `port` in your app's connection block when it connects over wss. |
+| **WSS Port** | `5443` | The **wss** port, matched the same way: your app's `endpoint` when it names one, or the advertised port when it discovers the host. |
 
 Changing any of the three reveals a single **Apply** button, which confirms before restarting the
 server — restarting disconnects every session. All three are applied together, because the server

--- a/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
+++ b/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
@@ -67,8 +67,9 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigu
         abstract fun <get-port>(): kotlin/Int // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.port.<get-port>|<get-port>(){}[0]
         abstract fun <set-port>(kotlin/Int) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.port.<set-port>|<set-port>(kotlin.Int){}[0]
 
-    abstract fun discovered(com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint, kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope, kotlin/Unit> = ...): com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.discovered|discovered(com.kitakkun.jetwhale.agent.runtime.JetWhaleFixedEndpoint;kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleDiscoveredEndpointScope,kotlin.Unit>){}[0]
+    abstract fun discovered(com.kitakkun.jetwhale.agent.runtime/JetWhaleLiteralEndpoint, kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope, kotlin/Unit> = ...): com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.discovered|discovered(com.kitakkun.jetwhale.agent.runtime.JetWhaleLiteralEndpoint;kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleDiscoveredEndpointScope,kotlin.Unit>){}[0]
     abstract fun fixed(kotlin/String, kotlin/Int): com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.fixed|fixed(kotlin.String;kotlin.Int){}[0]
+    abstract fun plainLoopback(kotlin/Int): com.kitakkun.jetwhale.agent.runtime/JetWhalePlainLoopbackEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.plainLoopback|plainLoopback(kotlin.Int){}[0]
     abstract fun ssl(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.ssl|ssl(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleSslConfigurationScope,kotlin.Unit>){}[0]
 }
 
@@ -104,6 +105,10 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationS
 
 sealed interface com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint|null[0]
 
-final class com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint : com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint|null[0]
+sealed interface com.kitakkun.jetwhale.agent.runtime/JetWhaleLiteralEndpoint : com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleLiteralEndpoint|null[0]
+
+final class com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint : com.kitakkun.jetwhale.agent.runtime/JetWhaleLiteralEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint|null[0]
+
+final class com.kitakkun.jetwhale.agent.runtime/JetWhalePlainLoopbackEndpoint : com.kitakkun.jetwhale.agent.runtime/JetWhaleLiteralEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhalePlainLoopbackEndpoint|null[0]
 
 final fun com.kitakkun.jetwhale.agent.runtime/startJetWhale(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope, kotlin/Unit>): com.kitakkun.jetwhale.agent.runtime/JetWhaleSession // com.kitakkun.jetwhale.agent.runtime/startJetWhale|startJetWhale(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleConfigurationScope,kotlin.Unit>){}[0]

--- a/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
+++ b/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
@@ -17,12 +17,13 @@ public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleConf
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope {
-	public abstract fun discovered (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint;Lkotlin/jvm/functions/Function1;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
-	public static synthetic fun discovered$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
+	public abstract fun discovered (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint;Lkotlin/jvm/functions/Function1;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
+	public static synthetic fun discovered$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
 	public abstract fun fixed (Ljava/lang/String;I)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint;
 	public abstract fun getEndpoint ()Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
 	public abstract fun getHost ()Ljava/lang/String;
 	public abstract fun getPort ()I
+	public abstract fun plainLoopback (I)Lcom/kitakkun/jetwhale/agent/runtime/JetWhalePlainLoopbackEndpoint;
 	public abstract fun setEndpoint (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;)V
 	public abstract fun setHost (Ljava/lang/String;)V
 	public abstract fun setPort (I)V
@@ -30,7 +31,7 @@ public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleConn
 }
 
 public final class com/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope$DefaultImpls {
-	public static synthetic fun discovered$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
+	public static synthetic fun discovered$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleDiscoveredEndpointScope {
@@ -41,7 +42,10 @@ public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleDisc
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint {
 }
 
-public final class com/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint : com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint {
+public final class com/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint : com/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint {
+}
+
+public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint : com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint {
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleLoggingConfigurationScope {
@@ -51,6 +55,9 @@ public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleLogg
 	public abstract fun setEnabled (Z)V
 	public abstract fun setKtorLogLevel (Lcom/kitakkun/jetwhale/agent/runtime/KtorLogLevel;)V
 	public abstract fun setLogLevel (Lcom/kitakkun/jetwhale/agent/runtime/LogLevel;)V
+}
+
+public final class com/kitakkun/jetwhale/agent/runtime/JetWhalePlainLoopbackEndpoint : com/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint {
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhalePluginConfigurationScope {

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/DefaultJetWhaleMessagingService.kt
@@ -94,7 +94,7 @@ internal class DefaultJetWhaleMessagingService(
                 // generous: its job is to bound a candidate that swallows packets — a firewall that
                 // drops rather than refuses — not to be tight.
                 val connection = withTimeoutOrNull(CANDIDATE_TIMEOUT_MILLIS) {
-                    socketClient.openConnection(candidate.host, candidate.port)
+                    socketClient.openConnection(candidate)
                 }
                 if (connection == null) {
                     failures += CandidateFailure(candidate, "timed out after ${CANDIDATE_TIMEOUT_MILLIS}ms")

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/EndpointResolver.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/EndpointResolver.kt
@@ -1,8 +1,13 @@
 package com.kitakkun.jetwhale.agent.runtime
 
-/** A concrete address to dial — what resolution produces. */
-internal data class ResolvedEndpoint(val host: String, val port: Int) {
-    override fun toString(): String = "$host:$port"
+/**
+ * A concrete address to dial — what resolution produces.
+ *
+ * [useWss] travels with the address rather than being read from `ssl { }` at dial time: `ssl { }`
+ * still decides it for every endpoint but one, and `plainLoopback` is that one.
+ */
+internal data class ResolvedEndpoint(val host: String, val port: Int, val useWss: Boolean) {
+    override fun toString(): String = "${if (useWss) "wss" else "ws"}://$host:$port"
 }
 
 /**

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
@@ -98,7 +98,7 @@ internal class MdnsEndpointResolver(
             is DiscoveryResult.Browsed -> {
                 val usable = selectHosts(result.services, discovery)
                 report(if (usable.isEmpty()) noHostMessage(result.services) else foundMessage(usable))
-                usable.map { ResolvedEndpoint(it.service.address, it.port) }
+                usable.map { ResolvedEndpoint(it.service.address, it.port, useWss = discovery.useWss) }
             }
         }
         // Deduplicated, order kept: the fallback may well be an address that was also advertised, and

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -62,7 +62,7 @@ public fun startJetWhale(configure: JetWhaleConfigurationScope.() -> Unit): JetW
 
 /** The resolver a configured `endpoint` amounts to, once `ssl {}` is known. */
 internal fun JetWhaleConnectionConfiguration.endpointResolver(): EndpointResolver = when (val endpoint = endpoint) {
-    is JetWhaleFixedEndpoint -> FixedEndpointResolver(endpoint.resolved())
+    is JetWhaleLiteralEndpoint -> FixedEndpointResolver(endpoint.resolved(sslConfiguration.isEnabled))
 
     is JetWhaleDiscoveredEndpoint -> MdnsEndpointResolver(
         discovery = HostDiscoveryConfig(
@@ -73,11 +73,18 @@ internal fun JetWhaleConnectionConfiguration.endpointResolver(): EndpointResolve
             // `endpoint =` can appear in either order.
             useWss = sslConfiguration.isEnabled,
         ),
-        fallback = endpoint.fallback.resolved(),
+        fallback = endpoint.fallback.resolved(sslConfiguration.isEnabled),
     )
 }
 
-private fun JetWhaleFixedEndpoint.resolved(): ResolvedEndpoint = ResolvedEndpoint(host, port)
+/** @param sslConfigured what `ssl { }` decided, which every endpoint but [JetWhalePlainLoopbackEndpoint] follows. */
+private fun JetWhaleLiteralEndpoint.resolved(sslConfigured: Boolean): ResolvedEndpoint = when (this) {
+    is JetWhaleFixedEndpoint -> ResolvedEndpoint(host, port, useWss = sslConfigured)
+    is JetWhalePlainLoopbackEndpoint -> ResolvedEndpoint(LOOPBACK_HOST, port, useWss = false)
+}
+
+/** The name loopback is dialled by. RFC 6761 reserves it, so it always resolves to the loopback interface. */
+private const val LOOPBACK_HOST = "localhost"
 
 private class MessagingServiceSession(private val service: JetWhaleMessagingService) : JetWhaleSession {
     override fun stop() {
@@ -157,6 +164,26 @@ public interface JetWhaleConnectionConfigurationScope {
     public fun fixed(host: String, port: Int): JetWhaleFixedEndpoint
 
     /**
+     * The loopback interface, reached in the clear on [port] whatever `ssl { }` says.
+     *
+     * There is no host parameter, and that is the point: plain text is safe here because it cannot
+     * leave the machine, and a signature that cannot name anything else cannot be pointed at the
+     * network by accident. The host serves its plain-ws port on loopback only, for the same reason.
+     *
+     * Use it as the fallback for targets that cannot do wss but can reach the host locally. A browser
+     * is the clear case: TLS trust belongs to the browser there, so `trustServerCertificate()` has
+     * nothing to pin with and no wss connection is possible — while `ws://localhost` is unremarkable.
+     * Emulators and ADB-forwarded devices reach loopback too, so one shared configuration covers them
+     * alongside a discovered host for physical devices.
+     *
+     * Nothing about `ssl { }` is skipped for other endpoints; this is the one exception, and it is
+     * limited to loopback by construction.
+     *
+     * @param port The host's plain-ws port.
+     */
+    public fun plainLoopback(port: Int): JetWhalePlainLoopbackEndpoint
+
+    /**
      * A host found by zero-config discovery over mDNS/DNS-SD (Bonjour): the agent browses the local
      * network for the `_jetwhale._tcp` service the host advertises while its debug server runs, and
      * connects to the address and port it advertises. Use this for physical LAN devices, which cannot
@@ -180,7 +207,7 @@ public interface JetWhaleConnectionConfigurationScope {
      * @param configure Optional filters narrowing which discovered host is accepted.
      */
     public fun discovered(
-        fallback: JetWhaleFixedEndpoint,
+        fallback: JetWhaleLiteralEndpoint,
         configure: JetWhaleDiscoveredEndpointScope.() -> Unit = {},
     ): JetWhaleEndpoint
 
@@ -199,11 +226,24 @@ public interface JetWhaleConnectionConfigurationScope {
  */
 public sealed interface JetWhaleEndpoint
 
-/** A literal host/port, as built by [JetWhaleConnectionConfigurationScope.at]. */
+/**
+ * An endpoint written down rather than looked up, and so usable as a discovery fallback.
+ *
+ * Discovery cannot fall back to more discovery, which is why the fallback is typed to this rather
+ * than to [JetWhaleEndpoint].
+ */
+public sealed interface JetWhaleLiteralEndpoint : JetWhaleEndpoint
+
+/** A literal host/port, as built by [JetWhaleConnectionConfigurationScope.fixed]. */
 public class JetWhaleFixedEndpoint internal constructor(
     internal val host: String,
     internal val port: Int,
-) : JetWhaleEndpoint
+) : JetWhaleLiteralEndpoint
+
+/** A loopback port reached in the clear, as built by [JetWhaleConnectionConfigurationScope.plainLoopback]. */
+public class JetWhalePlainLoopbackEndpoint internal constructor(
+    internal val port: Int,
+) : JetWhaleLiteralEndpoint
 
 /**
  * Allowlists narrowing which discovered host is accepted. Each is repeatable and independently
@@ -317,7 +357,7 @@ private class JetWhaleAppConfiguration : JetWhaleAppConfigurationScope {
 internal class JetWhaleDiscoveredEndpoint(
     val hostNames: List<String>,
     val addresses: List<String>,
-    val fallback: JetWhaleFixedEndpoint,
+    val fallback: JetWhaleLiteralEndpoint,
 ) : JetWhaleEndpoint
 
 @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
@@ -338,8 +378,10 @@ internal class JetWhaleConnectionConfiguration : JetWhaleConnectionConfiguration
 
     override fun fixed(host: String, port: Int): JetWhaleFixedEndpoint = JetWhaleFixedEndpoint(host, port)
 
+    override fun plainLoopback(port: Int): JetWhalePlainLoopbackEndpoint = JetWhalePlainLoopbackEndpoint(port)
+
     override fun discovered(
-        fallback: JetWhaleFixedEndpoint,
+        fallback: JetWhaleLiteralEndpoint,
         configure: JetWhaleDiscoveredEndpointScope.() -> Unit,
     ): JetWhaleEndpoint {
         val filters = JetWhaleDiscoveredEndpointConfiguration().apply(configure)

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -190,20 +190,22 @@ public interface JetWhaleConnectionConfigurationScope {
      * reach the host over `localhost`.
      *
      * The advertised wss port is used when `ssl {}` is configured, otherwise the plain-ws port — so
-     * discovery resolves the port too, and [fallback]'s port applies only when discovery finds nothing.
+     * discovery resolves the port too, and [fallback]'s port is its own.
      *
-     * Discovery is best-effort, which is why [fallback] is required: when no matching host is found
-     * within a short timeout, or the platform does not support mDNS (JS/Wasm/Linux/Windows), the
-     * connection falls back to it with a warning log.
+     * Every advertised host this agent can use becomes a candidate and they are tried in turn, with
+     * [fallback] last. It is required rather than optional because answering mDNS says a host is
+     * advertising, not that it will accept a connection, and because a platform without mDNS
+     * (JS/Wasm/Linux/Windows) has nothing to browse at all.
      *
      * iOS requires `_jetwhale._tcp` to be listed under `NSBonjourServices` in `Info.plist` alongside
      * `NSLocalNetworkUsageDescription`, otherwise the OS blocks the browse.
      *
-     * When several JetWhale hosts advertise on the network, narrow the selection with [configure]
-     * (see [JetWhaleDiscoveredEndpointScope]); with no filter the first discovered host is used and a
-     * warning listing all discovered hosts is logged when more than one is found.
+     * Use [configure] to say which host you want when several advertise (see
+     * [JetWhaleDiscoveredEndpointScope]). Those filters choose; they do not authenticate — mDNS
+     * advertisements are unauthenticated, so a certificate pinned with `trustCertificate` is what
+     * establishes who answered.
      *
-     * @param fallback Used when discovery finds no matching host in time, or the platform lacks mDNS.
+     * @param fallback Tried after every discovered candidate, and on its own where mDNS is unavailable.
      * @param configure Optional filters narrowing which discovered host is accepted.
      */
     public fun discovered(
@@ -249,6 +251,10 @@ public class JetWhalePlainLoopbackEndpoint internal constructor(
  * Allowlists narrowing which discovered host is accepted. Each is repeatable and independently
  * optional; a host has to satisfy every allowlist that has entries, and one that does not is skipped
  * rather than connected to.
+ *
+ * They choose between hosts; they do not authenticate one. An mDNS advertisement is unauthenticated,
+ * so anything on the network can claim any hostname — matching one proves nothing about who answered.
+ * That is what pinning a certificate with `trustCertificate` is for.
  */
 @JetWhaleDsl
 public interface JetWhaleDiscoveredEndpointScope {

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleSocketClient.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleSocketClient.kt
@@ -11,7 +11,7 @@ internal data class JetWhaleConnection(
 
 internal interface JetWhaleSocketClient {
     suspend fun sendDebuggeeEvent(event: JetWhaleDebuggeeEvent)
-    suspend fun openConnection(host: String, port: Int): JetWhaleConnection
+    suspend fun openConnection(endpoint: ResolvedEndpoint): JetWhaleConnection
 
     /**
      * Closes the current session, if any, so the host observes the debuggee going away instead of

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClient.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClient.kt
@@ -80,25 +80,31 @@ internal class KtorWebSocketClient(
         releaseHttpClient()
     }
 
-    override suspend fun openConnection(
-        host: String,
-        port: Int,
-    ): JetWhaleConnection {
+    override suspend fun openConnection(endpoint: ResolvedEndpoint): JetWhaleConnection {
         // A connection that ended on its own (host disconnect, error) never reached closeConnection,
         // so its client is still held here. Release it before this attempt allocates another.
         releaseHttpClient()
 
-        val resolvedConfiguration = resolveSslConfiguration(host, port)
+        // A plain endpoint has no certificate to fetch or pin, so none of the trust machinery runs for
+        // it — including the CA fetch, which on a browser is two failed requests before every attempt.
+        val resolvedConfiguration = if (endpoint.useWss) {
+            resolveSslConfiguration(endpoint.host, endpoint.port)
+        } else {
+            JetWhaleSslConfiguration()
+        }
         val client = httpClientProvider(resolvedConfiguration)
         httpClient = client
 
         try {
             val session = client.webSocketSession(
-                host = host,
-                port = port,
+                host = endpoint.host,
+                port = endpoint.port,
             ) {
                 url {
-                    protocol = if (resolvedConfiguration.isEnabled) URLProtocol.WSS else URLProtocol.WS
+                    // From the endpoint, not from whether trust material was obtained: a wss endpoint
+                    // whose CA could not be fetched must fail visibly on trust, not quietly dial plain
+                    // text at a TLS port and fail there instead.
+                    protocol = if (endpoint.useWss) URLProtocol.WSS else URLProtocol.WS
                 }
             }
             this.session = session

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
@@ -20,7 +20,7 @@ class ConnectionEndpointTest {
 
     @Test
     fun `an unconfigured connection targets the default host and port`() {
-        assertEquals(ResolvedEndpoint("localhost", 8080), fixedEndpoint { })
+        assertEquals(ResolvedEndpoint("localhost", 8080, useWss = false), fixedEndpoint { })
     }
 
     @Suppress("DEPRECATION")
@@ -43,7 +43,44 @@ class ConnectionEndpointTest {
             endpoint = fixed("192.168.3.26", 5443)
         }
 
-        assertEquals(ResolvedEndpoint("192.168.3.26", 5443), resolved)
+        assertEquals(ResolvedEndpoint("192.168.3.26", 5443, useWss = false), resolved)
+    }
+
+    @Test
+    fun `a fixed endpoint follows the ssl block`() {
+        val plain = fixedEndpoint { endpoint = fixed("192.168.3.26", 5080) }
+        val secure = fixedEndpoint {
+            endpoint = fixed("192.168.3.26", 5443)
+            ssl { trustServerCertificate() }
+        }
+
+        assertEquals(false, plain.useWss)
+        assertEquals(true, secure.useWss)
+    }
+
+    @Test
+    fun `a plain loopback endpoint stays plain whatever the ssl block says`() {
+        // The one exception to ssl {} deciding the scheme, and the reason it takes no host: plain text
+        // is only safe because loopback cannot leave the machine.
+        val resolved = fixedEndpoint {
+            endpoint = plainLoopback(5080)
+            ssl { trustServerCertificate() }
+        }
+
+        assertEquals(ResolvedEndpoint("localhost", 5080, useWss = false), resolved)
+    }
+
+    @Test
+    fun `a plain loopback endpoint can be the fallback for discovery`() {
+        // One shared configuration for every target: a physical device discovers a host over wss, and
+        // anything that can only reach loopback — a browser above all — takes the plain fallback.
+        val resolver = mdns {
+            endpoint = discovered(fallback = plainLoopback(5080))
+            ssl { trustServerCertificate() }
+        }
+
+        assertEquals(ResolvedEndpoint("localhost", 5080, useWss = false), resolver.fallback)
+        assertEquals(true, resolver.discovery.useWss)
     }
 
     @Test
@@ -57,7 +94,7 @@ class ConnectionEndpointTest {
             }
         }
 
-        assertEquals(ResolvedEndpoint("localhost", 5443), resolver.fallback)
+        assertEquals(ResolvedEndpoint("localhost", 5443, useWss = false), resolver.fallback)
         // Both allowlists accumulate, so neither call silently drops the one before it.
         assertEquals(listOf("build-machine", "spare-machine"), resolver.discovery.hostNames)
         assertEquals(listOf("192.168.3.26", "192.168.3.27"), resolver.discovery.addresses)

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClientHttpClientLifecycleTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClientHttpClientLifecycleTest.kt
@@ -35,7 +35,7 @@ class KtorWebSocketClientHttpClientLifecycleTest {
         configureTestServer()
         val provider = recordingProvider()
         val webSocketClient = webSocketClient(provider)
-        webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
+        webSocketClient.openConnection(ResolvedEndpoint(TEST_SERVER_HOST, TEST_SERVER_PORT, useWss = false))
 
         webSocketClient.closeConnection()
 
@@ -49,7 +49,7 @@ class KtorWebSocketClientHttpClientLifecycleTest {
         val webSocketClient = webSocketClient(provider)
 
         assertFailsWith<Throwable> {
-            webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
+            webSocketClient.openConnection(ResolvedEndpoint(TEST_SERVER_HOST, TEST_SERVER_PORT, useWss = false))
         }
 
         assertReleased(provider.handedOut.single(), "a refused attempt stranded its client")
@@ -63,10 +63,10 @@ class KtorWebSocketClientHttpClientLifecycleTest {
         val provider = recordingProvider()
         val webSocketClient = webSocketClient(provider)
 
-        val connection = webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
+        val connection = webSocketClient.openConnection(ResolvedEndpoint(TEST_SERVER_HOST, TEST_SERVER_PORT, useWss = false))
         connection.debuggerEventFlow.collect { }
 
-        webSocketClient.openConnection(host = TEST_SERVER_HOST, port = TEST_SERVER_PORT)
+        webSocketClient.openConnection(ResolvedEndpoint(TEST_SERVER_HOST, TEST_SERVER_PORT, useWss = false))
 
         assertEquals(2, provider.handedOut.size)
         assertReleased(provider.handedOut.first(), "the ended connection's client was left open")

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClientTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClientTest.kt
@@ -30,10 +30,7 @@ class KtorWebSocketClientTest {
         val webSocketClient = webSocketClient()
 
         assertFailsWith<Throwable> {
-            webSocketClient.openConnection(
-                host = TEST_SERVER_HOST,
-                port = TEST_SERVER_PORT,
-            )
+            webSocketClient.openConnection(ResolvedEndpoint(TEST_SERVER_HOST, TEST_SERVER_PORT, useWss = false))
         }
     }
 
@@ -43,10 +40,7 @@ class KtorWebSocketClientTest {
 
         val webSocketClient = webSocketClient()
 
-        webSocketClient.openConnection(
-            host = TEST_SERVER_HOST,
-            port = TEST_SERVER_PORT,
-        )
+        webSocketClient.openConnection(ResolvedEndpoint(TEST_SERVER_HOST, TEST_SERVER_PORT, useWss = false))
     }
 
     @Test
@@ -55,10 +49,7 @@ class KtorWebSocketClientTest {
 
         val webSocketClient = webSocketClient()
 
-        webSocketClient.openConnection(
-            host = TEST_SERVER_HOST,
-            port = TEST_SERVER_PORT,
-        )
+        webSocketClient.openConnection(ResolvedEndpoint(TEST_SERVER_HOST, TEST_SERVER_PORT, useWss = false))
 
         webSocketClient.sendDebuggeeEvent(
             event = JetWhaleDebuggeeEvent.PluginFrameMessage(
@@ -81,10 +72,7 @@ class KtorWebSocketClientTest {
 
         val webSocketClient = webSocketClient()
 
-        val connectionResult = webSocketClient.openConnection(
-            host = TEST_SERVER_HOST,
-            port = TEST_SERVER_PORT,
-        )
+        val connectionResult = webSocketClient.openConnection(ResolvedEndpoint(TEST_SERVER_HOST, TEST_SERVER_PORT, useWss = false))
 
         assertEquals(
             expected = expectedEvent,

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
@@ -36,8 +36,7 @@ private class RecordingSocketClient(
 
     override suspend fun sendDebuggeeEvent(event: JetWhaleDebuggeeEvent) = Unit
 
-    override suspend fun openConnection(host: String, port: Int): JetWhaleConnection {
-        val endpoint = ResolvedEndpoint(host, port)
+    override suspend fun openConnection(endpoint: ResolvedEndpoint): JetWhaleConnection {
         attempts.add(endpoint)
         attemptCount.send(endpoint)
         if (endpoint !in reachable) throw IllegalStateException("unreachable")
@@ -74,8 +73,8 @@ class MessagingServiceResolutionTest {
     fun `a candidate that refuses is passed over for the next one in the same round`() = runBlocking {
         // The point of the whole list: a host that answers discovery but refuses connections must not
         // strand the session. Both are dialled before any backoff is owed.
-        val unreachable = ResolvedEndpoint("unreachable", 1)
-        val reachable = ResolvedEndpoint("reachable", 2)
+        val unreachable = ResolvedEndpoint("unreachable", 1, useWss = false)
+        val reachable = ResolvedEndpoint("reachable", 2, useWss = false)
         val socketClient = RecordingSocketClient(reachable = setOf(reachable))
         val service = service(socketClient, ScriptedEndpointResolver(listOf(listOf(unreachable, reachable))))
 
@@ -92,8 +91,8 @@ class MessagingServiceResolutionTest {
     fun `the fallback is reached when the discovered candidate refuses`() = runBlocking {
         // Resolving once per round is not enough on its own: before the chain, a discovered host that
         // refused was re-picked every round and the configured fallback was never dialled at all.
-        val discovered = ResolvedEndpoint("192.168.3.26", 5443)
-        val fallback = ResolvedEndpoint("localhost", 5443)
+        val discovered = ResolvedEndpoint("192.168.3.26", 5443, useWss = false)
+        val fallback = ResolvedEndpoint("localhost", 5443, useWss = false)
         val socketClient = RecordingSocketClient(reachable = setOf(fallback))
         val service = service(socketClient, ScriptedEndpointResolver(listOf(listOf(discovered, fallback))))
 
@@ -111,8 +110,8 @@ class MessagingServiceResolutionTest {
         // Refusals before the candidate that worked are not the round's verdict, so a session that ran
         // is not treated as a failed round: it reconnects at once, as it did before candidates were
         // tried in turn.
-        val refused = ResolvedEndpoint("refused", 1)
-        val reachable = ResolvedEndpoint("reachable", 2)
+        val refused = ResolvedEndpoint("refused", 1, useWss = false)
+        val reachable = ResolvedEndpoint("reachable", 2, useWss = false)
         val socketClient = RecordingSocketClient(reachable = setOf(reachable))
         val service = service(socketClient, ScriptedEndpointResolver(listOf(listOf(refused, reachable))))
 
@@ -138,7 +137,7 @@ class MessagingServiceResolutionTest {
     fun `a host that accepts and drops straight away does not spin the loop`() = runBlocking {
         // Seen for real: a host whose websocket handler threw after the upgrade, accepting and closing
         // each time. Reconnecting with no delay would dial it as fast as it can close.
-        val flapping = ResolvedEndpoint("flapping", 1)
+        val flapping = ResolvedEndpoint("flapping", 1, useWss = false)
         val socketClient = RecordingSocketClient(reachable = setOf(flapping), closeImmediately = true)
         val service = service(socketClient, ScriptedEndpointResolver(listOf(listOf(flapping))))
 
@@ -158,7 +157,7 @@ class MessagingServiceResolutionTest {
 
     @Test
     fun `a resolver that throws is a failed round, not the end of the session`() = runBlocking {
-        val reachable = ResolvedEndpoint("reachable", 1)
+        val reachable = ResolvedEndpoint("reachable", 1, useWss = false)
         val socketClient = RecordingSocketClient(reachable = setOf(reachable))
         var firstCall = true
         val service = service(socketClient) {
@@ -187,8 +186,8 @@ class MessagingServiceResolutionTest {
         val socketClient = RecordingSocketClient()
         val resolver = ScriptedEndpointResolver(
             listOf(
-                listOf(ResolvedEndpoint("first-round", 1)),
-                listOf(ResolvedEndpoint("second-round", 2)),
+                listOf(ResolvedEndpoint("first-round", 1, useWss = false)),
+                listOf(ResolvedEndpoint("second-round", 2, useWss = false)),
             ),
         )
         val service = service(socketClient, resolver)
@@ -203,7 +202,7 @@ class MessagingServiceResolutionTest {
         }
 
         assertTrue(socketClient.attempts.size >= 2, "expected a second round, got ${socketClient.attempts}")
-        assertEquals(ResolvedEndpoint("first-round", 1), socketClient.attempts[0])
-        assertEquals(ResolvedEndpoint("second-round", 2), socketClient.attempts[1])
+        assertEquals(ResolvedEndpoint("first-round", 1, useWss = false), socketClient.attempts[0])
+        assertEquals(ResolvedEndpoint("second-round", 2, useWss = false), socketClient.attempts[1])
     }
 }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceStopTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceStopTest.kt
@@ -31,7 +31,7 @@ private class FakeSocketClient : JetWhaleSocketClient {
 
     override suspend fun sendDebuggeeEvent(event: JetWhaleDebuggeeEvent) = Unit
 
-    override suspend fun openConnection(host: String, port: Int): JetWhaleConnection {
+    override suspend fun openConnection(endpoint: ResolvedEndpoint): JetWhaleConnection {
         debuggerEvents = Channel(Channel.UNLIMITED)
         openedConnections.send(Unit)
         return JetWhaleConnection(
@@ -74,7 +74,7 @@ class MessagingServiceStopTest {
     ): JetWhaleMessagingService = DefaultJetWhaleMessagingService(
         socketClient = socketClient,
         pluginService = JetWhaleAgentPluginService(plugins = listOf(plugin)),
-    ).also { it.startService(FixedEndpointResolver(ResolvedEndpoint(host = "localhost", port = 1))) }
+    ).also { it.startService(FixedEndpointResolver(ResolvedEndpoint("localhost", 1, useWss = false))) }
 
     @Test
     fun `stopService closes the socket so the host sees the session go away`() = runBlocking {


### PR DESCRIPTION
> Stacked on #225. Base is `feat/endpoint-candidate-chain` and will be retargeted to `main` once that
> merges; the diff to review is the last commit.

## Motivation

**A browser cannot use wss with JetWhale at all.** Two independent reasons, both confirmed in Firefox
against a running host:

1. TLS trust belongs to the browser, so `trustServerCertificate()` has nothing to pin with. There is
   no API to install a CA from page script.
2. Even with the CA trusted, `/jetwhale/ca` is a different origin (`http://localhost:8080` →
   `https://localhost:5443`) and the host sends no `Access-Control-Allow-Origin`, so the certificate
   cannot be read either.

What happens today: both fetches fail, `resolveSslConfiguration` returns nothing, the connection
degrades to plain ws — at the **wss** port, because that is what the fallback names — and fails there.
Web has never worked.

`ws://localhost` has neither problem. Saying so, though, meant either giving up the shared
`initializeJetWhale()` that a Compose Multiplatform app is built around, or adding per-target source
sets for the sake of a port number. For a library whose whole audience writes shared code, that is the
wrong trade.

## What this adds

```kotlin
connection {
    endpoint = discovered(fallback = plainLoopback(5080))
    ssl { trustServerCertificate() }
}
```

Physical devices discover the host over wss; everything that can only reach loopback — emulators,
simulators, ADB-forwarded devices, browsers — takes the plain fallback. One configuration, every
target.

**`plainLoopback(port)` takes no host, and that is the design rather than an omission.** Plain text is
safe here only because loopback cannot leave the machine, so a signature that cannot name anything
else cannot be aimed at the network by mistake. The host binds its plain-ws port to loopback alone for
the same reason, which is also why `fixed("192.168.x.x", 5080)` was never a way to reach it.

`ssl { }` still decides the scheme for every other endpoint. This is one exception, limited to
loopback by construction, and named so that it is visible at the call site rather than hidden behind a
distant flag.

## Consequences worth noting

**The scheme travels with the address.** `ResolvedEndpoint` gains `useWss` instead of the client
reading `ssl { }` at dial time. Two things follow:

- A plain endpoint skips the trust machinery entirely, including the CA fetch a browser pays twice per
  attempt for nothing.
- A wss endpoint whose CA could not be fetched now **fails on trust** rather than quietly dialling
  plain text at a TLS port and failing there instead. That silent degradation is exactly the confusing
  failure the browser was hitting, and it is gone.

**`discovered`'s fallback widens** from `JetWhaleFixedEndpoint` to a new sealed
`JetWhaleLiteralEndpoint`, so both literal kinds qualify. Source-compatible; the binary signature of
`discovered` changes. Discovery still cannot fall back to more discovery — that is what the type is
for.

## Tests

`ConnectionEndpointTest` gains three cases: a fixed endpoint follows `ssl { }`; a plain loopback
endpoint stays plain whatever `ssl { }` says; a plain loopback endpoint can be the discovery fallback,
with discovery still resolving wss.

## Verification

`:jetwhale-agent-runtime:jvmTest`, `compileKotlinIosArm64`, `compileKotlinMacosArm64`,
`compileKotlinJs`, `compileKotlinWasmJs`, `compileKotlinLinuxX64`, `compileKotlinMingwX64`,
`checkKotlinAbi`, `:demo:shared:compileKotlinJvm` and `spotlessCheck` pass locally. ABI dumps updated.

Exercised in a browser against a headless host, with the demo carrying the configuration above:
**`WebSocket session established`**, and the host shows the session. The CA-fetch failures that used
to repeat before every attempt are gone. This is the first time the web target has connected.

The demo now ships that configuration, so the same file serves every target it is built for.
