### PR TITLE
feat(agent)!: replace the endpoint property with an ordered endpoints block

### DIFF
--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
@@ -7,11 +7,21 @@ import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 fun initializeJetWhale() {
     startJetWhale {
         connection {
-            // Zero-config discovery of the host over mDNS for physical LAN devices, which reach it
-            // over wss. Everything that can only reach loopback — emulators, simulators, ADB-forwarded
-            // devices, and the browser, which cannot pin a local CA at all — falls back to the plain
-            // ws port. One configuration, every target.
-            endpoint = discovered(fallback = plainLoopback(5080))
+            // Tried in order. Loopback first, because everything that can reach it — emulators,
+            // simulators, ADB-forwarded devices, the desktop app, the browser — is already there and
+            // need not wait out a network browse. In the clear, because it never leaves the machine
+            // and a browser cannot pin a locally-issued CA at all.
+            //
+            // A physical device on the network reaches neither, so it falls through to discovery and
+            // connects over wss.
+            endpoints {
+                ws("localhost", 5080)
+                discoverWss {
+                    // The demo cannot know the machine it will be run from, so it takes any host it
+                    // finds. A real app on a shared network should name its own with allowHostName.
+                    allowAll()
+                }
+            }
             ssl {
                 // Fetches the host's active CA over the plain channel (via ADB forwarding) and pins
                 // the wss connection to it, so the app never has to hardcode a CA certificate.

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -112,7 +112,7 @@ import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 import com.kitakkun.jetwhale.plugins.semantics.agent.JetWhaleSemanticsAgentPlugin
 
 startJetWhale {
-    connection { endpoint = fixed("localhost", 5080) }
+    connection { endpoints { ws("localhost", 5080) } }
     plugins { register(JetWhaleSemanticsAgentPlugin()) }
 }
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -68,7 +68,7 @@ import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 fun initializeJetWhale() {
     startJetWhale {
         connection {
-            endpoint = fixed("localhost", 5080) // the host's WebSocket server port
+            endpoints { ws("localhost", 5080) } // the host's plain WebSocket server port
         }
         plugins {
             // register agent plugins here, e.g. the Network Inspector:
@@ -78,16 +78,16 @@ fun initializeJetWhale() {
 }
 ```
 
-::: warning Always set `endpoint`
-The agent's `connection { }` defaults to `fixed("localhost", 8080)`, while the host's debug server
-listens on **5080**. The defaults deliberately do not match, so set `endpoint` explicitly to
-whichever port the host reports in
-[Settings → Connection → Debug Server](/guide/host-settings#debug-server).
+::: warning Always declare `endpoints`
+Without an `endpoints { }` block the agent falls back to `localhost:8080`, while the host's debug
+server listens on **5080**. The defaults deliberately do not match, so declare the port the host
+reports in [Settings → Connection → Debug Server](/guide/host-settings#debug-server).
 :::
 
 ::: info `host` / `port` are deprecated
 Earlier releases configured the address with separate `host` and `port` properties. They still work
-and mean exactly `endpoint = fixed(host, port)`, but new code should assign `endpoint` — it is what
+and amount to a single candidate taking its scheme from `ssl { }`, but new code should declare
+`endpoints { }` — it is what
 [host discovery](#zero-config-host-discovery-recommended-for-physical-devices) extends.
 :::
 
@@ -197,16 +197,24 @@ since `WARN` is the default log level.
 ## Zero-config host discovery (recommended for physical devices)
 
 A physical iPhone or Android device on the same Wi-Fi cannot reach the host over `localhost`. Rather
-than hardcoding the host machine's LAN IP (which changes between machines and networks), assign a
-`discovered(...)` endpoint and let the agent find the host over mDNS/Bonjour:
+than hardcoding the host machine's LAN IP (which changes between machines and networks), declare a
+`discoverWss` candidate and let the agent find the host over mDNS/Bonjour.
+
+Candidates are tried **in the order they are declared**, and each names its own scheme — which is
+what lets one configuration serve targets that disagree about which one is possible:
 
 ```kotlin
 startJetWhale {
     connection {
-        // Browse the LAN for the host advertised as `_jetwhale._tcp` and connect to it. The fallback
-        // applies when nothing is discovered in time (or the platform lacks mDNS), which keeps
-        // emulators/simulators, ADB-forwarded devices and browsers working over loopback.
-        endpoint = discovered(fallback = plainLoopback(5080))
+        endpoints {
+            // Anything that can reach loopback is already there and need not wait out a network
+            // browse: emulators, simulators, ADB-forwarded devices, the desktop app, the browser.
+            // In the clear, because it never leaves the machine.
+            ws("localhost", 5080)
+
+            // A physical device reaches neither, so it falls through to here and connects over wss.
+            discoverWss { allowHostName("my-macbook") }
+        }
 
         ssl { trustServerCertificate() }
     }
@@ -214,53 +222,85 @@ startJetWhale {
 }
 ```
 
-The fallback is a required argument rather than a separate property, so a discovered endpoint can
-never be left without one.
+On a device, `localhost:5080` is refused at once — nothing is listening on the device itself — and
+discovery takes over. On everything else the first candidate connects and the browse never runs.
 
-While its debug server runs, the host advertises a `_jetwhale._tcp.local.` service whose TXT records
-carry the `wsPort` and `wssPort` (the latter only when wss is enabled), the host machine's `hostName`,
-and a protocol marker `v=1`. Discovery therefore resolves the **port** as well as the address, and the
-fallback's port applies only when discovery finds nothing.
+### What each candidate contributes
 
-The scheme is not negotiable: the agent uses wss exactly when an `ssl { }` block is configured. So a
-host counts as a candidate only if it advertises the port for that scheme — an ssl-configured agent
-**skips** a host whose wss is disabled, rather than dialling `wss://` at its plain-ws port. If every
-matching host is skipped that way, the log says so by name, since the host being there but serving
-the wrong scheme looks nothing like the host being absent.
+`ws(host, port)` and `wss(host, port)` contribute exactly the address you wrote, over exactly the
+scheme you named.
 
-### `plainLoopback` for targets that cannot do wss
+`discoverWss { }` contributes **every** host that answers and passes the block's policy, each as its
+own candidate, in browse order. While its debug server runs, the host advertises a
+`_jetwhale._tcp.local.` service whose TXT records carry the `wsPort` and `wssPort` (the latter only
+when wss is enabled), the host machine's `hostName`, and a protocol marker `v=1` — so discovery
+resolves the **port** as well as the address. A host advertising no wss port is passed over rather
+than dialled on the wrong one, and the log says so by name, since a host being there but serving no
+wss looks nothing like a host being absent.
 
-`plainLoopback(port)` is the one endpoint that ignores `ssl { }` and connects in the clear. It takes
-no host: plain text is safe here only because loopback never leaves the machine, and a signature that
-cannot name anything else cannot be aimed at the network by mistake. The host serves its plain-ws port
-on loopback alone for the same reason.
+There is deliberately no plain-ws counterpart to `discoverWss`. Beyond sending in the clear across a
+network being a poor idea, the host binds ws to loopback only — so a discovered address would refuse
+the connection anyway.
 
-It exists because **a browser cannot use wss with JetWhale at all**. TLS trust belongs to the browser,
-so `trustServerCertificate()` has nothing to pin with — and the CA endpoint is a different origin with
-no CORS headers, so the certificate cannot even be read. `ws://localhost` has neither problem.
+::: warning `discoverWss { }` needs a policy
+A block that states nothing accepts nothing, and logs why. Discovery reaches **every** JetWhale host
+on the network, so on a shared one — an office, a coworking space — an unqualified browse can hand
+your app's debug traffic to a colleague's window, whichever host answers first.
 
-As a fallback it also covers emulators, simulators and ADB-forwarded devices, so the single
-configuration above serves every target: physical devices discover the host over wss, everything else
-takes loopback in the clear.
+Name your machine where you can:
 
-Use `fixed("localhost", 5443)` instead when you do want wss over loopback — an ADB-forwarded device
-pinning the CA fetched over the same link, for instance.
+```kotlin
+discoverWss { allowHostName("my-macbook") }  // or allowAddress("192.168.3.26")
+```
+
+`allowAll()` takes any host advertising the service. It is the right call on a network that is
+exclusively yours, and something to ask for rather than receive by omission.
+:::
+
+Where mDNS is unavailable (**JS/Wasm, Linux, Windows**) `discovered` contributes nothing at all, and
+whatever comes next is reached immediately.
+
+### `ssl` belongs to the candidate; `ssl { }` says what to trust
+
+These answer different questions and sit in different places:
+
+| | |
+|---|---|
+| `ssl = true` on a candidate | whether TLS is spoken to *this* host |
+| `ssl { trustCertificate(...) }` | which certificates are trusted when it is |
+
+`ssl = true` with no `ssl { }` block is meaningful: the platform's own trust store applies, as it
+would for any ordinary HTTPS. `ssl { }` adds to that rather than switching it on.
+
+`ssl = false` sends in the clear. Over loopback that is unremarkable — the traffic cannot leave the
+machine, and the host serves its plain-ws port there alone. Anywhere else it means plain text on the
+network, so the agent logs a line saying so at startup. It is your call to make; it is not made
+quietly.
+
+**A browser cannot use wss with JetWhale at all**, which is the clearest case for `ssl = false`. TLS
+trust belongs to the browser, so `trustServerCertificate()` has nothing to pin with — and the CA
+endpoint is a different origin with no CORS headers, so the certificate cannot even be read.
+`ws://localhost` has neither problem.
 
 ### Narrowing discovery
 
-Every advertised host the agent can use is a candidate, tried in turn until one accepts. When several
-run on the same network and you want a particular one, say which:
+`discoverWss { }` has to say which hosts it will accept — an empty block accepts none, and logs why.
+Every host that passes is a candidate, tried in turn until one accepts:
 
 ```kotlin
 connection {
-    endpoint = discovered(fallback = plainLoopback(5080)) {
-        // Accept only a host advertising this machine hostname (exact, case-insensitive).
-        allowHostName("my-macbook")
+    endpoints {
+        ws("localhost", 5080)
 
-        // ...and/or only hosts resolving to specific IPs — your build machine, say, which may
-        // answer on both Wi-Fi and Ethernet.
-        allowAddress("192.168.3.26")
-        allowAddress("192.168.3.27")
+        discoverWss {
+            // Accept only a host advertising this machine hostname (exact, case-insensitive).
+            allowHostName("my-macbook")
+
+            // ...and/or only hosts resolving to specific IPs — your build machine, say, which may
+            // answer on both Wi-Fi and Ethernet.
+            allowAddress("192.168.3.26")
+            allowAddress("192.168.3.27")
+        }
     }
     ssl { trustServerCertificate() }
 }
@@ -323,7 +363,7 @@ one trusted certificate is configured, the connection switches from ws to wss:
 ```kotlin
 startJetWhale {
     connection {
-        endpoint = fixed("localhost", 5443) // the host's wss port
+        endpoints { wss("localhost", 5443) } // the host's wss port
 
         ssl {
             // Option A: fetch and pin the host's active CA automatically (trust-on-first-use).
@@ -380,7 +420,7 @@ behind a user permission, so add a usage-description string to the app's `Info.p
 ```xml
 <key>NSLocalNetworkUsageDescription</key>
 <string>JetWhale connects to the debugger host running on your local network.</string>
-<!-- Required when using discovered(): iOS blocks the Bonjour browse without it. -->
+<!-- Required when using discoverWss: iOS blocks the Bonjour browse without it. -->
 <key>NSBonjourServices</key>
 <array>
     <string>_jetwhale._tcp</string>
@@ -388,7 +428,7 @@ behind a user permission, so add a usage-description string to the app's `Info.p
 ```
 
 iOS prompts the user to allow local-network access on the first connection. `NSBonjourServices` is
-required whenever you use [`discovered()`](#zero-config-host-discovery-recommended-for-physical-devices):
+required whenever you use [`discoverWss`](#zero-config-host-discovery-recommended-for-physical-devices):
 iOS silently blocks browsing for a service type that is not declared. If you dial the host by an
 explicit address instead of discovering it, `NSBonjourServices` can be omitted. Because the CA fetch
 falls back to `https` over the wss port, no App Transport Security exception for plain HTTP is needed.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -257,27 +257,27 @@ discoverWss { allowHostName("my-macbook") }  // or allowAddress("192.168.3.26")
 exclusively yours, and something to ask for rather than receive by omission.
 :::
 
-Where mDNS is unavailable (**JS/Wasm, Linux, Windows**) `discovered` contributes nothing at all, and
-whatever comes next is reached immediately.
+Where mDNS is unavailable (**JS/Wasm, Linux, Windows**) `discoverWss` contributes nothing at all,
+and whatever comes next is reached immediately.
 
-### `ssl` belongs to the candidate; `ssl { }` says what to trust
+### The candidate says whether; `ssl { }` says what to trust
 
 These answer different questions and sit in different places:
 
 | | |
 |---|---|
-| `ssl = true` on a candidate | whether TLS is spoken to *this* host |
+| `ws(...)` vs `wss(...)` | whether TLS is spoken to *this* host |
 | `ssl { trustCertificate(...) }` | which certificates are trusted when it is |
 
-`ssl = true` with no `ssl { }` block is meaningful: the platform's own trust store applies, as it
-would for any ordinary HTTPS. `ssl { }` adds to that rather than switching it on.
+A `wss(...)` candidate with no `ssl { }` block is meaningful: the platform's own trust store applies,
+as it would for any ordinary HTTPS. `ssl { }` adds to that rather than switching wss on.
 
-`ssl = false` sends in the clear. Over loopback that is unremarkable — the traffic cannot leave the
+`ws(...)` sends in the clear. Over loopback that is unremarkable — the traffic cannot leave the
 machine, and the host serves its plain-ws port there alone. Anywhere else it means plain text on the
 network, so the agent logs a line saying so at startup. It is your call to make; it is not made
 quietly.
 
-**A browser cannot use wss with JetWhale at all**, which is the clearest case for `ssl = false`. TLS
+**A browser cannot use wss with JetWhale at all**, which is the clearest case for `ws(...)`. TLS
 trust belongs to the browser, so `trustServerCertificate()` has nothing to pin with — and the CA
 endpoint is a different origin with no CORS headers, so the certificate cannot even be read.
 `ws://localhost` has neither problem.
@@ -328,9 +328,10 @@ takes the CA from whoever answered, which is trust-on-first-use and no stronger 
 runs over. See [Which one to use](#which-one-to-use).
 :::
 
-`fallback` is offered **after** the discovered hosts, not only when none were found: answering mDNS
-says a host is advertising, not that it will accept a connection. The whole list is worked through in
-turn, and only once every entry has refused does the agent wait and start again.
+Whatever is declared after `discoverWss` is reached even when discovery found hosts, not only when it
+found none: answering mDNS says a host is advertising, not that it will accept a connection. The whole
+list is worked through in turn, and only once every entry has refused does the agent wait and start
+again.
 
 That next round browses afresh, so [the usual reconnect promise](#reconnecting) still holds with
 discovery enabled: start the app first and the host later, and the next browse picks it up. The same
@@ -338,7 +339,7 @@ applies when a host restarts on a different port. A failed round is reported onc
 while the outcome stays the same, so an unreachable host does not flood the log.
 
 On a platform without mDNS support (**JS/Wasm, Linux, Windows**) there is nothing to browse, and the
-agent goes straight to `fallback`.
+agent goes straight to whatever was declared next.
 
 | Platform | Discovery backend |
 |----------|-------------------|

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -54,7 +54,7 @@ connect to.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| **Debug Server Port** | `5080` | The plain **ws** port. Must match the port your app dials in `startJetWhale { connection { endpoint = ... } }`, unless it discovers the host — discovery reads the port from what the host advertises. |
+| **Debug Server Port** | `5080` | The plain **ws** port. Must match the port your app dials in `startJetWhale { connection { endpoints { ... } } }`, unless it discovers the host — discovery reads the port from what the host advertises. |
 | **Enable WSS** | on | Whether the secure **wss** connector is exposed at all. |
 | **WSS Port** | `5443` | The **wss** port, matched the same way: your app's `endpoint` when it names one, or the advertised port when it discovers the host. |
 

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -56,7 +56,7 @@ connect to.
 |---------|---------|-------------|
 | **Debug Server Port** | `5080` | The plain **ws** port. Must match the port your app dials in `startJetWhale { connection { endpoints { ... } } }`, unless it discovers the host — discovery reads the port from what the host advertises. |
 | **Enable WSS** | on | Whether the secure **wss** connector is exposed at all. |
-| **WSS Port** | `5443` | The **wss** port, matched the same way: your app's `endpoint` when it names one, or the advertised port when it discovers the host. |
+| **WSS Port** | `5443` | The **wss** port, matched the same way: your app's `wss(host, port)` when it names one, or the advertised port when it discovers the host. |
 
 Changing any of the three reveals a single **Apply** button, which confirms before restarting the
 server — restarting disconnects every session. All three are applied together, because the server

--- a/docs/guide/network-inspector.md
+++ b/docs/guide/network-inspector.md
@@ -52,7 +52,7 @@ val client = HttpClient {
 }
 
 startJetWhale {
-    connection { endpoint = fixed("localhost", 5080) }
+    connection { endpoints { ws("localhost", 5080) } }
     plugins { register(networkAgent) }
 }
 ```
@@ -90,7 +90,7 @@ val client = OkHttpClient.Builder()
     .build()
 
 startJetWhale {
-    connection { endpoint = fixed("localhost", 5080) }
+    connection { endpoints { ws("localhost", 5080) } }
     plugins { register(networkAgent) }
 }
 ```

--- a/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
+++ b/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
@@ -57,9 +57,6 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScop
 }
 
 abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope|null[0]
-    abstract var endpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.endpoint|{}endpoint[0]
-        abstract fun <get-endpoint>(): com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.endpoint.<get-endpoint>|<get-endpoint>(){}[0]
-        abstract fun <set-endpoint>(com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.endpoint.<set-endpoint>|<set-endpoint>(com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpoint){}[0]
     abstract var host // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.host|{}host[0]
         abstract fun <get-host>(): kotlin/String // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.host.<get-host>|<get-host>(){}[0]
         abstract fun <set-host>(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.host.<set-host>|<set-host>(kotlin.String){}[0]
@@ -67,15 +64,20 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigu
         abstract fun <get-port>(): kotlin/Int // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.port.<get-port>|<get-port>(){}[0]
         abstract fun <set-port>(kotlin/Int) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.port.<set-port>|<set-port>(kotlin.Int){}[0]
 
-    abstract fun discovered(com.kitakkun.jetwhale.agent.runtime/JetWhaleLiteralEndpoint, kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope, kotlin/Unit> = ...): com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.discovered|discovered(com.kitakkun.jetwhale.agent.runtime.JetWhaleLiteralEndpoint;kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleDiscoveredEndpointScope,kotlin.Unit>){}[0]
-    abstract fun fixed(kotlin/String, kotlin/Int): com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.fixed|fixed(kotlin.String;kotlin.Int){}[0]
-    abstract fun plainLoopback(kotlin/Int): com.kitakkun.jetwhale.agent.runtime/JetWhalePlainLoopbackEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.plainLoopback|plainLoopback(kotlin.Int){}[0]
+    abstract fun endpoints(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.endpoints|endpoints(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope,kotlin.Unit>){}[0]
     abstract fun ssl(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleConnectionConfigurationScope.ssl|ssl(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleSslConfigurationScope,kotlin.Unit>){}[0]
 }
 
-abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope|null[0]
-    abstract fun allowAddress(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope.allowAddress|allowAddress(kotlin.String){}[0]
-    abstract fun allowHostName(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveredEndpointScope.allowHostName|allowHostName(kotlin.String){}[0]
+abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveryScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveryScope|null[0]
+    abstract fun allowAddress(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveryScope.allowAddress|allowAddress(kotlin.String){}[0]
+    abstract fun allowAll() // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveryScope.allowAll|allowAll(){}[0]
+    abstract fun allowHostName(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveryScope.allowHostName|allowHostName(kotlin.String){}[0]
+}
+
+abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope|null[0]
+    abstract fun discoverWss(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveryScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope.discoverWss|discoverWss(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleDiscoveryScope,kotlin.Unit>){}[0]
+    abstract fun ws(kotlin/String, kotlin/Int) // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope.ws|ws(kotlin.String;kotlin.Int){}[0]
+    abstract fun wss(kotlin/String, kotlin/Int) // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope.wss|wss(kotlin.String;kotlin.Int){}[0]
 }
 
 abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleLoggingConfigurationScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleLoggingConfigurationScope|null[0]
@@ -102,13 +104,5 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationS
     abstract fun trustCertificate(kotlin/String) // com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope.trustCertificate|trustCertificate(kotlin.String){}[0]
     abstract fun trustServerCertificate() // com.kitakkun.jetwhale.agent.runtime/JetWhaleSslConfigurationScope.trustServerCertificate|trustServerCertificate(){}[0]
 }
-
-sealed interface com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint|null[0]
-
-sealed interface com.kitakkun.jetwhale.agent.runtime/JetWhaleLiteralEndpoint : com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleLiteralEndpoint|null[0]
-
-final class com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint : com.kitakkun.jetwhale.agent.runtime/JetWhaleLiteralEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhaleFixedEndpoint|null[0]
-
-final class com.kitakkun.jetwhale.agent.runtime/JetWhalePlainLoopbackEndpoint : com.kitakkun.jetwhale.agent.runtime/JetWhaleLiteralEndpoint // com.kitakkun.jetwhale.agent.runtime/JetWhalePlainLoopbackEndpoint|null[0]
 
 final fun com.kitakkun.jetwhale.agent.runtime/startJetWhale(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleConfigurationScope, kotlin/Unit>): com.kitakkun.jetwhale.agent.runtime/JetWhaleSession // com.kitakkun.jetwhale.agent.runtime/startJetWhale|startJetWhale(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleConfigurationScope,kotlin.Unit>){}[0]

--- a/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
+++ b/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
@@ -17,35 +17,24 @@ public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleConf
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope {
-	public abstract fun discovered (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint;Lkotlin/jvm/functions/Function1;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
-	public static synthetic fun discovered$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
-	public abstract fun fixed (Ljava/lang/String;I)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint;
-	public abstract fun getEndpoint ()Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
+	public abstract fun endpoints (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun getHost ()Ljava/lang/String;
 	public abstract fun getPort ()I
-	public abstract fun plainLoopback (I)Lcom/kitakkun/jetwhale/agent/runtime/JetWhalePlainLoopbackEndpoint;
-	public abstract fun setEndpoint (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;)V
 	public abstract fun setHost (Ljava/lang/String;)V
 	public abstract fun setPort (I)V
 	public abstract fun ssl (Lkotlin/jvm/functions/Function1;)V
 }
 
-public final class com/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope$DefaultImpls {
-	public static synthetic fun discovered$default (Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleConnectionConfigurationScope;Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint;
-}
-
-public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleDiscoveredEndpointScope {
+public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleDiscoveryScope {
 	public abstract fun allowAddress (Ljava/lang/String;)V
+	public abstract fun allowAll ()V
 	public abstract fun allowHostName (Ljava/lang/String;)V
 }
 
-public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint {
-}
-
-public final class com/kitakkun/jetwhale/agent/runtime/JetWhaleFixedEndpoint : com/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint {
-}
-
-public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint : com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpoint {
+public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpointScope {
+	public abstract fun discoverWss (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun ws (Ljava/lang/String;I)V
+	public abstract fun wss (Ljava/lang/String;I)V
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleLoggingConfigurationScope {
@@ -55,9 +44,6 @@ public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleLogg
 	public abstract fun setEnabled (Z)V
 	public abstract fun setKtorLogLevel (Lcom/kitakkun/jetwhale/agent/runtime/KtorLogLevel;)V
 	public abstract fun setLogLevel (Lcom/kitakkun/jetwhale/agent/runtime/LogLevel;)V
-}
-
-public final class com/kitakkun/jetwhale/agent/runtime/JetWhalePlainLoopbackEndpoint : com/kitakkun/jetwhale/agent/runtime/JetWhaleLiteralEndpoint {
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhalePluginConfigurationScope {

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/EndpointResolver.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/EndpointResolver.kt
@@ -26,3 +26,14 @@ internal fun interface EndpointResolver {
 internal class FixedEndpointResolver(private val endpoint: ResolvedEndpoint) : EndpointResolver {
     override suspend fun resolve(): List<ResolvedEndpoint> = listOf(endpoint)
 }
+
+/**
+ * Every declared candidate in the order it was declared, each contributing what it resolves to — one
+ * address for a literal, however many answered for a discovered one, none where mDNS is unavailable.
+ *
+ * Deduplicated with the order kept: the same address reached two ways is one address, and dialling it
+ * twice in a round would only spend the establishment budget twice.
+ */
+internal class CandidateListResolver(private val candidates: List<EndpointResolver>) : EndpointResolver {
+    override suspend fun resolve(): List<ResolvedEndpoint> = candidates.flatMap { it.resolve() }.distinct()
+}

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
@@ -58,52 +58,63 @@ internal data class SelectedHost(val service: DiscoveredService, val port: Int)
 /**
  * Every host among [services] this agent could use, in the order they were browsed.
  *
- * A host qualifies only when it satisfies every configured filter **and** advertises the port for the
- * scheme the connection will use. The scheme comes from the `ssl {}` block alone, so an ssl-configured
- * agent cannot use a host that advertises no wss port: dialling `wss://` at its plain-ws port would
- * fail every handshake. Such a host is dropped rather than dialled.
+ * A host qualifies only when it satisfies every configured filter **and** advertises a wss port. A
+ * host that advertises none is dropped rather than dialled: it serves plain ws on loopback, which is
+ * not the address that was discovered.
  *
  * All of them are returned, not just the first: browse order is arbitrary and a host that answers mDNS
  * may still refuse a connection, so the caller tries them in turn.
  */
-internal fun selectHosts(services: List<DiscoveredService>, discovery: HostDiscoveryConfig): List<SelectedHost> = services
-    .filter { it.matches(discovery) }
-    .mapNotNull { service -> service.portFor(discovery.useWss)?.let { SelectedHost(service, it) } }
+internal fun selectHosts(services: List<DiscoveredService>, discovery: HostDiscoveryConfig): List<SelectedHost> {
+    if (discovery.acceptsNothing) return emptyList()
+    return services
+        .filter { it.matches(discovery) }
+        .mapNotNull { service -> service.wssPort?.let { SelectedHost(service, it) } }
+}
 
 /**
- * Browses for JetWhale hosts over mDNS and offers every usable one, with [fallback] last.
+ * Browses for JetWhale hosts over mDNS and offers every usable one, in browse order.
  *
  * Browsing on every call is the point: a host started after the app, or one that came back on a
  * different port, is only reached by looking again. That makes the outcome repetitive by nature, so
  * the resolver remembers what it last reported and stays quiet while nothing changes.
  *
- * [fallback] is offered even when hosts were found. Answering mDNS says a host is advertising, not
- * that it will accept a connection — a firewall between them is invisible to the browse — so the
- * configured address stays available behind the discovered ones.
+ * Contributing nothing is a normal outcome, not a failure: nothing advertised, nothing matched, or
+ * the platform cannot browse. Whatever was declared after this is reached either way.
  */
-internal class MdnsEndpointResolver(
-    val discovery: HostDiscoveryConfig,
-    val fallback: ResolvedEndpoint,
-) : EndpointResolver {
+internal class MdnsEndpointResolver(val discovery: HostDiscoveryConfig) : EndpointResolver {
     private var lastReported: String? = null
 
     override suspend fun resolve(): List<ResolvedEndpoint> {
+        if (discovery.acceptsAnyHost && discovery.hasFilter) {
+            // Two different answers to the same question. Taking the wider one is what the code does,
+            // but it is the opposite of what naming a machine asks for, so it is not done quietly.
+            report(
+                "discoverWss { } states allowAll() alongside an allowlist. allowAll() wins, so hosts " +
+                    "the allowlist would have excluded are accepted too — drop one of the two.",
+            )
+        }
+        if (discovery.acceptsNothing) {
+            report(
+                "discoverWss { } was declared without a policy, so no discovered host can be accepted. " +
+                    "Name the machine with allowHostName/allowAddress, or state allowAll() to take any " +
+                    "JetWhale host on the network.",
+            )
+            return emptyList()
+        }
         val result = browseJetWhaleServices(HOST_DISCOVERY_TIMEOUT_MILLIS)
-        val discovered = when (result) {
+        return when (result) {
             is DiscoveryResult.Unavailable -> {
-                report("mDNS host discovery is unavailable because ${result.reason}; using $fallback")
+                report("mDNS host discovery is unavailable because ${result.reason}; the remaining candidates carry the connection")
                 emptyList()
             }
 
             is DiscoveryResult.Browsed -> {
                 val usable = selectHosts(result.services, discovery)
                 report(if (usable.isEmpty()) noHostMessage(result.services) else foundMessage(usable))
-                usable.map { ResolvedEndpoint(it.service.address, it.port, useWss = discovery.useWss) }
+                usable.map { ResolvedEndpoint(it.service.address, it.port, useWss = true) }
             }
         }
-        // Deduplicated, order kept: the fallback may well be an address that was also advertised, and
-        // dialling the same endpoint twice in a round only spends the establishment budget twice.
-        return (discovered + fallback).distinct()
     }
 
     private fun report(message: String) {
@@ -114,19 +125,18 @@ internal class MdnsEndpointResolver(
 
     private fun foundMessage(usable: List<SelectedHost>): String {
         val listed = usable.joinToString { "${it.service.displayName()} at ${it.service.address}:${it.port}" }
-        return "Discovered ${usable.size} JetWhale host(s) over mDNS: $listed. Falling back to $fallback if none accepts a connection."
+        return "Discovered ${usable.size} JetWhale host(s) over mDNS: $listed"
     }
 
     private fun noHostMessage(services: List<DiscoveredService>): String {
         val matched = services.filter { it.matches(discovery) }
         if (matched.isEmpty()) {
-            return "mDNS host discovery found no matching host within ${HOST_DISCOVERY_TIMEOUT_MILLIS}ms; using $fallback"
+            return "mDNS host discovery found no matching host within ${HOST_DISCOVERY_TIMEOUT_MILLIS}ms"
         }
         // Matched but unusable is worth spelling out: the agent would otherwise look like it simply
         // found nothing, when in fact the host is there and only its wss connector is missing.
-        val scheme = if (discovery.useWss) "wss" else "ws"
         val listed = matched.joinToString { it.displayName() }
-        return "mDNS host discovery matched ${matched.size} host(s) ($listed) but none advertised a $scheme port; using $fallback. " +
+        return "mDNS host discovery matched ${matched.size} host(s) ($listed) but none advertised a wss port. " +
             "A host advertises its wss port only while wss is enabled in its settings."
     }
 }
@@ -145,5 +155,3 @@ private fun DiscoveredService.matches(discovery: HostDiscoveryConfig): Boolean {
     }
     return true
 }
-
-private fun DiscoveredService.portFor(useWss: Boolean): Int? = if (useWss) wssPort else wsPort

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/HostDiscovery.kt
@@ -87,11 +87,11 @@ internal class MdnsEndpointResolver(val discovery: HostDiscoveryConfig) : Endpoi
 
     override suspend fun resolve(): List<ResolvedEndpoint> {
         if (discovery.acceptsAnyHost && discovery.hasFilter) {
-            // Two different answers to the same question. Taking the wider one is what the code does,
-            // but it is the opposite of what naming a machine asks for, so it is not done quietly.
+            // Two answers to one question. The narrower is kept, because widening a stated allowlist
+            // by accident is the failure that costs something; it is still worth saying out loud.
             report(
-                "discoverWss { } states allowAll() alongside an allowlist. allowAll() wins, so hosts " +
-                    "the allowlist would have excluded are accepted too — drop one of the two.",
+                "discoverWss { } states allowAll() alongside an allowlist. The allowlist still " +
+                    "applies, so allowAll() adds nothing here — drop one of the two.",
             )
         }
         if (discovery.acceptsNothing) {

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleMessagingService.kt
@@ -35,8 +35,17 @@ internal interface JetWhaleMessagingService {
 internal data class HostDiscoveryConfig(
     val hostNames: List<String>,
     val addresses: List<String>,
-    val useWss: Boolean,
+    /** Set by `allowAll()`: take any host that advertises the service, allowlists or not. */
+    val acceptsAnyHost: Boolean,
 ) {
     /** True when at least one allowlist narrows the discovered hosts. */
     val hasFilter: Boolean get() = hostNames.isNotEmpty() || addresses.isNotEmpty()
+
+    /**
+     * True when nothing at all was stated, so no host can be accepted.
+     *
+     * Discovery reaches every JetWhale host on the network, which on a shared one is other people's.
+     * An empty block therefore takes nobody rather than everybody; `allowAll()` says otherwise.
+     */
+    val acceptsNothing: Boolean get() = !acceptsAnyHost && !hasFilter
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -60,31 +60,40 @@ public fun startJetWhale(configure: JetWhaleConfigurationScope.() -> Unit): JetW
     return MessagingServiceSession(service)
 }
 
-/** The resolver a configured `endpoint` amounts to, once `ssl {}` is known. */
-internal fun JetWhaleConnectionConfiguration.endpointResolver(): EndpointResolver = when (val endpoint = endpoint) {
-    is JetWhaleLiteralEndpoint -> FixedEndpointResolver(endpoint.resolved(sslConfiguration.isEnabled))
+/** The resolver a configured `endpoints { }` amounts to, in the order its candidates were declared. */
+internal fun JetWhaleConnectionConfiguration.endpointResolver(): EndpointResolver {
+    val declared = candidates.ifEmpty {
+        // Nothing declared: the deprecated host/port carry whatever they hold, defaults included, and
+        // take their scheme from `ssl { }` the way the whole connection used to.
+        @Suppress("DEPRECATION")
+        listOf(EndpointCandidate.Static(host, port, useWss = sslConfiguration.isEnabled))
+    }
+    declared.forEach { it.warnIfPlainOffMachine() }
+    return CandidateListResolver(declared.map { it.resolver() })
+}
 
-    is JetWhaleDiscoveredEndpoint -> MdnsEndpointResolver(
-        discovery = HostDiscoveryConfig(
-            hostNames = endpoint.hostNames,
-            addresses = endpoint.addresses,
-            // The connection uses wss exactly when SSL is configured, so a discovered host has to
-            // advertise that scheme's port. Read here rather than in `discovered()` so `ssl {}` and
-            // `endpoint =` can appear in either order.
-            useWss = sslConfiguration.isEnabled,
-        ),
-        fallback = endpoint.fallback.resolved(sslConfiguration.isEnabled),
+private fun EndpointCandidate.resolver(): EndpointResolver = when (this) {
+    is EndpointCandidate.Static -> FixedEndpointResolver(ResolvedEndpoint(host, port, useWss = useWss))
+
+    is EndpointCandidate.Dynamic -> MdnsEndpointResolver(
+        HostDiscoveryConfig(hostNames = hostNames, addresses = addresses, acceptsAnyHost = acceptsAnyHost),
     )
 }
 
-/** @param sslConfigured what `ssl { }` decided, which every endpoint but [JetWhalePlainLoopbackEndpoint] follows. */
-private fun JetWhaleLiteralEndpoint.resolved(sslConfigured: Boolean): ResolvedEndpoint = when (this) {
-    is JetWhaleFixedEndpoint -> ResolvedEndpoint(host, port, useWss = sslConfigured)
-    is JetWhalePlainLoopbackEndpoint -> ResolvedEndpoint(LOOPBACK_HOST, port, useWss = false)
+/**
+ * Says so when a candidate will send in the clear to something that is not this machine.
+ *
+ * Not an error: `ws` is what the caller asked for, and a debug tool may take it. But plain text
+ * leaving the machine is worth one line in the log rather than none. Discovered hosts cannot reach
+ * this state — they are always dialled over wss — so only a written-out address is checked.
+ */
+private fun EndpointCandidate.warnIfPlainOffMachine() {
+    if (this !is EndpointCandidate.Static || useWss || isLoopbackHost(host)) return
+    JetWhaleLogger.w("Configured to connect to $host:$port in the clear — plain text will leave this machine.")
 }
 
-/** The name loopback is dialled by. RFC 6761 reserves it, so it always resolves to the loopback interface. */
-private const val LOOPBACK_HOST = "localhost"
+/** RFC 6761 reserves `localhost` for the loopback interface, so the name is as good as the addresses. */
+private fun isLoopbackHost(host: String): Boolean = host == "localhost" || host == "::1" || host.startsWith("127.")
 
 private class MessagingServiceSession(private val service: JetWhaleMessagingService) : JetWhaleSession {
     override fun stop() {
@@ -133,85 +142,43 @@ public interface JetWhaleAppConfigurationScope {
 @JetWhaleDsl
 public interface JetWhaleConnectionConfigurationScope {
     /**
-     * The JetWhale host this agent connects to. Assign either [at] for a literal address, or
-     * [discovered] to find the host on the local network over mDNS/Bonjour.
+     * Where this agent will look for the host, best first.
      *
-     * Defaults to `fixed("localhost", 8080)`.
+     * **Declaration order is dial order.** The agent works down the list from the top, and the first
+     * candidate that accepts a connection keeps it — the rest are never tried. When none accepts, it
+     * waits and starts again from the top, so a host that comes up later is still found. A
+     * `discoverWss` entry expands to every host it finds, each tried in browse order before whatever
+     * was declared after it.
+     *
+     * Put the cheapest and most likely first. Declaring several is how one configuration serves
+     * targets that reach the host differently: an emulator over loopback, a physical device over the
+     * network, a browser which can only ever do plain ws.
+     *
+     * ```
+     * endpoints {
+     *     ws("localhost", 5080)
+     *     discoverWss { allowHostName("my-macbook") }
+     * }
+     * ```
+     *
+     * Repeated blocks add to the list rather than replacing it. With no `endpoints { }` at all the
+     * deprecated [host]/[port] apply, defaults included.
      */
-    public var endpoint: JetWhaleEndpoint
+    public fun endpoints(configure: JetWhaleEndpointScope.() -> Unit)
 
     @Deprecated(
-        message = "Superseded by 'endpoint'. Assign endpoint = fixed(host, port) instead. " +
-            "Setting host/port still works and is equivalent to that assignment.",
+        message = "Superseded by 'endpoints { }'. Declare endpoints { wss(host, port) } instead. " +
+            "Setting host/port still works and amounts to a single candidate taking its scheme from ssl { }.",
         level = DeprecationLevel.WARNING,
     )
     public var host: String
 
     @Deprecated(
-        message = "Superseded by 'endpoint'. Assign endpoint = fixed(host, port) instead. " +
-            "Setting host/port still works and is equivalent to that assignment.",
+        message = "Superseded by 'endpoints { }'. Declare endpoints { wss(host, port) } instead. " +
+            "Setting host/port still works and amounts to a single candidate taking its scheme from ssl { }.",
         level = DeprecationLevel.WARNING,
     )
     public var port: Int
-
-    /**
-     * A literal address to connect to, e.g. `localhost` for an emulator/simulator or an
-     * ADB-forwarded device.
-     *
-     * @param host The hostname or IP address of the JetWhale host.
-     * @param port The port the JetWhale host's debug server listens on.
-     */
-    public fun fixed(host: String, port: Int): JetWhaleFixedEndpoint
-
-    /**
-     * The loopback interface, reached in the clear on [port] whatever `ssl { }` says.
-     *
-     * There is no host parameter, and that is the point: plain text is safe here because it cannot
-     * leave the machine, and a signature that cannot name anything else cannot be pointed at the
-     * network by accident. The host serves its plain-ws port on loopback only, for the same reason.
-     *
-     * Use it as the fallback for targets that cannot do wss but can reach the host locally. A browser
-     * is the clear case: TLS trust belongs to the browser there, so `trustServerCertificate()` has
-     * nothing to pin with and no wss connection is possible — while `ws://localhost` is unremarkable.
-     * Emulators and ADB-forwarded devices reach loopback too, so one shared configuration covers them
-     * alongside a discovered host for physical devices.
-     *
-     * Nothing about `ssl { }` is skipped for other endpoints; this is the one exception, and it is
-     * limited to loopback by construction.
-     *
-     * @param port The host's plain-ws port.
-     */
-    public fun plainLoopback(port: Int): JetWhalePlainLoopbackEndpoint
-
-    /**
-     * A host found by zero-config discovery over mDNS/DNS-SD (Bonjour): the agent browses the local
-     * network for the `_jetwhale._tcp` service the host advertises while its debug server runs, and
-     * connects to the address and port it advertises. Use this for physical LAN devices, which cannot
-     * reach the host over `localhost`.
-     *
-     * The advertised wss port is used when `ssl {}` is configured, otherwise the plain-ws port — so
-     * discovery resolves the port too, and [fallback]'s port is its own.
-     *
-     * Every advertised host this agent can use becomes a candidate and they are tried in turn, with
-     * [fallback] last. It is required rather than optional because answering mDNS says a host is
-     * advertising, not that it will accept a connection, and because a platform without mDNS
-     * (JS/Wasm/Linux/Windows) has nothing to browse at all.
-     *
-     * iOS requires `_jetwhale._tcp` to be listed under `NSBonjourServices` in `Info.plist` alongside
-     * `NSLocalNetworkUsageDescription`, otherwise the OS blocks the browse.
-     *
-     * Use [configure] to say which host you want when several advertise (see
-     * [JetWhaleDiscoveredEndpointScope]). Those filters choose; they do not authenticate — mDNS
-     * advertisements are unauthenticated, so a certificate pinned with `trustCertificate` is what
-     * establishes who answered.
-     *
-     * @param fallback Tried after every discovered candidate, and on its own where mDNS is unavailable.
-     * @param configure Optional filters narrowing which discovered host is accepted.
-     */
-    public fun discovered(
-        fallback: JetWhaleLiteralEndpoint,
-        configure: JetWhaleDiscoveredEndpointScope.() -> Unit = {},
-    ): JetWhaleEndpoint
 
     /**
      * Configures SSL settings for the connection. When at least one trusted certificate is
@@ -223,41 +190,76 @@ public interface JetWhaleConnectionConfigurationScope {
 }
 
 /**
- * Where the agent connects to. Build one with [JetWhaleConnectionConfigurationScope.at] or
- * [JetWhaleConnectionConfigurationScope.discovered].
- */
-public sealed interface JetWhaleEndpoint
-
-/**
- * An endpoint written down rather than looked up, and so usable as a discovery fallback.
+ * Declares where to look for the host, in order.
  *
- * Discovery cannot fall back to more discovery, which is why the fallback is typed to this rather
- * than to [JetWhaleEndpoint].
+ * Each candidate names its own scheme, because the targets one configuration serves do not agree on
+ * it: a browser cannot do wss against a locally-issued CA at all, while a physical device on the
+ * network can do nothing else. What TLS trusts, once it is spoken, is the separate concern `ssl { }`
+ * answers.
  */
-public sealed interface JetWhaleLiteralEndpoint : JetWhaleEndpoint
+@JetWhaleDsl
+public interface JetWhaleEndpointScope {
+    /**
+     * A written-out `ws://host:port` — no TLS.
+     *
+     * The host serves plain ws on loopback alone, so this is for the targets that are already on the
+     * machine: emulators, simulators, ADB-forwarded devices, the desktop app, and browsers, which
+     * cannot pin a locally-issued CA and so have no other way in. Anywhere else the traffic leaves
+     * the machine unencrypted, which is logged as a warning.
+     *
+     * @param host The hostname or IP address of the JetWhale host.
+     * @param port The port serving plain ws. The host listens for ws and wss on different ports, and
+     *   dialling the wrong one fails the handshake.
+     */
+    public fun ws(host: String, port: Int)
 
-/** A literal host/port, as built by [JetWhaleConnectionConfigurationScope.fixed]. */
-public class JetWhaleFixedEndpoint internal constructor(
-    internal val host: String,
-    internal val port: Int,
-) : JetWhaleLiteralEndpoint
+    /**
+     * A written-out `wss://host:port`.
+     *
+     * @param host The hostname or IP address of the JetWhale host.
+     * @param port The port serving wss. The host listens for ws and wss on different ports, and
+     *   dialling the wrong one fails the handshake.
+     */
+    public fun wss(host: String, port: Int)
 
-/** A loopback port reached in the clear, as built by [JetWhaleConnectionConfigurationScope.plainLoopback]. */
-public class JetWhalePlainLoopbackEndpoint internal constructor(
-    internal val port: Int,
-) : JetWhaleLiteralEndpoint
+    /**
+     * Whatever hosts are found by zero-config discovery over mDNS/DNS-SD (Bonjour), each dialled over
+     * wss: the agent browses the local network for the `_jetwhale._tcp` service a host advertises
+     * while its debug server runs. Use this for physical devices, which cannot reach the host over
+     * loopback.
+     *
+     * There is no plain-ws counterpart, and not only because sending in the clear across a network is
+     * a poor idea: the host binds ws to loopback, so a discovered address would refuse the connection
+     * anyway.
+     *
+     * Every host that answers and advertises a wss port becomes a candidate of its own, in browse
+     * order, before whatever is declared next — answering mDNS says a host is advertising, not that
+     * it will accept a connection. Where mDNS is unavailable (JS/Wasm, Linux, Windows) this
+     * contributes nothing and the next candidate is reached immediately.
+     *
+     * iOS requires `_jetwhale._tcp` to be listed under `NSBonjourServices` in `Info.plist` alongside
+     * `NSLocalNetworkUsageDescription`, otherwise the OS blocks the browse.
+     *
+     * @param configure Which discovered hosts are acceptable. Required, and not merely as a matter of
+     *   taste: a block stating nothing accepts nothing, because discovery reaches every JetWhale host
+     *   on the network and on a shared one those belong to other people.
+     */
+    public fun discoverWss(configure: JetWhaleDiscoveryScope.() -> Unit)
+}
 
 /**
- * Allowlists narrowing which discovered host is accepted. Each is repeatable and independently
- * optional; a host has to satisfy every allowlist that has entries, and one that does not is skipped
- * rather than connected to.
+ * Which discovered hosts this agent will connect to.
+ *
+ * Something has to be stated: a block that says nothing accepts nothing, and logs why. The allowlists
+ * are repeatable and independent — a host has to satisfy every allowlist that has entries, and one
+ * that does not is skipped rather than connected to.
  *
  * They choose between hosts; they do not authenticate one. An mDNS advertisement is unauthenticated,
  * so anything on the network can claim any hostname — matching one proves nothing about who answered.
  * That is what pinning a certificate with `trustCertificate` is for.
  */
 @JetWhaleDsl
-public interface JetWhaleDiscoveredEndpointScope {
+public interface JetWhaleDiscoveryScope {
     /**
      * Adds a hostname to the allowlist: a discovered host is accepted only when its advertised
      * hostname equals one of the added names, compared case-insensitively. Repeatable. The compared
@@ -276,6 +278,17 @@ public interface JetWhaleDiscoveredEndpointScope {
      * @param ip An IP address a discovered host is allowed to resolve to.
      */
     public fun allowAddress(ip: String)
+
+    /**
+     * Accepts every host advertising the service, wherever it is and whoever runs it.
+     *
+     * This is the one way to browse without qualification, and it is stated rather than assumed: on a
+     * shared network — an office, a coworking space — an unqualified browse reaches colleagues' hosts
+     * too, and whichever answers first wins. That would hand this app's debug traffic to someone
+     * else's window. Naming the machine with [allowHostName] or [allowAddress] is the better answer
+     * wherever the network is not exclusively yours; reach for this on one that is.
+     */
+    public fun allowAll()
 }
 
 @JetWhaleDsl
@@ -359,12 +372,17 @@ private class JetWhaleAppConfiguration : JetWhaleAppConfigurationScope {
     )
 }
 
-/** A host to be discovered over mDNS, as built by [JetWhaleConnectionConfigurationScope.discovered]. */
-internal class JetWhaleDiscoveredEndpoint(
-    val hostNames: List<String>,
-    val addresses: List<String>,
-    val fallback: JetWhaleLiteralEndpoint,
-) : JetWhaleEndpoint
+/** One place to look for the host, as declared in `endpoints { }`. */
+internal sealed interface EndpointCandidate {
+    data class Static(val host: String, val port: Int, val useWss: Boolean) : EndpointCandidate
+
+    /** Always wss: the host serves plain ws on loopback, which discovery never returns. */
+    data class Dynamic(
+        val hostNames: List<String>,
+        val addresses: List<String>,
+        val acceptsAnyHost: Boolean,
+    ) : EndpointCandidate
+}
 
 @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
 internal class JetWhaleConnectionConfiguration : JetWhaleConnectionConfigurationScope {
@@ -372,30 +390,13 @@ internal class JetWhaleConnectionConfiguration : JetWhaleConnectionConfiguration
     override var port: Int = 8080
     val sslConfiguration: JetWhaleSslConfiguration = JetWhaleSslConfiguration()
 
-    private var assignedEndpoint: JetWhaleEndpoint? = null
+    private val declaredCandidates: MutableList<EndpointCandidate> = mutableListOf()
+    val candidates: List<EndpointCandidate> get() = declaredCandidates
 
-    // Falling back to host/port keeps the deprecated properties working: leaving `endpoint` unassigned
-    // resolves to whatever they hold, defaults included.
-    override var endpoint: JetWhaleEndpoint
-        get() = assignedEndpoint ?: fixed(host, port)
-        set(value) {
-            assignedEndpoint = value
-        }
-
-    override fun fixed(host: String, port: Int): JetWhaleFixedEndpoint = JetWhaleFixedEndpoint(host, port)
-
-    override fun plainLoopback(port: Int): JetWhalePlainLoopbackEndpoint = JetWhalePlainLoopbackEndpoint(port)
-
-    override fun discovered(
-        fallback: JetWhaleLiteralEndpoint,
-        configure: JetWhaleDiscoveredEndpointScope.() -> Unit,
-    ): JetWhaleEndpoint {
-        val filters = JetWhaleDiscoveredEndpointConfiguration().apply(configure)
-        return JetWhaleDiscoveredEndpoint(
-            hostNames = filters.hostNames,
-            addresses = filters.addresses,
-            fallback = fallback,
-        )
+    // Repeated blocks add to the list rather than replacing it, so the order candidates were written
+    // in is the order they are tried, wherever they were written.
+    override fun endpoints(configure: JetWhaleEndpointScope.() -> Unit) {
+        JetWhaleEndpointConfiguration(declaredCandidates).configure()
     }
 
     override fun ssl(configure: JetWhaleSslConfigurationScope.() -> Unit) {
@@ -403,12 +404,32 @@ internal class JetWhaleConnectionConfiguration : JetWhaleConnectionConfiguration
     }
 }
 
-private class JetWhaleDiscoveredEndpointConfiguration : JetWhaleDiscoveredEndpointScope {
+private class JetWhaleEndpointConfiguration(
+    private val candidates: MutableList<EndpointCandidate>,
+) : JetWhaleEndpointScope {
+    override fun ws(host: String, port: Int) {
+        candidates += EndpointCandidate.Static(host, port, useWss = false)
+    }
+
+    override fun wss(host: String, port: Int) {
+        candidates += EndpointCandidate.Static(host, port, useWss = true)
+    }
+
+    override fun discoverWss(configure: JetWhaleDiscoveryScope.() -> Unit) {
+        val policy = JetWhaleDiscoveryConfiguration().apply(configure)
+        candidates += EndpointCandidate.Dynamic(policy.hostNames, policy.addresses, policy.acceptsAnyHost)
+    }
+}
+
+private class JetWhaleDiscoveryConfiguration : JetWhaleDiscoveryScope {
     private val mutableHostNames: MutableList<String> = mutableListOf()
     val hostNames: List<String> get() = mutableHostNames
 
     private val mutableAddresses: MutableList<String> = mutableListOf()
     val addresses: List<String> get() = mutableAddresses
+
+    var acceptsAnyHost: Boolean = false
+        private set
 
     override fun allowHostName(name: String) {
         mutableHostNames.add(name)
@@ -416,6 +437,10 @@ private class JetWhaleDiscoveredEndpointConfiguration : JetWhaleDiscoveredEndpoi
 
     override fun allowAddress(ip: String) {
         mutableAddresses.add(ip)
+    }
+
+    override fun allowAll() {
+        acceptsAnyHost = true
     }
 }
 

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -181,8 +181,16 @@ public interface JetWhaleConnectionConfigurationScope {
     public var port: Int
 
     /**
-     * Configures SSL settings for the connection. When at least one trusted certificate is
-     * registered, the connection is established over wss instead of plain ws.
+     * What TLS trusts, wherever it is spoken. Whether it is spoken at all is each candidate's own
+     * business, stated by [JetWhaleEndpointScope.ws] or [JetWhaleEndpointScope.wss] — so this block
+     * neither switches wss on nor implies it.
+     *
+     * A `wss` candidate with no `ssl { }` at all is perfectly meaningful: the platform's own trust
+     * store applies, as it would for any ordinary HTTPS. This adds to that store rather than
+     * replacing it.
+     *
+     * The deprecated [host]/[port] are the one exception: having no scheme of their own, they take
+     * one from here.
      *
      * @param configure A lambda function to configure SSL settings.
      */

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
@@ -4,125 +4,160 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class ConnectionEndpointTest {
-    private fun connection(
+    private fun candidates(
         configure: JetWhaleConnectionConfigurationScope.() -> Unit,
-    ): EndpointResolver = JetWhaleConnectionConfiguration().apply(configure).endpointResolver()
+    ): List<EndpointCandidate> = JetWhaleConnectionConfiguration().apply(configure).candidates
 
-    private fun fixedEndpoint(
+    /** Only for configurations without a discovered candidate, which would browse the network for real. */
+    private fun literalAddresses(
         configure: JetWhaleConnectionConfigurationScope.() -> Unit,
-    ): ResolvedEndpoint = runBlocking { assertIs<FixedEndpointResolver>(connection(configure)).resolve().single() }
-
-    private fun mdns(
-        configure: JetWhaleConnectionConfigurationScope.() -> Unit,
-    ): MdnsEndpointResolver = assertIs<MdnsEndpointResolver>(connection(configure))
-
-    @Test
-    fun `an unconfigured connection targets the default host and port`() {
-        assertEquals(ResolvedEndpoint("localhost", 8080, useWss = false), fixedEndpoint { })
+    ): List<ResolvedEndpoint> = runBlocking {
+        JetWhaleConnectionConfiguration().apply(configure).endpointResolver().resolve()
     }
 
     @Suppress("DEPRECATION")
     @Test
-    fun `the deprecated host and port amount to the same address as a fixed endpoint`() {
-        val legacy = fixedEndpoint {
+    fun `the deprecated host and port stand in for undeclared endpoints`() {
+        val resolved = literalAddresses {
             host = "192.168.3.26"
             port = 5443
-        }
-
-        assertEquals(fixedEndpoint { endpoint = fixed("192.168.3.26", 5443) }, legacy)
-    }
-
-    @Suppress("DEPRECATION")
-    @Test
-    fun `an assigned endpoint wins over the deprecated host and port`() {
-        val resolved = fixedEndpoint {
-            host = "ignored"
-            port = 1
-            endpoint = fixed("192.168.3.26", 5443)
-        }
-
-        assertEquals(ResolvedEndpoint("192.168.3.26", 5443, useWss = false), resolved)
-    }
-
-    @Test
-    fun `a fixed endpoint follows the ssl block`() {
-        val plain = fixedEndpoint { endpoint = fixed("192.168.3.26", 5080) }
-        val secure = fixedEndpoint {
-            endpoint = fixed("192.168.3.26", 5443)
             ssl { trustServerCertificate() }
         }
 
-        assertEquals(false, plain.useWss)
-        assertEquals(true, secure.useWss)
+        assertEquals(listOf(ResolvedEndpoint("192.168.3.26", 5443, useWss = true)), resolved)
     }
 
     @Test
-    fun `a plain loopback endpoint stays plain whatever the ssl block says`() {
-        // The one exception to ssl {} deciding the scheme, and the reason it takes no host: plain text
-        // is only safe because loopback cannot leave the machine.
-        val resolved = fixedEndpoint {
-            endpoint = plainLoopback(5080)
-            ssl { trustServerCertificate() }
-        }
-
-        assertEquals(ResolvedEndpoint("localhost", 5080, useWss = false), resolved)
+    fun `undeclared endpoints keep the old defaults`() {
+        assertEquals(listOf(ResolvedEndpoint("localhost", 8080, useWss = false)), literalAddresses { })
     }
 
     @Test
-    fun `a plain loopback endpoint can be the fallback for discovery`() {
-        // One shared configuration for every target: a physical device discovers a host over wss, and
-        // anything that can only reach loopback — a browser above all — takes the plain fallback.
-        val resolver = mdns {
-            endpoint = discovered(fallback = plainLoopback(5080))
-            ssl { trustServerCertificate() }
-        }
-
-        assertEquals(ResolvedEndpoint("localhost", 5080, useWss = false), resolver.fallback)
-        assertEquals(true, resolver.discovery.useWss)
-    }
-
-    @Test
-    fun `a discovered endpoint carries its filters and its fallback`() {
-        val resolver = mdns {
-            endpoint = discovered(fallback = fixed("localhost", 5443)) {
-                allowHostName("build-machine")
-                allowHostName("spare-machine")
-                allowAddress("192.168.3.26")
-                allowAddress("192.168.3.27")
+    fun `candidates are kept in the order they were declared`() {
+        val declared = candidates {
+            endpoints {
+                wss("localhost", 5443)
+                discoverWss { allowAll() }
+                ws("localhost", 5080)
             }
         }
 
-        assertEquals(ResolvedEndpoint("localhost", 5443, useWss = false), resolver.fallback)
-        // Both allowlists accumulate, so neither call silently drops the one before it.
-        assertEquals(listOf("build-machine", "spare-machine"), resolver.discovery.hostNames)
-        assertEquals(listOf("192.168.3.26", "192.168.3.27"), resolver.discovery.addresses)
+        assertEquals(
+            listOf(
+                EndpointCandidate.Static("localhost", 5443, useWss = true),
+                EndpointCandidate.Dynamic(emptyList(), emptyList(), acceptsAnyHost = true),
+                EndpointCandidate.Static("localhost", 5080, useWss = false),
+            ),
+            declared,
+        )
     }
 
     @Test
-    fun `a discovered endpoint without filters accepts any advertised host`() {
-        val resolver = mdns { endpoint = discovered(fallback = fixed("localhost", 5443)) }
+    fun `the scheme is per candidate, so one configuration can mix them`() {
+        // The whole point of stating it per candidate: the targets a single configuration serves do
+        // not agree on whether wss is possible.
+        val resolved = literalAddresses {
+            endpoints {
+                wss("192.168.3.26", 5443)
+                ws("localhost", 5080)
+            }
+        }
 
-        assertEquals(emptyList(), resolver.discovery.hostNames)
-        assertEquals(emptyList(), resolver.discovery.addresses)
-        assertEquals(false, resolver.discovery.hasFilter)
+        assertEquals(
+            listOf(
+                ResolvedEndpoint("192.168.3.26", 5443, useWss = true),
+                ResolvedEndpoint("localhost", 5080, useWss = false),
+            ),
+            resolved,
+        )
     }
 
     @Test
-    fun `ssl declared after the endpoint still uses wss`() {
-        val resolver = mdns {
-            endpoint = discovered(fallback = fixed("localhost", 5443))
+    fun `a candidate's scheme owes nothing to the ssl block`() {
+        // ssl { } says what to trust; the candidate says whether TLS is spoken at all.
+        val resolved = literalAddresses {
+            endpoints { ws("localhost", 5080) }
             ssl { trustServerCertificate() }
         }
 
-        assertEquals(true, resolver.discovery.useWss)
+        assertEquals(listOf(ResolvedEndpoint("localhost", 5080, useWss = false)), resolved)
     }
 
     @Test
-    fun `an endpoint without ssl uses plain ws`() {
-        val resolver = mdns { endpoint = discovered(fallback = fixed("localhost", 5080)) }
+    fun `a repeated endpoints block adds to the list rather than replacing it`() {
+        val declared = candidates {
+            endpoints { ws("first", 1) }
+            endpoints { ws("second", 2) }
+        }
 
-        assertEquals(false, resolver.discovery.useWss)
+        assertEquals(listOf("first", "second"), declared.map { (it as EndpointCandidate.Static).host })
+    }
+
+    @Test
+    fun `a discovered candidate carries its allowlists`() {
+        val declared = candidates {
+            endpoints {
+                discoverWss {
+                    allowHostName("build-machine")
+                    allowHostName("spare-machine")
+                    allowAddress("192.168.3.26")
+                    allowAddress("192.168.3.27")
+                }
+            }
+        }
+
+        // Both allowlists accumulate, so neither call silently drops the one before it.
+        assertEquals(
+            EndpointCandidate.Dynamic(
+                hostNames = listOf("build-machine", "spare-machine"),
+                addresses = listOf("192.168.3.26", "192.168.3.27"),
+                acceptsAnyHost = false,
+            ),
+            declared.single(),
+        )
+    }
+
+    @Test
+    fun `discovery takes any host only when allowAll says so`() {
+        val open = assertIs<EndpointCandidate.Dynamic>(
+            candidates { endpoints { discoverWss { allowAll() } } }.single(),
+        )
+
+        assertTrue(open.acceptsAnyHost)
+        assertEquals(emptyList(), open.hostNames)
+        assertEquals(emptyList(), open.addresses)
+    }
+
+    @Test
+    fun `a discovery block that states nothing accepts nothing`() {
+        // Discovery reaches every JetWhale host on the network, which on a shared one is other
+        // people's. Saying nothing must not amount to taking all of them.
+        val silent = assertIs<EndpointCandidate.Dynamic>(
+            candidates { endpoints { discoverWss { } } }.single(),
+        )
+
+        assertTrue(!silent.acceptsAnyHost)
+        assertTrue(
+            HostDiscoveryConfig(
+                hostNames = silent.hostNames,
+                addresses = silent.addresses,
+                acceptsAnyHost = silent.acceptsAnyHost,
+            ).acceptsNothing,
+        )
+    }
+
+    @Test
+    fun `the same address declared twice is dialled once`() {
+        val resolved = literalAddresses {
+            endpoints {
+                ws("localhost", 5080)
+                ws("localhost", 5080)
+            }
+        }
+
+        assertEquals(1, resolved.size)
     }
 }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/SelectHostTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/SelectHostTest.kt
@@ -2,7 +2,6 @@ package com.kitakkun.jetwhale.agent.runtime
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 private fun service(
     hostName: String,
@@ -20,38 +19,38 @@ private fun service(
 private fun discovery(
     hostNames: List<String> = emptyList(),
     addresses: List<String> = emptyList(),
-    useWss: Boolean = false,
-) = HostDiscoveryConfig(hostNames = hostNames, addresses = addresses, useWss = useWss)
+    acceptsAnyHost: Boolean = false,
+) = HostDiscoveryConfig(hostNames = hostNames, addresses = addresses, acceptsAnyHost = acceptsAnyHost)
+
+/** What `discoverWss { allowAll() }` amounts to, which most of these are about. */
+private val anyHost = discovery(acceptsAnyHost = true)
 
 class SelectHostTest {
     private val plainOnly = service("plain-host", "192.168.3.26", wsPort = 5080, wssPort = null)
-    private val bothPorts = service("secure-host", "192.168.3.27", wsPort = 5080, wssPort = 5443)
+    private val secureHost = service("secure-host", "192.168.3.27", wsPort = 5080, wssPort = 5443)
+    private val spareHost = service("spare-host", "192.168.3.28", wsPort = 5080, wssPort = 5444)
 
     @Test
     fun `no advertised host means nothing to select`() {
-        assertEquals(emptyList(), selectHosts(emptyList(), discovery()))
+        assertEquals(emptyList(), selectHosts(emptyList(), anyHost))
     }
 
     @Test
-    fun `a plain connection takes the advertised ws port`() {
-        assertEquals(5080, selectHosts(listOf(bothPorts), discovery(useWss = false)).firstOrNull()?.port)
+    fun `a discovered host is taken at its advertised wss port`() {
+        assertEquals(5443, selectHosts(listOf(secureHost), anyHost).firstOrNull()?.port)
     }
 
     @Test
-    fun `an ssl connection takes the advertised wss port`() {
-        assertEquals(5443, selectHosts(listOf(bothPorts), discovery(useWss = true)).firstOrNull()?.port)
+    fun `a host advertising no wss port is skipped`() {
+        // Its ws port serves loopback only, so the discovered address would refuse the connection.
+        // Dialling wss at that port would fail the handshake just as surely, hence not a candidate at
+        // all rather than a candidate reached on the wrong port.
+        assertEquals(emptyList(), selectHosts(listOf(plainOnly), anyHost))
     }
 
     @Test
-    fun `an ssl connection skips a host that advertises no wss port`() {
-        // Dialling wss at the plain-ws port would fail every handshake, so the host is not a candidate
-        // at all rather than a candidate reached on the wrong port.
-        assertEquals(emptyList(), selectHosts(listOf(plainOnly), discovery(useWss = true)))
-    }
-
-    @Test
-    fun `an ssl connection passes over a plain host to reach one that serves wss`() {
-        val selected = selectHosts(listOf(plainOnly, bothPorts), discovery(useWss = true))
+    fun `a plain host is passed over to reach one that serves wss`() {
+        val selected = selectHosts(listOf(plainOnly, secureHost), anyHost)
 
         assertEquals(1, selected.size)
         assertEquals("192.168.3.27", selected.single().service.address)
@@ -62,40 +61,53 @@ class SelectHostTest {
     fun `every usable host is offered, in browse order`() {
         // Answering mDNS is not the same as accepting a connection, so the caller gets them all and
         // works down the list rather than being handed one and stranded if it refuses.
-        val selected = selectHosts(listOf(plainOnly, bothPorts), discovery(useWss = false))
+        val selected = selectHosts(listOf(secureHost, spareHost), anyHost)
 
-        assertEquals(listOf("192.168.3.26", "192.168.3.27"), selected.map { it.service.address })
+        assertEquals(listOf("192.168.3.27", "192.168.3.28"), selected.map { it.service.address })
+    }
+
+    @Test
+    fun `stating no policy at all selects nothing`() {
+        // Discovery reaches every JetWhale host on the network, which on a shared one belongs to
+        // someone else. An empty `discoverWss { }` therefore takes nobody rather than everybody.
+        assertEquals(emptyList(), selectHosts(listOf(secureHost, spareHost), discovery()))
     }
 
     @Test
     fun `hostName is matched case-insensitively`() {
-        assertEquals("192.168.3.26", selectHosts(listOf(plainOnly, bothPorts), discovery(hostNames = listOf("PLAIN-HOST"))).firstOrNull()?.service?.address)
+        assertEquals(
+            "192.168.3.27",
+            selectHosts(listOf(secureHost, spareHost), discovery(hostNames = listOf("SECURE-HOST"))).firstOrNull()?.service?.address,
+        )
     }
 
     @Test
     fun `a hostName that matches nothing selects nothing`() {
-        assertEquals(emptyList(), selectHosts(listOf(plainOnly, bothPorts), discovery(hostNames = listOf("absent-host"))))
+        assertEquals(emptyList(), selectHosts(listOf(secureHost, spareHost), discovery(hostNames = listOf("absent-host"))))
     }
 
     @Test
     fun `the hostName allowlist admits a host matching any of its entries`() {
-        val allowed = discovery(hostNames = listOf("absent-host", "secure-host"))
+        val allowed = discovery(hostNames = listOf("absent-host", "spare-host"))
 
-        assertEquals("192.168.3.27", selectHosts(listOf(plainOnly, bothPorts), allowed).firstOrNull()?.service?.address)
+        assertEquals("192.168.3.28", selectHosts(listOf(secureHost, spareHost), allowed).firstOrNull()?.service?.address)
     }
 
     @Test
     fun `the address allowlist admits only hosts resolving to one of its entries`() {
-        assertEquals("192.168.3.27", selectHosts(listOf(plainOnly, bothPorts), discovery(addresses = listOf("192.168.3.27"))).firstOrNull()?.service?.address)
-        assertEquals(emptyList(), selectHosts(listOf(plainOnly, bothPorts), discovery(addresses = listOf("10.0.0.1"))))
+        assertEquals(
+            "192.168.3.28",
+            selectHosts(listOf(secureHost, spareHost), discovery(addresses = listOf("192.168.3.28"))).firstOrNull()?.service?.address,
+        )
+        assertEquals(emptyList(), selectHosts(listOf(secureHost, spareHost), discovery(addresses = listOf("10.0.0.1"))))
     }
 
     @Test
     fun `hostName and address must both match when both are set`() {
-        assertEquals(emptyList(), selectHosts(listOf(plainOnly), discovery(hostNames = listOf("plain-host"), addresses = listOf("10.0.0.1"))))
+        assertEquals(emptyList(), selectHosts(listOf(secureHost), discovery(hostNames = listOf("secure-host"), addresses = listOf("10.0.0.1"))))
         assertEquals(
-            "192.168.3.26",
-            selectHosts(listOf(plainOnly), discovery(hostNames = listOf("plain-host"), addresses = listOf("192.168.3.26"))).firstOrNull()?.service?.address,
+            "192.168.3.27",
+            selectHosts(listOf(secureHost), discovery(hostNames = listOf("secure-host"), addresses = listOf("192.168.3.27"))).firstOrNull()?.service?.address,
         )
     }
 
@@ -104,11 +116,11 @@ class SelectHostTest {
         val unnamed = DiscoveredService(
             instanceName = "fallback-name",
             advertisedHostName = null,
-            address = "192.168.3.28",
+            address = "192.168.3.29",
             wsPort = 5080,
-            wssPort = null,
+            wssPort = 5443,
         )
 
-        assertEquals("192.168.3.28", selectHosts(listOf(unnamed), discovery(hostNames = listOf("fallback-name"))).firstOrNull()?.service?.address)
+        assertEquals("192.168.3.29", selectHosts(listOf(unnamed), discovery(hostNames = listOf("fallback-name"))).firstOrNull()?.service?.address)
     }
 }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/SelectHostTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/SelectHostTest.kt
@@ -74,6 +74,15 @@ class SelectHostTest {
     }
 
     @Test
+    fun `an allowlist still applies when allowAll is stated alongside it`() {
+        // Two answers to one question, which the resolver warns about. The narrower is kept: widening
+        // a stated allowlist by accident is the failure that costs something.
+        val contradictory = discovery(hostNames = listOf("secure-host"), acceptsAnyHost = true)
+
+        assertEquals(listOf("192.168.3.27"), selectHosts(listOf(secureHost, spareHost), contradictory).map { it.service.address })
+    }
+
+    @Test
     fun `hostName is matched case-insensitively`() {
         assertEquals(
             "192.168.3.27",

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaApp.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaApp.kt
@@ -70,7 +70,9 @@ internal fun startQaApp(name: String, options: QaAgentOptions): QaApp {
             deviceId = QA_DEVICE_ID
         }
         connection {
-            endpoint = fixed(options.hostName, options.hostPort)
+            endpoints {
+                wss(options.hostName, options.hostPort)
+            }
             ssl {
                 trustServerCertificate()
             }


### PR DESCRIPTION
## Why

The connection had a single endpoint whose scheme was decided elsewhere, by `ssl { }`. That made one configuration unable to serve targets that disagree about which scheme is even possible:

- a **browser** cannot do wss with JetWhale at all — there is no API to pin a locally-issued CA from page script, and `/jetwhale/ca` is a different origin with no CORS headers, so the certificate cannot be read either;
- a **physical device** on the network can do nothing but wss.

## What

Endpoints are now declared as an ordered list, each naming its own scheme:

```kotlin
connection {
    endpoints {
        ws("localhost", 5080)
        discoverWss { allowHostName("my-macbook") }
    }
    ssl { trustServerCertificate() }
}
```

**Declaration order is dial order.** The agent works down the list and the first candidate that accepts keeps the connection; when none does, it waits and starts again from the top. A `discoverWss` entry expands to every host it finds, in browse order, before whatever was declared after it.

### Scheme in the function name, not in a flag

`ws(host, port)` / `wss(host, port)` instead of `endpoint(host, port, ssl = true)`. Kotlin cannot force a named argument, so a scheme flag can always be written as a bare `true` at the call site — unreadable for something that decides whether the traffic is encrypted. Naming it in the function removes that, and removes the enum that would otherwise be needed to guard against it.

This also drops the whole `JetWhaleEndpoint` type hierarchy from the public API (`JetWhaleEndpoint`, `JetWhaleFixedEndpoint`, `JetWhaleLiteralEndpoint`, `JetWhalePlainLoopbackEndpoint` — four types) in favour of three functions.

### No plain-ws discovery

There is deliberately no `discoverWs`. Beyond sending in the clear across a network being a poor idea, the host binds ws to loopback only — so a discovered address would refuse the connection anyway. Making it unwritable also removes the runtime warning that used to cover the case, and with it `HostDiscoveryConfig.useWss` and the ws/wss port selection in discovery.

### `discoverWss` requires a policy

An empty `discoverWss { }` accepts nothing and logs why:

```
discoverWss { } was declared without a policy, so no discovered host can be accepted.
Name the machine with allowHostName/allowAddress, or state allowAll() to take any
JetWhale host on the network.
```

Discovery reaches **every** JetWhale host on the network. On a shared one — an office, a coworking space — an unqualified browse can hand this app's debug traffic to whichever colleague's host answers first. `allowAll()` asks for that explicitly; `allowHostName`/`allowAddress` narrow it. Stating both logs a warning rather than silently taking the wider one.

## Compatibility

The API is not published yet, so the old `endpoint` property is removed outright. The deprecated `host`/`port` still work and amount to a single candidate taking its scheme from `ssl { }`.

## Verification

`spotlessCheck`, `jvmTest`, `compileKotlinIosSimulatorArm64`, `compileAndroidMain`, `checkKotlinAbi`, `demo:shared` (Android + iOS), `tools:qa-agent:build` — all green. JS and WasmJS compile, including the demo's `commonMain` call sites.

Not yet re-verified on physical iOS/Android devices. The previous discovery PR turned up three bugs that appeared only there, so that is worth doing before merge.