### PR TITLE
feat(agent): bake the build machine's address via a compiler plugin

### DIFF
--- a/.github/workflows/agent-compiler-plugin-matrix.yml
+++ b/.github/workflows/agent-compiler-plugin-matrix.yml
@@ -2,7 +2,10 @@ name: Agent Compiler Plugin (Kotlin matrix)
 
 # The Kotlin compiler plugin API is @ExperimentalCompilerApi and JetBrains breaks it across minor
 # versions by design, so "supports Kotlin 2.3 through 2.4" is only true for the versions actually
-# built here. A version missing from this matrix is not supported, whatever the README says.
+# exercised here. A version missing from this matrix is not supported, whatever the docs say.
+#
+# Keep in step with SupportedKotlinVersions.kt, which turns this same range into a diagnostic for
+# consumers outside it.
 on:
   push:
     branches:
@@ -23,11 +26,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      # Every cell is reported: knowing which Kotlin broke is the point of the matrix.
+      # Every cell is reported: which Kotlin broke is the whole point of a matrix.
       fail-fast: false
       matrix:
-        # 2.3.0 is the floor: CompilerPluginRegistrar.pluginId became abstract there, and does not
-        # exist at all before it, so supporting 2.2 would mean a per-version registrar source set.
+        # 2.3.0 is the floor: CompilerPluginRegistrar.pluginId became abstract there and does not
+        # exist before it, so supporting 2.2 would mean a per-version registrar source set.
         kotlin: ['2.3.0', '2.3.21', '2.4.0', '2.4.10']
 
     name: Kotlin ${{ matrix.kotlin }}
@@ -38,8 +41,22 @@ jobs:
 
       - uses: ./.github/actions/setup-java
 
-      - name: Build against Kotlin ${{ matrix.kotlin }}
+      # The one that matters. `kotlin.compiler` moves only the *consumer* — the Kotlin Gradle plugin
+      # and therefore `sample` — while the compiler plugin stays built against the shipped Kotlin.
+      # That is exactly what a consumer on 2.3 downloads: one artifact, built elsewhere, acting on
+      # their code. Rebuilding the plugin per version would prove something nobody experiences.
+      - name: Shipped plugin against a Kotlin ${{ matrix.kotlin }} consumer
         run: >
           ./gradlew -p jetwhale-agent-plugin build
           -Pkotlin.compiler=${{ matrix.kotlin }}
+          --no-configuration-cache
+
+      # Source compatibility, separately: pinning both properties compiles the plugin itself against
+      # the old API, which catches a 2.4-only call the runtime test would only find if `sample`
+      # happened to exercise that path.
+      - name: Plugin source against the Kotlin ${{ matrix.kotlin }} API
+        run: >
+          ./gradlew -p jetwhale-agent-plugin :jetwhale-agent-compiler-plugin:compileKotlin
+          -Pkotlin.compiler=${{ matrix.kotlin }}
+          -Pkotlin.plugin.api=${{ matrix.kotlin }}
           --no-configuration-cache

--- a/.github/workflows/agent-compiler-plugin-matrix.yml
+++ b/.github/workflows/agent-compiler-plugin-matrix.yml
@@ -1,0 +1,45 @@
+name: Agent Compiler Plugin (Kotlin matrix)
+
+# The Kotlin compiler plugin API is @ExperimentalCompilerApi and JetBrains breaks it across minor
+# versions by design, so "supports Kotlin 2.3 through 2.4" is only true for the versions actually
+# built here. A version missing from this matrix is not supported, whatever the README says.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'jetwhale-agent-plugin/**'
+      - '.github/workflows/agent-compiler-plugin-matrix.yml'
+  pull_request:
+    paths:
+      - 'jetwhale-agent-plugin/**'
+      - '.github/workflows/agent-compiler-plugin-matrix.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      # Every cell is reported: knowing which Kotlin broke is the point of the matrix.
+      fail-fast: false
+      matrix:
+        # 2.3.0 is the floor: CompilerPluginRegistrar.pluginId became abstract there, and does not
+        # exist at all before it, so supporting 2.2 would mean a per-version registrar source set.
+        kotlin: ['2.3.0', '2.3.21', '2.4.0', '2.4.10']
+
+    name: Kotlin ${{ matrix.kotlin }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-java
+
+      - name: Build against Kotlin ${{ matrix.kotlin }}
+        run: >
+          ./gradlew -p jetwhale-agent-plugin build
+          -Pkotlin.compiler=${{ matrix.kotlin }}
+          --no-configuration-cache

--- a/.github/workflows/agent-compiler-plugin-matrix.yml
+++ b/.github/workflows/agent-compiler-plugin-matrix.yml
@@ -12,10 +12,14 @@ on:
       - main
     paths:
       - 'jetwhale-agent-plugin/**'
+      # The plugin rewrites JetWhaleEndpointScope's members by name, so a change there can break it
+      # without touching a single file under jetwhale-agent-plugin/.
+      - 'jetwhale-agent-runtime/src/commonMain/**'
       - '.github/workflows/agent-compiler-plugin-matrix.yml'
   pull_request:
     paths:
       - 'jetwhale-agent-plugin/**'
+      - 'jetwhale-agent-runtime/src/commonMain/**'
       - '.github/workflows/agent-compiler-plugin-matrix.yml'
 
 concurrency:

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -69,6 +69,17 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+      # Same again for the agent-side plugins, which are a third included build. The Gradle plugin
+      # names the compiler plugin's coordinates in getPluginArtifact(), so publishing one without the
+      # other leaves consumers resolving an artifact that does not exist.
+      - name: Publish agent plugin snapshot to Maven Central
+        run: ./gradlew -p jetwhale-agent-plugin publishToMavenCentral -PjetwhaleSnapshot --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
       - uses: actions/download-artifact@v4
         with:
           path: dist

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,3 +31,14 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+      # Same again for the agent-side plugins, which are a third included build. The Gradle plugin
+      # names the compiler plugin's coordinates in getPluginArtifact(), so publishing one without the
+      # other leaves consumers resolving an artifact that does not exist.
+      - name: Publish agent compiler + Gradle plugin to MavenCentral
+        run: ./gradlew -p jetwhale-agent-plugin publishToMavenCentral --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,19 @@ jobs:
       - name: Run tests
         run: ./gradlew check
 
-      # `check` on the root build does not descend into included builds — it pulls in the agent
-      # plugin's `jar` (the demo consumes it) but none of its tests. The Kotlin matrix runs them,
-      # but only when jetwhale-agent-plugin/** changes, which is precisely not the case for the
-      # change most likely to break them: a rename in the runtime DSL the plugin rewrites.
+  # A job of its own rather than a second step in `test`. `check` on the root build does not descend
+  # into included builds — it pulls in the agent plugin's jar, because the demo consumes it, but none
+  # of its tests — so these have to be asked for separately. Running them beside the root build
+  # rather than after it keeps two Gradle daemons and the compiler test framework off one runner's
+  # memory, and the two finish in parallel.
+  agent-plugin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-java
+
       - name: Run agent plugin tests
         run: ./gradlew -p jetwhale-agent-plugin check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,10 @@ jobs:
 
       - name: Run tests
         run: ./gradlew check
+
+      # `check` on the root build does not descend into included builds — it pulls in the agent
+      # plugin's `jar` (the demo consumes it) but none of its tests. The Kotlin matrix runs them,
+      # but only when jetwhale-agent-plugin/** changes, which is precisely not the case for the
+      # change most likely to break them: a rename in the runtime DSL the plugin rewrites.
+      - name: Run agent plugin tests
+        run: ./gradlew -p jetwhale-agent-plugin check

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,10 @@ plugins {
 spotless {
     kotlin {
         target("**/*.kt")
-        targetExclude("**/build/**")
+        // Compiler-plugin fixtures are compiled by the test framework and compared against IR dumps
+        // that record source offsets, so reformatting them would invalidate the golden files rather
+        // than tidy anything. Their shape is part of what they assert.
+        targetExclude("**/build/**", "**/testData/**")
         ktlint()
     }
     kotlinGradle {

--- a/demo/shared/build.gradle.kts
+++ b/demo/shared/build.gradle.kts
@@ -13,6 +13,9 @@ plugins {
     // The demo's NavKeys are @Serializable: that is what Navigation 3 saved state — and the Nav3
     // plugin's key catalog — are both built on.
     alias(libs.plugins.kotlinxSerialization)
+    // Bakes this machine's LAN address into the demo's buildMachineWss(5443) candidate, so a
+    // physical device reaches the host without waiting out an mDNS browse.
+    alias(libs.plugins.jetwhaleAgent)
 }
 
 kotlin {

--- a/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
+++ b/demo/shared/src/commonMain/kotlin/com/kitakkun/jetwhale/demo/shared/InitializeJetWhale.kt
@@ -3,7 +3,9 @@ package com.kitakkun.jetwhale.demo.shared
 import com.kitakkun.jetwhale.agent.runtime.KtorLogLevel
 import com.kitakkun.jetwhale.agent.runtime.LogLevel
 import com.kitakkun.jetwhale.agent.runtime.startJetWhale
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 
+@OptIn(ExperimentalJetWhaleApi::class)
 fun initializeJetWhale() {
     startJetWhale {
         connection {
@@ -16,6 +18,12 @@ fun initializeJetWhale() {
             // connects over wss.
             endpoints {
                 ws("localhost", 5080)
+
+                // The machine that compiled this — no browse needed to learn its address. Only the
+                // build machine's own host is reachable this way, so discovery still follows for the
+                // case where the host runs somewhere else on the network.
+                buildMachineWss(5443)
+
                 discoverWss {
                     // The demo cannot know the machine it will be run from, so it takes any host it
                     // finds. A real app on a shared network should name its own with allowHostName.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -390,11 +390,12 @@ On a Kotlin the plugin has not caught up with, calls are simply left unrewritten
 
 ### Without the Gradle plugin
 
-The call still compiles. It contributes no candidate and says why, once:
+The call still compiles. It contributes no candidate and logs why:
 
 ```
-buildMachineWss(5443) was declared but the JetWhale Gradle plugin is not applied, so no build
-machine address was baked in and this contributes no candidate.
+buildMachineWss(5443) was declared but the agent Gradle plugin ('com.kitakkun.jetwhale.agent')
+is not applied to this module, so no build machine address was baked in and this contributes no
+candidate. Apply that plugin, or write the address out with wss().
 ```
 
 That is deliberate. A generated constant would have been simpler to build, but referencing it from

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -534,6 +534,8 @@ version as the host release they belong to.
 | `jetwhale-annotations` | `@McpDescription`. Reaches both SDKs transitively; rarely named directly. |
 | `jetwhale-host-sdk` | A host plugin module, as `compileOnly` — see [Developing Plugins](/guide/developing-plugins). |
 | `jetwhale-host-gradle-plugin` | Applied as the `com.kitakkun.jetwhale.host` Gradle plugin id. |
+| `jetwhale-agent-gradle-plugin` | Applied as the `com.kitakkun.jetwhale.agent` Gradle plugin id — see [Baking in the build machine's address](#baking-in-the-build-machine-s-address-no-browse). |
+| `jetwhale-agent-compiler-plugin` | The Kotlin compiler plugin the above points at. Never named directly. |
 | `jetwhale-qa-agent` | Run, not depended on — see [QA Agent](/guide/qa-agent). |
 | `jetwhale-network-inspector`, `-agent`, `-agent-ktor`, `-agent-okhttp`, `-protocol` | [Network Inspector](/guide/network-inspector). |
 | `jetwhale-nav3-navigator`, `jetwhale-nav3-agent`, `jetwhale-nav3-protocol` | [Nav3 Navigator](/guide/nav3-navigator). |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -351,6 +351,82 @@ agent goes straight to whatever was declared next.
 On **iOS**, browsing for the service also requires listing it under `NSBonjourServices` in
 `Info.plist` (see [iOS Local Network permission](#ios-local-network-permission)).
 
+## Baking in the build machine's address (no browse)
+
+Discovery exists because a physical device cannot reach the host over loopback. But when the host
+runs on the same machine as the compiler — the usual arrangement — that address is already known at
+build time, and a browse is a slow way to rediscover it. `buildMachineWss(port)` bakes it in:
+
+```kotlin
+// the app being debugged — build.gradle.kts
+plugins {
+    id("com.kitakkun.jetwhale.agent") version "<version>"
+}
+```
+
+```kotlin
+endpoints {
+    ws("localhost", 5080)   // emulators, simulators, the desktop app, the browser
+    buildMachineWss(5443)   // physical devices — no browse, no Info.plist entry
+}
+```
+
+At compile time the call is rewritten to `wss("192.168.3.26", 5443)` — whatever the machine's
+address was — and the build log says so once per module:
+
+```
+w: JetWhale: baked the build machine address 192.168.3.26 into 1 buildMachineWss call(s) in 'shared'.
+```
+
+wss for the same reason `discoverWss` is: the host binds ws to loopback, so its LAN address would
+refuse a plain connection anyway.
+
+::: warning `@ExperimentalJetWhaleApi`
+Unlike the rest of `endpoints { }`, this one's behaviour comes from a Kotlin compiler plugin, and the
+compiler plugin API is `@ExperimentalCompilerApi` — JetBrains breaks it across minor versions by
+design. Supported Kotlin versions are those in the project's CI matrix (currently **2.3.0 – 2.4.x**).
+On a Kotlin the plugin has not caught up with, calls are simply left unrewritten.
+:::
+
+### Without the Gradle plugin
+
+The call still compiles. It contributes no candidate and says why, once:
+
+```
+buildMachineWss(5443) was declared but the JetWhale Gradle plugin is not applied, so no build
+machine address was baked in and this contributes no candidate.
+```
+
+That is deliberate. A generated constant would have been simpler to build, but referencing it from
+your source would mean the code does not *compile* without the plugin — and a missing build-time
+convenience should not be a broken build. Keep a `discoverWss { }` or a written-out `wss(...)` after
+it if you need the connection to work either way.
+
+### Choosing the address
+
+Detection asks the routing table which source address would reach the wider network. Override it
+where that is not the answer — several interfaces with the device on the other one, a VPN holding the
+default route, a host reached through a forwarded port:
+
+```kotlin
+jetwhaleAgent {
+    address = "192.168.3.26"
+}
+```
+
+With neither an override nor a detected address — an offline machine — nothing is baked in and the
+runtime explains, rather than the build failing.
+
+### What it costs the build cache
+
+The address is a **compile task input**, deliberately. Two consequences:
+
+| | |
+|---|---|
+| A stale address surviving in an "up-to-date" build | Cannot happen — changing it re-runs the compilation. |
+| Moving between networks | Recompiles the modules that apply the plugin. Apply it only to the module that declares the endpoint, not project-wide. |
+| Remote / shared build cache | Those compilations will not be shared: the address is per-developer. |
+
 ## Secure connections (wss)
 
 By default the agent connects over plain **ws** (port **5080**). The host can additionally serve
@@ -457,7 +533,7 @@ version as the host release they belong to.
 | `jetwhale-protocol-core` | The shared module of a plugin pair, for `JetWhaleEvent` / `JetWhaleRequest`. |
 | `jetwhale-annotations` | `@McpDescription`. Reaches both SDKs transitively; rarely named directly. |
 | `jetwhale-host-sdk` | A host plugin module, as `compileOnly` — see [Developing Plugins](/guide/developing-plugins). |
-| `jetwhale-gradle-plugin` | Applied as the `com.kitakkun.jetwhale.host` Gradle plugin id. |
+| `jetwhale-host-gradle-plugin` | Applied as the `com.kitakkun.jetwhale.host` Gradle plugin id. |
 | `jetwhale-qa-agent` | Run, not depended on — see [QA Agent](/guide/qa-agent). |
 | `jetwhale-network-inspector`, `-agent`, `-agent-ktor`, `-agent-okhttp`, `-protocol` | [Network Inspector](/guide/network-inspector). |
 | `jetwhale-nav3-navigator`, `jetwhale-nav3-agent`, `jetwhale-nav3-protocol` | [Nav3 Navigator](/guide/nav3-navigator). |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -198,5 +198,6 @@ serialization = { id = "serialization" }
 debuggerComposeFeature = { id = "debugger-compose-feature" }
 publish = { id = "publish" }
 jetwhalePlugin = { id = "com.kitakkun.jetwhale.host" }
+jetwhaleAgent = { id = "com.kitakkun.jetwhale.agent" }
 # In-repo only: adds `runJetWhale` (launches the local :jetwhale-host:app). Not published.
 jetwhaleHostLaunch = { id = "jetwhale-host-launch" }

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/build.gradle.kts
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/build.gradle.kts
@@ -35,6 +35,61 @@ dependencies {
     // produces duplicate-class conflicts that stop the plugin loading at all.
     compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinPluginApi")
     compileOnly(kotlin("stdlib"))
+
+    // Runners live in `test` rather than test-fixtures so they can see the plugin's `internal`
+    // declarations — Kotlin associates `test` with `main`, test-fixtures is its own compilation.
+    // The test framework links against the *un-shaded* kotlin-compiler, so the tests get that while
+    // the published JAR keeps compiling against the embeddable one. Safe here only because this
+    // plugin references no IntelliJ classes at all — verified by grepping the compiled bytecode for
+    // `com/intellij` — so the same .class files load under either compiler.
+    testImplementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinPluginApi")
+    testImplementation("org.jetbrains.kotlin:kotlin-compiler-internal-test-framework:$kotlinPluginApi")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinPluginApi")
+    // The framework still reaches for JUnit 4 at runtime despite running on the JUnit 5 platform.
+    testRuntimeOnly("junit:junit:4.13.2")
+}
+
+/** Jars the test framework locates by absolute path, handed over as system properties below. */
+val testArtifacts: Configuration by configurations.creating
+
+dependencies {
+    testArtifacts("org.jetbrains.kotlin:kotlin-stdlib:$kotlinPluginApi")
+    testArtifacts("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinPluginApi")
+    testArtifacts("org.jetbrains.kotlin:kotlin-reflect:$kotlinPluginApi")
+    testArtifacts("org.jetbrains.kotlin:kotlin-test:$kotlinPluginApi")
+    testArtifacts("org.jetbrains.kotlin:kotlin-script-runtime:$kotlinPluginApi")
+    testArtifacts("org.jetbrains.kotlin:kotlin-annotations-jvm:$kotlinPluginApi")
+}
+
+sourceSets {
+    test {
+        resources.setSrcDirs(listOf("testData"))
+    }
+}
+
+tasks.test {
+    dependsOn(testArtifacts)
+    useJUnitPlatform()
+    // testData paths in the runners are resolved against this.
+    workingDir = layout.projectDirectory.asFile
+
+    systemProperty("idea.home.path", layout.projectDirectory.asFile.path)
+    systemProperty("idea.ignore.disabled.plugins", "true")
+
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-stdlib", "kotlin-stdlib")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-stdlib-jdk8", "kotlin-stdlib-jdk8")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-reflect", "kotlin-reflect")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-test", "kotlin-test")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-script-runtime", "kotlin-script-runtime")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-annotations-jvm", "kotlin-annotations-jvm")
+}
+
+fun Test.setLibraryProperty(propName: String, jarName: String) {
+    val path = testArtifacts.files
+        .find { """$jarName-\d.*""".toRegex().matches(it.name) }
+        ?.absolutePath
+        ?: error("testArtifacts is missing $jarName")
+    systemProperty(propName, path)
 }
 
 jetwhalePublish {

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/build.gradle.kts
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/build.gradle.kts
@@ -23,7 +23,11 @@ val kotlinPluginApi: String = providers.gradleProperty("kotlin.plugin.api")
     .get()
 
 kotlin {
-    jvmToolchain(21)
+    // 17, matching gradle-conventions/jvm.gradle.kts — and not a matter of tidiness. Both of these
+    // JARs are loaded by someone else's JVM: the Gradle daemon for the Gradle plugin, the Kotlin
+    // compile daemon for the compiler plugin. Emitting Java 21 bytecode makes a consumer building on
+    // JDK 17 fail with UnsupportedClassVersionError before any of this runs.
+    jvmToolchain(17)
     compilerOptions {
         // The plugin API is @ExperimentalCompilerApi by design; opting in per-file would be noise.
         freeCompilerArgs.add("-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/build.gradle.kts
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/build.gradle.kts
@@ -1,0 +1,41 @@
+plugins {
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.publish)
+}
+
+group = "com.kitakkun.jetwhale"
+version = libs.versions.jetwhale.get() + if (hasProperty("jetwhaleSnapshot")) "-SNAPSHOT" else ""
+
+/**
+ * Which Kotlin compiler this plugin is built against.
+ *
+ * The one switch the whole supported range turns on: `-Pkotlin.compiler=2.3.21` rebuilds and tests
+ * against that compiler without touching a source file. CI sweeps it across every version in
+ * `supportedKotlinVersions` (see the workflow); a version that is not swept is not supported,
+ * whatever the README says.
+ */
+val kotlinCompiler: String = providers.gradleProperty("kotlin.compiler")
+    .orElse(libs.versions.kotlin)
+    .get()
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        // The plugin API is @ExperimentalCompilerApi by design; opting in per-file would be noise.
+        freeCompilerArgs.add("-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")
+    }
+}
+
+dependencies {
+    // compileOnly, always: kotlinc already has these on its classloader, and bundling them again
+    // produces duplicate-class conflicts that stop the plugin loading at all.
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinCompiler")
+    compileOnly(kotlin("stdlib"))
+}
+
+jetwhalePublish {
+    artifactId = "jetwhale-agent-compiler-plugin"
+    name = "JetWhale Agent Compiler Plugin"
+    description = "Kotlin compiler plugin that bakes the build machine's address into buildMachineWss(port)."
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/build.gradle.kts
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/build.gradle.kts
@@ -8,14 +8,17 @@ group = "com.kitakkun.jetwhale"
 version = libs.versions.jetwhale.get() + if (hasProperty("jetwhaleSnapshot")) "-SNAPSHOT" else ""
 
 /**
- * Which Kotlin compiler this plugin is built against.
+ * Which Kotlin compiler API this plugin is compiled against — that is, which version's JAR ships.
  *
- * The one switch the whole supported range turns on: `-Pkotlin.compiler=2.3.21` rebuilds and tests
- * against that compiler without touching a source file. CI sweeps it across every version in
- * `supportedKotlinVersions` (see the workflow); a version that is not swept is not supported,
- * whatever the README says.
+ * Deliberately separate from `kotlin.compiler`, which is the *consumer's* Kotlin and drives the
+ * Kotlin Gradle plugin for the whole build. Keeping them apart is what lets CI compile `sample` with
+ * Kotlin 2.3 while the plugin acting on it was built against 2.4 — the arrangement a consumer on 2.3
+ * actually gets from a single published artifact, and therefore the one worth testing.
+ *
+ * Set both to the same value to sweep source compatibility instead: `-Pkotlin.compiler=2.3.0
+ * -Pkotlin.plugin.api=2.3.0` proves the source only touches API that 2.3 already had.
  */
-val kotlinCompiler: String = providers.gradleProperty("kotlin.compiler")
+val kotlinPluginApi: String = providers.gradleProperty("kotlin.plugin.api")
     .orElse(libs.versions.kotlin)
     .get()
 
@@ -30,7 +33,7 @@ kotlin {
 dependencies {
     // compileOnly, always: kotlinc already has these on its classloader, and bundling them again
     // produces duplicate-class conflicts that stop the plugin loading at all.
-    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinCompiler")
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinPluginApi")
     compileOnly(kotlin("stdlib"))
 }
 

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/BuildMachineIrGenerationExtension.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/BuildMachineIrGenerationExtension.kt
@@ -84,8 +84,8 @@ private class BuildMachineCallTransformer(
             messageCollector.report(
                 CompilerMessageSeverity.ERROR,
                 "JetWhale: found $BUILD_MACHINE_WSS_NAME but no matching wss(String, Int) on " +
-                    "${ENDPOINT_SCOPE_FQ_NAME.asString()}. The JetWhale Gradle plugin and " +
-                    "jetwhale-agent-runtime versions do not match.",
+                    "${ENDPOINT_SCOPE_FQ_NAME.asString()}. jetwhale-agent-compiler-plugin and " +
+                    "jetwhale-agent-runtime are at versions that do not agree; align them.",
             )
             return call
         }

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/BuildMachineIrGenerationExtension.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/BuildMachineIrGenerationExtension.kt
@@ -1,0 +1,87 @@
+@file:OptIn(org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI::class)
+
+package com.kitakkun.jetwhale.agent.compiler
+
+import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.util.parentClassOrNull
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import org.jetbrains.kotlin.name.FqName
+
+private val ENDPOINT_SCOPE = FqName("com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope")
+
+/**
+ * Rewrites `buildMachineWss(port)` into `wss("<build machine address>", port)`.
+ *
+ * Registered only when an address was supplied, so reaching here means there is one to bake in.
+ */
+internal class BuildMachineIrGenerationExtension(
+    private val address: String,
+    private val messageCollector: MessageCollector,
+) : IrGenerationExtension {
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+        val transformer = BuildMachineCallTransformer(address, pluginContext, messageCollector)
+        moduleFragment.transformChildrenVoid(transformer)
+
+        // Worth one line per module that uses it: this bakes a machine-specific address into the
+        // output, which is not something to discover only by decompiling it later.
+        if (transformer.rewritten > 0) {
+            messageCollector.report(
+                CompilerMessageSeverity.WARNING,
+                "JetWhale: baked the build machine address $address into ${transformer.rewritten} " +
+                    "$BUILD_MACHINE_WSS_NAME call(s) in '${moduleFragment.name}'.",
+            )
+        }
+    }
+}
+
+private class BuildMachineCallTransformer(
+    private val address: String,
+    private val pluginContext: IrPluginContext,
+    private val messageCollector: MessageCollector,
+) : IrElementTransformerVoidWithContext() {
+    var rewritten: Int = 0
+        private set
+
+    override fun visitCall(expression: IrCall): IrExpression {
+        // Recurse first, so a buildMachineWss nested inside another call's arguments is rewritten too.
+        val call = super.visitCall(expression) as IrCall
+        val callee = call.symbol.owner
+        if (callee.name.asString() != BUILD_MACHINE_WSS_NAME) return call
+
+        // Name alone proves nothing — anyone may declare a buildMachineWss. The declaring interface
+        // is what identifies ours.
+        val scope = callee.parentClassOrNull ?: return call
+        if (scope.kotlinFqName != ENDPOINT_SCOPE) return call
+
+        val wss = scope.findWss() ?: run {
+            // The runtime on the classpath declares buildMachineWss but no matching wss. That is a
+            // version mismatch between this plugin and jetwhale-agent-runtime, and rewriting into a
+            // guess would be worse than refusing.
+            messageCollector.report(
+                CompilerMessageSeverity.ERROR,
+                "JetWhale: found $BUILD_MACHINE_WSS_NAME but no matching wss(String, Int) on " +
+                    "${ENDPOINT_SCOPE.asString()}. The JetWhale Gradle plugin and " +
+                    "jetwhale-agent-runtime versions do not match.",
+            )
+            return call
+        }
+
+        val builder = DeclarationIrBuilder(
+            pluginContext,
+            symbol = currentScope!!.scope.scopeOwnerSymbol,
+            startOffset = call.startOffset,
+            endOffset = call.endOffset,
+        )
+        rewritten++
+        return builder.buildWssCall(original = call, wss = wss, address = address)
+    }
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/BuildMachineIrGenerationExtension.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/BuildMachineIrGenerationExtension.kt
@@ -49,7 +49,14 @@ private class BuildMachineCallTransformer(
 
     override fun visitCall(expression: IrCall): IrExpression {
         // Recurse first, so a buildMachineWss nested inside another call's arguments is rewritten too.
-        val call = super.visitCall(expression) as IrCall
+        //
+        // Safe-cast rather than `as IrCall`: today the base chain ends in visitExpression, which
+        // transforms children in place and hands back the very same instance, so the cast could not
+        // fail. But every method in that chain is `open` on an API JetBrains breaks at minor
+        // versions, and the cast failing would throw a ClassCastException from inside a user's
+        // compilation. Returning whatever came back costs nothing and owes nothing to that chain.
+        val transformed = super.visitCall(expression)
+        val call = transformed as? IrCall ?: return transformed
         val callee = call.symbol.owner
         if (callee.name.asString() != BUILD_MACHINE_WSS_NAME) return call
 

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/BuildMachineIrGenerationExtension.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/BuildMachineIrGenerationExtension.kt
@@ -48,23 +48,30 @@ private class BuildMachineCallTransformer(
         private set
 
     override fun visitCall(expression: IrCall): IrExpression {
-        // Recurse first, so a buildMachineWss nested inside another call's arguments is rewritten too.
-        //
-        // Safe-cast rather than `as IrCall`: today the base chain ends in visitExpression, which
-        // transforms children in place and hands back the very same instance, so the cast could not
-        // fail. But every method in that chain is `open` on an API JetBrains breaks at minor
-        // versions, and the cast failing would throw a ClassCastException from inside a user's
-        // compilation. Returning whatever came back costs nothing and owes nothing to that chain.
+        // Decide before recursing. The recursion is needed so a buildMachineWss nested inside another
+        // call's arguments is rewritten too, but its result is only trustworthy for calls that are
+        // not ours — see below.
+        val isOurs = expression.symbol.owner.isBuildMachineWss()
         val transformed = super.visitCall(expression)
-        val call = transformed as? IrCall ?: return transformed
-        val callee = call.symbol.owner
-        if (callee.name.asString() != BUILD_MACHINE_WSS_NAME) return call
+        if (!isOurs) return transformed
 
-        // Name alone proves nothing — anyone may declare a buildMachineWss. The declaring interface
-        // is what identifies ours, and it has to be looked for through overrides: inside
-        // `with(recordingScope) { }` the receiver's static type is the implementation, so the call
-        // resolves to *its* override rather than to the interface member.
-        if (!callee.overridesEndpointScope()) return call
+        // Not `as IrCall`. Today the base chain ends in visitExpression, which transforms children in
+        // place and returns the same instance, so a cast could not fail — but every method in that
+        // chain is `open`, and another compiler plugin's IR extension may have replaced this call
+        // with something else entirely before we ran. Crashing a consumer's build with a
+        // ClassCastException is the wrong answer, and so is skipping quietly: an unrewritten call
+        // falls back to contributing no candidate and then blames a Gradle plugin that *is* applied.
+        // Say what actually happened instead.
+        val call = transformed as? IrCall ?: run {
+            messageCollector.report(
+                CompilerMessageSeverity.WARNING,
+                "JetWhale: a $BUILD_MACHINE_WSS_NAME call was replaced by another compiler plugin " +
+                    "before this one ran, so no address could be baked into it. It will contribute no " +
+                    "endpoint at runtime — write the address out with wss() if you need that candidate.",
+            )
+            return transformed
+        }
+        val callee = call.symbol.owner
 
         // Look wss up on whatever class the call resolved against, so an implementation's own
         // override is dispatched to exactly as the original call would have been. Any class that

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/BuildMachineIrGenerationExtension.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/BuildMachineIrGenerationExtension.kt
@@ -11,12 +11,8 @@ import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
-import org.jetbrains.kotlin.name.FqName
-
-private val ENDPOINT_SCOPE = FqName("com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope")
 
 /**
  * Rewrites `buildMachineWss(port)` into `wss("<build machine address>", port)`.
@@ -58,10 +54,15 @@ private class BuildMachineCallTransformer(
         if (callee.name.asString() != BUILD_MACHINE_WSS_NAME) return call
 
         // Name alone proves nothing — anyone may declare a buildMachineWss. The declaring interface
-        // is what identifies ours.
-        val scope = callee.parentClassOrNull ?: return call
-        if (scope.kotlinFqName != ENDPOINT_SCOPE) return call
+        // is what identifies ours, and it has to be looked for through overrides: inside
+        // `with(recordingScope) { }` the receiver's static type is the implementation, so the call
+        // resolves to *its* override rather than to the interface member.
+        if (!callee.overridesEndpointScope()) return call
 
+        // Look wss up on whatever class the call resolved against, so an implementation's own
+        // override is dispatched to exactly as the original call would have been. Any class that
+        // reaches here implements the interface, so it carries wss as a declaration or fake override.
+        val scope = callee.parentClassOrNull ?: return call
         val wss = scope.findWss() ?: run {
             // The runtime on the classpath declares buildMachineWss but no matching wss. That is a
             // version mismatch between this plugin and jetwhale-agent-runtime, and rewriting into a
@@ -69,7 +70,7 @@ private class BuildMachineCallTransformer(
             messageCollector.report(
                 CompilerMessageSeverity.ERROR,
                 "JetWhale: found $BUILD_MACHINE_WSS_NAME but no matching wss(String, Int) on " +
-                    "${ENDPOINT_SCOPE.asString()}. The JetWhale Gradle plugin and " +
+                    "${ENDPOINT_SCOPE_FQ_NAME.asString()}. The JetWhale Gradle plugin and " +
                     "jetwhale-agent-runtime versions do not match.",
             )
             return call

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/CompilerApiCompat.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/CompilerApiCompat.kt
@@ -72,7 +72,15 @@ internal fun IrClass.findWss(): IrSimpleFunction? = functions
     .firstOrNull { it.name.asString() == WSS_NAME && it.parameters.size == WSS_ARITY }
 
 /**
- * Whether [this] is `JetWhaleEndpointScope.buildMachineWss`, or any override of it.
+ * Whether a call to [this] is one this plugin rewrites.
+ *
+ * Name alone proves nothing — anyone may declare a `buildMachineWss` — so the declaring interface
+ * decides.
+ */
+internal fun IrSimpleFunction.isBuildMachineWss(): Boolean = name.asString() == BUILD_MACHINE_WSS_NAME && overridesEndpointScope()
+
+/**
+ * Whether [this] is declared on `JetWhaleEndpointScope`, or overrides something that is.
  *
  * Overrides matter more than they look: inside `with(someImplementation) { }` the receiver's static
  * type is the implementation, so the call resolves to its override and the interface member is never

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/CompilerApiCompat.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/CompilerApiCompat.kt
@@ -10,6 +10,9 @@ import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.util.parentClassOrNull
+import org.jetbrains.kotlin.name.FqName
 
 /**
  * Every compiler-API call this plugin makes that JetBrains has moved, or has said they will.
@@ -67,6 +70,26 @@ internal fun IrBuilderWithScope.buildWssCall(
 )
 internal fun IrClass.findWss(): IrSimpleFunction? = functions
     .firstOrNull { it.name.asString() == WSS_NAME && it.parameters.size == WSS_ARITY }
+
+/**
+ * Whether [this] is `JetWhaleEndpointScope.buildMachineWss`, or any override of it.
+ *
+ * Overrides matter more than they look: inside `with(someImplementation) { }` the receiver's static
+ * type is the implementation, so the call resolves to its override and the interface member is never
+ * the callee. Matching only the interface silently skipped those, which is the worst shape of bug
+ * here — the untransformed call falls back to contributing no candidate, so nothing complains.
+ */
+@CompatSensitive(
+    since = "2.2.0",
+    what = "`overriddenSymbols` is walked directly rather than via the `allOverridden()` helper, " +
+        "whose overloads and defaults have moved between minors while the property has not.",
+)
+internal fun IrSimpleFunction.overridesEndpointScope(): Boolean {
+    if (parentClassOrNull?.kotlinFqName == ENDPOINT_SCOPE_FQ_NAME) return true
+    return overriddenSymbols.any { it.owner.overridesEndpointScope() }
+}
+
+internal val ENDPOINT_SCOPE_FQ_NAME: FqName = FqName("com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope")
 
 internal const val BUILD_MACHINE_WSS_NAME: String = "buildMachineWss"
 private const val WSS_NAME = "wss"

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/CompilerApiCompat.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/CompilerApiCompat.kt
@@ -1,0 +1,80 @@
+@file:OptIn(org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI::class)
+
+package com.kitakkun.jetwhale.agent.compiler
+
+import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
+import org.jetbrains.kotlin.ir.util.functions
+
+/**
+ * Every compiler-API call this plugin makes that JetBrains has moved, or has said they will.
+ *
+ * The plugin API is `@ExperimentalCompilerApi`: it breaks across minors, routinely. Keeping the
+ * volatile calls here means a Kotlin bump that breaks the build breaks it in *one file*, and the
+ * escalation path — a per-version compat interface, should one file stop being enough — starts from
+ * a surface that is already enumerated rather than scattered through the transformer.
+ *
+ * Each entry carries [CompatSensitive] saying what moved and when, so dropping support for a Kotlin
+ * version tells you exactly which workarounds become dead: `grep 'since = "2.3'`.
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+internal annotation class CompatSensitive(
+    /** Kotlin version whose change this accommodates. */
+    val since: String,
+    /** What upstream did. */
+    val what: String,
+)
+
+/**
+ * Rewrites a `buildMachineWss(port)` call into `wss(address, port)`.
+ *
+ * Both are members of the same interface, so the receiver sits in the same slot on either side and
+ * only the host literal is new.
+ */
+@CompatSensitive(
+    since = "2.2.0",
+    what = "KT-68003 collapsed dispatchReceiver/extensionReceiver/valueArguments into one flat " +
+        "`arguments` list indexed by IrParameterKind. Kotlin 2.4 then removed the old accessors " +
+        "outright. Indexing `arguments` is the form that compiles on 2.3 and 2.4 alike — the " +
+        "removed accessors must not come back, and `dispatchReceiver`, which survives 2.4 as a " +
+        "convenience over arguments[0], is soft-deprecated and deliberately unused here.",
+)
+internal fun IrBuilderWithScope.buildWssCall(
+    original: IrCall,
+    wss: IrSimpleFunction,
+    address: String,
+): IrCall = irCall(wss.symbol).apply {
+    // deepCopyWithSymbols because an IrElement cannot have two parents; aliasing the original's
+    // expressions here fails IR validation later, far from the cause.
+    arguments[BUILD_MACHINE_RECEIVER] = original.arguments[BUILD_MACHINE_RECEIVER]?.deepCopyWithSymbols()
+    arguments[WSS_HOST] = irString(address)
+    arguments[WSS_PORT] = original.arguments[BUILD_MACHINE_PORT]?.deepCopyWithSymbols()
+}
+
+/**
+ * `wss(host, port)` on [this], matched by shape so a future overload cannot be picked up by name.
+ */
+@CompatSensitive(
+    since = "2.2.0",
+    what = "`IrFunction.parameters` replaced valueParameters/extensionReceiverParameter; its size " +
+        "counts the dispatch receiver, which is why the expected arity is 3 rather than 2.",
+)
+internal fun IrClass.findWss(): IrSimpleFunction? = functions
+    .firstOrNull { it.name.asString() == WSS_NAME && it.parameters.size == WSS_ARITY }
+
+internal const val BUILD_MACHINE_WSS_NAME: String = "buildMachineWss"
+private const val WSS_NAME = "wss"
+
+// Slot layout, by IrParameterKind. Both functions are interface members, so slot 0 is the dispatch
+// receiver on either side; the rest are Regular.
+private const val BUILD_MACHINE_RECEIVER = 0
+private const val BUILD_MACHINE_PORT = 1
+private const val WSS_HOST = 1
+private const val WSS_PORT = 2
+private const val WSS_ARITY = 3

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/JetWhaleAgentCommandLineProcessor.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/JetWhaleAgentCommandLineProcessor.kt
@@ -1,0 +1,35 @@
+@file:OptIn(org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi::class)
+
+package com.kitakkun.jetwhale.agent.compiler
+
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOptionProcessingException
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+class JetWhaleAgentCommandLineProcessor : CommandLineProcessor {
+    private val buildMachineAddress = CliOption(
+        optionName = JetWhaleAgentPluginNames.ADDRESS_OPTION,
+        valueDescription = "<ip-or-hostname>",
+        description = "Address that buildMachineWss(port) is rewritten to dial.",
+        // Optional: with no address the plugin leaves every call alone, and the runtime says why.
+        // That is a better failure than refusing to compile a machine that has no LAN address.
+        required = false,
+        allowMultipleOccurrences = false,
+    )
+
+    override val pluginId: String = JetWhaleAgentPluginNames.PLUGIN_ID
+    override val pluginOptions: Collection<CliOption> = listOf(buildMachineAddress)
+
+    override fun processOption(
+        option: AbstractCliOption,
+        value: String,
+        configuration: CompilerConfiguration,
+    ) {
+        when (option.optionName) {
+            buildMachineAddress.optionName -> configuration.put(BUILD_MACHINE_ADDRESS_KEY, value)
+            else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
+        }
+    }
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/JetWhaleAgentCompilerPluginRegistrar.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/JetWhaleAgentCompilerPluginRegistrar.kt
@@ -1,0 +1,28 @@
+@file:OptIn(org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi::class)
+
+package com.kitakkun.jetwhale.agent.compiler
+
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+class JetWhaleAgentCompilerPluginRegistrar : CompilerPluginRegistrar() {
+    override val pluginId: String = JetWhaleAgentPluginNames.PLUGIN_ID
+    override val supportsK2: Boolean = true
+
+    override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+        // No address: every buildMachineWss call is left as written, and its own body explains the
+        // silence at runtime. Registering nothing keeps this compilation identical to an unplugged
+        // one rather than half-transformed.
+        val address = configuration.get(BUILD_MACHINE_ADDRESS_KEY) ?: return
+        val messageCollector = configuration.get(
+            CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY,
+            MessageCollector.NONE,
+        )
+        IrGenerationExtension.registerExtension(
+            BuildMachineIrGenerationExtension(address = address, messageCollector = messageCollector),
+        )
+    }
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/JetWhaleAgentPluginNames.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/compiler/JetWhaleAgentPluginNames.kt
@@ -1,0 +1,19 @@
+package com.kitakkun.jetwhale.agent.compiler
+
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
+
+/**
+ * Names shared by the registrar, the CLI processor and the Gradle plugin.
+ *
+ * The Gradle plugin repeats [PLUGIN_ID] and [ADDRESS_OPTION] in its own source — it must not depend
+ * on the compiler plugin, whose classpath is `kotlin-compiler-embeddable`. Keeping them here as the
+ * origin at least gives the duplication one obvious side to fix first.
+ */
+internal object JetWhaleAgentPluginNames {
+    const val PLUGIN_ID: String = "com.kitakkun.jetwhale.agent"
+    const val ADDRESS_OPTION: String = "buildMachineAddress"
+}
+
+/** The address `buildMachineWss` is rewritten to dial. Absent when the Gradle plugin found none. */
+internal val BUILD_MACHINE_ADDRESS_KEY: CompilerConfigurationKey<String> =
+    CompilerConfigurationKey.create("JetWhale build machine address")

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -1,0 +1,1 @@
+com.kitakkun.jetwhale.agent.compiler.JetWhaleAgentCommandLineProcessor

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -1,0 +1,1 @@
+com.kitakkun.jetwhale.agent.compiler.JetWhaleAgentCompilerPluginRegistrar

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/test/kotlin/com/kitakkun/jetwhale/agent/compiler/test/AbstractBuildMachineBoxTest.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/test/kotlin/com/kitakkun/jetwhale/agent/compiler/test/AbstractBuildMachineBoxTest.kt
@@ -1,0 +1,65 @@
+package com.kitakkun.jetwhale.agent.compiler.test
+
+import com.kitakkun.jetwhale.agent.compiler.BUILD_MACHINE_ADDRESS_KEY
+import com.kitakkun.jetwhale.agent.compiler.JetWhaleAgentCompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.test.FirParser
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
+import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.runners.codegen.AbstractFirBlackBoxCodegenTestBase
+import org.jetbrains.kotlin.test.services.EnvironmentBasedStandardLibrariesPathProvider
+import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.TestServices
+
+/** The address the fixtures assert on: RFC 5737 TEST-NET-2, documentation-only. */
+const val TEST_BUILD_MACHINE_ADDRESS: String = "198.51.100.7"
+
+/**
+ * Runs `testData/box` through the real compiler with this plugin registered.
+ *
+ * The sample module already proves the shipped JAR transforms a consumer's code; this proves the
+ * transform's *shape*. Fixtures carry `// DUMP_IR`, so the framework writes an `.ir.txt` golden file
+ * next to each and fails on any later divergence — which catches structural drift (a moved argument
+ * slot, a lost source offset, an IR node that stops validating) that a behavioural test can only
+ * notice if it happens to change the program's output.
+ */
+abstract class AbstractBuildMachineBoxTest : AbstractFirBlackBoxCodegenTestBase(FirParser.LightTree) {
+    override fun createKotlinStandardLibrariesPathProvider() = EnvironmentBasedStandardLibrariesPathProvider
+
+    override fun configure(builder: TestConfigurationBuilder) {
+        super.configure(builder)
+        with(builder) {
+            defaultDirectives {
+                +CodegenTestDirectives.DUMP_IR
+                // The default box pipeline runs D8/R8, which is not on this classpath and has
+                // nothing to say about a plugin that does not target Android specifically.
+                +CodegenTestDirectives.IGNORE_DEXING
+                +JvmEnvironmentConfigurationDirectives.FULL_JDK
+            }
+            useConfigurators(::BuildMachinePluginConfigurator)
+        }
+    }
+}
+
+/**
+ * Registers the plugin inside the test compiler, with an address supplied.
+ *
+ * Supplying one is what makes the registrar install the IR extension at all — the no-address path
+ * registers nothing, which the sample covers from the other side.
+ */
+internal class BuildMachinePluginConfigurator(testServices: TestServices) : EnvironmentConfigurator(testServices) {
+    private val registrar = JetWhaleAgentCompilerPluginRegistrar()
+
+    @OptIn(ExperimentalCompilerApi::class)
+    override fun CompilerPluginRegistrar.ExtensionStorage.registerCompilerExtensions(
+        module: TestModule,
+        configuration: CompilerConfiguration,
+    ) {
+        configuration.put(BUILD_MACHINE_ADDRESS_KEY, TEST_BUILD_MACHINE_ADDRESS)
+        with(registrar) { registerExtensions(configuration) }
+    }
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/test/kotlin/com/kitakkun/jetwhale/agent/compiler/test/BuildMachineBoxTest.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/src/test/kotlin/com/kitakkun/jetwhale/agent/compiler/test/BuildMachineBoxTest.kt
@@ -1,0 +1,27 @@
+package com.kitakkun.jetwhale.agent.compiler.test
+
+import org.junit.jupiter.api.Test
+
+/**
+ * Named per fixture rather than generated, because there are three of them.
+ *
+ * The framework ships a `generateTestGroupSuiteWithJUnit5` generator that walks `testData/` and
+ * emits a class per runner; that pays off at dozens of fixtures and costs a regeneration step you
+ * can forget. At this size, listing them is the cheaper mistake to avoid.
+ */
+class BuildMachineBoxTest : AbstractBuildMachineBoxTest() {
+    @Test
+    fun `buildMachineWss becomes wss at the supplied address`() {
+        runTest("testData/box/rewrite.kt")
+    }
+
+    @Test
+    fun `a same-named member on another interface is left alone`() {
+        runTest("testData/box/notOurScope.kt")
+    }
+
+    @Test
+    fun `every occurrence is rewritten, including nested ones`() {
+        runTest("testData/box/nestedAndRepeated.kt")
+    }
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/nestedAndRepeated.fir.ir.txt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/nestedAndRepeated.fir.ir.txt
@@ -1,0 +1,164 @@
+FILE fqName:<root> fileName:/box.kt
+  CLASS CLASS name:Recording modality:FINAL visibility:public superTypes:[com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Recording
+    PROPERTY name:dialled visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:dialled type:kotlin.collections.MutableList<kotlin.String> visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'public final fun mutableListOf <T> (): kotlin.collections.MutableList<T of kotlin.collections.mutableListOf> declared in kotlin.collections' type=kotlin.collections.MutableList<kotlin.String> origin=null
+            TYPE_ARG T: kotlin.String
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-dialled> visibility:public modality:FINAL returnType:kotlin.collections.MutableList<kotlin.String>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Recording
+        correspondingProperty: PROPERTY name:dialled visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:dialled type:kotlin.collections.MutableList<kotlin.String> visibility:private [final]' type=kotlin.collections.MutableList<kotlin.String> origin=null
+              receiver: GET_VAR '<this>: <root>.Recording declared in <root>.Recording.<get-dialled>' type=<root>.Recording origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.Recording [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Recording modality:FINAL visibility:public superTypes:[com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+    FUN name:buildMachineWss visibility:public modality:OPEN returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Recording
+      VALUE_PARAMETER kind:Regular name:port index:1 type:kotlin.Int
+      overridden:
+        public abstract fun buildMachineWss (port: kotlin.Int): kotlin.Unit declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      BLOCK_BODY
+        CALL 'public final fun plusAssign <T> (<this>: kotlin.collections.MutableCollection<in T of kotlin.collections.plusAssign>, element: T of kotlin.collections.plusAssign): kotlin.Unit declared in kotlin.collections' type=kotlin.Unit origin=PLUSEQ
+          TYPE_ARG T: kotlin.String
+          ARG <this>: CALL 'public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording' type=kotlin.collections.MutableList<kotlin.String> origin=PLUSEQ
+            ARG <this>: GET_VAR '<this>: <root>.Recording declared in <root>.Recording.buildMachineWss' type=<root>.Recording origin=IMPLICIT_ARGUMENT
+          ARG element: STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="unrewritten:"
+            GET_VAR 'port: kotlin.Int declared in <root>.Recording.buildMachineWss' type=kotlin.Int origin=null
+    FUN name:ws visibility:public modality:OPEN returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Recording
+      VALUE_PARAMETER kind:Regular name:host index:1 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:port index:2 type:kotlin.Int
+      overridden:
+        public abstract fun ws (host: kotlin.String, port: kotlin.Int): kotlin.Unit declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      BLOCK_BODY
+        CALL 'public final fun plusAssign <T> (<this>: kotlin.collections.MutableCollection<in T of kotlin.collections.plusAssign>, element: T of kotlin.collections.plusAssign): kotlin.Unit declared in kotlin.collections' type=kotlin.Unit origin=PLUSEQ
+          TYPE_ARG T: kotlin.String
+          ARG <this>: CALL 'public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording' type=kotlin.collections.MutableList<kotlin.String> origin=PLUSEQ
+            ARG <this>: GET_VAR '<this>: <root>.Recording declared in <root>.Recording.ws' type=<root>.Recording origin=IMPLICIT_ARGUMENT
+          ARG element: STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="ws://"
+            GET_VAR 'host: kotlin.String declared in <root>.Recording.ws' type=kotlin.String origin=null
+            CONST String type=kotlin.String value=":"
+            GET_VAR 'port: kotlin.Int declared in <root>.Recording.ws' type=kotlin.Int origin=null
+    FUN name:wss visibility:public modality:OPEN returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Recording
+      VALUE_PARAMETER kind:Regular name:host index:1 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:port index:2 type:kotlin.Int
+      overridden:
+        public abstract fun wss (host: kotlin.String, port: kotlin.Int): kotlin.Unit declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      BLOCK_BODY
+        CALL 'public final fun plusAssign <T> (<this>: kotlin.collections.MutableCollection<in T of kotlin.collections.plusAssign>, element: T of kotlin.collections.plusAssign): kotlin.Unit declared in kotlin.collections' type=kotlin.Unit origin=PLUSEQ
+          TYPE_ARG T: kotlin.String
+          ARG <this>: CALL 'public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording' type=kotlin.collections.MutableList<kotlin.String> origin=PLUSEQ
+            ARG <this>: GET_VAR '<this>: <root>.Recording declared in <root>.Recording.wss' type=<root>.Recording origin=IMPLICIT_ARGUMENT
+          ARG element: STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="wss://"
+            GET_VAR 'host: kotlin.String declared in <root>.Recording.wss' type=kotlin.String origin=null
+            CONST String type=kotlin.String value=":"
+            GET_VAR 'port: kotlin.Int declared in <root>.Recording.wss' type=kotlin.Int origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:scope type:<root>.Recording [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Recording' type=<root>.Recording origin=null
+      CALL 'public open fun wss (host: kotlin.String, port: kotlin.Int): kotlin.Unit declared in <root>.Recording' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'val scope: <root>.Recording declared in <root>.box' type=<root>.Recording origin=null
+        ARG host: CONST String type=kotlin.String value="198.51.100.7"
+        ARG port: CONST Int type=kotlin.Int value=5443
+      CALL 'public final fun endpoints (scope: com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope, configure: @[ExtensionFunctionType] kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope, kotlin.Unit>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+        ARG scope: GET_VAR 'val scope: <root>.Recording declared in <root>.box' type=<root>.Recording origin=null
+        ARG configure: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope, kotlin.Unit> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+            VALUE_PARAMETER kind:ExtensionReceiver name:$this$endpoints index:0 type:com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+            BLOCK_BODY
+              CALL 'public abstract fun wss (host: kotlin.String, port: kotlin.Int): kotlin.Unit declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope' type=kotlin.Unit origin=null
+                ARG <this>: GET_VAR '$this$endpoints: com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope declared in <root>.box.<anonymous>' type=com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope origin=IMPLICIT_ARGUMENT
+                ARG host: CONST String type=kotlin.String value="198.51.100.7"
+                ARG port: CONST Int type=kotlin.Int value=5444
+              CALL 'public final fun forEach <T> (<this>: kotlin.collections.Iterable<T of kotlin.collections.forEach>, action: kotlin.Function1<T of kotlin.collections.forEach, kotlin.Unit>): kotlin.Unit declared in kotlin.collections' type=kotlin.Unit origin=null
+                TYPE_ARG T: kotlin.Int
+                ARG <this>: CALL 'public final fun listOf <T> (element: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Int> origin=null
+                  TYPE_ARG T: kotlin.Int
+                  ARG element: CONST Int type=kotlin.Int value=5445
+                ARG action: FUN_EXPR type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                    VALUE_PARAMETER kind:Regular name:it index:0 type:kotlin.Int
+                    BLOCK_BODY
+                      CALL 'public abstract fun wss (host: kotlin.String, port: kotlin.Int): kotlin.Unit declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope' type=kotlin.Unit origin=null
+                        ARG <this>: GET_VAR '$this$endpoints: com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope declared in <root>.box.<anonymous>' type=com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope origin=IMPLICIT_ARGUMENT
+                        ARG host: CONST String type=kotlin.String value="198.51.100.7"
+                        ARG port: GET_VAR 'it: kotlin.Int declared in <root>.box.<anonymous>.<anonymous>' type=kotlin.Int origin=null
+      VAR name:expected type:kotlin.collections.List<kotlin.String> [val]
+        CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<kotlin.String> origin=null
+          TYPE_ARG T: kotlin.String
+          ARG elements: VARARG type=kotlin.Array<out kotlin.String> varargElementType=kotlin.String
+            CONST String type=kotlin.String value="wss://198.51.100.7:5443"
+            CONST String type=kotlin.String value="wss://198.51.100.7:5444"
+            CONST String type=kotlin.String value="wss://198.51.100.7:5445"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              ARG arg0: CALL 'public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+                ARG <this>: GET_VAR 'val scope: <root>.Recording declared in <root>.box' type=<root>.Recording origin=null
+              ARG arg1: GET_VAR 'val expected: kotlin.collections.List<kotlin.String> declared in <root>.box' type=kotlin.collections.List<kotlin.String> origin=null
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: "
+              CALL 'public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+                ARG <this>: GET_VAR 'val scope: <root>.Recording declared in <root>.box' type=<root>.Recording origin=null
+  FUN name:endpoints visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:scope index:0 type:com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+    VALUE_PARAMETER kind:Regular name:configure index:1 type:@[ExtensionFunctionType] kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope, kotlin.Unit>
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun endpoints (scope: com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope, configure: @[ExtensionFunctionType] kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope, kotlin.Unit>): kotlin.Unit declared in <root>'
+        CALL 'public abstract fun invoke (p1: P1 of kotlin.Function1): R of kotlin.Function1 declared in kotlin.Function1' type=kotlin.Unit origin=INVOKE
+          ARG <this>: GET_VAR 'configure: @[ExtensionFunctionType] kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope, kotlin.Unit> declared in <root>.endpoints' type=@[ExtensionFunctionType] kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope, kotlin.Unit> origin=VARIABLE_AS_FUNCTION
+          ARG p1: GET_VAR 'scope: com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope declared in <root>.endpoints' type=com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope origin=null
+FILE fqName:com.kitakkun.jetwhale.agent.runtime fileName:/scope.kt
+  CLASS INTERFACE name:JetWhaleEndpointScope modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:buildMachineWss visibility:public modality:ABSTRACT returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      VALUE_PARAMETER kind:Regular name:port index:1 type:kotlin.Int
+    FUN name:ws visibility:public modality:ABSTRACT returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      VALUE_PARAMETER kind:Regular name:host index:1 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:port index:2 type:kotlin.Int
+    FUN name:wss visibility:public modality:ABSTRACT returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      VALUE_PARAMETER kind:Regular name:host index:1 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:port index:2 type:kotlin.Int

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/nestedAndRepeated.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/nestedAndRepeated.kt
@@ -1,0 +1,38 @@
+// Several calls, one of them inside a lambda. The transformer recurses before deciding, so a call
+// nested in another expression must be rewritten too — and each occurrence independently.
+
+// FILE: scope.kt
+package com.kitakkun.jetwhale.agent.runtime
+
+interface JetWhaleEndpointScope {
+    fun ws(host: String, port: Int)
+    fun wss(host: String, port: Int)
+    fun buildMachineWss(port: Int)
+}
+
+// FILE: box.kt
+import com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+
+class Recording : JetWhaleEndpointScope {
+    val dialled = mutableListOf<String>()
+    override fun ws(host: String, port: Int) { dialled += "ws://$host:$port" }
+    override fun wss(host: String, port: Int) { dialled += "wss://$host:$port" }
+    override fun buildMachineWss(port: Int) { dialled += "unrewritten:$port" }
+}
+
+fun endpoints(scope: JetWhaleEndpointScope, configure: JetWhaleEndpointScope.() -> Unit) = scope.configure()
+
+fun box(): String {
+    val scope = Recording()
+    scope.buildMachineWss(5443)
+    endpoints(scope) {
+        buildMachineWss(5444)
+        listOf(5445).forEach { buildMachineWss(it) }
+    }
+    val expected = listOf(
+        "wss://198.51.100.7:5443",
+        "wss://198.51.100.7:5444",
+        "wss://198.51.100.7:5445",
+    )
+    return if (scope.dialled == expected) "OK" else "FAIL: ${scope.dialled}"
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/notOurScope.fir.ir.txt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/notOurScope.fir.ir.txt
@@ -1,0 +1,88 @@
+FILE fqName:<root> fileName:/box.kt
+  CLASS CLASS name:Impostor modality:FINAL visibility:public superTypes:[someone.elses.library.JetWhaleEndpointScope]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Impostor
+    PROPERTY name:seen visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:seen type:kotlin.Int visibility:private
+        EXPRESSION_BODY
+          CONST Int type=kotlin.Int value=0
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-seen> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Impostor
+        correspondingProperty: PROPERTY name:seen visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-seen> (): kotlin.Int declared in <root>.Impostor'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:seen type:kotlin.Int visibility:private' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.Impostor declared in <root>.Impostor.<get-seen>' type=<root>.Impostor origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-seen> visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Impostor
+        VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.Int
+        correspondingProperty: PROPERTY name:seen visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:seen type:kotlin.Int visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.Impostor declared in <root>.Impostor.<set-seen>' type=<root>.Impostor origin=null
+            value: GET_VAR '<set-?>: kotlin.Int declared in <root>.Impostor.<set-seen>' type=kotlin.Int origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.Impostor [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Impostor modality:FINAL visibility:public superTypes:[someone.elses.library.JetWhaleEndpointScope]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in someone.elses.library.JetWhaleEndpointScope
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in someone.elses.library.JetWhaleEndpointScope
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in someone.elses.library.JetWhaleEndpointScope
+    FUN name:buildMachineWss visibility:public modality:OPEN returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Impostor
+      VALUE_PARAMETER kind:Regular name:port index:1 type:kotlin.Int
+      overridden:
+        public abstract fun buildMachineWss (port: kotlin.Int): kotlin.Unit declared in someone.elses.library.JetWhaleEndpointScope
+      BLOCK_BODY
+        CALL 'public final fun <set-seen> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Impostor' type=kotlin.Unit origin=EQ
+          ARG <this>: GET_VAR '<this>: <root>.Impostor declared in <root>.Impostor.buildMachineWss' type=<root>.Impostor origin=IMPLICIT_ARGUMENT
+          ARG <set-?>: GET_VAR 'port: kotlin.Int declared in <root>.Impostor.buildMachineWss' type=kotlin.Int origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:impostor type:<root>.Impostor [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Impostor' type=<root>.Impostor origin=null
+      CALL 'public open fun buildMachineWss (port: kotlin.Int): kotlin.Unit declared in <root>.Impostor' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'val impostor: <root>.Impostor declared in <root>.box' type=<root>.Impostor origin=null
+        ARG port: CONST Int type=kotlin.Int value=5443
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              ARG arg0: CALL 'public final fun <get-seen> (): kotlin.Int declared in <root>.Impostor' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: GET_VAR 'val impostor: <root>.Impostor declared in <root>.box' type=<root>.Impostor origin=null
+              ARG arg1: CONST Int type=kotlin.Int value=5443
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: "
+              CALL 'public final fun <get-seen> (): kotlin.Int declared in <root>.Impostor' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: GET_VAR 'val impostor: <root>.Impostor declared in <root>.box' type=<root>.Impostor origin=null
+FILE fqName:someone.elses.library fileName:/other.kt
+  CLASS INTERFACE name:JetWhaleEndpointScope modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:someone.elses.library.JetWhaleEndpointScope
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:buildMachineWss visibility:public modality:ABSTRACT returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:someone.elses.library.JetWhaleEndpointScope
+      VALUE_PARAMETER kind:Regular name:port index:1 type:kotlin.Int

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/notOurScope.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/notOurScope.kt
@@ -1,0 +1,23 @@
+// A same-named member on an unrelated type must be left alone. The plugin matches on the declaring
+// interface, not the function name, and this is what proves the difference is load-bearing.
+
+// FILE: other.kt
+package someone.elses.library
+
+interface JetWhaleEndpointScope {
+    fun buildMachineWss(port: Int)
+}
+
+// FILE: box.kt
+import someone.elses.library.JetWhaleEndpointScope
+
+class Impostor : JetWhaleEndpointScope {
+    var seen: Int = 0
+    override fun buildMachineWss(port: Int) { seen = port }
+}
+
+fun box(): String {
+    val impostor = Impostor()
+    impostor.buildMachineWss(5443)
+    return if (impostor.seen == 5443) "OK" else "FAIL: ${impostor.seen}"
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/rewrite.fir.ir.txt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/rewrite.fir.ir.txt
@@ -1,0 +1,144 @@
+FILE fqName:<root> fileName:/box.kt
+  CLASS CLASS name:Recording modality:FINAL visibility:public superTypes:[com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Recording
+    PROPERTY name:dialled visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:dialled type:kotlin.collections.MutableList<kotlin.String> visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'public final fun mutableListOf <T> (): kotlin.collections.MutableList<T of kotlin.collections.mutableListOf> declared in kotlin.collections' type=kotlin.collections.MutableList<kotlin.String> origin=null
+            TYPE_ARG T: kotlin.String
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-dialled> visibility:public modality:FINAL returnType:kotlin.collections.MutableList<kotlin.String>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Recording
+        correspondingProperty: PROPERTY name:dialled visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:dialled type:kotlin.collections.MutableList<kotlin.String> visibility:private [final]' type=kotlin.collections.MutableList<kotlin.String> origin=null
+              receiver: GET_VAR '<this>: <root>.Recording declared in <root>.Recording.<get-dialled>' type=<root>.Recording origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.Recording [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Recording modality:FINAL visibility:public superTypes:[com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+    FUN name:buildMachineWss visibility:public modality:OPEN returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Recording
+      VALUE_PARAMETER kind:Regular name:port index:1 type:kotlin.Int
+      overridden:
+        public abstract fun buildMachineWss (port: kotlin.Int): kotlin.Unit declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      BLOCK_BODY
+        CALL 'public final fun plusAssign <T> (<this>: kotlin.collections.MutableCollection<in T of kotlin.collections.plusAssign>, element: T of kotlin.collections.plusAssign): kotlin.Unit declared in kotlin.collections' type=kotlin.Unit origin=PLUSEQ
+          TYPE_ARG T: kotlin.String
+          ARG <this>: CALL 'public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording' type=kotlin.collections.MutableList<kotlin.String> origin=PLUSEQ
+            ARG <this>: GET_VAR '<this>: <root>.Recording declared in <root>.Recording.buildMachineWss' type=<root>.Recording origin=IMPLICIT_ARGUMENT
+          ARG element: STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="unrewritten:"
+            GET_VAR 'port: kotlin.Int declared in <root>.Recording.buildMachineWss' type=kotlin.Int origin=null
+    FUN name:ws visibility:public modality:OPEN returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Recording
+      VALUE_PARAMETER kind:Regular name:host index:1 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:port index:2 type:kotlin.Int
+      overridden:
+        public abstract fun ws (host: kotlin.String, port: kotlin.Int): kotlin.Unit declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      BLOCK_BODY
+        CALL 'public final fun plusAssign <T> (<this>: kotlin.collections.MutableCollection<in T of kotlin.collections.plusAssign>, element: T of kotlin.collections.plusAssign): kotlin.Unit declared in kotlin.collections' type=kotlin.Unit origin=PLUSEQ
+          TYPE_ARG T: kotlin.String
+          ARG <this>: CALL 'public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording' type=kotlin.collections.MutableList<kotlin.String> origin=PLUSEQ
+            ARG <this>: GET_VAR '<this>: <root>.Recording declared in <root>.Recording.ws' type=<root>.Recording origin=IMPLICIT_ARGUMENT
+          ARG element: STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="ws://"
+            GET_VAR 'host: kotlin.String declared in <root>.Recording.ws' type=kotlin.String origin=null
+            CONST String type=kotlin.String value=":"
+            GET_VAR 'port: kotlin.Int declared in <root>.Recording.ws' type=kotlin.Int origin=null
+    FUN name:wss visibility:public modality:OPEN returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Recording
+      VALUE_PARAMETER kind:Regular name:host index:1 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:port index:2 type:kotlin.Int
+      overridden:
+        public abstract fun wss (host: kotlin.String, port: kotlin.Int): kotlin.Unit declared in com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      BLOCK_BODY
+        CALL 'public final fun plusAssign <T> (<this>: kotlin.collections.MutableCollection<in T of kotlin.collections.plusAssign>, element: T of kotlin.collections.plusAssign): kotlin.Unit declared in kotlin.collections' type=kotlin.Unit origin=PLUSEQ
+          TYPE_ARG T: kotlin.String
+          ARG <this>: CALL 'public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording' type=kotlin.collections.MutableList<kotlin.String> origin=PLUSEQ
+            ARG <this>: GET_VAR '<this>: <root>.Recording declared in <root>.Recording.wss' type=<root>.Recording origin=IMPLICIT_ARGUMENT
+          ARG element: STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="wss://"
+            GET_VAR 'host: kotlin.String declared in <root>.Recording.wss' type=kotlin.String origin=null
+            CONST String type=kotlin.String value=":"
+            GET_VAR 'port: kotlin.Int declared in <root>.Recording.wss' type=kotlin.Int origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:scope type:<root>.Recording [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Recording' type=<root>.Recording origin=null
+      CALL 'public final fun with <T, R> (receiver: T of kotlin.with, block: @[ExtensionFunctionType] kotlin.Function1<T of kotlin.with, R of kotlin.with>): R of kotlin.with declared in kotlin' type=kotlin.Unit origin=null
+        TYPE_ARG T: <root>.Recording
+        TYPE_ARG R: kotlin.Unit
+        ARG receiver: GET_VAR 'val scope: <root>.Recording declared in <root>.box' type=<root>.Recording origin=null
+        ARG block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<<root>.Recording, kotlin.Unit> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+            VALUE_PARAMETER kind:ExtensionReceiver name:$this$with index:0 type:<root>.Recording
+            BLOCK_BODY
+              CALL 'public open fun ws (host: kotlin.String, port: kotlin.Int): kotlin.Unit declared in <root>.Recording' type=kotlin.Unit origin=null
+                ARG <this>: GET_VAR '$this$with: <root>.Recording declared in <root>.box.<anonymous>' type=<root>.Recording origin=IMPLICIT_ARGUMENT
+                ARG host: CONST String type=kotlin.String value="localhost"
+                ARG port: CONST Int type=kotlin.Int value=5080
+              CALL 'public open fun wss (host: kotlin.String, port: kotlin.Int): kotlin.Unit declared in <root>.Recording' type=kotlin.Unit origin=null
+                ARG <this>: GET_VAR '$this$with: <root>.Recording declared in <root>.box.<anonymous>' type=<root>.Recording origin=IMPLICIT_ARGUMENT
+                ARG host: CONST String type=kotlin.String value="198.51.100.7"
+                ARG port: CONST Int type=kotlin.Int value=5443
+      VAR name:expected type:kotlin.collections.List<kotlin.String> [val]
+        CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<kotlin.String> origin=null
+          TYPE_ARG T: kotlin.String
+          ARG elements: VARARG type=kotlin.Array<out kotlin.String> varargElementType=kotlin.String
+            CONST String type=kotlin.String value="ws://localhost:5080"
+            CONST String type=kotlin.String value="wss://198.51.100.7:5443"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              ARG arg0: CALL 'public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+                ARG <this>: GET_VAR 'val scope: <root>.Recording declared in <root>.box' type=<root>.Recording origin=null
+              ARG arg1: GET_VAR 'val expected: kotlin.collections.List<kotlin.String> declared in <root>.box' type=kotlin.collections.List<kotlin.String> origin=null
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: "
+              CALL 'public final fun <get-dialled> (): kotlin.collections.MutableList<kotlin.String> declared in <root>.Recording' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+                ARG <this>: GET_VAR 'val scope: <root>.Recording declared in <root>.box' type=<root>.Recording origin=null
+FILE fqName:com.kitakkun.jetwhale.agent.runtime fileName:/scope.kt
+  CLASS INTERFACE name:JetWhaleEndpointScope modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:buildMachineWss visibility:public modality:ABSTRACT returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      VALUE_PARAMETER kind:Regular name:port index:1 type:kotlin.Int
+    FUN name:ws visibility:public modality:ABSTRACT returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      VALUE_PARAMETER kind:Regular name:host index:1 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:port index:2 type:kotlin.Int
+    FUN name:wss visibility:public modality:ABSTRACT returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+      VALUE_PARAMETER kind:Regular name:host index:1 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:port index:2 type:kotlin.Int

--- a/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/rewrite.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-compiler-plugin/testData/box/rewrite.kt
@@ -1,0 +1,31 @@
+// The declaring interface's fully qualified name is the whole of what the plugin matches on, so
+// declaring it here keeps the fixture self-contained — no runtime artifact on the test classpath.
+
+// FILE: scope.kt
+package com.kitakkun.jetwhale.agent.runtime
+
+interface JetWhaleEndpointScope {
+    fun ws(host: String, port: Int)
+    fun wss(host: String, port: Int)
+    fun buildMachineWss(port: Int)
+}
+
+// FILE: box.kt
+import com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+
+class Recording : JetWhaleEndpointScope {
+    val dialled = mutableListOf<String>()
+    override fun ws(host: String, port: Int) { dialled += "ws://$host:$port" }
+    override fun wss(host: String, port: Int) { dialled += "wss://$host:$port" }
+    override fun buildMachineWss(port: Int) { dialled += "unrewritten:$port" }
+}
+
+fun box(): String {
+    val scope = Recording()
+    with(scope) {
+        ws("localhost", 5080)
+        buildMachineWss(5443)
+    }
+    val expected = listOf("ws://localhost:5080", "wss://198.51.100.7:5443")
+    return if (scope.dialled == expected) "OK" else "FAIL: ${scope.dialled}"
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/build.gradle.kts
+++ b/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/build.gradle.kts
@@ -1,0 +1,68 @@
+plugins {
+    `java-gradle-plugin`
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.publish)
+}
+
+group = "com.kitakkun.jetwhale"
+version = libs.versions.jetwhale.get() + if (hasProperty("jetwhaleSnapshot")) "-SNAPSHOT" else ""
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    // compileOnly: the consumer brings their own Kotlin Gradle plugin, and it must be theirs — this
+    // is what lets one Gradle plugin serve every Kotlin version in the supported range.
+    compileOnly(libs.kotlinGradlePlugin)
+}
+
+/**
+ * The plugin's own version, as source.
+ *
+ * `getPluginArtifact()` has to name the compiler plugin's coordinates, and a hand-written literal
+ * there is a version-skew bug waiting for the next release: publish 1.1.0 and the Gradle plugin
+ * quietly keeps fetching the 1.0.0 compiler plugin. Generating it from the same `version` that
+ * publishes the artifact removes the opportunity.
+ */
+val generateVersionConstant by tasks.registering {
+    val output = layout.buildDirectory.dir("generated/version/kotlin")
+    val pluginVersion = version.toString()
+    inputs.property("version", pluginVersion)
+    outputs.dir(output)
+    doLast {
+        val file = output.get().file("com/kitakkun/jetwhale/agent/gradle/JetWhaleAgentVersion.kt").asFile
+        file.parentFile.mkdirs()
+        file.writeText(
+            """
+            package com.kitakkun.jetwhale.agent.gradle
+
+            /** Generated from the Gradle plugin's own version. Do not edit. */
+            internal const val VERSION: String = "$pluginVersion"
+
+            """.trimIndent(),
+        )
+    }
+}
+
+kotlin.sourceSets.named("main") {
+    kotlin.srcDir(generateVersionConstant)
+}
+
+gradlePlugin {
+    plugins {
+        create("jetwhaleAgent") {
+            id = "com.kitakkun.jetwhale.agent"
+            displayName = "JetWhale Agent"
+            description = "Bakes the build machine's address into JetWhale's buildMachineWss(port) endpoint."
+            implementationClass = "com.kitakkun.jetwhale.agent.gradle.JetWhaleAgentSubplugin"
+        }
+    }
+}
+
+jetwhalePublish {
+    artifactId = "jetwhale-agent-gradle-plugin"
+    name = "JetWhale Agent Gradle Plugin"
+    description = "Gradle plugin feeding the build machine's address to the JetWhale agent compiler plugin."
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/build.gradle.kts
+++ b/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/build.gradle.kts
@@ -9,7 +9,11 @@ group = "com.kitakkun.jetwhale"
 version = libs.versions.jetwhale.get() + if (hasProperty("jetwhaleSnapshot")) "-SNAPSHOT" else ""
 
 kotlin {
-    jvmToolchain(21)
+    // 17, matching gradle-conventions/jvm.gradle.kts — and not a matter of tidiness. Both of these
+    // JARs are loaded by someone else's JVM: the Gradle daemon for the Gradle plugin, the Kotlin
+    // compile daemon for the compiler plugin. Emitting Java 21 bytecode makes a consumer building on
+    // JDK 17 fail with UnsupportedClassVersionError before any of this runs.
+    jvmToolchain(17)
 }
 
 dependencies {

--- a/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/build.gradle.kts
+++ b/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/build.gradle.kts
@@ -16,6 +16,12 @@ dependencies {
     // compileOnly: the consumer brings their own Kotlin Gradle plugin, and it must be theirs — this
     // is what lets one Gradle plugin serve every Kotlin version in the supported range.
     compileOnly(libs.kotlinGradlePlugin)
+
+    testImplementation(kotlin("test"))
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }
 
 /**

--- a/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/gradle/BuildMachineAddressSource.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/gradle/BuildMachineAddressSource.kt
@@ -1,0 +1,40 @@
+package com.kitakkun.jetwhale.agent.gradle
+
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import java.net.DatagramSocket
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.InetSocketAddress
+
+/**
+ * The build machine's address on the network a device could reach it at.
+ *
+ * A `ValueSource` rather than a plain configuration-time lookup: the address is external state that
+ * changes between builds — moving between Wi-Fi and Ethernet, home and office — and this is the
+ * mechanism that lets the configuration cache notice instead of serving yesterday's value.
+ */
+internal abstract class BuildMachineAddressSource : ValueSource<String, ValueSourceParameters.None> {
+    override fun obtain(): String? = primaryAddress()
+}
+
+/**
+ * The source address the OS would use to reach the wider network.
+ *
+ * `InetAddress.getLocalHost()` is not usable for this: on a machine whose hostname resolves through
+ * `/etc/hosts` it answers `127.0.0.1`, which no device can reach. Connecting a UDP socket asks the
+ * routing table instead — and because UDP connect sends nothing, the address need not exist.
+ * [TEST_NET_1] is reserved by RFC 5737 for exactly this kind of use.
+ */
+private fun primaryAddress(): String? = runCatching {
+    DatagramSocket().use { socket ->
+        socket.connect(InetSocketAddress(InetAddress.getByName(TEST_NET_1), DISCARD_PORT))
+        (socket.localAddress as? Inet4Address)
+            ?.hostAddress
+            ?.takeUnless { it == "0.0.0.0" || it.startsWith("127.") }
+    }
+}.getOrNull()
+
+/** RFC 5737 TEST-NET-1: documentation-only, so nothing is ever actually addressed. */
+private const val TEST_NET_1 = "192.0.2.1"
+private const val DISCARD_PORT = 9

--- a/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/gradle/JetWhaleAgentSubplugin.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/gradle/JetWhaleAgentSubplugin.kt
@@ -1,0 +1,66 @@
+package com.kitakkun.jetwhale.agent.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
+import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
+import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
+
+/**
+ * Bakes the build machine's address into `buildMachineWss(port)` calls in this module.
+ *
+ * Applied per-module rather than to a whole project on purpose. The address is a compile task input,
+ * so it invalidates every compilation it reaches; keeping it on the one module that declares the
+ * endpoint means changing networks recompiles that module rather than the build.
+ */
+abstract class JetWhaleAgentSubplugin : KotlinCompilerPluginSupportPlugin {
+    override fun apply(target: Project) {
+        target.extensions.create("jetwhaleAgent", JetWhaleAgentExtension::class.java)
+    }
+
+    override fun getCompilerPluginId(): String = COMPILER_PLUGIN_ID
+
+    override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
+        groupId = "com.kitakkun.jetwhale",
+        artifactId = "jetwhale-agent-compiler-plugin",
+        version = VERSION,
+    )
+
+    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
+
+    override fun applyToCompilation(
+        kotlinCompilation: KotlinCompilation<*>,
+    ): Provider<List<SubpluginOption>> {
+        val project = kotlinCompilation.target.project
+        val extension = project.extensions.getByType(JetWhaleAgentExtension::class.java)
+        val detected = project.providers.of(BuildMachineAddressSource::class.java) { }
+        return extension.address.orElse(detected).map { address ->
+            // A plain SubpluginOption, never InternalSubpluginOption: only the former is carried into
+            // the compile task's inputs, and an address outside the inputs would let a stale one
+            // survive in an "up to date" build.
+            listOf(SubpluginOption(key = BUILD_MACHINE_ADDRESS_OPTION, value = address))
+        }.orElse(emptyList())
+    }
+}
+
+/** Configuration for the `com.kitakkun.jetwhale.agent` plugin. */
+abstract class JetWhaleAgentExtension {
+    /**
+     * The address to bake in, overriding detection.
+     *
+     * Detection asks the routing table which source address would reach the wider network, which is
+     * the right answer on an ordinary machine. Set this where it is not: several interfaces where the
+     * device is on the other one, a VPN capturing the default route, a host reached through a
+     * forwarded port.
+     *
+     * When neither this nor detection yields an address — an offline machine, say — no address is
+     * passed, calls are left as written, and the agent explains at runtime rather than the build
+     * failing.
+     */
+    abstract val address: Property<String>
+}
+
+private const val COMPILER_PLUGIN_ID = "com.kitakkun.jetwhale.agent"
+private const val BUILD_MACHINE_ADDRESS_OPTION = "buildMachineAddress"

--- a/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/gradle/JetWhaleAgentSubplugin.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/gradle/JetWhaleAgentSubplugin.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.agent.gradle
 
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -7,6 +8,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
 /**
  * Bakes the build machine's address into `buildMachineWss(port)` calls in this module.
@@ -18,6 +20,24 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 abstract class JetWhaleAgentSubplugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project) {
         target.extensions.create("jetwhaleAgent", JetWhaleAgentExtension::class.java)
+        target.reportKotlinSupport()
+    }
+
+    /**
+     * Says up front when the consumer's Kotlin is outside the range the compiler plugin is proven on.
+     *
+     * Left unsaid, the same situation surfaces as an `AbstractMethodError` or a `NoSuchMethodError`
+     * from inside a compilation, which reads as a JetWhale bug rather than a version mismatch. Too old
+     * fails here, because the plugin provably cannot load; merely untested only warns, since it may
+     * well work and blocking an upgrade on the absence of evidence would be its own nuisance.
+     */
+    private fun Project.reportKotlinSupport() {
+        val support = kotlinSupportFor(getKotlinPluginVersion())
+        val message = support.message() ?: return
+        when (support) {
+            is KotlinSupport.TooOld -> throw GradleException(message)
+            else -> logger.warn("w: $message")
+        }
     }
 
     override fun getCompilerPluginId(): String = COMPILER_PLUGIN_ID

--- a/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/gradle/SupportedKotlinVersions.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/src/main/kotlin/com/kitakkun/jetwhale/agent/gradle/SupportedKotlinVersions.kt
@@ -1,0 +1,84 @@
+package com.kitakkun.jetwhale.agent.gradle
+
+/**
+ * The Kotlin versions the compiler plugin is built and tested against.
+ *
+ * One artifact serves the whole range — it only touches API that every version in it agrees on, and
+ * CI compiles a consumer with the shipped JAR on each. Outside the range there is no such evidence,
+ * and the failure mode is a linkage error from deep inside someone else's compile, so the range is
+ * checked up front where it can be explained.
+ *
+ * Keep in step with the matrix in `.github/workflows/agent-compiler-plugin-matrix.yml`.
+ */
+internal object SupportedKotlinVersions {
+    /**
+     * Below this the plugin cannot work at all: `CompilerPluginRegistrar.pluginId` is abstract from
+     * 2.3 and absent before it, so a registrar written for one side fails to load on the other.
+     */
+    val MINIMUM: KotlinMinor = KotlinMinor(2, 3)
+
+    /** Highest minor CI proves. Newer may well work — it simply has not been shown to. */
+    val HIGHEST_TESTED: KotlinMinor = KotlinMinor(2, 4)
+}
+
+/** A Kotlin `major.minor`, which is the granularity the compiler plugin API breaks at. */
+internal data class KotlinMinor(val major: Int, val minor: Int) : Comparable<KotlinMinor> {
+    override fun compareTo(other: KotlinMinor): Int = compareValuesBy(this, other, KotlinMinor::major, KotlinMinor::minor)
+
+    override fun toString(): String = "$major.$minor"
+}
+
+/**
+ * Reads `major.minor` out of a Kotlin version string, tolerating everything that trails it.
+ *
+ * Versions in the wild are not all `2.4.10`: dev builds (`2.4.20-dev-1762`), IDE-tagged builds
+ * (`2.3.20-ij253-105`) and the placeholder majors Android Studio reports (`2.3.255-dev-255`) all
+ * appear. Only the first two numbers are needed, and null for anything unparseable is the right
+ * answer — an unrecognised version is a reason to stay quiet, not to guess.
+ */
+internal fun parseKotlinMinor(version: String): KotlinMinor? {
+    val parts = version.split('.')
+    if (parts.size < 2) return null
+    val major = parts[0].toIntOrNull() ?: return null
+    val minor = parts[1].takeWhile { it.isDigit() }.toIntOrNull() ?: return null
+    return KotlinMinor(major, minor)
+}
+
+internal sealed interface KotlinSupport {
+    /** Within the tested range. */
+    data object Supported : KotlinSupport
+
+    /** Older than the plugin can work with at all. */
+    data class TooOld(val found: KotlinMinor) : KotlinSupport
+
+    /** Newer than anything CI proves. Might work; nobody has shown it does. */
+    data class Untested(val found: KotlinMinor) : KotlinSupport
+
+    /** Version string in a shape this plugin does not recognise. */
+    data object Unknown : KotlinSupport
+}
+
+internal fun kotlinSupportFor(version: String): KotlinSupport {
+    val found = parseKotlinMinor(version) ?: return KotlinSupport.Unknown
+    return when {
+        found < SupportedKotlinVersions.MINIMUM -> KotlinSupport.TooOld(found)
+        found > SupportedKotlinVersions.HIGHEST_TESTED -> KotlinSupport.Untested(found)
+        else -> KotlinSupport.Supported
+    }
+}
+
+/** What to tell the user, or null when there is nothing worth saying. */
+internal fun KotlinSupport.message(): String? = when (this) {
+    KotlinSupport.Supported, KotlinSupport.Unknown -> null
+
+    is KotlinSupport.TooOld ->
+        "The JetWhale agent plugin needs Kotlin ${SupportedKotlinVersions.MINIMUM} or newer, but this " +
+            "build uses $found. The compiler plugin cannot load on it, so buildMachineWss() would fail " +
+            "the compilation rather than degrade. Upgrade Kotlin, or write the address out with wss()."
+
+    is KotlinSupport.Untested ->
+        "The JetWhale agent plugin is tested up to Kotlin ${SupportedKotlinVersions.HIGHEST_TESTED}, " +
+            "and this build uses $found. It may work unchanged — the compiler plugin API is only known " +
+            "to break at minor versions, not guaranteed to. If the compilation fails to load the " +
+            "plugin, drop the plugin and write the address out with wss() until JetWhale catches up."
+}

--- a/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/src/test/kotlin/com/kitakkun/jetwhale/agent/gradle/SupportedKotlinVersionsTest.kt
+++ b/jetwhale-agent-plugin/jetwhale-agent-gradle-plugin/src/test/kotlin/com/kitakkun/jetwhale/agent/gradle/SupportedKotlinVersionsTest.kt
@@ -1,0 +1,64 @@
+package com.kitakkun.jetwhale.agent.gradle
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class SupportedKotlinVersionsTest {
+    @Test
+    fun `versions inside the tested range are supported`() {
+        listOf("2.3.0", "2.3.21", "2.4.0", "2.4.10").forEach {
+            assertEquals(KotlinSupport.Supported, kotlinSupportFor(it), it)
+        }
+    }
+
+    @Test
+    fun `anything below the floor is rejected outright`() {
+        // 2.2 cannot work: CompilerPluginRegistrar.pluginId does not exist there, so the registrar
+        // fails to load rather than misbehaving quietly.
+        assertIs<KotlinSupport.TooOld>(kotlinSupportFor("2.2.20"))
+        assertIs<KotlinSupport.TooOld>(kotlinSupportFor("1.9.24"))
+    }
+
+    @Test
+    fun `anything above the tested ceiling is untested rather than rejected`() {
+        // Absence of evidence, not evidence of breakage — the plugin may well work on 2.5.
+        assertIs<KotlinSupport.Untested>(kotlinSupportFor("2.5.0"))
+        assertIs<KotlinSupport.Untested>(kotlinSupportFor("3.0.0"))
+    }
+
+    @Test
+    fun `dev and IDE-tagged versions resolve to their base minor`() {
+        // Versions in the wild are not all x.y.z: dev builds, IntelliJ tags, and the placeholder
+        // majors Android Studio reports all appear, and all of them carry a usable major.minor.
+        assertEquals(KotlinMinor(2, 4), parseKotlinMinor("2.4.20-dev-1762"))
+        assertEquals(KotlinMinor(2, 3), parseKotlinMinor("2.3.20-ij253-105"))
+        assertEquals(KotlinMinor(2, 3), parseKotlinMinor("2.3.255-dev-255"))
+        assertEquals(KotlinSupport.Supported, kotlinSupportFor("2.4.20-dev-1762"))
+    }
+
+    @Test
+    fun `an unrecognised version says nothing rather than guessing`() {
+        // KotlinCompilerVersion reports "@snapshot@" for compiler dev builds. Guessing a minor from
+        // that would produce a confident, wrong diagnostic; staying quiet is the honest answer.
+        assertEquals(KotlinSupport.Unknown, kotlinSupportFor("@snapshot@"))
+        assertEquals(KotlinSupport.Unknown, kotlinSupportFor("2"))
+        assertNull(parseKotlinMinor("not-a-version"))
+    }
+
+    @Test
+    fun `only the cases worth reporting carry a message`() {
+        assertNull(KotlinSupport.Supported.message())
+        assertNull(KotlinSupport.Unknown.message())
+        assertNotNull(KotlinSupport.TooOld(KotlinMinor(2, 2)).message())
+        assertNotNull(KotlinSupport.Untested(KotlinMinor(2, 5)).message())
+    }
+
+    @Test
+    fun `minors order by major first`() {
+        assertEquals(KotlinMinor(2, 4), maxOf(KotlinMinor(2, 4), KotlinMinor(2, 3)))
+        assertEquals(KotlinMinor(3, 0), maxOf(KotlinMinor(3, 0), KotlinMinor(2, 30)))
+    }
+}

--- a/jetwhale-agent-plugin/sample/build.gradle.kts
+++ b/jetwhale-agent-plugin/sample/build.gradle.kts
@@ -1,0 +1,45 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    alias(libs.plugins.kotlinJvm)
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+/**
+ * A fixed, documentation-only address (RFC 5737 TEST-NET-2).
+ *
+ * Detection is deliberately bypassed here: the sample asserts on an exact string, and a test that
+ * depended on whatever network the CI runner happened to be on would be a flake generator.
+ * Detection itself is covered where it belongs, in the Gradle plugin's own tests.
+ */
+val sampleAddress = "198.51.100.7"
+
+// The plugin is wired by raw -Xplugin= rather than by applying com.kitakkun.jetwhale.agent, so the
+// artifact under test is the JAR this build just produced. Applying the Gradle plugin would resolve
+// the compiler plugin from Maven Central by coordinates and test a previous release instead.
+val compilerPlugin: Configuration by configurations.creating
+
+dependencies {
+    compilerPlugin(project(":jetwhale-agent-compiler-plugin"))
+    testImplementation(kotlin("test"))
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    inputs.files(compilerPlugin)
+    compilerOptions.freeCompilerArgs.addAll(
+        compilerPlugin.elements.map { files ->
+            listOf(
+                "-Xplugin=${files.first().asFile.absolutePath}",
+                "-P",
+                "plugin:com.kitakkun.jetwhale.agent:buildMachineAddress=$sampleAddress",
+            )
+        },
+    )
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}

--- a/jetwhale-agent-plugin/sample/src/main/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpointScope.kt
+++ b/jetwhale-agent-plugin/sample/src/main/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpointScope.kt
@@ -1,0 +1,18 @@
+package com.kitakkun.jetwhale.agent.runtime
+
+/**
+ * A stand-in for the real scope in `jetwhale-agent-runtime`.
+ *
+ * The compiler plugin identifies its target by fully qualified name, so a local declaration under
+ * the same name is indistinguishable to it — and lets this sample compile with nothing but the
+ * plugin on the classpath. Pulling the actual runtime in would drag a multiplatform build and its
+ * own Kotlin version constraints into a build whose whole purpose is varying the Kotlin version.
+ *
+ * Only the members the rewrite touches are declared. If the real scope's `wss` signature ever
+ * changes, this stub stops matching and the sample fails — which is the intended alarm.
+ */
+interface JetWhaleEndpointScope {
+    fun ws(host: String, port: Int)
+    fun wss(host: String, port: Int)
+    fun buildMachineWss(port: Int)
+}

--- a/jetwhale-agent-plugin/sample/src/main/kotlin/sample/Endpoints.kt
+++ b/jetwhale-agent-plugin/sample/src/main/kotlin/sample/Endpoints.kt
@@ -1,0 +1,29 @@
+package sample
+
+import com.kitakkun.jetwhale.agent.runtime.JetWhaleEndpointScope
+
+/** Records what a scope was asked to dial, so a test can assert on it. */
+class RecordingScope : JetWhaleEndpointScope {
+    val dialled: MutableList<String> = mutableListOf()
+
+    override fun ws(host: String, port: Int) {
+        dialled += "ws://$host:$port"
+    }
+
+    override fun wss(host: String, port: Int) {
+        dialled += "wss://$host:$port"
+    }
+
+    // Reaching this means the call was not rewritten — the plugin did not run, or ran and declined.
+    override fun buildMachineWss(port: Int) {
+        dialled += "unrewritten:$port"
+    }
+}
+
+/** The shape a consumer writes. Exercised by the test against whatever the plugin did to it. */
+fun declareEndpoints(scope: JetWhaleEndpointScope) {
+    with(scope) {
+        ws("localhost", 5080)
+        buildMachineWss(5443)
+    }
+}

--- a/jetwhale-agent-plugin/sample/src/test/kotlin/BuildMachineRewriteTest.kt
+++ b/jetwhale-agent-plugin/sample/src/test/kotlin/BuildMachineRewriteTest.kt
@@ -1,0 +1,21 @@
+import sample.RecordingScope
+import sample.declareEndpoints
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Proves the *published* plugin JAR transforms code compiled by this build's Kotlin.
+ *
+ * The point is the pairing, not the transform: CI runs this with the plugin built against the
+ * shipped Kotlin and the sample compiled by each supported version in turn. A plugin that merely
+ * recompiles against an older Kotlin proves nothing about the single artifact consumers download.
+ */
+class BuildMachineRewriteTest {
+    @Test
+    fun `buildMachineWss is rewritten to the address the build supplied`() {
+        val scope = RecordingScope()
+        declareEndpoints(scope)
+
+        assertEquals(listOf("ws://localhost:5080", "wss://198.51.100.7:5443"), scope.dialled)
+    }
+}

--- a/jetwhale-agent-plugin/settings.gradle.kts
+++ b/jetwhale-agent-plugin/settings.gradle.kts
@@ -1,0 +1,36 @@
+rootProject.name = "jetwhale-agent-plugin"
+
+// A build of its own rather than modules inside jetwhale-gradle-plugin: that build's root applies
+// `kotlin-dsl`, which puts an unversioned Kotlin Gradle plugin on the classpath and leaves
+// subprojects unable to name the Kotlin version they compile against. Naming it is the whole point
+// here — `-Pkotlin.compiler=<version>` is how the supported range is swept.
+// Directory names match the published artifactIds on purpose: a composite build substitutes
+// local projects for external coordinates by matching group + *project name*, not the
+// maven-publish artifactId. Shorter names here would send the demo to Maven Central for a
+// version that does not exist yet.
+include("jetwhale-agent-compiler-plugin")
+include("jetwhale-agent-gradle-plugin")
+
+pluginManagement {
+    // Reuse the internal `publish` convention (jetwhalePublish { ... }) that simplifies maven-publish.
+    includeBuild("../gradle-conventions")
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        google()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        google()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/jetwhale-agent-plugin/settings.gradle.kts
+++ b/jetwhale-agent-plugin/settings.gradle.kts
@@ -11,7 +11,25 @@ rootProject.name = "jetwhale-agent-plugin"
 include("jetwhale-agent-compiler-plugin")
 include("jetwhale-agent-gradle-plugin")
 
+// Consumes the compiler plugin JAR the way a real project's compilation does, and asserts on the
+// result. Not published — its job is to fail CI when the shipped artifact stops transforming code
+// compiled by a Kotlin version we claim to support.
+include("sample")
+
 pluginManagement {
+    // `kotlin.compiler` is the consumer's Kotlin: it drives the Kotlin Gradle plugin, and so the
+    // version that compiles `sample`. The compiler plugin's own `kotlin.plugin.api` is separate and
+    // defaults to the shipped version, so CI can point a 2.4-built plugin at a 2.3 consumer — which
+    // is the arrangement consumers actually get, and the one worth proving.
+    val shippedKotlin = java.io.File(settingsDir, "../gradle/libs.versions.toml")
+        .readLines()
+        .first { it.startsWith("kotlin = ") }
+        .substringAfter('"')
+        .substringBefore('"')
+    plugins {
+        kotlin("jvm") version providers.gradleProperty("kotlin.compiler").getOrElse(shippedKotlin)
+    }
+
     // Reuse the internal `publish` convention (jetwhalePublish { ... }) that simplifies maven-publish.
     includeBuild("../gradle-conventions")
     repositories {

--- a/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
+++ b/jetwhale-agent-runtime/api/jetwhale-agent-runtime.klib.api
@@ -75,6 +75,7 @@ abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveryScope { 
 }
 
 abstract interface com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope { // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope|null[0]
+    abstract fun buildMachineWss(kotlin/Int) // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope.buildMachineWss|buildMachineWss(kotlin.Int){}[0]
     abstract fun discoverWss(kotlin/Function1<com.kitakkun.jetwhale.agent.runtime/JetWhaleDiscoveryScope, kotlin/Unit>) // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope.discoverWss|discoverWss(kotlin.Function1<com.kitakkun.jetwhale.agent.runtime.JetWhaleDiscoveryScope,kotlin.Unit>){}[0]
     abstract fun ws(kotlin/String, kotlin/Int) // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope.ws|ws(kotlin.String;kotlin.Int){}[0]
     abstract fun wss(kotlin/String, kotlin/Int) // com.kitakkun.jetwhale.agent.runtime/JetWhaleEndpointScope.wss|wss(kotlin.String;kotlin.Int){}[0]

--- a/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
+++ b/jetwhale-agent-runtime/api/jvm/jetwhale-agent-runtime.api
@@ -32,6 +32,7 @@ public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleDisc
 }
 
 public abstract interface class com/kitakkun/jetwhale/agent/runtime/JetWhaleEndpointScope {
+	public abstract fun buildMachineWss (I)V
 	public abstract fun discoverWss (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun ws (Ljava/lang/String;I)V
 	public abstract fun wss (Ljava/lang/String;I)V

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.agent.runtime
 
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.annotations.InternalJetWhaleApi
 import com.kitakkun.jetwhale.protocol.serialization.JetWhaleJson
 
@@ -253,6 +254,37 @@ public interface JetWhaleEndpointScope {
      *   on the network and on a shared one those belong to other people.
      */
     public fun discoverWss(configure: JetWhaleDiscoveryScope.() -> Unit)
+
+    /**
+     * The machine that compiled this code, at [port], over wss.
+     *
+     * Discovery's answer to "a physical device cannot reach loopback" costs a network browse, needs
+     * `NSBonjourServices` on iOS, and does not exist on JS/Wasm/Linux/Windows. But when the host runs
+     * on the same machine as the compiler — which is the usual way of working — the address is already
+     * known at build time. This bakes it in, and the browse is not needed to learn it.
+     *
+     * wss for the same reason [discoverWss] is: the host binds ws to loopback, so its LAN address
+     * would refuse a plain connection anyway.
+     *
+     * Experimental, and for a sharper reason than most: unlike the rest of this scope, the behaviour
+     * rests on a Kotlin compiler plugin, whose API JetBrains breaks across minor versions by design.
+     * A Kotlin release the plugin has not caught up with leaves calls unrewritten — which degrades
+     * to the same explained silence as never applying the Gradle plugin, but is worth knowing about
+     * before depending on it.
+     *
+     * **Requires the `com.kitakkun.jetwhale.agent` Gradle plugin**, which resolves the address and
+     * hands it to a compiler plugin that rewrites this call. Without it this compiles and runs — it
+     * simply contributes no candidate, and says so once in the log. Baking in an address is a
+     * build-time convenience, and a missing convenience should not be a broken build.
+     *
+     * The address is a compile task input, so moving between networks recompiles rather than leaving
+     * a stale address in place. It is also machine-specific, so those compilations will not be shared
+     * through a remote build cache — worth knowing before applying the Gradle plugin widely.
+     *
+     * @param port The port serving wss on the build machine.
+     */
+    @ExperimentalJetWhaleApi
+    public fun buildMachineWss(port: Int)
 }
 
 /**
@@ -426,6 +458,17 @@ private class JetWhaleEndpointConfiguration(
     override fun discoverWss(configure: JetWhaleDiscoveryScope.() -> Unit) {
         val policy = JetWhaleDiscoveryConfiguration().apply(configure)
         candidates += EndpointCandidate.Dynamic(policy.hostNames, policy.addresses, policy.acceptsAnyHost)
+    }
+
+    // Reaching this body means the call was never rewritten, because rewriting replaces it outright
+    // with wss(<baked address>, port). So there is no address to contribute — only an explanation.
+    @ExperimentalJetWhaleApi
+    override fun buildMachineWss(port: Int) {
+        JetWhaleLogger.w(
+            "buildMachineWss($port) was declared but the JetWhale Gradle plugin is not applied, so no " +
+                "build machine address was baked in and this contributes no candidate. Apply the " +
+                "'com.kitakkun.jetwhale.agent' plugin to this module, or write the address out with wss().",
+        )
     }
 }
 

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -274,8 +274,8 @@ public interface JetWhaleEndpointScope {
      *
      * **Requires the `com.kitakkun.jetwhale.agent` Gradle plugin**, which resolves the address and
      * hands it to a compiler plugin that rewrites this call. Without it this compiles and runs — it
-     * simply contributes no candidate, and says so once in the log. Baking in an address is a
-     * build-time convenience, and a missing convenience should not be a broken build.
+     * simply contributes no candidate, and logs why. Baking in an address is a build-time
+     * convenience, and a missing convenience should not be a broken build.
      *
      * The address is a compile task input, so moving between networks recompiles rather than leaving
      * a stale address in place. It is also machine-specific, so those compilations will not be shared
@@ -465,9 +465,10 @@ private class JetWhaleEndpointConfiguration(
     @ExperimentalJetWhaleApi
     override fun buildMachineWss(port: Int) {
         JetWhaleLogger.w(
-            "buildMachineWss($port) was declared but the JetWhale Gradle plugin is not applied, so no " +
-                "build machine address was baked in and this contributes no candidate. Apply the " +
-                "'com.kitakkun.jetwhale.agent' plugin to this module, or write the address out with wss().",
+            "buildMachineWss($port) was declared but the agent Gradle plugin " +
+                "('com.kitakkun.jetwhale.agent') is not applied to this module, so no build machine " +
+                "address was baked in and this contributes no candidate. Apply that plugin, or write " +
+                "the address out with wss().",
         )
     }
 }

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/ConnectionEndpointTest.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.agent.runtime
 
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -146,6 +147,43 @@ class ConnectionEndpointTest {
                 addresses = silent.addresses,
                 acceptsAnyHost = silent.acceptsAnyHost,
             ).acceptsNothing,
+        )
+    }
+
+    @Test
+    fun `an unrewritten buildMachineWss contributes no candidate`() {
+        // Without the agent Gradle plugin the call reaches its own body, which only explains itself.
+        // Contributing a candidate here would be worse than contributing none: there is no address
+        // to contribute, so anything it added would be invented.
+        val declared = candidates {
+            endpoints {
+                @OptIn(ExperimentalJetWhaleApi::class)
+                buildMachineWss(5443)
+            }
+        }
+
+        assertEquals(emptyList(), declared)
+    }
+
+    @Test
+    fun `an unrewritten buildMachineWss does not disturb the order of its neighbours`() {
+        // It drops out of the list rather than leaving a gap, so whatever was declared after it is
+        // still reached — and still in the order it was written.
+        val declared = candidates {
+            endpoints {
+                ws("localhost", 5080)
+                @OptIn(ExperimentalJetWhaleApi::class)
+                buildMachineWss(5443)
+                wss("192.168.3.26", 5443)
+            }
+        }
+
+        assertEquals(
+            listOf(
+                EndpointCandidate.Static("localhost", 5080, useWss = false),
+                EndpointCandidate.Static("192.168.3.26", 5443, useWss = true),
+            ),
+            declared,
         )
     }
 

--- a/jetwhale-annotations/api/jetwhale-annotations.klib.api
+++ b/jetwhale-annotations/api/jetwhale-annotations.klib.api
@@ -6,6 +6,10 @@
 // - Show declarations: true
 
 // Library unique name: <com.kitakkun.jetwhale:jetwhale-annotations>
+open annotation class com.kitakkun.jetwhale.annotations/ExperimentalJetWhaleApi : kotlin/Annotation { // com.kitakkun.jetwhale.annotations/ExperimentalJetWhaleApi|null[0]
+    constructor <init>() // com.kitakkun.jetwhale.annotations/ExperimentalJetWhaleApi.<init>|<init>(){}[0]
+}
+
 open annotation class com.kitakkun.jetwhale.annotations/InternalJetWhaleApi : kotlin/Annotation { // com.kitakkun.jetwhale.annotations/InternalJetWhaleApi|null[0]
     constructor <init>() // com.kitakkun.jetwhale.annotations/InternalJetWhaleApi.<init>|<init>(){}[0]
 }

--- a/jetwhale-annotations/api/jvm/jetwhale-annotations.api
+++ b/jetwhale-annotations/api/jvm/jetwhale-annotations.api
@@ -1,3 +1,6 @@
+public abstract interface annotation class com/kitakkun/jetwhale/annotations/ExperimentalJetWhaleApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/kitakkun/jetwhale/annotations/InternalJetWhaleApi : java/lang/annotation/Annotation {
 }
 

--- a/jetwhale-annotations/src/commonMain/kotlin/com/kitakkun/jetwhale/annotations/ExperimentalJetWhaleApi.kt
+++ b/jetwhale-annotations/src/commonMain/kotlin/com/kitakkun/jetwhale/annotations/ExperimentalJetWhaleApi.kt
@@ -1,0 +1,13 @@
+package com.kitakkun.jetwhale.annotations
+
+/**
+ * Marks an API that may change or be withdrawn in a later release.
+ *
+ * Distinct from [InternalJetWhaleApi], which is not meant to be called at all. This one is meant to
+ * be called — it simply has not settled, so opting in is an acknowledgement that a future upgrade
+ * may ask you to change the call.
+ *
+ * A warning rather than an error: the point is to be noticed, not to stop a build.
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+public annotation class ExperimentalJetWhaleApi

--- a/jetwhale-gradle-plugin/build.gradle.kts
+++ b/jetwhale-gradle-plugin/build.gradle.kts
@@ -15,7 +15,7 @@ group = "com.kitakkun.jetwhale"
 version = libs.versions.jetwhale.get() + if (hasProperty("jetwhaleSnapshot")) "-SNAPSHOT" else ""
 
 jetwhalePublish {
-    artifactId = "jetwhale-gradle-plugin"
-    name = "JetWhale Gradle Plugin"
+    artifactId = "jetwhale-host-gradle-plugin"
+    name = "JetWhale Host Gradle Plugin"
     description = "Gradle plugin for developing JetWhale host plugins (packagePlugin, runJetWhale, runJetWhaleHot)."
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
     includeBuild("gradle-conventions")
     includeBuild("jetwhale-gradle-plugin")
+    includeBuild("jetwhale-agent-plugin")
     repositories {
         mavenCentral()
         gradlePluginPortal()
@@ -22,6 +23,13 @@ dependencyResolutionManagement {
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
+
+// Also at the top level, not only in pluginManagement: that block resolves the *plugin*, while the
+// compiler-plugin JAR the plugin points `getPluginArtifact()` at is an ordinary dependency, and only
+// a top-level include substitutes the local project for those coordinates. Without this the demo
+// resolves jetwhale-agent-compiler-plugin from Maven Central, where the version being developed does
+// not exist yet.
+includeBuild("jetwhale-agent-plugin")
 
 include(":jetwhale-annotations")
 include(":jetwhale-protocol:core")


### PR DESCRIPTION
## Why

A physical device cannot reach the host over loopback, so it needs the host's LAN address. Today that comes from `discoverWss { }`, which costs an mDNS browse, requires `NSBonjourServices` on iOS, and does not exist on JS/Wasm/Linux/Windows.

But when the host runs on the machine that compiled the app — the usual arrangement — that address is already known at build time. Discovering it at runtime is a slow way to learn something the build already knew.

## What

```kotlin
// build.gradle.kts
plugins { id("com.kitakkun.jetwhale.agent") }
```

```kotlin
endpoints {
    ws("localhost", 5080)   // emulators, simulators, the desktop app, the browser
    buildMachineWss(5443)   // physical devices — no browse, no Info.plist entry
}
```

The Gradle plugin resolves the address; a Kotlin compiler plugin rewrites the call at IR time:

```
w: JetWhale: baked the build machine address 192.168.3.9 into 1 buildMachineWss call(s) in 'shared'.
```

wss for the same reason `discoverWss` has no plain counterpart: the host binds ws to loopback, so its LAN address would refuse a plain connection anyway.

## Why a compiler plugin and not a generated constant

A generated `BuildConfig`-style constant would have been far less machinery, but it changes the failure mode. Source that references a generated symbol does not **compile** without the plugin — so every consumer would be forced to apply the Gradle plugin, and would carry generated sources in their own module.

With a compiler plugin the declaration is real. Without the Gradle plugin the call compiles, contributes no candidate, and says so once at runtime. A missing build-time convenience should not be a broken build.

## `@ExperimentalJetWhaleApi`

New warning-level opt-in annotation. Unlike the rest of `endpoints { }`, this one's behaviour rests on `@ExperimentalCompilerApi` — an API JetBrains breaks across minor versions by design. That is a materially different stability contract from the pure-runtime members next to it, and worth saying so at the call site.

## Build cache

The address is passed as a plain `SubpluginOption`, which `CompilerPluginConfig.getAsTaskInputArgs()` exposes as `@Input` (`KotlinGradleSubplugin.kt:141`). Never `InternalSubpluginOption`, which the same file excludes from task inputs at :159.

Verified both directions:

| | |
|---|---|
| Address unchanged | `Task :demo:shared:compileKotlinJvm UP-TO-DATE` |
| Address changed | Task re-runs, new address baked |

So the dangerous failure — a stale address surviving in an "up to date" build — cannot happen. The costs are real and documented: network changes recompile, and those compilations are never shared through a remote build cache since the address is per-developer. That is why the plugin is applied per-module rather than project-wide.

Address detection uses a Gradle `ValueSource`, so the configuration cache notices a changed address rather than serving yesterday's. `jetwhaleAgent { address = "..." }` overrides it.

## Kotlin version support: 2.3.0 – 2.4.x, one source set

The floor is fixed by upstream, not by taste: `CompilerPluginRegistrar.pluginId` became abstract in 2.3 and does not exist at all before it, so supporting 2.2 would mean a per-version registrar source set. KT-68003's flat `arguments` list — which the rewrite indexes rather than using the accessors 2.4 removed — spans 2.2 onward. 2.3.0 is where a single source set starts working.

Structure for surviving version bumps:

- One `kotlin.compiler` Gradle property flips the whole toolchain.
- The volatile compiler API is isolated in `CompilerApiCompat.kt`, each entry annotated `@CompatSensitive(since, what)` so dropping a Kotlin version tells you which workarounds became dead code.
- A CI matrix builds every claimed version. A version not in the matrix is not supported.

All four verified locally: 2.3.0, 2.3.21, 2.4.0, 2.4.10.

## Verification

The transform runs on **all five** of the demo's compilations — JVM, Android, iOS (Native), JS, WasmJS — confirmed by the per-module warning and by inspecting the output: `ldc "192.168.3.9"` followed by `JetWhaleEndpointScope.wss` in JVM bytecode, and the address present with `buildMachineWss` gone from the iOS klib's serialized IR.

`spotlessCheck`, `jvmTest`, `checkKotlinAbi` green.

## Also here

Renames the host Gradle plugin's artifactId to `jetwhale-host-gradle-plugin` so the pair reads symmetrically with `jetwhale-agent-gradle-plugin`. Consumers applying it by plugin id are unaffected — the published marker is keyed on the plugin id, not the artifactId.

The directory `jetwhale-gradle-plugin/` is deliberately **not** renamed: the publish workflows reference it by path, and that seemed worth leaving to a deliberate change rather than folding into this one.