### PR TITLE
docs: reconcile the documentation with the current API and behaviour

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,12 @@
 
 ## Project Structure & Module Organization
 - Multi-module Gradle (Kotlin) project. Top-level modules are declared in `settings.gradle.kts`.
-- Core libraries live under `jetwhale-protocol`, `jetwhale-agent-sdk`, `jetwhale-agent-runtime`, and `jetwhale-host-sdk`.
+- Core libraries live under `jetwhale-annotations`, `jetwhale-protocol`, `jetwhale-agent-sdk`, `jetwhale-agent-runtime`, and `jetwhale-host-sdk`.
 - Host application code is under `jetwhale-host/` (desktop Compose app with features in `jetwhale-host/feature/*` and shared layers in `jetwhale-host/core/*`).
-- Example plugins are in `jetwhale-plugins/example/*`.
-- Demo apps live in `demo/` (`demo/desktop`, `demo/android`, `demo/shared`).
+- Gradle plugins are separate included builds: `jetwhale-gradle-plugin` (published as the `com.kitakkun.jetwhale.host` id, for host plugin modules) and `jetwhale-agent-plugin` (the `com.kitakkun.jetwhale.agent` id plus the Kotlin compiler plugin it points at).
+- Bundled plugins are in `jetwhale-plugins/*` (`example`, `network`, `nav3`, `semantics`), each split into `protocol` / `agent` / `host` modules.
+- Developer tooling lives in `tools/` (e.g. `tools/qa-agent`).
+- Demo apps live in `demo/` (`demo/shared`, `demo/desktop`, `demo/android`, `demo/web`, and the Xcode project `demo/ios-cmp`).
 - Tests appear alongside modules (e.g., `jetwhale-host/app/src/test` or `jetwhale-agent-runtime/src/commonTest`).
 
 ## Build, Test, and Development Commands

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.4.10-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org)
 [![License](https://img.shields.io/github/license/kitakkun/JetWhale)](LICENSE)
 
-JetWhale is an extensible debugging tool for Kotlin apps, inspired
+JetWhale is an extensible debugging tool inspired
 by [Flipper](https://github.com/facebook/flipper).
 
-It is built with Kotlin and Jetpack Compose, so the debugger you run — and the plugins you write for
-it — use the APIs you already know.
+It is built with Kotlin and Jetpack Compose, making it especially familiar and approachable for
+Kotlin / Android developers.
+Thanks to its Kotlin-first design, JetWhale can be introduced with a minimal learning curve.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,18 @@ Thanks to its Kotlin-first design, JetWhale can be introduced with a minimal lea
 
 ## Features
 
-- 🐳 **Multi-session debugging** — an Android device and a desktop build side by side, grouped by device
-- 🔌 **Runtime plugins** — loaded from JAR files; the built-in ones and your own alike
-- 🛜 **Type-safe messaging** — kotlinx.serialization between the host and your app
-- ✅ **Multiplatform** — Android, Desktop (JVM), iOS (simulator & physical devices), Web (JS / WasmJS)
-- ⚙️ **Zero Android setup** — the host wires `adb reverse` for you
-- 🤖 **[MCP server](https://kitakkun.github.io/JetWhale/guide/mcp-server)** *(experimental)* — let an AI agent drive the app
-- 🔥 **Hot-reloadable plugin development** — against the published SDK, from your own repository
+- 🐳 **Multi-session debugging.** Several apps stay connected at once, grouped by the device they
+  run on.
+- 🔌 **Every tool is a plugin.** Add one to a running host; the shipped inspectors work the same way
+  as yours.
+- 🛜 **Type-safe messaging.** Plugins exchange Kotlin types rather than hand-parsed JSON.
+- ✅ **Multiplatform.** Android, Desktop (JVM), iOS (simulator and physical devices) and Web
+  (JS / WasmJS).
+- ⚙️ **Zero Android setup.** The host wires `adb reverse` for you.
+- 🤖 **[MCP server](https://kitakkun.github.io/JetWhale/guide/mcp-server)** *(experimental)*. An AI
+  agent can drive the app — screenshot, click, type, scroll, drag, read the accessibility tree.
+- 🔥 **Hot-reloadable plugin development.** Edit a plugin and the host reloads it, without
+  restarting.
 
 > [!NOTE]
 > Under active development. Feedback is welcome as we work toward a stable release; the Plugin SDK
@@ -82,8 +87,8 @@ from its plugin catalog, add the matching artifact to your app, and register it 
 
 ## Developing plugins
 
-Your own plugins live in **your** repository — no fork needed. One command gives you a hot-reload
-loop:
+Plugins are ordinary Gradle projects built against the published SDK. One command gives you a
+hot-reload loop:
 
 ```bash
 ./gradlew :myPlugin:runJetWhaleHot

--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ JetWhale's debugging tools are plugins, and you can build your own in your **own
 fast, **hot-reload** dev loop:
 
 - Apply the published `com.kitakkun.jetwhale.host` Gradle plugin and compile against the published SDK.
-- Run a real host with `./gradlew :myPlugin:runJetWhale` (it downloads the host for your
-  OS — no manual install).
-- Re-stage on save with `./gradlew :myPlugin:stageDevPlugin -t`; the host reloads your plugin without
-  a restart — keeping its state for simple (method-body) edits, and recreating it for structural
+- Run the whole loop with one command: `./gradlew :myPlugin:runJetWhaleHot` downloads a real host for
+  your OS (no manual install), launches it with your plugin loaded, and re-stages the plugin on every
+  source change. The host reloads it without a restart.
+- Prefer a plain JDK? `./gradlew :myPlugin:runJetWhale` in one terminal and
+  `./gradlew :myPlugin:stageDevPlugin -t` in another does the same, keeping the plugin's state for
+  simple (method-body) edits and recreating it for structural
   changes (see the [limitations](https://kitakkun.github.io/JetWhale/guide/developing-plugins#limitations)).
 
 See **[Developing plugins](https://kitakkun.github.io/JetWhale/guide/developing-plugins)** for the full guide.

--- a/README.md
+++ b/README.md
@@ -8,66 +8,83 @@
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.4.10-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org)
 [![License](https://img.shields.io/github/license/kitakkun/JetWhale)](LICENSE)
 
-JetWhale is a next-generation, extensible debugging tool inspired
+JetWhale is an extensible debugging tool for Kotlin apps, inspired
 by [Flipper](https://github.com/facebook/flipper).
 
-It is built with Kotlin and Jetpack Compose, making it especially familiar and approachable for
-Kotlin / Android developers.
-Thanks to its Kotlin-first design, JetWhale can be introduced with a minimal learning curve.
-
-> [!NOTE]
-> This project is under active development.
-> We welcome feedback as we work toward a stable release.
-> Please note that the Plugin SDK APIs are not yet finalized and may change in the future.
-
-📖 **Documentation: <https://kitakkun.github.io/JetWhale/>**
+It is built with Kotlin and Jetpack Compose, so the debugger you run — and the plugins you write for
+it — use the APIs you already know.
 
 ## Features
 
-- 🐳 **Powerful Debugging Platform**
-    - Provides a modern and rich debugging experience powered by **Kotlin** and **Jetpack Compose**
-    - Supports debugging **multiple sessions simultaneously**
-    - Debugging tools are implemented as **plugins**, which can be dynamically loaded at runtime as
-      JAR files
+- 🐳 **Multi-session debugging** — an Android device and a desktop build side by side, grouped by device
+- 🔌 **Runtime plugins** — loaded from JAR files; the built-in ones and your own alike
+- 🛜 **Type-safe messaging** — kotlinx.serialization between the host and your app
+- ✅ **Multiplatform** — Android, Desktop (JVM), iOS (simulator & physical devices), Web (JS / WasmJS)
+- ⚙️ **Zero Android setup** — the host wires `adb reverse` for you
+- 🤖 **[MCP server](https://kitakkun.github.io/JetWhale/guide/mcp-server)** *(experimental)* — let an AI agent drive the app
+- 🔥 **Hot-reloadable plugin development** — against the published SDK, from your own repository
 
-- ⚙️ **Easy Integration and Customization**
-    - DSL-based APIs allow you to quickly set up and configure JetWhale in your application
-    - Customize the debugging experience by creating your own plugins using familiar **Kotlin**
-      and **Jetpack Compose** paradigms
+> [!NOTE]
+> Under active development. Feedback is welcome as we work toward a stable release; the Plugin SDK
+> APIs are not finalized and may still change.
 
-- 🛜 **Type-safe Communication with kotlinx.serialization**
-    - Leverages **kotlinx.serialization** to enable type-safe communication between the debugger
-      and debuggees
+📖 **Documentation: <https://kitakkun.github.io/JetWhale/>**
 
-- ✅ **Multiplatform Support**
-    - Supports **Android**, **Desktop(JVM)**, **iOS** (Simulator & physical devices over the local network), and **Web** (Js, WasmJs)
-      debuggees
+## Getting started
 
-- 🤖 **MCP Server Support** *(Experimental)*
-    - JetWhale exposes a built-in **MCP (Model Context Protocol) HTTP+SSE server**, allowing AI
-      agents (e.g. Claude) to interact with debuggee apps directly
-    - Built-in tools include `screenshot`, `click`, `type`, `scroll`, `drag`, and
-      `getAccessibilityTree`
-    - Plugins can expose their own custom MCP tools by implementing `JetWhaleMcpCapablePlugin`
+**1. Install the host** — download the installer for your OS from
+the [releases page](https://github.com/kitakkun/JetWhale/releases) (`.dmg` for macOS, `.deb` for
+Linux, `.msi` for Windows), and launch it.
 
-- 🔥 **Hot-Reloadable Plugin Development**
-    - Build your own plugins in your **own** repository against the published SDK — no fork needed
-    - `runJetWhale` downloads a real JetWhale host and launches it with your plugin loaded;
-      edit your plugin, re-stage, and the host **hot-reloads** it — no restart
-    - See [Developing plugins](https://kitakkun.github.io/JetWhale/guide/developing-plugins)
+**2. Add the runtime** to the app you want to debug:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("com.kitakkun.jetwhale:jetwhale-agent-runtime:<version>")
+}
+```
+
+**3. Start a session** as early as you can in your app's startup:
+
+```kotlin
+startJetWhale {
+    connection {
+        endpoints {
+            ws("localhost", 5080)
+        }
+    }
+    plugins {
+        // each inspector below is its own artifact; register the ones you want
+    }
+}
+```
+
+That is the whole integration — the app shows up in the host as soon as it runs.
+
+See **[Getting Started](https://kitakkun.github.io/JetWhale/guide/getting-started)** for physical iOS
+devices, secure connections, and the rest.
+
+## What you can inspect
+
+| | |
+|---|---|
+| **[Network Inspector](https://kitakkun.github.io/JetWhale/guide/network-inspector)** | HTTP traffic, with request/response bodies — and mock rules to reshape responses without touching the server |
+| **[Compose Semantics Inspector](https://kitakkun.github.io/JetWhale/guide/compose-semantics-inspector)** | The Compose node tree of a running screen |
+| **[Nav3 Navigator](https://kitakkun.github.io/JetWhale/guide/nav3-navigator)** | The Navigation 3 back stack, and pushing or popping entries from the host |
+| **[MCP server](https://kitakkun.github.io/JetWhale/guide/mcp-server)** *(experimental)* | Lets an AI agent drive the app — screenshot, click, type, scroll, drag, read the accessibility tree |
 
 ## Developing plugins
 
-JetWhale's debugging tools are plugins, and you can build your own in your **own** repository with a
-fast, **hot-reload** dev loop:
+JetWhale's debugging tools are plugins, and yours live in **your** repository — no fork needed. One
+command gives you a hot-reload loop:
 
-- Apply the published `com.kitakkun.jetwhale.host` Gradle plugin and compile against the published SDK.
-- Run the whole loop with one command: `./gradlew :myPlugin:runJetWhaleHot` downloads a real host for
-  your OS (no manual install), launches it with your plugin loaded, and re-stages the plugin on every
-  source change. The host reloads it without a restart.
-- Prefer a plain JDK? `./gradlew :myPlugin:runJetWhale` in one terminal and
-  `./gradlew :myPlugin:stageDevPlugin -t` in another does the same, keeping the plugin's state for
-  simple (method-body) edits and recreating it for structural
-  changes (see the [limitations](https://kitakkun.github.io/JetWhale/guide/developing-plugins#limitations)).
+```bash
+./gradlew :myPlugin:runJetWhaleHot
+```
 
-See **[Developing plugins](https://kitakkun.github.io/JetWhale/guide/developing-plugins)** for the full guide.
+It downloads a real host for your OS, launches it with your plugin loaded, and reloads the plugin on
+every source change without restarting.
+
+See **[Developing plugins](https://kitakkun.github.io/JetWhale/guide/developing-plugins)** for the
+full guide.

--- a/README.md
+++ b/README.md
@@ -66,19 +66,24 @@ That is the whole integration — the app shows up in the host as soon as it run
 See **[Getting Started](https://kitakkun.github.io/JetWhale/guide/getting-started)** for physical iOS
 devices, secure connections, and the rest.
 
-## What you can inspect
+## Official plugins
 
-| | |
-|---|---|
-| **[Network Inspector](https://kitakkun.github.io/JetWhale/guide/network-inspector)** | HTTP traffic, with request/response bodies — and mock rules to reshape responses without touching the server |
-| **[Compose Semantics Inspector](https://kitakkun.github.io/JetWhale/guide/compose-semantics-inspector)** | The Compose node tree of a running screen |
-| **[Nav3 Navigator](https://kitakkun.github.io/JetWhale/guide/nav3-navigator)** | The Navigation 3 back stack, and pushing or popping entries from the host |
-| **[MCP server](https://kitakkun.github.io/JetWhale/guide/mcp-server)** *(experimental)* | Lets an AI agent drive the app — screenshot, click, type, scroll, drag, read the accessibility tree |
+The debugging tools themselves are plugins. These ship with JetWhale — install one into the host
+from its plugin catalog, add the matching artifact to your app, and register it in
+`startJetWhale { }`:
+
+- **[Network Inspector](https://kitakkun.github.io/JetWhale/guide/network-inspector)** — HTTP
+  traffic with request and response bodies, plus mock rules that reshape responses without touching
+  the server
+- **[Compose Semantics Inspector](https://kitakkun.github.io/JetWhale/guide/compose-semantics-inspector)**
+  — the Compose node tree of a running screen
+- **[Nav3 Navigator](https://kitakkun.github.io/JetWhale/guide/nav3-navigator)** — the Navigation 3
+  back stack, and pushing or popping entries from the host
 
 ## Developing plugins
 
-JetWhale's debugging tools are plugins, and yours live in **your** repository — no fork needed. One
-command gives you a hot-reload loop:
+Your own plugins live in **your** repository — no fork needed. One command gives you a hot-reload
+loop:
 
 ```bash
 ./gradlew :myPlugin:runJetWhaleHot

--- a/docs/guide/adb-auto-port-mapping.md
+++ b/docs/guide/adb-auto-port-mapping.md
@@ -13,7 +13,9 @@ manual `adb reverse` commands needed.
 
 It is **on by default** — Android debugging needs no setup. The toggle lives under
 [**Settings → Connection → ADB Support**](/guide/host-settings#adb-support) if you want to turn it
-off.
+off. The debug server reads the setting only when it starts, so a change takes effect the next time
+the server is restarted (Apply on the Debug Server page, `jetwhale.restartDebugServer`, or a host
+restart).
 
 While enabled, the host:
 
@@ -30,10 +32,12 @@ While enabled, the host:
 4. When a device goes offline, removes its reverse mappings.
 
 If the ADB server restarts or crashes (for example, another tool ran `adb kill-server`), JetWhale
-automatically re-attaches to the device tracking stream after a short backoff — you don't need to
-toggle the setting again.
+automatically re-attaches to the device tracking stream two seconds later, and keeps retrying — you
+don't need to toggle the setting again.
 
-Disabling the setting stops the device tracking and removes all reverse mappings JetWhale created.
+Stopping the debug server stops the device tracking and removes all reverse mappings JetWhale
+created. Turning the setting off does not, on its own, tear anything down: it only decides whether
+the *next* server start wires anything up.
 
 ## How adb is found
 

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -14,61 +14,6 @@ browse it in the host and hand it to an AI agent over [MCP](/guide/mcp-server).
 - 🪟 Dialogs and popups appear as their own roots, because that is what they are in Compose
 - 🤖 Three MCP tools so an agent can see the screen structurally instead of guessing at pixels
 
-## Why not the CLI?
-
-`android layout` and `adb shell uiautomator dump` both go out to the accessibility framework across
-a process boundary and write a file on the device before anything can read it. This plugin reads the
-semantics tree **inside** the app, on its main thread, and sends it back over the JetWhale
-connection that is already open — so a capture costs about as much as a frame.
-
-Measured on one machine, on the same screen, back to back — a Pixel-class emulator (1080×2400,
-density 2.625) showing the demo app's *Compose nodes* screen, 38–39 elements:
-
-| | median | 
-|---|---|
-| **`com.kitakkun.jetwhale.semantics.getNodeTree`** (host → app → host) | **14 ms** (min 12, p90 15) |
-| ⤷ of which reading the tree on the device | **1 ms** (max 6) |
-| **`com.kitakkun.jetwhale.semantics.findNodes`** | **11 ms** |
-| `adb shell uiautomator dump` + `adb pull` | 1,960 ms |
-| `android layout` (Google's Android CLI) | 2,703 ms |
-
-That is **~190× faster than `android layout`** on this setup — fast enough that an agent can capture
-between every action instead of budgeting for the dump. Treat the ratio as indicative rather than a
-spec: an emulator is slower than a physical device, and a bigger screen means more nodes.
-
-The host shows both numbers live — what the capture cost on the device, and the round trip from the
-host — so a slow capture says where the time went.
-
-### Are the coordinates right?
-
-`bounds` and `tap` are screen pixels, so they have to survive whatever the device does to the
-window. They were checked two ways at once — cross-checked against `android layout`'s reading of the
-same screen, and proved by tapping the reported point and watching the intended node react — across
-the conditions that move a window around:
-
-| Condition | nodes cross-checked | worst disagreement | tap reached the node |
-|---|---|---|---|
-| gesture nav, portrait, density 420 | 19 | 1 px | ✅ |
-| 3-button navigation bar | 18 | 1 px | ✅ |
-| landscape | 10 | 1 px | ✅ |
-| density 320 | 29 | 1 px | ✅ |
-| 800×1280 @ density 320 | 12 | 1 px | ✅ |
-
-The residual 1 px is rounding: this plugin rounds, `android layout` truncates.
-
-Each condition was also re-run with a dialog open, which is the case that actually exercises the
-arithmetic — a dialog is its own window and does **not** start at the screen origin, so a
-window-relative coordinate reported as if it were absolute would be off by the whole offset. In
-landscape that offset reaches `(717, 298)`; the dialog's nodes still agreed to within 1 px, and
-tapping the reported point closed the dialog. Every root reports its own `windowOffset`, so a
-suspicious coordinate can be traced back to the window it came from.
-
-The tree is also richer than what the CLIs return: `android layout` gives a flat list with text,
-`content-desc` and bounds, but no `testTag`, no role and no per-node id, so an agent can only aim by
-label or by pixel. This plugin reports all three, which is what makes
-[`performNodeAction`](#com-kitakkun-jetwhale-semantics-performnodeaction) able to address a node
-directly.
-
 ## What the tree contains
 
 The tree is the Compose **semantics** tree: the same tree an accessibility service sees, and the one
@@ -86,9 +31,8 @@ Two views of it are available, switchable in the host and per MCP call:
 
 ### Install the host plugin
 
-The Compose Semantics Inspector is in the host's **official catalog**, so no coordinates are needed:
-open **Settings → Plugins → Add Plugins → Official Plugins** and install it with one click. The
-version matching your host is fetched automatically. See
+The Compose Semantics Inspector is in the host's **official catalog**: open **Settings → Plugins →
+Add Plugins → Official Plugins** and install it with one click — no coordinates needed. See
 [Host Settings → Plugins](/guide/host-settings#plugins) for the other install routes.
 
 ### Add the agent to your app
@@ -179,7 +123,8 @@ JetWhale connection. Wire both up in debug builds only, exactly as you would the
 
 ## Using the host UI
 
-Open the **Compose Semantics Inspector** tab for a session and press **Refresh**.
+Open the **Compose Semantics Inspector** in the host, select your app's session, and press
+**Refresh**.
 
 - **Auto** re-captures once a second. It is off by default: a capture reads the app's semantics on
   its main thread, so leaving it on makes the app do that work forever.
@@ -223,7 +168,7 @@ whatever moved into that spot in the meantime — prefer it over `adb shell inpu
 optional: without it the node is looked up in the most recent capture.
 
 It is also the more *reliable* route, not just the tidier one: on the emulator used for the
-benchmark above, `adb shell input swipe` did not scroll a `LazyColumn` at all, while
+[benchmarks](#why-not-the-cli), `adb shell input swipe` did not scroll a `LazyColumn` at all, while
 `ScrollBy` moved it by exactly the requested distance on the first try.
 
 A typical agent loop:
@@ -233,6 +178,61 @@ findNodes(testTag: "login-button")     → { "nodes": [{ "rootId": "compose-root
 performNodeAction(nodeId: 42, action: "Click")
 findNodes()                            → the new screen's interactive nodes
 ```
+
+## Why not the CLI?
+
+`android layout` and `adb shell uiautomator dump` both go out to the accessibility framework across
+a process boundary and write a file on the device before anything can read it. This plugin reads the
+semantics tree **inside** the app, on its main thread, and sends it back over the JetWhale
+connection that is already open — so a capture costs about as much as a frame.
+
+Measured on one machine, on the same screen, back to back — a Pixel-class emulator (1080×2400,
+density 2.625) showing the demo app's *Compose nodes* screen, 38–39 elements:
+
+| | median | 
+|---|---|
+| **`com.kitakkun.jetwhale.semantics.getNodeTree`** (host → app → host) | **14 ms** (min 12, p90 15) |
+| ⤷ of which reading the tree on the device | **1 ms** (max 6) |
+| **`com.kitakkun.jetwhale.semantics.findNodes`** | **11 ms** |
+| `adb shell uiautomator dump` + `adb pull` | 1,960 ms |
+| `android layout` (Google's Android CLI) | 2,703 ms |
+
+That is **~190× faster than `android layout`** on this setup — fast enough that an agent can capture
+between every action instead of budgeting for the dump. Treat the ratio as indicative rather than a
+spec: an emulator is slower than a physical device, and a bigger screen means more nodes.
+
+The host shows both numbers live — what the capture cost on the device, and the round trip from the
+host — so a slow capture says where the time went.
+
+The tree is also richer than what the CLIs return: `android layout` gives a flat list with text,
+`content-desc` and bounds, but no `testTag`, no role and no per-node id, so an agent can only aim by
+label or by pixel. This plugin reports all three, which is what makes
+[`performNodeAction`](#com-kitakkun-jetwhale-semantics-performnodeaction) able to address a node
+directly.
+
+### Are the coordinates right?
+
+`bounds` and `tap` are screen pixels, so they have to survive whatever the device does to the
+window. They were checked two ways at once — cross-checked against `android layout`'s reading of the
+same screen, and proved by tapping the reported point and watching the intended node react — across
+the conditions that move a window around:
+
+| Condition | nodes cross-checked | worst disagreement | tap reached the node |
+|---|---|---|---|
+| gesture nav, portrait, density 420 | 19 | 1 px | ✅ |
+| 3-button navigation bar | 18 | 1 px | ✅ |
+| landscape | 10 | 1 px | ✅ |
+| density 320 | 29 | 1 px | ✅ |
+| 800×1280 @ density 320 | 12 | 1 px | ✅ |
+
+The residual 1 px is rounding: this plugin rounds, `android layout` truncates.
+
+Each condition was also re-run with a dialog open, which is the case that actually exercises the
+arithmetic — a dialog is its own window and does **not** start at the screen origin, so a
+window-relative coordinate reported as if it were absolute would be off by the whole offset. In
+landscape that offset reaches `(717, 298)`; the dialog's nodes still agreed to within 1 px, and
+tapping the reported point closed the dialog. Every root reports its own `windowOffset`, so a
+suspicious coordinate can be traced back to the window it came from.
 
 ## Platform support
 

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -237,7 +237,7 @@ The capture and action layer is written against `SemanticsOwner`, which lives in
 | Target | Probe | What you write |
 |---|---|---|
 | **Android** | ✅ | `installJetWhaleSemanticsProbe(application)`, or `JetWhaleSemanticsProbe()` in a composition |
-| **Desktop (JVM)** | ✅ | `JetWhaleSemanticsProbe()` inside your `Window { }` |
+| **Desktop (JVM)** | ✅ | `JetWhaleSemanticsProbe()` inside your `Window { }`, under `@OptIn(ExperimentalComposeUiApi::class)` |
 | iOS, JS, Wasm | — | the standard entry points expose no owner — see [iOS and web](#ios-and-web) |
 
 Those are the targets the agent artifact ships for — Compose Multiplatform's own set. Linux, mingw
@@ -248,7 +248,10 @@ Android finds roots process-wide through the callback Compose fires when it crea
 a composition. Desktop has no such callback, so its probe is scoped to a window and reads
 `ComposeWindow.semanticsOwners` — which is snapshot-backed, so a dialog or popup rendered inside
 that window appears and disappears on its own. A second `Window { }` is a second composition and
-needs its own call.
+needs its own call. `ComposeWindow.semanticsOwners` is `@ExperimentalComposeUiApi`, so the desktop
+probe carries that marker too — opt in at the call site
+(`@OptIn(ExperimentalComposeUiApi::class)`), or the module will not compile. The Android probe has
+no such requirement.
 
 ### iOS and web
 

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -112,8 +112,14 @@ import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 import com.kitakkun.jetwhale.plugins.semantics.agent.JetWhaleSemanticsAgentPlugin
 
 startJetWhale {
-    connection { endpoints { ws("localhost", 5080) } }
-    plugins { register(JetWhaleSemanticsAgentPlugin()) }
+    connection {
+        endpoints {
+            ws("localhost", 5080)
+        }
+    }
+    plugins {
+        register(JetWhaleSemanticsAgentPlugin())
+    }
 }
 ```
 

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -493,8 +493,9 @@ class MyPlugin : JetWhaleMessagingHostPlugin() {
 ```
 
 The API is suspend/`Flow` based: `put` / `get` / `getFlow` / `contains` / `remove` / `clear`, plus
-`keysFlow` to observe the stored key set. Each has an explicit-`KSerializer` overload alongside the
-reified one, for types whose serializer you resolve yourself.
+`keysFlow` to observe the stored key set. The three that carry a value — `put` / `get` / `getFlow` —
+are the ones with a serializer: each is an explicit-`KSerializer` member with a reified extension
+alongside it, so you can resolve the serializer yourself when the type needs it.
 
 The key `__jetwhale_storage_version` is **reserved** — writing it throws, and it never shows up in
 `keysFlow` or `contains`. `clear()` wipes the store and re-stamps the current `storageVersion`, so a

--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -5,28 +5,6 @@ A JetWhale host plugin is a fat-jar that the JetWhale host loads at runtime. You
 Gradle plugin to package it and to run a real host with your plugin loaded — with **hot reload**, so
 you can edit your plugin and see it update without restarting the host.
 
-The `com.kitakkun.jetwhale.host` plugin gives your plugin's module these tasks:
-
-| Task                     | What it does                                                                                          |
-|--------------------------|------------------------------------------------------------------------------------------------------|
-| `packagePlugin`          | Builds the distributable plugin fat-jar (the artifact you drop into `~/.jetwhale/plugins/`). Hooked to `assemble`, so a plain `./gradlew build` already produces it. |
-| `installPlugin`          | Copies the packaged fat-jar into `~/.jetwhale/plugins/` — your real installation, not the [sandbox](#isolated-sandbox-environment). |
-| `stageDevPlugin`         | Stages the packaged fat-jar into a private dev directory the host watches for hot reload.             |
-| `packageMavenPlugin`     | Builds the publishable plugin jar (see [Publishing your plugin to Maven](#publishing-your-plugin-to-maven)). |
-| `generatePluginDependencyManifest` | Writes the runtime dependency list `packageMavenPlugin` embeds. Runs as part of it. |
-| `downloadJetWhaleHost`   | Downloads the released host uber jar for `hostVersion`. Runs as part of `runJetWhale`.                |
-| `runJetWhale`            | Downloads a released JetWhale host for your OS and launches it with your plugin loaded.|
-| `runJetWhaleHot`         | Like `runJetWhale`, but runs the host on the JetBrains Runtime so structural changes hot-reload in place (see [Limitations](#limitations)), and auto re-stages your plugin in the background — the whole hot-reload loop in one command. |
-| `runJetWhaleQaAgent`     | Runs a headless debuggee your plugin can render against, driven over HTTP — see [QA Agent](/guide/qa-agent). |
-
-Pass `--args="--headless"` to `runJetWhale` to launch the host without its window, which is how a
-plugin is exercised on a machine with no display — see
-[Headless mode](/guide/host-settings#headless-mode).
-
-`runJetWhale` and `runJetWhaleHot` launch the host on a **Java 21** toolchain (`runJetWhaleHot`
-additionally requires the JetBrains vendor), independently of the toolchain your plugin module
-itself compiles with.
-
 ## Set up
 
 ### 1. Repositories
@@ -219,11 +197,12 @@ class MyHostPlugin : JetWhaleMessagingHostPlugin(), JetWhaleHostPluginUi {
 Requests work in **both directions** — the agent can `request` the host just as the host can `request`
 the agent. A failed/timed-out request throws `JetWhaleRequestException` (and `sendOrFail`/`request`
 throw `JetWhaleConnectionClosedException` while disconnected — both are `JetWhaleMessagingException`);
-pass `timeout` to `request`
-to override the default per call (e.g. `request(SlowOp, timeout = 30.seconds)`). Implement `JetWhaleHostPluginUi`
-(`@Composable Content()`) to render a UI; plugins that don't are **headless** (e.g. MCP-only). Opening a
-headless plugin in the host shows a "this plugin has no screen" notice instead of an empty view, and
-the host does not offer to pop it out into a window.
+pass `timeout` to `request` to override the default per call (e.g.
+`request(SlowOp, timeout = 30.seconds)`).
+
+Implement `JetWhaleHostPluginUi` (`@Composable Content()`) to render a UI; plugins that don't are
+**headless** (e.g. MCP-only). Opening a headless plugin in the host shows a "this plugin has no
+screen" notice instead of an empty view, and the host does not offer to pop it out into a window.
 
 ::: tip `onDispose()` is public
 `onCreate()` is `protected`, but `onDispose()` is `public open` — override it without a `protected`
@@ -232,13 +211,11 @@ modifier or it will not compile.
 
 **The host plugin's `messenger` is a plain, always-connected property.** A host plugin instance
 lives exactly as long as its session's connection, so `messenger` is valid from `onCreate()` through
-`onDispose()` and may be used anywhere — UI callbacks, MCP tool handlers, background jobs. Because
-the instance only exists while its session is connected, the host messenger is **always connected**
-for the instance's lifetime and exposes only `trySend` and `request` — there is no offline-buffering
-vocabulary (`sendOrQueue` / `sendOrFail` / send policy), since a host plugin has nothing to buffer
-across. Launch background work on `pluginScope` (also a property): the runtime cancels it when the
-instance is disposed, so nothing can outlive the plugin. State that must survive across sessions does
-**not** belong in the instance.
+`onDispose()` and may be used anywhere — UI callbacks, MCP tool handlers, background jobs. It exposes
+only `trySend` and `request`: there is no offline-buffering vocabulary (`sendOrQueue` / `sendOrFail` /
+send policy), since a host plugin has nothing to buffer across. Launch background work on
+`pluginScope` (also a property): the runtime cancels it when the instance is disposed, so nothing can
+outlive the plugin. State that must survive across sessions does **not** belong in the instance.
 
 **On the agent** the `messenger` property is **connection-independent** (it outlives any single
 connection), so app code may send at any time and choose the offline behavior per call: `trySend`
@@ -404,7 +381,7 @@ alone. Open polymorphic types have no statically known subclasses and fall back 
 ahead of time, `jsonObject` and `jsonArray` hand back the raw `JsonElement` — but they can only
 advertise `object` / `array`, so reach for `serializable` whenever the shape is known.
 
-### Choosing the format
+### Argument decoding
 
 Arguments are decoded with `DefaultArgumentJson`, tuned for input written by an AI agent: unknown
 keys are ignored, a scalar of the wrong JSON type is accepted where the value is unambiguous, enum
@@ -439,12 +416,6 @@ raised. Masking only in the drawing layer is not enough: the semantics tree woul
 the original string. The interactive window never observes the raised state, so there is no
 on-screen flicker.
 
-The `LocalJetWhaleDarkTheme` CompositionLocal tells your plugin whether the host is rendering it in
-a dark theme — the host provides the authoritative value from its actually-applied color scheme.
-Read it (`LocalJetWhaleDarkTheme.current`) to pick theme-appropriate colors instead of
-`isSystemInDarkTheme()`, which reflects the OS setting and can disagree with the host's own Theme
-option.
-
 ### Theming: you already match the host
 
 The host wraps your `Content()` in **its own** `MaterialTheme` before calling it, so plain
@@ -452,6 +423,12 @@ The host wraps your `Content()` in **its own** `MaterialTheme` before calling it
 host's applied scheme. Do not install a theme of your own unless you deliberately want to look
 different — that is why `material3` is a `compileOnly` dependency and why plugins get visual
 consistency for free.
+
+The `LocalJetWhaleDarkTheme` CompositionLocal tells your plugin whether the host is rendering it in
+a dark theme — the host provides the authoritative value from its actually-applied color scheme.
+Read it (`LocalJetWhaleDarkTheme.current`) to pick theme-appropriate colors instead of
+`isSystemInDarkTheme()`, which reflects the OS setting and can disagree with the host's own Theme
+option.
 
 The SDK ships **no component library** — no shared Composables, icons, scaffolds or spacing tokens.
 Build your UI from Compose and Material 3 directly. Your composition is kept for the lifetime of the
@@ -549,9 +526,33 @@ Rules of thumb:
 
 - Stores written before versioning existed are treated as version `1`.
 - A store written by a **newer** plugin version than the running one is left untouched; values that
-  no longer decode simply read as `null`.
+  no longer decode read as `null`.
 - A value that fails to decode (for example after a schema change without a migration) is treated as
   absent rather than crashing your plugin — but prefer writing a migration so the data is not lost.
+
+## Gradle tasks
+
+The `com.kitakkun.jetwhale.host` plugin gives your plugin's module these tasks:
+
+| Task                     | What it does                                                                                          |
+|--------------------------|------------------------------------------------------------------------------------------------------|
+| `packagePlugin`          | Builds the distributable plugin fat-jar (the artifact you drop into `~/.jetwhale/plugins/`). Hooked to `assemble`, so a plain `./gradlew build` already produces it. |
+| `installPlugin`          | Copies the packaged fat-jar into `~/.jetwhale/plugins/` — your real installation, not the [sandbox](#isolated-sandbox-environment). |
+| `stageDevPlugin`         | Stages the packaged fat-jar into a private dev directory the host watches for hot reload.             |
+| `packageMavenPlugin`     | Builds the publishable plugin jar (see [Publishing your plugin to Maven](#publishing-your-plugin-to-maven)). |
+| `generatePluginDependencyManifest` | Writes the runtime dependency list `packageMavenPlugin` embeds. Runs as part of it. |
+| `downloadJetWhaleHost`   | Downloads the released host uber jar for `hostVersion`. Runs as part of `runJetWhale`.                |
+| `runJetWhale`            | Downloads a released JetWhale host for your OS and launches it with your plugin loaded.|
+| `runJetWhaleHot`         | Like `runJetWhale`, but runs the host on the JetBrains Runtime so structural changes hot-reload in place (see [Limitations](#limitations)), and auto re-stages your plugin in the background — the whole hot-reload loop in one command. |
+| `runJetWhaleQaAgent`     | Runs a headless debuggee your plugin can render against, driven over HTTP — see [QA Agent](/guide/qa-agent). |
+
+Pass `--args="--headless"` to `runJetWhale` to launch the host without its window, which is how a
+plugin is exercised on a machine with no display — see
+[Headless mode](/guide/host-settings#headless-mode).
+
+`runJetWhale` and `runJetWhaleHot` launch the host on a **Java 21** toolchain (`runJetWhaleHot`
+additionally requires the JetBrains vendor), independently of the toolchain your plugin module
+itself compiles with.
 
 ## Hot reload (the live dev loop)
 
@@ -561,29 +562,6 @@ it: whenever the plugin jar is re-staged, the host reloads it and refreshes the 
 **no host restart needed**. For simple edits it redefines your classes in place and keeps the plugin's
 state; for changes it can't apply that way it recreates the plugin from a fresh classloader (see
 [Limitations](#limitations) below).
-
-### Isolated sandbox environment
-
-`runJetWhale`, `runJetWhaleHot` and the in-repo `runJetWhaleLocal` run the host against an
-**isolated, per-project sandbox** at
-`build/jetwhale-sandbox/` instead of your real `~/.jetwhale/`. Everything the host persists — installed
-plugins (`plugins/`, with Maven-installed dependencies under `plugins/libs/`), settings, per-plugin
-data (`plugin-data/`), TLS material (`ssl/`) and the plugin trust registry
-(`trusted-plugins.json`) — lives there, so trying a plugin never reads or mutates your actual JetWhale
-installation. The sandbox starts empty: only your dev plugin is loaded (dev-directory plugins are
-trusted implicitly, so there is no trust prompt to click through), and there are no leftover plugins
-or settings from previous work.
-
-Two system properties do this, both set for you by the launch tasks: `jetwhale.appDataDir` redirects
-the app data root, and `jetwhale.devPluginsDir` names the watched staging directory. Note that
-`installPlugin` is **not** affected — it deliberately targets your real `~/.jetwhale/plugins/`.
-
-The sandbox lives under `build/`, so it **persists across re-launches** of the same project — test data
-you set up survives the next `runJetWhale`. Running `./gradlew :myPlugin:clean` wipes it for a
-completely fresh environment.
-
-Non-dev launches (the installed JetWhale app) are unaffected: without the override they use
-`~/.jetwhale/` exactly as before.
 
 The simplest loop is a single command — `runJetWhaleHot` launches the host **and** keeps re-staging
 your plugin for you:
@@ -625,6 +603,29 @@ fetched once; a `-SNAPSHOT` `hostVersion` is re-checked against the release asse
 launch, so you pick up a newer snapshot without clearing anything by hand. The supported matrix is
 macOS / Linux / Windows on `arm64` or `x64`; anything else fails with an explicit
 *Unsupported OS/architecture* message.
+
+### Isolated sandbox environment
+
+`runJetWhale`, `runJetWhaleHot` and the in-repo `runJetWhaleLocal` run the host against an
+**isolated, per-project sandbox** at
+`build/jetwhale-sandbox/` instead of your real `~/.jetwhale/`. Everything the host persists — installed
+plugins (`plugins/`, with Maven-installed dependencies under `plugins/libs/`), settings, per-plugin
+data (`plugin-data/`), TLS material (`ssl/`) and the plugin trust registry
+(`trusted-plugins.json`) — lives there, so trying a plugin never reads or mutates your actual JetWhale
+installation. The sandbox starts empty: only your dev plugin is loaded (dev-directory plugins are
+trusted implicitly, so there is no trust prompt to click through), and there are no leftover plugins
+or settings from previous work.
+
+Two system properties do this, both set for you by the launch tasks: `jetwhale.appDataDir` redirects
+the app data root, and `jetwhale.devPluginsDir` names the watched staging directory. Note that
+`installPlugin` is **not** affected — it deliberately targets your real `~/.jetwhale/plugins/`.
+
+The sandbox lives under `build/`, so it **persists across re-launches** of the same project — test data
+you set up survives the next `runJetWhale`. Running `./gradlew :myPlugin:clean` wipes it for a
+completely fresh environment.
+
+Non-dev launches (the installed JetWhale app) are unaffected: without the override they use
+`~/.jetwhale/` exactly as before.
 
 ### Testing against a real session
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -143,11 +143,18 @@ process lifetime and never stop it.
 
 ### Reconnecting
 
-The agent retries **forever**. After a failed connection or negotiation it drops the plugins'
-peers, waits, and tries again with a linear backoff that grows by one second per attempt and is
-capped at five (1s, 2s, 3s, 4s, 5s, 5s, …); the counter resets on the first success. None of this is
-configurable, and there is no connection-state API to poll — start the host before the app, or just
-leave the app running until the host comes up.
+The agent retries **forever**. The unit it retries is a whole **round** — every candidate in
+`endpoints { }`, in order — so a candidate that refuses costs nothing but a move to the next one, and
+a candidate that swallows packets rather than refusing is abandoned after 30 seconds. A round that
+served a session costs no delay however many candidates refused first; only a round where nothing
+accepted waits, with a linear backoff that grows by one second per round and is capped at five (1s,
+2s, 3s, 4s, 5s, 5s, …). Either way the plugins' peers are dropped and the next round starts from the
+top of the list.
+
+The counter resets on a connection that **held** — a session that ends within two seconds of opening
+counts as a failure, so a host that accepts the upgrade and immediately drops it cannot make the
+agent spin. None of this is configurable, and there is no connection-state API to poll — start the
+host before the app, or just leave the app running until the host comes up.
 
 A disconnect is **not** a deactivation: registered plugins stay activated across it, so an agent
 plugin that buffers events keeps buffering for the next connection.
@@ -212,7 +219,7 @@ startJetWhale {
             // In the clear, because it never leaves the machine.
             ws("localhost", 5080)
 
-            // A physical device reaches neither, so it falls through to here and connects over wss.
+            // A physical device reaches none of those, so it falls through to here and connects over wss.
             discoverWss { allowHostName("my-macbook") }
         }
 
@@ -338,15 +345,14 @@ discovery enabled: start the app first and the host later, and the next browse p
 applies when a host restarts on a different port. A failed round is reported once and not repeated
 while the outcome stays the same, so an unreachable host does not flood the log.
 
-On a platform without mDNS support (**JS/Wasm, Linux, Windows**) there is nothing to browse, and the
-agent goes straight to whatever was declared next.
+The backend doing the browsing differs by target:
 
 | Platform | Discovery backend |
 |----------|-------------------|
 | **JVM (Desktop)** | jmDNS |
 | **Android** | `NsdManager` (`android.net.nsd`) |
-| **iOS / macOS** | `NSNetServiceBrowser` (Network.framework / Bonjour) |
-| **JS / Wasm / Linux / Windows** | Not supported — falls back to the configured host |
+| **iOS / macOS** | `NSNetServiceBrowser` (Foundation / Bonjour) |
+| **JS / Wasm / Linux / Windows** | Not supported — contributes nothing, and the next candidate is reached immediately |
 
 On **iOS**, browsing for the service also requires listing it under `NSBonjourServices` in
 `Info.plist` (see [iOS Local Network permission](#ios-local-network-permission)).
@@ -384,8 +390,16 @@ refuse a plain connection anyway.
 ::: warning `@ExperimentalJetWhaleApi`
 Unlike the rest of `endpoints { }`, this one's behaviour comes from a Kotlin compiler plugin, and the
 compiler plugin API is `@ExperimentalCompilerApi` — JetBrains breaks it across minor versions by
-design. Supported Kotlin versions are those in the project's CI matrix (currently **2.3.0 – 2.4.x**).
-On a Kotlin the plugin has not caught up with, calls are simply left unrewritten.
+design. CI proves the shipped plugin against **Kotlin 2.3.0 – 2.4.x**, and the Gradle plugin checks
+your Kotlin version up front rather than letting a mismatch surface as a linkage error inside a
+compilation:
+
+- **Below 2.3** — the build **fails** with an explanation. `CompilerPluginRegistrar.pluginId` is
+  abstract from 2.3 and absent before it, so the plugin provably cannot load; write the address out
+  with `wss()` instead.
+- **Above the highest tested minor** — a warning, and the build carries on. It may well work; nobody
+  has shown that it does. If the compilation fails to load the plugin, drop the plugin and use
+  `wss()` until JetWhale catches up.
 :::
 
 ### Without the Gradle plugin
@@ -430,13 +444,15 @@ The address is a **compile task input**, deliberately. Two consequences:
 
 ## Secure connections (wss)
 
-By default the agent connects over plain **ws** (port **5080**). The host can additionally serve
-**secure WebSocket (wss)** on port **5443**, backed by a locally-issued CA — see
-[Host Settings → SSL certificates](/guide/host-settings#ssl-certificates) for generating and
-activating a certificate.
+The host serves plain **ws** on port **5080** and, unless you turn it off, **secure WebSocket (wss)**
+on port **5443** as well, backed by a locally-issued CA. The CA is generated the first time the TLS
+connector starts, so there is nothing to set up — see
+[Host Settings → SSL certificates](/guide/host-settings#ssl-certificates) only when you want to
+export, replace or activate a different one.
 
-To make the agent connect over wss, add an `ssl { }` block to `connection { }`. As soon as at least
-one trusted certificate is configured, the connection switches from ws to wss:
+Whether TLS is spoken at all is the **candidate's** business: write `wss(host, port)` instead of
+`ws(host, port)`. `ssl { }` only says what to trust once it is — it neither switches a `ws` candidate
+over nor is required by a `wss` one (without it, the platform's own trust store applies):
 
 ```kotlin
 startJetWhale {
@@ -470,7 +486,9 @@ startJetWhale {
   verification in step 2 is security-equivalent to the plain fetch in step 1 (the fetched CA still
   pins the subsequent wss session). Over ADB port forwarding (the usual case) the download never
   leaves the machine, so it is as trustworthy as the ADB link. If the CA cannot be fetched over
-  either channel, the connection falls back to plain ws.
+  either channel, the candidate is still dialled over wss — against the platform's trust store, which
+  a locally-issued CA is not in, so it fails visibly on trust rather than quietly sending in the clear
+  at a TLS port.
 - **`trustCertificate(pem)`** — pins a CA PEM you exported yourself from the host's
   [SSL Certificate](/guide/host-settings#ssl-certificates) settings (**Show Details → Copy to
   Clipboard**). Prefer this on an untrusted LAN, where strict pinning
@@ -532,7 +550,7 @@ version as the host release they belong to.
 | `jetwhale-agent-runtime` | The app being debugged. Brings `jetwhale-agent-sdk` and `jetwhale-protocol-core` with it, so you rarely need to name those. |
 | `jetwhale-agent-sdk` | Only when a module writes agent plugins without depending on the runtime. |
 | `jetwhale-protocol-core` | The shared module of a plugin pair, for `JetWhaleEvent` / `JetWhaleRequest`. |
-| `jetwhale-annotations` | `@McpDescription`. Reaches both SDKs transitively; rarely named directly. |
+| `jetwhale-annotations` | `@McpDescription` and the opt-in markers `@ExperimentalJetWhaleApi` / `@InternalJetWhaleApi`. Reaches both SDKs transitively, so it rarely needs declaring. |
 | `jetwhale-host-sdk` | A host plugin module, as `compileOnly` — see [Developing Plugins](/guide/developing-plugins). |
 | `jetwhale-host-gradle-plugin` | Applied as the `com.kitakkun.jetwhale.host` Gradle plugin id. |
 | `jetwhale-agent-gradle-plugin` | Applied as the `com.kitakkun.jetwhale.agent` Gradle plugin id — see [Baking in the build machine's address](#baking-in-the-build-machine-s-address-no-browse). |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -68,7 +68,10 @@ import com.kitakkun.jetwhale.agent.runtime.startJetWhale
 fun initializeJetWhale() {
     startJetWhale {
         connection {
-            endpoints { ws("localhost", 5080) } // the host's plain WebSocket server port
+            endpoints {
+                // the host's plain WebSocket server port
+                ws("localhost", 5080)
+            }
         }
         plugins {
             // register agent plugins here, e.g. the Network Inspector:
@@ -457,7 +460,10 @@ over nor is required by a `wss` one (without it, the platform's own trust store 
 ```kotlin
 startJetWhale {
     connection {
-        endpoints { wss("localhost", 5443) } // the host's wss port
+        endpoints {
+            // the host's wss port
+            wss("localhost", 5443)
+        }
 
         ssl {
             // Option A: fetch and pin the host's active CA automatically (trust-on-first-use).

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -88,9 +88,10 @@ reports in [Settings → Connection → Debug Server](/guide/host-settings#debug
 :::
 
 ::: info `host` / `port` are deprecated
-Earlier releases configured the address with separate `host` and `port` properties. They still work
-and amount to a single candidate taking its scheme from `ssl { }`, but new code should declare
-`endpoints { }` — it is what
+Earlier releases configured the address with separate `host` and `port` properties. They still work,
+as a single candidate — and they are the one case where `ssl { }` does decide the scheme, because
+unlike `ws(...)` and `wss(...)` they carry none of their own. New code should declare
+`endpoints { }`; it is what
 [host discovery](#zero-config-host-discovery-recommended-for-physical-devices) extends.
 :::
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -146,13 +146,14 @@ process lifetime and never stop it.
 
 ### Reconnecting
 
-The agent retries **forever**. The unit it retries is a whole **round** — every candidate in
-`endpoints { }`, in order — so a candidate that refuses costs nothing but a move to the next one, and
-a candidate that swallows packets rather than refusing is abandoned after 30 seconds. A round that
-served a session costs no delay however many candidates refused first; only a round where nothing
-accepted waits, with a linear backoff that grows by one second per round and is capped at five (1s,
-2s, 3s, 4s, 5s, 5s, …). Either way the plugins' peers are dropped and the next round starts from the
-top of the list.
+The agent retries **forever**. The unit it retries is a whole **round**: every candidate in
+`endpoints { }`, in order. A candidate that refuses costs nothing but a move to the next one; a
+candidate that swallows packets rather than refusing is abandoned after 30 seconds.
+
+Only a round where *nothing* accepted waits before the next one, with a linear backoff that grows by
+one second per round and is capped at five (1s, 2s, 3s, 4s, 5s, 5s, …). A round that served a session
+costs no delay, however many candidates refused first. Either way the plugins' peers are dropped and
+the next round starts from the top of the list.
 
 The counter resets on a connection that **held** — a session that ends within two seconds of opening
 counts as a failure, so a host that accepts the upgrade and immediately drops it cannot make the
@@ -165,9 +166,8 @@ plugin that buffers events keeps buffering for the next connection.
 ### Session metadata
 
 The agent reports app/device metadata to the host during connection, and the host uses it to label
-and group sessions (for example, all sessions from the same physical device). Everything is
-resolved automatically on a best-effort basis — the app name on Android/iOS/macOS, a stable device
-identifier and the device name per platform — so usually you configure nothing.
+and group sessions (for example, all sessions from the same physical device). Most of it is resolved
+automatically, on a best-effort basis, so usually you configure nothing.
 
 To override any of it (or supply values on platforms where auto-resolution is unavailable), add an
 `app { }` block; explicit values always win over the auto-resolved defaults:
@@ -204,14 +204,27 @@ desktop and web in particular, setting `appName` is what makes a session readabl
 An `appIconPng` whose base64 form exceeds the 32KB cap is dropped with a warning — which is visible,
 since `WARN` is the default log level.
 
+## 4. Connect a device
+
+- **Desktop / iOS Simulator / Web** debuggees reach the host directly on `localhost` — no extra
+  setup.
+- **Android** devices and emulators need `adb reverse` port forwarding.
+  [ADB auto port mapping](/guide/adb-auto-port-mapping) is on by default, so JetWhale wires it up
+  automatically; turn it off in the host settings to run `adb reverse tcp:5080 tcp:5080` yourself.
+- **Physical devices over Wi-Fi** can use neither route, and need the host's LAN address over wss —
+  see [host discovery](#zero-config-host-discovery-recommended-for-physical-devices) below.
+
+Launch your app — it appears as a new session in the host. JetWhale supports multiple simultaneous
+sessions, so you can debug several apps or devices at once.
+
 ## Zero-config host discovery (recommended for physical devices)
 
 A physical iPhone or Android device on the same Wi-Fi cannot reach the host over `localhost`. Rather
 than hardcoding the host machine's LAN IP (which changes between machines and networks), declare a
 `discoverWss` candidate and let the agent find the host over mDNS/Bonjour.
 
-Candidates are tried **in the order they are declared**, and each names its own scheme — which is
-what lets one configuration serve targets that disagree about which one is possible:
+Candidates are tried **in the order they are declared**, and each names its own scheme — so a single
+configuration can serve targets that cannot use the same one:
 
 ```kotlin
 startJetWhale {
@@ -294,8 +307,7 @@ endpoint is a different origin with no CORS headers, so the certificate cannot e
 
 ### Narrowing discovery
 
-`discoverWss { }` has to say which hosts it will accept — an empty block accepts none, and logs why.
-Every host that passes is a candidate, tried in turn until one accepts:
+`discoverWss { }` accepts hosts by advertised name, by resolved address, or by both:
 
 ```kotlin
 connection {
@@ -364,7 +376,8 @@ On **iOS**, browsing for the service also requires listing it under `NSBonjourSe
 
 Discovery exists because a physical device cannot reach the host over loopback. But when the host
 runs on the same machine as the compiler — the usual arrangement — that address is already known at
-build time, and a browse is a slow way to rediscover it. `buildMachineWss(port)` bakes it in:
+build time, and a browse is a slow way to rediscover it. `buildMachineWss(port)` bakes it in. Apply
+the agent Gradle plugin:
 
 ```kotlin
 // the app being debugged — build.gradle.kts
@@ -372,6 +385,8 @@ plugins {
     id("com.kitakkun.jetwhale.agent") version "<version>"
 }
 ```
+
+…then declare the candidate:
 
 ```kotlin
 endpoints {
@@ -453,9 +468,8 @@ connector starts, so there is nothing to set up — see
 [Host Settings → SSL certificates](/guide/host-settings#ssl-certificates) only when you want to
 export, replace or activate a different one.
 
-Whether TLS is spoken at all is the **candidate's** business: write `wss(host, port)` instead of
-`ws(host, port)`. `ssl { }` only says what to trust once it is — it neither switches a `ws` candidate
-over nor is required by a `wss` one (without it, the platform's own trust store applies):
+As above, whether TLS is spoken is the **candidate's** business — write `wss(host, port)` instead of
+`ws(host, port)` — and `ssl { }` only says what to trust once it is:
 
 ```kotlin
 startJetWhale {
@@ -534,17 +548,6 @@ required whenever you use [`discoverWss`](#zero-config-host-discovery-recommende
 iOS silently blocks browsing for a service type that is not declared. If you dial the host by an
 explicit address instead of discovering it, `NSBonjourServices` can be omitted. Because the CA fetch
 falls back to `https` over the wss port, no App Transport Security exception for plain HTTP is needed.
-
-## 4. Connect a device
-
-- **Desktop / iOS Simulator / Web** debuggees reach the host directly on `localhost` — no extra
-  setup.
-- **Android** devices and emulators need `adb reverse` port forwarding.
-  [ADB auto port mapping](/guide/adb-auto-port-mapping) is on by default, so JetWhale wires it up
-  automatically; turn it off in the host settings to run `adb reverse tcp:5080 tcp:5080` yourself.
-
-Launch your app — it appears as a new session in the host. JetWhale supports multiple simultaneous
-sessions, so you can debug several apps or devices at once.
 
 ## Published artifacts
 

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -65,9 +65,10 @@ only reads them when it binds, so one restart covers the whole change.
 The status line above them shows the running ports, e.g. *Running on port 5080 (WSS: 5443)* when wss
 is active, and offers **Retry** if the server failed to bind.
 
-The two ports cannot be the same, and each has to be in `1..65535`; **Apply** stays disabled until
-they are. The wss port is stored even while **Enable WSS** is off, so switching wss back on brings
-back the port you last picked.
+Each port has to be in `1..65535` — the wss one too, even while **Enable WSS** is off — and while
+wss is enabled the two cannot be the same; **Apply** stays disabled until they are. The wss port is
+stored even while **Enable WSS** is off, so switching wss back on brings back the port you last
+picked.
 
 ::: tip Also settable outside the UI
 The same settings are available at launch with [`--wss-port`](#overriding-the-ports-at-startup), and
@@ -123,7 +124,7 @@ the host found the tool it needs for it:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| **Automatically wire ADB port to host PC port** | on | Runs `adb reverse` for Android devices as they connect. Inactive on machines without `adb`. See [ADB Auto Port Mapping](/guide/adb-auto-port-mapping). |
+| **Automatically wire ADB port to host PC port** | on | Runs `adb reverse` for Android devices as they connect. Inactive on machines without `adb`. Read only when the debug server starts, so a change lands on the next server restart. See [ADB Auto Port Mapping](/guide/adb-auto-port-mapping). |
 
 Under **Health Check**, **ADB Executable Path** shows where JetWhale found `adb` (see
 [How adb is found](/guide/adb-auto-port-mapping#how-adb-is-found)), or *ADB command not found*.
@@ -327,8 +328,9 @@ Three differences are worth knowing before you script against it:
   them over from a windowed session.
 - **A fresh app-data directory enables no plugins.** Enable them with `jetwhale.setPluginEnabled`
   over MCP, or point `-Djetwhale.appDataDir` at a directory where they already are. Approving a new
-  plugin jar's signature is still a settings-UI action, so headless runs load already-trusted jars
-  and the dev-plugins directory.
+  plugin jar is still a settings-UI action (the **Approve** button under
+  [Security](#plugin-trust)), so headless runs load already-trusted jars and the dev-plugins
+  directory.
 
 Headless is a little lighter than a windowed run — it starts a few hundred milliseconds sooner and
 uses roughly 15% less memory — but that is not the reason to use it. Use it because a windowed host

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -324,7 +324,7 @@ Three differences are worth knowing before you script against it:
   directly are unaffected.
 - **Coordinates differ from a windowed run.** With no window reporting a density, scenes render at
   density 1.0, so the same element sits at different coordinates than it would on a HiDPI display.
-  Always read coordinates from `jetwhale.accessibilityTree` in the same run rather than carrying
+  Always read coordinates from `jetwhale.getAccessibilityTree` in the same run rather than carrying
   them over from a windowed session.
 - **A fresh app-data directory enables no plugins.** Enable them with `jetwhale.setPluginEnabled`
   over MCP, or point `-Djetwhale.appDataDir` at a directory where they already are. Approving a new

--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -66,7 +66,7 @@ The status line above them shows the running ports, e.g. *Running on port 5080 (
 is active, and offers **Retry** if the server failed to bind.
 
 Each port has to be in `1..65535` — the wss one too, even while **Enable WSS** is off — and while
-wss is enabled the two cannot be the same; **Apply** stays disabled until they are. The wss port is
+wss is enabled the two cannot be the same. **Apply** stays disabled until both hold. The wss port is
 stored even while **Enable WSS** is off, so switching wss back on brings back the port you last
 picked.
 
@@ -119,8 +119,8 @@ unaffected.
 
 ### ADB support
 
-The **Settings → Connection → ADB Support** page carries the Android port forwarding, plus where
-the host found the tool it needs for it:
+The **Settings → Connection → ADB Support** page holds the Android port-forwarding toggle, plus
+where the host found the `adb` it needs for it:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -170,8 +170,8 @@ offers **Stop following**, which turns the setting off without a trip back to th
 
 ## Plugins
 
-The **Installed Plugins** page lists what is loaded; **Add Plugins** is where new ones come from and
-**Security** holds the trust settings below.
+The **Installed Plugins** page lists what is loaded, **Add Plugins** is where new ones come from,
+and **Security** holds the [plugin trust](#plugin-trust) settings.
 
 Installed plugins live in `~/.jetwhale/plugins/`. There are three ways to install one:
 
@@ -290,8 +290,8 @@ When you launch the host from a plugin project with
 
 | Option | Default | What it does |
 |--------|---------|--------------|
-| `--plugin-dir <path>` | — | Also load the jars in this directory, on top of `~/.jetwhale/plugins/`. **Repeatable.** These are not trust-gated — naming the directory on the command line *is* the approval — and they are not managed: they do not appear as installed plugins and cannot be uninstalled or revoked from the UI. |
-| `--log-level <level>` | the host's configured level | Minimum level the host's own logging emits: `DEBUG`, `INFO`, `WARN` or `ERROR`. Lower it when diagnosing a plugin that will not load, then read the result in the [log viewer](/guide/host-window#the-log-viewer). Left unset, whatever the host ships configured is used — this option only ever overrides. |
+| `--plugin-dir <path>` | — | Also load the jars in this directory, on top of `~/.jetwhale/plugins/`. **Repeatable.** Not trust-gated — naming the directory on the command line *is* the approval — and not managed: these jars do not appear as installed plugins and cannot be uninstalled or revoked from the UI. |
+| `--log-level <level>` | the host's configured level | Minimum level the host's own logging emits: `DEBUG`, `INFO`, `WARN` or `ERROR`. Lower it when diagnosing a plugin that will not load, then read the result in the [log viewer](/guide/host-window#the-log-viewer). |
 | `--mcp-allow-all-permissions` | off | Allows every MCP tool for that process only — see [MCP Server → Lifting every permission for one launch](/guide/mcp-server#lifting-every-permission-for-one-launch). |
 | `--headless` | off | Runs without the application window — see [Headless mode](#headless-mode) below. |
 

--- a/docs/guide/host-window.md
+++ b/docs/guide/host-window.md
@@ -7,20 +7,6 @@ Everything below is the host itself — the plugins it shows are documented on t
 ([Network Inspector](/guide/network-inspector), [Nav3 Navigator](/guide/nav3-navigator),
 [Compose Semantics Inspector](/guide/compose-semantics-inspector)).
 
-## The drawer
-
-The drawer can be **collapsed** to a narrow icon rail with the **✕** button at its top left, and
-expanded again with the unfold button on the rail. Collapsed, it keeps the same entries as icons —
-the device picker, the plugin list, the MCP tools button, Settings, and Info — but shortened: the
-rail lists only the **enabled** plugins, with no grouping and no overflow menu, and its device
-picker is a single flat list of *device · app* rather than the two dropdowns below. **Info** is only
-on the rail; the expanded drawer has no entry for it.
-
-::: tip Window size and position
-The host remembers its window size and position across launches (while the window is in its normal
-floating state; maximized/fullscreen is not persisted). There is nothing to configure.
-:::
-
 ## Choosing a session
 
 Sessions are picked with **two dropdowns**, because one host commonly holds several apps from the
@@ -90,6 +76,15 @@ is in flight.
 When a newer release is available, a banner appears above the content with a **View in Settings**
 shortcut. Updates are never applied automatically — see
 [Host Settings → Application](/guide/host-settings#application).
+
+## Collapsing the drawer
+
+The **✕** button at the drawer's top left collapses it to a narrow icon rail; the unfold button on
+the rail expands it again. Collapsed, it keeps the same entries as icons — the device picker, the
+plugin list, the MCP tools button, Settings, and Info — but shortened: the rail lists only the
+**enabled** plugins, with no grouping and no overflow menu, and its device picker is a single flat
+list of *device · app* rather than two dropdowns. **Info** is only on the rail; the expanded drawer
+has no entry for it.
 
 ## The log viewer
 

--- a/docs/guide/host-window.md
+++ b/docs/guide/host-window.md
@@ -11,7 +11,10 @@ Everything below is the host itself — the plugins it shows are documented on t
 
 The drawer can be **collapsed** to a narrow icon rail with the **✕** button at its top left, and
 expanded again with the unfold button on the rail. Collapsed, it keeps the same entries as icons —
-the device picker, the plugin list, the MCP tools button, Settings, and Info.
+the device picker, the plugin list, the MCP tools button, Settings, and Info — but shortened: the
+rail lists only the **enabled** plugins, with no grouping and no overflow menu, and its device
+picker is a single flat list of *device · app* rather than the two dropdowns below. **Info** is only
+on the rail; the expanded drawer has no entry for it.
 
 ::: tip Window size and position
 The host remembers its window size and position across launches (while the window is in its normal
@@ -33,8 +36,8 @@ Each entry carries a small lock icon for how its transport is secured — see
 [Session security indicator](/guide/what-is-jetwhale#session-security-indicator). When nothing is
 connected the device row reads *No session available*.
 
-When a session goes away the host says so (*&lt;app&gt; disconnected*, or *N sessions disconnected*
-when several drop at once, e.g. after a debug-server restart).
+When a session goes away the host says so (*&lt;device&gt; · &lt;app&gt; disconnected*, or
+*N sessions disconnected* when several drop at once, e.g. after a debug-server restart).
 
 ## The plugin list
 
@@ -45,16 +48,19 @@ grouping is computed against the **selected session**, so it changes as you swit
 |---------|------------------|
 | **Enabled Plugins** | Enabled in settings **and** available for this session. |
 | **Disabled Plugins** | Available for this session, but switched off. |
-| **Unavailable Plugins** | No session is selected, or the session's agent never advertised this plugin id. Host-only plugins (`"requiresAgent": false`) are available for every active session and never land here. |
+| **Unavailable Plugins** | No session is selected, or the session's agent never advertised this plugin id. Host-only plugins (`"requiresAgent": false`) are available for every active session, so once a session is selected they never land here. |
 
-Click a plugin to open it. Each row also has an overflow (**⋮**) menu:
+Click a plugin to open it. Enabled and disabled rows also carry an overflow (**⋮**) menu — an
+unavailable row has none, since there is nothing to do with it:
 
 - **Disable** / **Enable** — the same toggle as `jetwhale.setPluginEnabled` over
-  [MCP](/guide/mcp-server), applied host-wide rather than per session.
+  [MCP](/guide/mcp-server), applied host-wide rather than per session. This is the only entry a
+  disabled row offers.
 - **Pop out** — moves the plugin into a window of its own. The main window shows *This plugin is
-  popped out* with a **Bring back to main window** button, and the drawer entry's menu switches to
-  **Bring back**. Popping out is how you watch two plugins (or the same plugin on two sessions) side
-  by side.
+  popped out. Please check the separate window.* with a **Bring back to main window** button, and
+  the drawer entry's menu switches to **Bring back**. Popping out is how you watch two plugins (or
+  the same plugin on two sessions) side by side. A plugin that renders no UI has no scene to move,
+  so the entry is not offered for one.
 
 If no plugins are installed at all, the drawer says so and — when some jars failed to load — offers a
 shortcut to the plugin settings screen. See
@@ -64,12 +70,14 @@ shortcut to the plugin settings screen. See
 
 A plugin that contributes [MCP tools](/guide/mcp-server#plugin-provided-tools) carries an **MCP**
 badge on its drawer row. Clicking the badge opens the
-[MCP tools browser](/guide/mcp-server#the-mcp-tools-browser) already filtered to that plugin.
+[MCP tools browser](/guide/mcp-server#the-mcp-tools-browser) already filtered to that plugin and to
+the session currently selected.
 
-While an AI agent is actually calling one of that plugin's tools, the badge and the whole row take an
-accent-colored rotating ring, so the plugin being driven is unmistakable even if the label has
-scrolled out of view. A banner at the top of the drawer reports the connection itself — *AI agent
-connected*, and *AI agent is operating* while a call is in flight.
+While an AI agent is actually calling one of that plugin's tools, the badge fills with the accent
+color and the whole row takes an accent-colored rotating ring, so the plugin being driven is
+unmistakable even if the label has scrolled out of view. A banner at the top of the drawer reports
+the connection itself — *AI agent connected* — and names the tool running underneath it while a call
+is in flight.
 
 ## The rest of the drawer
 

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -125,8 +125,8 @@ itself, for example a plugin jar that failed to load. It takes `limit` (default 
 total counts. Individual messages longer than 2000 characters are truncated.
 
 `level` is `INFO` or `ERROR` — the buffer is the host's captured **stdout** and **stderr**, which is
-all the distinction there is. It has nothing to do with the `--log-level` startup option, which the
-host currently parses but does not act on.
+all the distinction there is. It has nothing to do with the `--log-level` startup option, which sets
+the root logger's threshold rather than choosing between these two streams.
 
 ### `jetwhale.updateSettings`
 

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -37,12 +37,20 @@ that `jetwhale.listSessions` returns and the tools below take as arguments.
 The tool list is computed **when a client connects** and never changes for that connection, so a
 plugin enabled (or a permission re-allowed) mid-session only shows up after the client reconnects.
 
+## Discovery tools
+
+Every other tool is addressed to one plugin in one session, and these are where those two ids come
+from. Start here.
+
+| Tool | What it does |
+|------|--------------|
+| `jetwhale.listSessions` | Lists connected debug sessions. Takes no arguments |
+| `jetwhale.listPlugins` | Lists the plugins available in a session. Takes a `sessionId` |
+
 ## Plugin UI tools
 
 | Tool | What it does |
 |------|--------------|
-| `jetwhale.listSessions` | Lists connected debug sessions; other tools take a `sessionId` from here |
-| `jetwhale.listPlugins` | Lists the plugins available in a session |
 | `jetwhale.screenshot` | Captures the current rendered frame of a plugin's Compose UI as a PNG |
 | `jetwhale.click` | Dispatches a mouse click at pixel coordinates in a plugin's UI |
 | `jetwhale.type` | Types text or a special key into a plugin's UI |
@@ -50,9 +58,9 @@ plugin enabled (or a permission re-allowed) mid-session only shows up after the 
 | `jetwhale.drag` | Simulates a drag gesture in a plugin's UI |
 | `jetwhale.getAccessibilityTree` | Returns the Compose semantics (accessibility) tree of a plugin's UI |
 
-Because a single host can debug multiple apps at once — each with several plugins — every tool that
-targets a plugin UI takes required `sessionId` **and** `pluginId` parameters: call
-`jetwhale.listSessions` first, then `jetwhale.listPlugins` to pick the plugin.
+Because a single host can debug multiple apps at once — each with several plugins — every one of
+these takes required `sessionId` **and** `pluginId` parameters: call `jetwhale.listSessions` first,
+then `jetwhale.listPlugins` to pick the plugin.
 
 ### Parameters
 
@@ -154,7 +162,7 @@ restarted, and notes explaining any deferred effect.
 | `destination` | yes | `HOME`, `PLUGIN`, `SETTINGS`, `INFO`, `LOG_VIEWER` |
 | `pluginId` | for `PLUGIN` | An installed, **enabled** plugin id. |
 | `sessionId` | no | Only for `PLUGIN`; defaults to the session already selected in the drawer. |
-| `settingsSection` | no | Only for `SETTINGS`: `GENERAL`, `SERVER`, `AI_AGENTS`, `PLUGINS`. Defaults to `GENERAL`. |
+| `settingsSection` | no | Only for `SETTINGS`: `GENERAL`, `SERVER`, `AI_AGENTS`, `PLUGINS`. Defaults to `GENERAL`. `SERVER` is the page the window titles **Connection**. |
 
 Navigating to `PLUGIN` also selects that session in the drawer, which is what a subsequent
 `jetwhale.screenshot` of the same plugin will show. The call waits up to two seconds for the window

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -74,7 +74,7 @@ Beyond that pair, each tool takes:
 `specialKey` accepts (case-insensitively): `ENTER`, `BACKSPACE`, `DELETE`, `TAB`, `ESCAPE`, `UP`,
 `DOWN`, `LEFT`, `RIGHT`, `HOME`, `END`, `PAGE_UP`, `PAGE_DOWN`. There are no modifier parameters.
 
-Two implementation details worth knowing when a call does not do what you expect:
+Worth knowing when a call does not do what you expect:
 
 - **`jetwhale.click` is not a raw pointer event.** It finds the deepest clickable node containing the
   point and invokes its `OnClick` semantics action, so a point with nothing clickable under it comes
@@ -98,14 +98,10 @@ to invoke a node's action there rather than aiming at pixels — use the
 
 ## Host tools
 
-These target the debug tool itself rather than one plugin instance, so none of them takes the
-required `sessionId` + `pluginId` pair the plugin UI tools route on. Some do take a `pluginId` or an
-optional `sessionId` as ordinary arguments — which plugin to enable, which session to open — but the
-tool is not scoped to them.
-
-`jetwhale.getStatus` is the recommended first call: one parameter-free request tells an agent the
-host version, both servers' endpoints, how many sessions and plugins are live, the current settings,
-and what the window is showing.
+These target the debug tool itself rather than one plugin instance. `jetwhale.getStatus` is the
+recommended first call: one parameter-free request tells an agent the host version, both servers'
+endpoints, how many sessions and plugins are live, the current settings, and what the window is
+showing.
 
 | Tool | What it does |
 |------|--------------|
@@ -118,6 +114,10 @@ and what the window is showing.
 | `jetwhale.updateSettings` | Changes host settings; only the arguments you supply are touched |
 | `jetwhale.restartDebugServer` | Restarts the debug WebSocket server |
 | `jetwhale.navigate` | Switches the main window to another screen, selecting the session and plugin as it goes |
+
+None of them takes the required `sessionId` + `pluginId` pair the plugin UI tools route on. Some do
+take a `pluginId` or an optional `sessionId` as ordinary arguments — which plugin to enable, which
+session to open — but the tool is not scoped to them.
 
 `jetwhale.getLogs` reads the **host's** log, not the debuggee app's — use it to diagnose JetWhale
 itself, for example a plugin jar that failed to load. It takes `limit` (default 200, maximum 1000),

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -125,8 +125,8 @@ itself, for example a plugin jar that failed to load. It takes `limit` (default 
 total counts. Individual messages longer than 2000 characters are truncated.
 
 `level` is `INFO` or `ERROR` — the buffer is the host's captured **stdout** and **stderr**, which is
-all the distinction there is. That is unrelated to the `--log-level` startup option, which decides
-how much the host writes to stdout in the first place.
+all the distinction there is. It has nothing to do with the `--log-level` startup option, which the
+host currently parses but does not act on.
 
 ### `jetwhale.updateSettings`
 
@@ -292,10 +292,11 @@ qualified names, the plugin that publishes it, its description, and each paramet
 whether it is **required**, and its description. A trailing badge counts how many times that tool has
 been called; while an agent is calling it, the badge takes an accent fill and a rotating ring.
 
-**History** — every call made in the current scope, newest first: the tool, the time of day, and
-whether it succeeded. Selecting one shows the arguments it was called with and the response it
+**History** — the last 100 calls made in the current scope, newest first: the tool, the time of day,
+and whether it succeeded. Selecting one shows the arguments it was called with and the response it
 returned. Each section has an inline copy button, and **Copy details** takes the whole record — a
-right-click on a history row offers the same four copy actions.
+right-click on a history row offers the same copy actions (up to four; the argument and response
+ones only appear when there are any).
 
 This is the fastest way to answer "what did the agent actually send, and what did it get back?" when
 a plugin behaves unexpectedly under automation.

--- a/docs/guide/nav3-navigator.md
+++ b/docs/guide/nav3-navigator.md
@@ -41,7 +41,11 @@ val navKeyModule = SerializersModule {
 val nav3Plugin = JetWhaleNav3AgentPlugin(Nav3KeyCodec.openPolymorphic(navKeyModule))
 
 startJetWhale {
-    connection { endpoints { ws("localhost", 5080) } }
+    connection {
+        endpoints {
+            ws("localhost", 5080)
+        }
+    }
     plugins {
         register(nav3Plugin)
     }

--- a/docs/guide/nav3-navigator.md
+++ b/docs/guide/nav3-navigator.md
@@ -8,13 +8,15 @@ MCP.
 It is generic: it knows nothing about your screens. Everything it can show and construct is derived
 from the serializers your app **already** gives `rememberNavBackStack`.
 
-## Install the host plugin
+## Setup
+
+### Install the host plugin
 
 The Nav3 Navigator is in the host's **official catalog**: open **Settings → Plugins → Add Plugins →
 Official Plugins** and install it with one click — no coordinates needed. See
 [Host Settings → Plugins](/guide/host-settings#plugins) for the other install routes.
 
-## Add it to your app
+### Add the agent to your app
 
 The agent side is a normal dependency of the app being debugged, alongside the agent runtime that
 `startJetWhale` lives in:
@@ -81,7 +83,7 @@ JetWhaleNav3AgentPlugin(Nav3KeyCodec.closedPolymorphic(Screen.serializer()))
 ```
 :::
 
-### Several back stacks
+#### Several back stacks
 
 An app that nests navigation registers each stack under its own id, and the host lets you pick:
 

--- a/docs/guide/nav3-navigator.md
+++ b/docs/guide/nav3-navigator.md
@@ -16,10 +16,14 @@ Official Plugins** and install it with one click — no coordinates needed. See
 
 ## Add it to your app
 
-The agent side is a normal dependency of the app being debugged:
+The agent side is a normal dependency of the app being debugged, alongside the agent runtime that
+`startJetWhale` lives in:
 
 ```kotlin
-implementation("com.kitakkun.jetwhale:jetwhale-nav3-agent:<version>")
+dependencies {
+    implementation("com.kitakkun.jetwhale:jetwhale-agent-runtime:<version>")
+    implementation("com.kitakkun.jetwhale:jetwhale-nav3-agent:<version>")
+}
 ```
 
 A Navigation 3 app already declares how its `NavKey`s serialize, because saved state needs it. Hand
@@ -37,6 +41,7 @@ val navKeyModule = SerializersModule {
 val nav3Plugin = JetWhaleNav3AgentPlugin(Nav3KeyCodec.openPolymorphic(navKeyModule))
 
 startJetWhale {
+    connection { endpoints { ws("localhost", 5080) } }
     plugins {
         register(nav3Plugin)
     }

--- a/docs/guide/network-inspector.md
+++ b/docs/guide/network-inspector.md
@@ -17,9 +17,8 @@ It works with **Ktor** and **OkHttp** clients.
 
 ### Install the host plugin
 
-The Network Inspector is in the host's **official catalog**, so no coordinates are needed: open
-**Settings → Plugins → Add Plugins → Official Plugins** and install it with one click. The version
-matching your host is fetched automatically. See
+The Network Inspector is in the host's **official catalog**: open **Settings → Plugins → Add Plugins
+→ Official Plugins** and install it with one click — no coordinates needed. See
 [Host Settings → Plugins](/guide/host-settings#plugins) for the other install routes.
 
 ### Add the agent to your app
@@ -185,7 +184,7 @@ interchangeable.
 | **enabled** | on | Whether the rule takes effect. Rules can be parked without deleting them. |
 | **Method** | any | HTTP method to match, compared case-insensitively. Blank matches any method. |
 | **URL pattern** | — | The pattern, interpreted per the match type. |
-| **match type** | `CONTAINS` | `CONTAINS` (substring), `EXACT` (whole URL), or `REGEX` (a regex that must match somewhere in the URL). An invalid regex simply never matches. |
+| **match type** | `CONTAINS` | `CONTAINS` (substring), `EXACT` (whole URL), or `REGEX` (a regex that must match somewhere in the URL). An invalid regex never matches. |
 | **Status** | `200` | Status code of the mocked response. |
 | **Content-Type** | none | Convenience field for the header of the same name. |
 | **Response body** | empty | The body to return. |

--- a/docs/guide/network-inspector.md
+++ b/docs/guide/network-inspector.md
@@ -52,8 +52,14 @@ val client = HttpClient {
 }
 
 startJetWhale {
-    connection { endpoints { ws("localhost", 5080) } }
-    plugins { register(networkAgent) }
+    connection {
+        endpoints {
+            ws("localhost", 5080)
+        }
+    }
+    plugins {
+        register(networkAgent)
+    }
 }
 ```
 
@@ -90,8 +96,14 @@ val client = OkHttpClient.Builder()
     .build()
 
 startJetWhale {
-    connection { endpoints { ws("localhost", 5080) } }
-    plugins { register(networkAgent) }
+    connection {
+        endpoints {
+            ws("localhost", 5080)
+        }
+    }
+    plugins {
+        register(networkAgent)
+    }
 }
 ```
 

--- a/docs/guide/network-inspector.md
+++ b/docs/guide/network-inspector.md
@@ -112,8 +112,9 @@ networkAgent.okHttpInterceptor(maxBodyChars = 500_000)
 
 Open the **Network Inspector** plugin in the JetWhale host and select your app's session. Each HTTP
 transaction appears live as your app makes requests. Select a transaction to inspect its request
-and response — headers, bodies (with a dedicated JSON view), and status. Use **copy** on a
-transaction to share it or reproduce the request elsewhere.
+and response — headers, bodies (with a dedicated JSON view), and status. Right-click a transaction
+for **Copy as cURL**, **Copy URL** and its request/response bodies, to share it or reproduce the
+request elsewhere.
 
 The host keeps the **latest 500 transactions** per session; older ones are dropped as new traffic
 arrives. Use **clear** (or `com.kitakkun.jetwhale.network.clearTransactions`) before reproducing an

--- a/docs/guide/qa-agent.md
+++ b/docs/guide/qa-agent.md
@@ -40,7 +40,7 @@ Pass the agent's own options with `-PjetwhaleQaAgentArgs` (space-separated):
 | `--app <name>` | one app named `qa-agent` | Connect as an app of this name, as its own session. **Repeatable** — one process can hold several apps under one device, which is how the host groups them. Names must be unique. |
 | `--plugin <id>[@<version>]` | none | Register a raw-messaging plugin under this id so `/send` and `/request` can drive its host counterpart. Registered for **every** app. Repeatable; the version defaults to `1.0.0`. |
 | `--host <name>` | `localhost` | The JetWhale host to connect to. |
-| `--port <n>` | `5443` | The host's debug port. The agent trusts the host's active CA automatically, so the default is the **wss** port; pass `--port 5080` to use plain ws. |
+| `--port <n>` | `5443` | The host's **wss** port. The agent always dials wss — it trusts the host's active CA automatically — so this is never the plain-ws port (`5080` by default). |
 | `--control-port <n>` | `7100` | Port for the agent's own control API. |
 | `--help`, `-h` | — | Print the usage text and exit. |
 

--- a/docs/guide/qa-agent.md
+++ b/docs/guide/qa-agent.md
@@ -32,7 +32,7 @@ Pass the agent's own options with `-PjetwhaleQaAgentArgs` (space-separated):
 
 ```shell
 ./gradlew :myPlugin:runJetWhaleQaAgent \
-  -PjetwhaleQaAgentArgs="--plugin com.example.myplugin --port 5080"
+  -PjetwhaleQaAgentArgs="--plugin com.example.myplugin --port 5443"
 ```
 
 | Option | Default | What it does |

--- a/docs/guide/qa-agent.md
+++ b/docs/guide/qa-agent.md
@@ -52,13 +52,17 @@ It binds loopback IPv4 only. `localhost` may resolve to `::1` first and be refus
 
 | Route | Body | What it does |
 |-------|------|--------------|
-| `GET /health` | — | `{status, ready, apps:{<name>:{connected, ready}}}`. **Poll this before sending anything**: the control API answers long before the debug session is up, and a send in that window is dropped — `/send` reports it as `sent: false` with a `hint`, but nothing retries it for you. |
+| `GET /health` | — | `{status, ready, apps:{<name>:{connected, ready}}}`. **Poll this before sending anything** — see below. |
 | `GET /plugins` | — | Per registered plugin id: `{version, activated, ready, apps:{…}}`. `activated: false` means the host has that plugin **disabled**, so waiting will not help. |
 | `POST /send` | `{app?, pluginId, messageType, payload, policy?}` | Sends a fire-and-forget event. `policy` is `DROP` (default), `QUEUE` or `FAIL`. Answers `{sent, hint?}` — `hint` says *why* a `false` happened. |
 | `POST /request` | `{app?, pluginId, messageType, payload, timeoutMs?}` | Sends a request and waits for the host's reply: `{durationMs, reply}`. |
 | `POST /fire` | `{app?, url, method?, headers?, body?, contentType?}` | Issues a real HTTP request through an instrumented client, so the [Network Inspector](/guide/network-inspector) captures it. Answers `{status, durationMs, bodyPreview}`. |
 | `POST /disconnect` | `{app?}` | Gives one app's session up while the process keeps running — this is how the host's disconnect handling gets exercised. Terminal for that app. |
 | `POST /shutdown` | — | Stops the process. |
+
+The control API answers long before the debug session is up, and a send in that window is dropped —
+`/send` reports it as `sent: false` with a `hint`, but nothing retries it for you. Wait for
+`/health` to report `ready` first.
 
 `app` is optional while only one app is running; with several, a call that does not name one is
 rejected rather than guessed at. `messageType` is the **serial name** of the message class — the

--- a/docs/guide/what-is-jetwhale.md
+++ b/docs/guide/what-is-jetwhale.md
@@ -1,11 +1,11 @@
 # What is JetWhale?
 
-JetWhale is an extensible debugging tool for Kotlin apps, inspired by
-[Flipper](https://github.com/facebook/flipper). You run a desktop app on your machine, add a small
-runtime to the app you are debugging, and inspect it live through plugins.
+JetWhale is an extensible debugging tool inspired by
+[Flipper](https://github.com/facebook/flipper).
 
-Both sides are written in Kotlin and Jetpack Compose, so the plugins you write — and the API you
-write them against — are the ones you already know.
+It is built with Kotlin and Jetpack Compose, making it especially familiar and approachable for
+Kotlin / Android developers. Thanks to its Kotlin-first design, JetWhale can be introduced with a
+minimal learning curve.
 
 ::: warning Active development
 This project is under active development. We welcome feedback as we work toward a stable release.

--- a/docs/guide/what-is-jetwhale.md
+++ b/docs/guide/what-is-jetwhale.md
@@ -1,11 +1,11 @@
 # What is JetWhale?
 
-JetWhale is a next-generation, extensible debugging tool inspired by
-[Flipper](https://github.com/facebook/flipper).
+JetWhale is an extensible debugging tool for Kotlin apps, inspired by
+[Flipper](https://github.com/facebook/flipper). You run a desktop app on your machine, add a small
+runtime to the app you are debugging, and inspect it live through plugins.
 
-It is built with Kotlin and Jetpack Compose, making it especially familiar and approachable for
-Kotlin / Android developers. Thanks to its Kotlin-first design, JetWhale can be introduced with a
-minimal learning curve.
+Both sides are written in Kotlin and Jetpack Compose, so the plugins you write — and the API you
+write them against — are the ones you already know.
 
 ::: warning Active development
 This project is under active development. We welcome feedback as we work toward a stable release.
@@ -38,21 +38,11 @@ Each session in the host shows a lock indicator for how its transport is secured
   never leaves the machine, so it is effectively secure.
 - **No lock** — plain ws to a non-loopback peer; the traffic is unencrypted on the network.
 
-## Features
-
-- 🐳 **Powerful debugging platform** — modern UI built with Kotlin and Jetpack Compose;
-  multi-session debugging; runtime-loadable JAR plugins
-- ⚙️ **Easy integration** — DSL-based setup in your app;
-  [ADB auto port mapping](/guide/adb-auto-port-mapping) for zero-setup Android debugging
-- 🛜 **Type-safe communication** — kotlinx.serialization between debugger and debuggee
-- ✅ **Multiplatform debuggees** — Android, Desktop (JVM), iOS (Simulator & physical devices over wss), Web (JS, WasmJS)
-- 🤖 **[MCP server](/guide/mcp-server)** *(experimental)* — AI agents can interact with your app
-- 🔥 **[Hot-reloadable plugin development](/guide/developing-plugins)** — build plugins in your own
-  repository against the published SDK
-
 ## Next steps
 
 - [Getting Started](/guide/getting-started) — install the host and integrate the agent into your app
 - [The Host Window](/guide/host-window) — sessions, the plugin drawer, and popping a plugin out
+- [ADB auto port mapping](/guide/adb-auto-port-mapping) — zero-setup Android debugging
 - [Network Inspector](/guide/network-inspector) — inspect and mock HTTP traffic
+- [MCP Server](/guide/mcp-server) *(experimental)* — let an AI agent drive the app
 - [Developing Plugins](/guide/developing-plugins) — build your own debugging tools

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -6,9 +6,28 @@ debuggee application. The protocol is defined in the
 published as `com.kitakkun.jetwhale:jetwhale-protocol-core`.
 
 Messages travel as JSON over one WebSocket connection (plain **ws**, or **wss** when the agent
-configures a trusted certificate — see
+declares a `wss` endpoint — `ssl { }` says what TLS trusts, not whether it is spoken; see
 [Secure connections](/guide/getting-started#secure-connections-wss)). Every message carries a stable
 `type` discriminator; the current **protocol version is 2**.
+
+## Finding the Host
+
+Before any of the below, the agent has to know where the host is. Besides a written-out address, it
+can browse for one: while its debug server runs, the host advertises a `_jetwhale._tcp` DNS-SD service
+over mDNS, named after the machine's hostname (its first label only), whose service port is the
+plain-ws port. The rest is carried in TXT records:
+
+| Record | Meaning |
+|--------|---------|
+| `v=1` | Version of the advertisement itself. The host writes it and no agent reads it yet — it is the marker by which a later format change can be recognized. |
+| `wsPort` | The port serving plain **ws**. |
+| `wssPort` | The port serving **wss**. Absent while the host has wss disabled. |
+| `hostName` | The host machine's hostname. Carried separately from the instance name because mDNS may uniquify that on collision (`name (2)`), and this is what the agent's `allowHostName` filter compares against. |
+
+A discovered host is only ever dialled over **wss**, on `wssPort`: the host binds plain ws to
+loopback, which is not the address discovery returns, so a host advertising no `wssPort` is skipped.
+See [Zero-config host discovery](/guide/getting-started#zero-config-host-discovery-recommended-for-physical-devices)
+for the agent-side configuration.
 
 ## Two Phases Before Starting a Debugging Session
 
@@ -57,10 +76,10 @@ stable — changing one breaks compatibility with older implementations — so t
 A **reject** carries a human-readable `reason` and the versions the host does support. The session
 response carries the assigned `sessionId`, which the agent may send back in a later
 `negotiation/agent/session` to resume. The plugin response splits the agent's list into
-`availablePlugins` (paired, and enabled on the host) and `incompatiblePlugins` (the plugin exists on
-both sides, but the agent's `pluginVersion` falls outside the host plugin manifest's
+`availablePlugins` (paired, and enabled on the host) and `incompatiblePlugins` (the host has that
+plugin enabled, but the agent's `pluginVersion` falls outside the host plugin manifest's
 [`agentVersionRange`](/guide/developing-plugins#manifest-reference)); a plugin the host does not have
-at all is simply absent from both.
+at all — or has, but has disabled — is simply absent from both.
 
 Capabilities are exchanged as a plain `Map<String, String>` in both directions. Nothing consumes them
 yet — the step exists so future versions can negotiate optional features without another protocol

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -29,7 +29,7 @@ loopback, which is not the address discovery returns, so a host advertising no `
 See [Zero-config host discovery](/guide/getting-started#zero-config-host-discovery-recommended-for-physical-devices)
 for the agent-side configuration.
 
-## Two Phases Before Starting a Debugging Session
+## The two phases
 
 There are two main phases in the JetWhale Debugger Protocol:
 
@@ -79,7 +79,7 @@ response carries the assigned `sessionId`, which the agent may send back in a la
 `availablePlugins` (paired, and enabled on the host) and `incompatiblePlugins` (the host has that
 plugin enabled, but the agent's `pluginVersion` falls outside the host plugin manifest's
 [`agentVersionRange`](/guide/developing-plugins#manifest-reference)); a plugin the host does not have
-at all — or has, but has disabled — is simply absent from both.
+at all — or has, but has disabled — is absent from both.
 
 Capabilities are exchanged as a plain `Map<String, String>` in both directions. Nothing consumes them
 yet — the step exists so future versions can negotiate optional features without another protocol

--- a/plugins/jetwhale/skills/plugin-qa/SKILL.md
+++ b/plugins/jetwhale/skills/plugin-qa/SKILL.md
@@ -340,7 +340,8 @@ List the tools before planning around one, and do not read a refusal as a bug in
 | Tool | Purpose |
 |------|---------|
 | `jetwhale.getStatus` | version, both servers, session/plugin counts, settings, current screen — call it first |
-| `jetwhale.listInstalledPlugins` | what is installed and whether it is enabled |
+| `jetwhale.listInstalledPlugins` | what is installed and whether it is enabled, plus the official catalog under `availableOfficial` |
+| `jetwhale.installOfficialPlugin` | install a plugin from that catalog — catalog entries only, and `setPluginEnabled` still has to follow |
 | `jetwhale.setPluginEnabled` | enable the plugin under test; reports which sessions got an instance |
 | `jetwhale.navigate` | move the main window (`HOME` / `PLUGIN` / `SETTINGS` / `INFO` / `LOG_VIEWER`) |
 | `jetwhale.getLogs` / `jetwhale.clearLogs` | the **host's** own log — clear, reproduce, read |


### PR DESCRIPTION
## Why

The `endpoints { }` rework, the second Gradle plugin (`com.kitakkun.jetwhale.agent`), and the
host-side plugin/MCP work all landed faster than the prose around them. This is a full audit of
`docs/`, `README.md`, `AGENTS.md` and the in-repo `plugin-qa` skill against source: every stated
default, port, version, platform and code snippet was traced back to the code that decides it.

**Docs were changed to match the code. No public API was touched**, and nothing that looked like a
code problem was "fixed" here — those are listed at the bottom instead.

## 1. API drift — snippets that no longer compile, or no longer do what they say

- **`docs/guide/nav3-navigator.md` never got the `endpoints { }` migration.** Its `startJetWhale`
  snippet had no `connection { }` block at all, so it fell through to the deprecated `host`/`port`
  defaults — `localhost:8080` — while the host's debug server listens on `5080`. It was the one
  snippet in the docs that silently dialled the wrong port. The same page also omitted
  `jetwhale-agent-runtime` from its dependency block, and that is where `startJetWhale` lives, so the
  documented dependency set did not compile either.
- **`docs/guide/compose-semantics-inspector.md`** — the desktop `JetWhaleSemanticsProbe()` is
  annotated `@ExperimentalComposeUiApi`, whose opt-in level is *error*, so a desktop caller must
  write `@OptIn(ExperimentalComposeUiApi::class)`. The guide never mentioned it, although
  `demo/desktop/.../Main.kt` does exactly that. The Android probe carries no such requirement, and
  the page now says which is which.
- **`docs/guide/developing-plugins.md`** — the plugin storage API does not give "each" member a
  `KSerializer` overload. Only the three that carry a value (`put` / `get` / `getFlow`) take a
  serializer, and the reified forms are extensions rather than overloads of the members.
- **`docs/guide/qa-agent.md`** — `--port 5080` was offered as the way to use plain ws. The QA agent
  declares `endpoints { wss(...) }` unconditionally, so `--port` is always the host's wss port.

## 2. Factual drift — behaviour that moved out from under the prose

- **`ssl { }` no longer decides the scheme.** Getting Started still said "as soon as at least one
  trusted certificate is configured, the connection switches from ws to wss", and
  `reference/protocol.md` said wss happens "when the agent configures a trusted certificate". Since
  `endpoints { }`, each candidate names its own scheme and `ssl { }` only says what TLS trusts once
  it is spoken. Getting Started already contradicted itself on this two sections earlier.
- **There is no plain-ws fallback when the CA fetch fails.** Both the wss section and the
  trust-on-first-use bullet promised one. The client now takes the protocol from the endpoint
  regardless, deliberately — a `wss` candidate whose CA could not be fetched fails visibly on trust
  rather than quietly sending in the clear at a TLS port.
- **wss needs no setup.** It is enabled by default and the CA is generated the first time the TLS
  connector starts. The guide pointed at Host Settings as though you had to generate and activate a
  certificate before wss would work at all.
- **An unsupported Kotlin is not silent.** `buildMachineWss` was documented as leaving calls
  unrewritten on any Kotlin the plugin has not caught up with. In fact the Gradle plugin checks up
  front: below 2.3 it **fails the build** with an explanation (the registrar provably cannot load),
  and above the highest tested minor it warns and carries on.
- **Reconnection is per round, not per attempt.** The backoff is owed by a round in which no
  candidate accepted; a candidate that swallows packets rather than refusing is abandoned after 30
  seconds; and the counter resets only on a session that *held* for two seconds, so a host that
  accepts the upgrade and drops it cannot make the agent spin.
- **A host plugin that is installed but disabled is absent from negotiation entirely**, not reported
  as incompatible — `protocol.md` had the classification wrong.
- **Discovery backend table** — `NSNetServiceBrowser` is Foundation, not Network.framework, and the
  unsupported-platform row still described the pre-`endpoints` "falls back to the configured host"
  behaviour rather than "contributes nothing; the next candidate is reached immediately".
- **`docs/guide/network-inspector.md`** — there is no copy button on a transaction. Copying is a
  right-click context menu (`Copy as cURL`, `Copy URL`, request/response bodies).

### Host UI and settings

- **Two startup options are parsed but do nothing.** `--plugin-dir` and `--log-level` are read into
  `JetWhaleCliOptions` and then never consulted by anything. The pages described what they were
  meant to do; they now say what they actually do, and the underlying problem is filed below.
- **The ADB toggle is read only when the debug server starts**, so flipping it does not wire or
  unwire anything until the next server restart. Both the ADB page and the settings table implied it
  took effect immediately, and that turning it off tore existing mappings down.
- **Port validation** — the "two ports cannot be the same" rule only applies while wss is enabled,
  and the wss port is range-checked even while it is off.
- **The collapsed drawer rail is not just the expanded drawer as icons** — it lists only enabled
  plugins, drops the grouping and overflow menus, flattens the device picker, and is the only place
  **Info** appears.
- **Overflow menus**: an unavailable plugin row has none, a disabled row offers only Enable, and
  **Pop out** is not offered for a plugin that renders no UI.
- **AI activity**: the banner names the tool in flight rather than reading *AI agent is operating*,
  and the MCP badge fills with the accent colour as well as taking the ring.
- **The MCP tools browser keeps the last 100 calls**, not every call, and its right-click menu shows
  fewer than four copy actions when there are no arguments or no response.
- Session-disconnect toast wording, and the *plugin is popped out* placeholder text, both drifted.

## 3. Gaps that mattered

- **`reference/protocol.md` documented no host discovery at all** — the page predates the feature.
  Added a short section for `_jetwhale._tcp`: the instance name (the machine hostname, first label
  only), the service port being the plain-ws port, and the TXT records `v=1` / `wsPort` / `wssPort` /
  `hostName`. `v` is written by the host and read by no agent yet; that is stated as the
  forward-compatibility marker it is, not as dead weight.
- The `plugin-qa` skill's host-tool table was missing `jetwhale.installOfficialPlugin`, which now
  exists in the `MANAGE_PLUGINS` group.
- Getting Started's artifact table described `jetwhale-annotations` as only `@McpDescription`,
  omitting the opt-in markers the same page goes on to use.

## 4. Quality

- **`README.md`** still described only the two-terminal `runJetWhale` + `stageDevPlugin -t` loop;
  `runJetWhaleHot` is the one-command loop the guide now leads with.
- **`AGENTS.md`**'s module map predated `demo/web`, `demo/ios-cmp`, `tools/`, three of the four
  bundled plugin families, and both Gradle-plugin included builds — the last of which matters now
  that there are two published plugin ids.
- Getting Started stated "mDNS is unavailable on JS/Wasm/Linux/Windows" three times inside ninety
  lines. One statement (the backend table) now carries it.

## Links and anchors

Every internal link and `#anchor` under `docs/` was checked against the ids VitePress actually emits,
by building the site and matching hrefs against `dist/`. All of them resolve — nothing needed fixing.
`npx vitepress build` is clean.

## Deliberately left alone

- The **capabilities exchange** in the handshake is an intentional forward-compatibility surface. It
  consumes nothing today and is documented as such rather than trimmed.
- Platform lists that name Android / Desktop (JVM) / iOS / Web omit the published Kotlin/Native
  macOS, Linux and Windows targets. That is a consistent editorial choice across the docs, and
  Getting Started's "Published Kotlin Multiplatform targets" warning states the full target set.
- The headless section's *"a few hundred milliseconds sooner and roughly 15% less memory"* is a
  measurement, not something the source states, so it was neither confirmed nor changed.
- `HostSettingsSection.SERVER` is documented as the wire value for `jetwhale.navigate`, which is
  correct even though the UI now calls that section **Connection**.

## Suspected code problems — reported, not changed

1. **Three KDoc/comment sites still promise the removed plain-ws fallback**, contradicting the code
   thirty lines below them: `KtorWebSocketClient.kt:130` and `:158`, `JetWhaleServiceDsl.kt:361`
   (`trustServerCertificate()`'s KDoc, which is public API documentation), and
   `SslConfig.js.kt:7`. The authority is `KtorWebSocketClient.kt:104-108`, which explicitly chooses
   the protocol from the endpoint so the failure is visible.
2. **`JetWhaleEndpointScope.buildMachineWss`'s KDoc** says a Kotlin release the plugin has not caught
   up with "leaves calls unrewritten". Below 2.3 the Gradle plugin throws a `GradleException`
   instead (`JetWhaleAgentSubplugin.kt`, `SupportedKotlinVersions.kt`).
3. **The agent's deprecated `port` default is `8080`** (`JetWhaleServiceDsl.kt`) while the host's
   default ws port is `5080`. The mismatch is documented as deliberate, but it does mean the
   deprecated path's defaults can never reach a default host.
4. **`schemas/plugin-manifest.schema.json` sets `"additionalProperties": false` at the root without
   declaring `"$schema"`**, so a strict validator rejects exactly the manifest shape the docs
   recommend and that `jetwhale-plugins/example/host` ships. The host itself is unaffected
   (`ignoreUnknownKeys = true`).
5. **`JetWhaleMcpCapablePlugin.mcpCommands` is documented as "read once per plugin instance
   activation"**, but `McpToolRegistry.dispatch` re-reads it on every invocation
   (`McpToolRegistry.kt:86`). The contract still holds; the KDoc overstates.
6. **MCP tool-name collisions are silent.** `McpToolRegistry.kt:48` uses `getOrPut(command.name)`, so
   a second plugin registering an existing name joins the first plugin's entry instead of erroring,
   despite names being documented as globally unique.
7. **`--plugin-dir` and `--log-level` are dead startup options.** Both are parsed and validated into
   `JetWhaleCliOptions` (`CommandLineArgumentsParser.kt:36-56`) and then read by nothing — `Main.kt`
   consults only `headless`, the port overrides and the MCP permission override. `--log-level FOO`
   currently fails startup for a flag that does nothing. Either wire them up or drop them; the docs
   now describe the real behaviour in the meantime.
8. **The ADB auto-wire toggle takes effect only on the next debug-server start**, but
   `GeneralSettingsScreen.kt:111-121` renders a bare switch with no hint, unlike every other
   deferred-effect setting.
9. **`AdbUtil.kt:23-34`** has no Windows `adb.exe` candidate, and consults `ANDROID_HOME` /
   `ANDROID_SDK_ROOT` *after* the hardcoded `/usr/bin`, `/usr/local/bin` and `$HOME` SDK paths — so
   an explicitly configured SDK loses to a stray system binary.
10. **`DefaultADBAutoWiringService.kt:149-156`** — `runAdb` has no `try`/`catch`, so an `adb` that
    disappears during `stopAutoWiring` propagates an `IOException` to the caller.
11. Unused string resources `server_port_apply_confirm_title` / `_message`
    (`feature/settings/.../values/strings.xml:67-68`).
