### PR TITLE
chore(deps): update dependencies to current stable releases

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ mavenPublish = "0.37.0"
 
 # kotlin
 kotlin = "2.4.10"
-ksp = "2.3.10"
+ksp = "2.3.11"
 kotlinDsl = "6.5.7"
 kotlinxSerializationJson = "1.11.0"
 kotlinxCollectionsImmutable = "0.5.1"
@@ -14,7 +14,7 @@ javaKeyring = "1.0.4"
 kotlinxDatetime = "0.8.0"
 
 # android
-androidGradlePlugin = "9.3.0"
+androidGradlePlugin = "9.3.1"
 androidxCoreKtx = "1.19.0"
 androidxActivity = "1.13.0"
 
@@ -26,22 +26,22 @@ lifecycle = "2.11.0"
 soil = "1.0.0-alpha15"
 
 androidxDatastore = "1.3.0-alpha10"
-metro = "1.3.2"
+metro = "1.4.0"
 mokkery = "3.4.2"
-ktor = "3.5.1"
+ktor = "3.5.2"
 okhttp = "5.4.0"
-mcpKotlinSdk = "0.14.0"
+mcpKotlinSdk = "0.15.0"
 
-logback = "1.5.38"
+logback = "1.6.1"
 kermit = "2.1.0"
 
 aboutLibraries = "15.0.4"
-spotless = "8.8.0"
+spotless = "8.9.0"
 conveyor = "2.0"
 conveyorControl = "1.1"
 
-bouncyCastle = "1.83"
-jmdns = "3.6.1"
+bouncyCastle = "1.85"
+jmdns = "3.6.3"
 
 [libraries]
 # Gradle Plugins


### PR DESCRIPTION
Routine dependency refresh ahead of the `1.0.0-alpha11` release. Everything below is a current
**stable** release; nothing was moved onto a new pre-release line.

## What moved

| Dependency | From | To | Note |
| --- | --- | --- | --- |
| KSP (`ksp`) | 2.3.10 | 2.3.11 | patch |
| Android Gradle Plugin | 9.3.0 | 9.3.1 | patch; still within Gradle 9.5.1's supported range |
| Metro | 1.3.2 | 1.4.0 | compiler plugin; applies cleanly on Kotlin 2.4.10 |
| Ktor | 3.5.1 | 3.5.2 | patch |
| MCP Kotlin SDK | 0.14.0 | 0.15.0 | |
| Logback | 1.5.38 | 1.6.1 | still JDK 11 baseline, SLF4J 2.0.18 |
| Spotless | 8.8.0 | 8.9.0 | |
| Bouncy Castle | 1.83 | 1.85 | |
| jmDNS | 3.6.1 | 3.6.3 | |

## Compose Multiplatform: the `1.11.0-beta03` mismatch

Investigated; the resolved graph is already consistent, and the remaining pin cannot be moved.

`org.jetbrains.compose.material3:material3:1.11.0-alpha07` declares `1.11.0-beta03` for the Compose
core modules (`runtime`, `ui`, `foundation`, `animation-core`, `material-ripple`, `ui-text`,
`ui-util`, `ui-backhandler`). Those are **requested** versions, not resolved ones — a full dump of
`:jetwhale-host:core:ui:runtimeClasspath` shows every `org.jetbrains.compose.*` module resolving to
**1.11.1**, matching the plugin, with `beta03` only ever appearing as a conflict-resolved-away
request.

`material3` itself stays at `1.11.0-alpha07` because there is nothing else to move it to:

- JetBrains stopped publishing stable `org.jetbrains.compose.material3:material3` after `1.9.0`.
  Since `1.10.0` it only ships alphas, because it tracks the androidx Material 3 Expressive line
  (`androidx.compose.material3:material3:1.5.0-alphaNN`), which is itself still alpha.
- `1.11.0`, `1.11.1`, `1.11.2` and `1.11.0-rc01` all 404 on Maven Central — `1.11.0-alpha07` is the
  newest release on the 1.11 line and the one paired with Compose Multiplatform 1.11.x.
- The next line up, `1.12.0-alpha03`, is paired with Compose Multiplatform `1.12.0-betaNN`, so
  taking it would drag the plugin and every runtime module onto a pre-release. Left alone.

So: not a stale alias, not a plugin/runtime split — an upstream transitive pin in a POM that was cut
against `1.11.0-beta03` and never re-published against `1.11.1`, and one that Gradle already
resolves the right way.

## Deliberately left alone

| Dependency | Pinned at | Why |
| --- | --- | --- |
| Kotlin | 2.4.10 | Already the newest **stable**. The newer `2.4.20-Beta2` is a pre-release, and a Kotlin bump moves the whole toolchain, the Compose compiler and the published metadata version. `SupportedKotlinVersions.kt` (2.3-2.4) and the `agent-compiler-plugin-matrix.yml` matrix stay truthful unchanged. |
| `kotlinDsl` | 6.5.7 | Must track the Gradle wrapper, not the newest release. `gradle-kotlin-dsl-plugins` 6.5.7 was cut by Gradle 9.5.0-rc-3 and strictly requires kotlin-stdlib 2.3.20 - exactly the Kotlin the Gradle 9.5.1 wrapper embeds. 6.6.x/6.7.x are built from the Gradle 9.6/9.7 lines. |
| Gradle wrapper | 9.5.1 | 9.6.1 is out, but moving it would also force `kotlinDsl` and re-open the KGP/Gradle compatibility question for no dependency-refresh benefit. Out of scope for this PR. |
| Compose Multiplatform | 1.11.1 | `1.12.0-beta03` is a pre-release. |
| `material3` | 1.11.0-alpha07 | See above - no stable exists, and the next alpha line requires a pre-release Compose Multiplatform. |
| `material3Adaptive` | 1.3.0-beta02 | Already the newest on its line; no stable 1.3.0 yet. |
| `navigation3` | 1.1.1 | The ref is shared between `androidx.navigation3:navigation3-runtime` (stable 1.1.5 available) and `org.jetbrains.androidx.navigation3:navigation3-ui`, whose newest stable *is* 1.1.1. Raising the shared ref would fail to resolve the JetBrains port. |
| `androidxDatastore` | 1.3.0-alpha10 | Newest on its line. |
| `soil` | 1.0.0-alpha15 | Newest release. |
| `jetbrainsComposeMaterialIconsExtended` | 1.7.3 | Frozen upstream; the Compose Multiplatform 1.11.1 plugin hardcodes this exact coordinate and version for its own `compose.materialIconsExtended` accessor. |
| AGP | 9.3.1 | `9.4.0-alphaNN` is a pre-release. |

Everything else in `gradle/libs.versions.toml` was already on its newest stable release
(`mavenPublish` 0.37.0, kotlinx serialization 1.11.0 / coroutines 1.11.0 / datetime 0.8.0 /
collections-immutable 0.5.1, `androidxCoreKtx` 1.19.0, `androidxActivity` 1.13.0, `lifecycle`
2.11.0, `mokkery` 3.4.2, `okhttp` 5.4.0, `kermit` 2.1.0, `aboutLibraries` 15.0.4, `byteBuddy`
1.18.11, `javaKeyring` 1.0.4, `conveyor` 2.0, `conveyorControl` 1.1).

## Verification

All run locally on macOS (arm64), JDK 21, against this branch. All green, no source changes needed.

| Command | Result |
| --- | --- |
| `./gradlew spotlessCheck` | BUILD SUCCESSFUL (14m 26s) |
| `./gradlew check` | BUILD SUCCESSFUL (22m 23s) |
| `./gradlew -p jetwhale-agent-plugin check` | BUILD SUCCESSFUL (19s) |
| `./gradlew -p jetwhale-gradle-plugin build` | BUILD SUCCESSFUL (2s) |
| `./gradlew :jetwhale-agent-runtime:checkLegacyAbi :jetwhale-annotations:checkLegacyAbi :jetwhale-agent-sdk:checkLegacyAbi :jetwhale-host-sdk:checkLegacyAbi :jetwhale-protocol:core:checkLegacyAbi` | BUILD SUCCESSFUL (22s) |

**No ABI dumps were regenerated** — `checkLegacyAbi` passed unchanged on all five published modules,
so no `updateKotlinAbi`/`updateLegacyAbi` was needed. (The tasks do log that `checkLegacyAbi` is
deprecated in favour of `checkKotlinAbi`; that is pre-existing and not touched here.)

No build breakage was hit: nothing in this set required a source or configuration migration.

Not covered by these commands, and unchanged by this PR: the Kotlin matrix in
`agent-compiler-plugin-matrix.yml` (`2.3.0`, `2.3.21`, `2.4.0`, `2.4.10`) runs on CI. Since Kotlin
did not move, that matrix and `SupportedKotlinVersions.kt` are still accurate as written.
