### PR TITLE
fix: correct documentation that outlived its code, and harden adb

### DIFF
--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/JetWhaleServiceDsl.kt
@@ -268,9 +268,9 @@ public interface JetWhaleEndpointScope {
      *
      * Experimental, and for a sharper reason than most: unlike the rest of this scope, the behaviour
      * rests on a Kotlin compiler plugin, whose API JetBrains breaks across minor versions by design.
-     * A Kotlin release the plugin has not caught up with leaves calls unrewritten — which degrades
-     * to the same explained silence as never applying the Gradle plugin, but is worth knowing about
-     * before depending on it.
+     * Below the supported floor the Gradle plugin fails the build with an explanation rather than
+     * letting a plugin that cannot load take the blame later; above the tested ceiling it warns and
+     * proceeds, since the plugin may well work there and has simply not been shown to.
      *
      * **Requires the `com.kitakkun.jetwhale.agent` Gradle plugin**, which resolves the address and
      * hands it to a compiler plugin that rewrites this call. Without it this compiles and runs — it
@@ -358,7 +358,10 @@ public interface JetWhaleSslConfigurationScope {
      * traffic never leaves the machine. On an untrusted LAN prefer [trustCertificate] with a
      * manually exported CA for strict pinning.
      *
-     * When the CA cannot be fetched over either channel, the connection falls back to plain ws.
+     * When the CA cannot be fetched over either channel, nothing is pinned and the connection is
+     * still attempted over wss — it then fails on trust rather than quietly sending in the clear
+     * at a TLS port. Declare a `ws(...)` candidate if you want a plain fallback; the endpoint list
+     * is where that choice belongs.
      */
     public fun trustServerCertificate()
 }

--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClient.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/KtorWebSocketClient.kt
@@ -126,8 +126,9 @@ internal class KtorWebSocketClient(
     /**
      * Produces the SSL configuration effective for this connection. When
      * [JetWhaleSslConfiguration.trustServerCertificate] is set, the host's active CA is fetched and
-     * pinned; on failure the manually configured certificates (if any) are used, otherwise the
-     * connection falls back to plain ws.
+     * pinned; on failure only the manually configured certificates (if any) remain. The scheme is not
+     * revisited either way — it comes from the endpoint, so a failed fetch surfaces as a trust failure
+     * rather than as traffic quietly sent in the clear.
      */
     private suspend fun resolveSslConfiguration(host: String, port: Int): JetWhaleSslConfiguration {
         val fetchedCaPem = if (sslConfiguration.trustServerCertificate) {
@@ -155,7 +156,7 @@ internal class KtorWebSocketClient(
      *    verification here is security-equivalent to the plain fetch: both are trust-on-first-use and
      *    the fetched CA still pins the subsequent wss session.
      *
-     * Returns null when neither attempt succeeds, so the caller falls back to plain ws.
+     * Returns null when neither attempt succeeds, leaving the caller with nothing to pin.
      */
     private suspend fun fetchCaCertificate(host: String, port: Int): String? {
         fetchCaCertificate("http://$host:$port/jetwhale/ca", disableVerification = false)?.let { return it }

--- a/jetwhale-agent-runtime/src/jsMain/kotlin/com/kitakkun/jetwhale/agent/runtime/SslConfig.js.kt
+++ b/jetwhale-agent-runtime/src/jsMain/kotlin/com/kitakkun/jetwhale/agent/runtime/SslConfig.js.kt
@@ -3,8 +3,9 @@ package com.kitakkun.jetwhale.agent.runtime
 import io.ktor.client.engine.HttpClientEngineConfig
 
 internal actual fun HttpClientEngineConfig.disableCertificateVerification() {
-    // The browser fully controls TLS verification; it cannot be disabled from code. The CA fetch
-    // over the wss port therefore fails here and the caller falls back to plain ws.
+    // The browser fully controls TLS verification; it cannot be disabled from code. The CA fetch over
+    // the wss port therefore fails here, leaving nothing to pin — which is why a browser reaches the
+    // host through a `ws(...)` candidate rather than through wss at all.
     JetWhaleLogger.w(
         "Certificate verification cannot be disabled in JavaScript environments; " +
             "the CA fetch over the wss port is not available.",

--- a/jetwhale-agent-runtime/src/wasmJsMain/kotlin/com/kitakkun/jetwhale/agent/runtime/SslConfig.wasmJs.kt
+++ b/jetwhale-agent-runtime/src/wasmJsMain/kotlin/com/kitakkun/jetwhale/agent/runtime/SslConfig.wasmJs.kt
@@ -3,8 +3,9 @@ package com.kitakkun.jetwhale.agent.runtime
 import io.ktor.client.engine.HttpClientEngineConfig
 
 internal actual fun HttpClientEngineConfig.disableCertificateVerification() {
-    // The browser fully controls TLS verification; it cannot be disabled from code. The CA fetch
-    // over the wss port therefore fails here and the caller falls back to plain ws.
+    // The browser fully controls TLS verification; it cannot be disabled from code. The CA fetch over
+    // the wss port therefore fails here, leaving nothing to pin — which is why a browser reaches the
+    // host through a `ws(...)` candidate rather than through wss at all.
     JetWhaleLogger.w(
         "Certificate verification cannot be disabled in WebAssembly environments; " +
             "the CA fetch over the wss port is not available.",

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultADBAutoWiringService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultADBAutoWiringService.kt
@@ -145,18 +145,30 @@ class DefaultADBAutoWiringService : ADBAutoWiringService {
         }
     }
 
-    /** Runs an adb command to completion and returns its exit code together with its merged output. */
-    private fun runAdb(vararg args: String): Pair<Int, String> {
+    /**
+     * Runs an adb command to completion and returns its exit code together with its merged output.
+     *
+     * A failure to launch adb at all is reported as a non-zero exit rather than thrown. The wiring
+     * job catches everything, but teardown does not run inside it — [stopAutoWiring] and [unwire]
+     * call this directly, and an adb that has been uninstalled or unmounted since wiring would
+     * otherwise throw IOException out of a shutdown path, where nothing is waiting to handle it.
+     * Callers already treat a non-zero exit as a failure to report.
+     */
+    private fun runAdb(vararg args: String): Pair<Int, String> = try {
         val process = ProcessBuilder(adbPath, *args)
             .redirectErrorStream(true)
             .start()
         val output = process.inputStream.bufferedReader().readText().trim()
-        val exitCode = process.waitFor()
-        return exitCode to output
+        process.waitFor() to output
+    } catch (e: IOException) {
+        ADB_LAUNCH_FAILED to "adb could not be launched from \"$adbPath\": ${e.message}"
     }
 }
 
 /** The adb executable itself could not be launched — no amount of retrying will bring it back. */
+// Distinct from any exit code adb itself returns, which are small positive integers.
+private const val ADB_LAUNCH_FAILED = -1
+
 private class AdbUnavailableException(adbPath: String, cause: IOException) : Exception("adb could not be launched from \"$adbPath\": ${cause.message}", cause)
 
 private sealed interface DeviceEvent {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/util/AdbUtil.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/util/AdbUtil.kt
@@ -3,33 +3,36 @@ package com.kitakkun.jetwhale.host.data.util
 import java.io.File
 
 /**
- * Finds the absolute path to the adb executable by checking common installation locations.
+ * The absolute path to the adb executable, or `"adb"` to let the OS resolve it from PATH.
  *
- * This function checks the following locations in order:
- * 1. /usr/bin/adb
- * 2. /usr/local/bin/adb
- * 3. $HOME/Android/Sdk/platform-tools/adb
- * 4. $HOME/Library/Android/sdk/platform-tools/adb (macOS)
- * 5. $ANDROID_HOME/platform-tools/adb
- * 6. $ANDROID_SDK_ROOT/platform-tools/adb
- *
- * @return The absolute path to adb if found, otherwise "adb" as a fallback
+ * `ANDROID_HOME` and `ANDROID_SDK_ROOT` are consulted first: someone who has set them has said which
+ * SDK they mean, and a stray `/usr/local/bin/adb` from an unrelated install should not outrank that.
+ * The rest are the conventional install locations, per OS — Windows keeps the SDK under LOCALAPPDATA
+ * and names the executable `adb.exe`, so a Windows host found nothing here before and fell through to
+ * PATH.
  */
 fun findAdbPath(): String {
     val homeDir = System.getProperty("user.home")
-    val androidHome = System.getenv("ANDROID_HOME")
-    val androidSdkRoot = System.getenv("ANDROID_SDK_ROOT")
+    val localAppData = System.getenv("LOCALAPPDATA")
+    val isWindows = System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
+    val executable = if (isWindows) "adb.exe" else "adb"
 
-    val candidatePaths = listOfNotNull(
-        "/usr/bin/adb",
-        "/usr/local/bin/adb",
-        homeDir?.let { "$it/Android/Sdk/platform-tools/adb" },
-        homeDir?.let { "$it/Library/Android/sdk/platform-tools/adb" },
-        androidHome?.let { "$it/platform-tools/adb" },
-        androidSdkRoot?.let { "$it/platform-tools/adb" },
+    val sdkRoots = listOfNotNull(
+        System.getenv("ANDROID_HOME"),
+        System.getenv("ANDROID_SDK_ROOT"),
+        homeDir?.let { "$it/Android/Sdk" },
+        // macOS
+        homeDir?.let { "$it/Library/Android/sdk" },
+        // Windows
+        localAppData?.let { "$it/Android/Sdk" },
+    )
+
+    val candidatePaths = sdkRoots.map { "$it/platform-tools/$executable" } + listOfNotNull(
+        "/usr/bin/$executable".takeUnless { isWindows },
+        "/usr/local/bin/$executable".takeUnless { isWindows },
     )
 
     return candidatePaths.firstOrNull { path ->
-        File(path).exists() && File(path).canExecute()
-    } ?: "adb" // Fallback to "adb" if not found
+        File(path).let { it.exists() && it.canExecute() }
+    } ?: executable
 }


### PR DESCRIPTION
Findings from the documentation audit that live in code rather than in `docs/`. Limited to the ones whose right answer is not a product decision — see the end for the one that is.

## Four KDoc sites promised a plain-ws fallback that does not exist

`trustServerCertificate()`'s KDoc — **public API documentation** — said:

> When the CA cannot be fetched over either channel, the connection falls back to plain ws.

It does not, and has not for some time. Traced rather than assumed:

- `KtorWebSocketClient.kt:90` picks the scheme from `endpoint.useWss`
- `:107` builds the URL from the same
- `resolveSslConfiguration` only assembles trusted certificates; a failed fetch yields a config with none

So a failed fetch dials wss anyway and fails on trust. That is the **better** behaviour — the alternative would be quietly sending in the clear at a TLS port — but it is not what four sites said. Corrected in `JetWhaleServiceDsl.kt`, `KtorWebSocketClient.kt` (two), and both `SslConfig.js.kt` and `SslConfig.wasmJs.kt`, which are twins and were both wrong. A plain fallback is now spelled as what it actually is: a `ws(...)` candidate in the endpoint list.

## `buildMachineWss` misdescribed its own version guard

The KDoc said an unsupported Kotlin "leaves calls unrewritten". Below the supported floor the Gradle plugin fails the build outright; above the tested ceiling it warns and proceeds. Both deliberate, neither what the KDoc said. Mine, from the commit that added the guard.

## `runAdb` could throw out of teardown

The wiring job catches everything, but `stopAutoWiring` and `unwire` call adb directly — outside it. An adb uninstalled or unmounted since wiring would propagate `IOException` out of a shutdown path with nothing waiting for it.

A launch failure is now a non-zero exit code, which every caller already treats as a failure to report.

## `findAdbPath` preferred a stray adb over the one you named

`ANDROID_HOME` and `ANDROID_SDK_ROOT` were checked **after** hardcoded system paths, so a `/usr/local/bin/adb` from an unrelated install outranked the SDK a user had explicitly pointed at. Environment first now.

It also had no Windows candidate at all — neither `adb.exe` nor the LOCALAPPDATA SDK location — so a Windows host found nothing and always fell through to PATH.

## Verification

`./gradlew spotlessCheck check` — **BUILD SUCCESSFUL**, no errors, no failures. Read from the build log; the wrapping shell reported exit 1, which came from a `grep -c` finding zero matches.

## Left for a decision, not fixed here

`--plugin-dir` and `--log-level` are parsed and validated into `JetWhaleCliOptions` and then read by **nothing but tests** — while `docs/guide/host-settings.md:292-293` documents both as working. `--log-level FOO` fails startup for a flag that has no effect.

Wiring them touches the DI graph, the plugin repository and the logging setup, and raises questions this PR should not answer alone: does a `--plugin-dir` plugin appear as installed in the UI, can it be uninstalled there. Removing them from the CLI and the docs is the smaller, more honest change for an alpha, but it withdraws two documented options.