### PR TITLE
feat(host): make --plugin-dir and --log-level do what they say

### DIFF
--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -289,8 +289,8 @@ When you launch the host from a plugin project with
 
 | Option | Default | What it does |
 |--------|---------|--------------|
-| `--plugin-dir <path>` | — | Load plugins from an additional directory, on top of `~/.jetwhale/plugins/`. **Repeatable.** |
-| `--log-level <level>` | `WARN` | Minimum level the host's own logging emits: `DEBUG`, `INFO`, `WARN` or `ERROR`. Raise it when diagnosing a plugin that will not load, then read the result in the [log viewer](/guide/host-window#the-log-viewer). |
+| `--plugin-dir <path>` | — | Also load the jars in this directory, on top of `~/.jetwhale/plugins/`. **Repeatable.** These are not trust-gated — naming the directory on the command line *is* the approval — and they are not managed: they do not appear as installed plugins and cannot be uninstalled or revoked from the UI. |
+| `--log-level <level>` | the host's configured level | Minimum level the host's own logging emits: `DEBUG`, `INFO`, `WARN` or `ERROR`. Lower it when diagnosing a plugin that will not load, then read the result in the [log viewer](/guide/host-window#the-log-viewer). Left unset, whatever the host ships configured is used — this option only ever overrides. |
 | `--mcp-allow-all-permissions` | off | Allows every MCP tool for that process only — see [MCP Server → Lifting every permission for one launch](/guide/mcp-server#lifting-every-permission-for-one-launch). |
 | `--headless` | off | Runs without the application window — see [Headless mode](#headless-mode) below. |
 

--- a/jetwhale-host/app/build.gradle.kts
+++ b/jetwhale-host/app/build.gradle.kts
@@ -151,6 +151,9 @@ dependencies {
     implementation(projects.jetwhaleHost.feature.plugin)
     implementation(projects.jetwhaleHost.core.model)
     implementation(projects.jetwhaleHost.core.data)
+    // main() applies --log-level to the root logger; logback is on the runtime classpath through
+    // core:data either way, but configuring it needs it visible at compile time here.
+    implementation(libs.logbackClassic)
     implementation(projects.jetwhaleHost.core.mcp)
     implementation(projects.jetwhaleHost.core.architecture)
     implementation(projects.jetwhaleHost.core.ui)

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
@@ -17,10 +17,13 @@ import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.awaitApplication
+import ch.qos.logback.classic.Level
 import com.kitakkun.jetwhale.host.cli.CommandLineArgumentsParser
+import com.kitakkun.jetwhale.host.cli.JetWhaleLogLevel
 import com.kitakkun.jetwhale.host.component.InitializingDialog
 import com.kitakkun.jetwhale.host.component.ShuttingDownDialog
 import com.kitakkun.jetwhale.host.di.JetWhaleAppGraph
+import com.kitakkun.jetwhale.host.model.AdditionalPluginDirectories
 import com.kitakkun.jetwhale.host.model.PersistedWindowState
 import com.kitakkun.jetwhale.host.ui.isShortcutModifierPressed
 import dev.zacsweers.metro.createGraphFactory
@@ -29,9 +32,12 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.painterResource
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.awt.Taskbar
 import javax.imageio.ImageIO
 import kotlin.system.exitProcess
+import ch.qos.logback.classic.Logger as LogbackLogger
 
 /**
  * Applies the application name and icon at runtime so they are correct even when the host is
@@ -68,10 +74,13 @@ fun main(args: Array<String>) = runBlocking {
         configureAppMetadata()
     }
 
+    cliOptions.logLevel?.let(::applyLogLevel)
+
     val appGraph: JetWhaleAppGraph = createGraphFactory<JetWhaleAppGraph.Factory>()
         .create(
             serverPortOverrides = cliOptions.serverPortOverrides,
             mcpPermissionOverride = cliOptions.mcpPermissionOverride,
+            additionalPluginDirectories = AdditionalPluginDirectories(cliOptions.pluginDirs),
         )
 
     // Start capturing logs
@@ -171,5 +180,28 @@ fun main(args: Array<String>) = runBlocking {
                 JetWhaleApp()
             }
         }
+    }
+}
+
+/**
+ * Raises or lowers the root logger for this launch.
+ *
+ * Applied only when `--log-level` was passed. `logback.xml` configures the root at `trace`, so
+ * defaulting this would silently reduce what the host logs — and so what the log viewer can show —
+ * for every launch that never asked.
+ *
+ * Set before the graph is built, so nothing constructed there logs at the old level first.
+ */
+private fun applyLogLevel(level: JetWhaleLogLevel) {
+    val root = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)
+    if (root !is LogbackLogger) {
+        // Another SLF4J binding is in charge; leave its configuration alone rather than guess at it.
+        return
+    }
+    root.level = when (level) {
+        JetWhaleLogLevel.DEBUG -> Level.DEBUG
+        JetWhaleLogLevel.INFO -> Level.INFO
+        JetWhaleLogLevel.WARN -> Level.WARN
+        JetWhaleLogLevel.ERROR -> Level.ERROR
     }
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsParser.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsParser.kt
@@ -5,7 +5,12 @@ import com.kitakkun.jetwhale.host.model.ServerPortOverrides
 
 data class JetWhaleCliOptions(
     val pluginDirs: List<String>,
-    val logLevel: JetWhaleLogLevel,
+    /**
+     * Null when `--log-level` was not passed, which leaves whatever `logback.xml` configures in
+     * place. Applying a default here would quietly reduce what the host logs — and so what the log
+     * viewer can show — for every launch that never asked for it.
+     */
+    val logLevel: JetWhaleLogLevel?,
     val serverPortOverrides: ServerPortOverrides,
     val mcpPermissionOverride: McpPermissionOverride,
     /** Runs the servers with no window, for CI and agent-driven QA. See [com.kitakkun.jetwhale.host.headless.HeadlessHostRunner]. */
@@ -22,7 +27,7 @@ enum class JetWhaleLogLevel {
 class CommandLineArgumentsParser {
     fun parse(args: Array<String>): JetWhaleCliOptions {
         val pluginDirs = mutableListOf<String>()
-        var logLevel: JetWhaleLogLevel = JetWhaleLogLevel.WARN
+        var logLevel: JetWhaleLogLevel? = null
         var serverPort: Int? = null
         var wssPort: Int? = null
         var mcpServerPort: Int? = null

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
@@ -7,6 +7,7 @@ import com.kitakkun.jetwhale.host.drawer.McpToolsScreenContext
 import com.kitakkun.jetwhale.host.drawer.ToolingScaffoldScreenContext
 import com.kitakkun.jetwhale.host.headless.HeadlessHostRunner
 import com.kitakkun.jetwhale.host.mcp.McpServerService
+import com.kitakkun.jetwhale.host.model.AdditionalPluginDirectories
 import com.kitakkun.jetwhale.host.model.AppearanceSettingsSubscriptionKey
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
 import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
@@ -72,6 +73,7 @@ interface JetWhaleAppGraph : ScreenContext {
         fun create(
             @Provides serverPortOverrides: ServerPortOverrides,
             @Provides mcpPermissionOverride: McpPermissionOverride,
+            @Provides additionalPluginDirectories: AdditionalPluginDirectories,
         ): JetWhaleAppGraph
     }
 

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsResolverTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsResolverTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CommandLineArgumentsResolverTest {
@@ -159,5 +160,20 @@ class CommandLineArgumentsResolverTest {
         assertFailsWith<IllegalStateException> {
             resolver.parse(arrayOf("--mcp-server-port", "65536"))
         }
+    }
+
+    @Test
+    fun `an absent log level leaves the configured one alone`() {
+        // Null rather than WARN: logback.xml sets the root at trace, so defaulting here would quietly
+        // reduce what every launch logs, and what the log viewer can show.
+        assertNull(CommandLineArgumentsParser().parse(arrayOf()).logLevel)
+    }
+
+    @Test
+    fun `an explicit log level is parsed`() {
+        assertEquals(
+            JetWhaleLogLevel.DEBUG,
+            CommandLineArgumentsParser().parse(arrayOf("--log-level", "DEBUG")).logLevel,
+        )
     }
 }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
@@ -153,7 +153,12 @@ class AppDataDirectoryProvider(
      */
     fun getAdditionalPluginJarFilePaths(): List<String> = additionalPluginDirectories.paths
         .flatMap { path ->
-            File(path).listFiles { file -> file.extension == "jar" }?.toList().orEmpty()
+            // listFiles returns null for a missing path or a plain file, but *throws* SecurityException
+            // when a directory exists and cannot be read. Both are the same thing from here — one
+            // unusable directory — and neither should take the launch down with it.
+            runCatching { File(path).listFiles { file -> file.extension == "jar" }?.toList() }
+                .getOrNull()
+                .orEmpty()
         }
         .map { it.absolutePath }
 

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProvider.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.data
 
+import com.kitakkun.jetwhale.host.model.AdditionalPluginDirectories
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -9,7 +10,9 @@ import java.io.File
 
 @SingleIn(AppScope::class)
 @Inject
-class AppDataDirectoryProvider {
+class AppDataDirectoryProvider(
+    private val additionalPluginDirectories: AdditionalPluginDirectories,
+) {
     private val homeDir = System.getProperty("user.home")
 
     // The app data root. Normally `~/.jetwhale`, but a launch may point it elsewhere via the
@@ -141,6 +144,18 @@ class AppDataDirectoryProvider {
      * sandbox, the sandbox root's `plugins` subdirectory).
      */
     fun getDevPluginsDir(): String? = System.getProperty(DEV_PLUGINS_DIR_PROPERTY)?.takeIf { it.isNotBlank() }
+
+    /**
+     * Absolute paths of every jar in the directories named with `--plugin-dir`, if any.
+     *
+     * Directories that do not exist, or that cannot be listed, contribute nothing rather than failing
+     * the launch: a stale path in a shell alias should not stop the host from starting.
+     */
+    fun getAdditionalPluginJarFilePaths(): List<String> = additionalPluginDirectories.paths
+        .flatMap { path ->
+            File(path).listFiles { file -> file.extension == "jar" }?.toList().orEmpty()
+        }
+        .map { it.absolutePath }
 
     /** Returns the absolute paths of every jar currently in the dev plugins directory, if configured. */
     fun getDevPluginJarFilePaths(): List<String> {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustService.kt
@@ -64,6 +64,15 @@ class DefaultPluginTrustService(
             }
         }
         untrustedJarPathsFlow.value = untrusted
+
+        // Directories named with `--plugin-dir` load without consulting the trust registry, exactly as
+        // the dev plugins directory already does. The registry answers "did the person running this
+        // host approve this jar", and typing the directory on the command line is that approval —
+        // there is also no UI path to approve them, since trusting is defined over the managed
+        // directory alone.
+        for (jarPath in appDataDirectoryProvider.getAdditionalPluginJarFilePaths()) {
+            pluginFactoryRepository.loadPlugin(jarPath)
+        }
     }
 
     override suspend fun trustAndLoad(jarPath: String) {

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/util/AdbUtil.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/util/AdbUtil.kt
@@ -3,7 +3,8 @@ package com.kitakkun.jetwhale.host.data.util
 import java.io.File
 
 /**
- * The absolute path to the adb executable, or `"adb"` to let the OS resolve it from PATH.
+ * The absolute path to the adb executable, or the bare executable name — `adb`, or `adb.exe` on
+ * Windows — to let the OS resolve it from PATH.
  *
  * `ANDROID_HOME` and `ANDROID_SDK_ROOT` are consulted first: someone who has set them has said which
  * SDK they mean, and a stray `/usr/local/bin/adb` from an unrelated install should not outrank that.

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProviderTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/AppDataDirectoryProviderTest.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.data
 
+import com.kitakkun.jetwhale.host.model.AdditionalPluginDirectories
 import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -26,7 +27,7 @@ class AppDataDirectoryProviderTest {
         System.setProperty("user.home", home)
         System.clearProperty(AppDataDirectoryProvider.APP_DATA_DIR_PROPERTY)
 
-        val provider = AppDataDirectoryProvider()
+        val provider = AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList()))
 
         assertEquals("~/.jetwhale", provider.getAppDataPath())
         assertTrue(provider.getPluginDirectory().path.startsWith("$home/.jetwhale"))
@@ -43,7 +44,7 @@ class AppDataDirectoryProviderTest {
         System.setProperty("user.home", home)
         System.setProperty(AppDataDirectoryProvider.APP_DATA_DIR_PROPERTY, sandbox)
 
-        val provider = AppDataDirectoryProvider()
+        val provider = AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList()))
 
         // Nothing resolves under the real home; everything flows from the sandbox root.
         assertEquals(sandbox, provider.getAppDataPath())
@@ -63,7 +64,7 @@ class AppDataDirectoryProviderTest {
         System.setProperty("user.home", home)
         System.setProperty(AppDataDirectoryProvider.APP_DATA_DIR_PROPERTY, "   ")
 
-        val provider = AppDataDirectoryProvider()
+        val provider = AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList()))
 
         assertEquals("~/.jetwhale", provider.getAppDataPath())
         assertTrue(provider.getPluginDirectory().path.startsWith("$home/.jetwhale"))

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/KtorWebSocketServerTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/KtorWebSocketServerTest.kt
@@ -5,6 +5,7 @@ import com.kitakkun.jetwhale.host.data.cert.KeyPairFactory
 import com.kitakkun.jetwhale.host.data.cert.ServerCertificateIssuer
 import com.kitakkun.jetwhale.host.data.server.KtorWebSocketServer
 import com.kitakkun.jetwhale.host.data.ssl.DefaultSslCertificateManager
+import com.kitakkun.jetwhale.host.model.AdditionalPluginDirectories
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
 import com.kitakkun.jetwhale.host.model.SslCertificateEntry
 import com.kitakkun.jetwhale.host.model.SslCertificateManager
@@ -93,7 +94,7 @@ class KtorWebSocketServerTest {
         val originalHome = System.getProperty("user.home")
         System.setProperty("user.home", tempHome.absolutePath)
         try {
-            val sslCertificateManager = DefaultSslCertificateManager(AppDataDirectoryProvider())
+            val sslCertificateManager = DefaultSslCertificateManager(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())))
             sslCertificateManager.generateAndAddCertificate("first")
 
             val server = KtorWebSocketServer(
@@ -187,7 +188,7 @@ class KtorWebSocketServerTest {
         val originalHome = System.getProperty("user.home")
         System.setProperty("user.home", tempHome.absolutePath)
         try {
-            val sslCertificateManager = DefaultSslCertificateManager(AppDataDirectoryProvider())
+            val sslCertificateManager = DefaultSslCertificateManager(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())))
             sslCertificateManager.generateAndAddCertificate("tls-ca")
             val expectedPem = sslCertificateManager.getActiveCertificate()?.caCertificatePem
 

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginDataStoreRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginDataStoreRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.host.data.plugin
 
 import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
+import com.kitakkun.jetwhale.host.model.AdditionalPluginDirectories
 import com.kitakkun.jetwhale.host.sdk.InternalJetWhaleHostApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
 import com.kitakkun.jetwhale.host.sdk.get
@@ -29,7 +30,7 @@ class DefaultPluginDataStoreRepositoryTest {
     private fun newRepository(): DefaultPluginDataStoreRepository {
         val tempHome = Files.createTempDirectory("jetwhale-plugin-data-test").toString()
         System.setProperty("user.home", tempHome)
-        return DefaultPluginDataStoreRepository(AppDataDirectoryProvider())
+        return DefaultPluginDataStoreRepository(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())))
     }
 
     @Test

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepositoryTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.host.data.plugin
 
 import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
+import com.kitakkun.jetwhale.host.model.AdditionalPluginDirectories
 import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.security.MessageDigest
@@ -36,7 +37,7 @@ class DefaultPluginTrustRepositoryTest {
     // A fresh repository each time so we exercise the on-disk read path, not just the in-memory
     // cache. Whether the registry is signed is decided entirely by the injected signer (key present
     // or not); the repository holds no policy of its own.
-    private fun newRepository(signer: TrustRegistrySigner = FakeTrustRegistrySigner()) = DefaultPluginTrustRepository(AppDataDirectoryProvider(), signer)
+    private fun newRepository(signer: TrustRegistrySigner = FakeTrustRegistrySigner()) = DefaultPluginTrustRepository(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())), signer)
 
     /**
      * Deterministic stand-in for the keyring-backed signer. "Signing enabled" is modeled by
@@ -103,7 +104,7 @@ class DefaultPluginTrustRepositoryTest {
 
         // Simulate a malicious process rewriting the file: swap in a different hash while leaving the
         // recorded signature untouched. With a key present the signature no longer matches → INVALID.
-        val registryFile = AppDataDirectoryProvider().getTrustRegistryFile()
+        val registryFile = AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())).getTrustRegistryFile()
         registryFile.writeText(registryFile.readText().replace("hash-a", "forged-hash"))
 
         val reloaded = newRepository().apply { load() }
@@ -116,7 +117,7 @@ class DefaultPluginTrustRepositoryTest {
         // signature it cannot produce. A key exists, so a missing signature must be rejected wholesale.
         newRepository().trust("/plugins/a.jar", "hash-a")
 
-        val registryFile = AppDataDirectoryProvider().getTrustRegistryFile()
+        val registryFile = AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())).getTrustRegistryFile()
         val stripped = registryFile.readText().replace(Regex("\"signature\"\\s*:\\s*\"[^\"]*\""), "\"signature\": null")
         registryFile.writeText(stripped)
 

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustServiceTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustServiceTest.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.host.data.plugin
 
 import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
+import com.kitakkun.jetwhale.host.model.AdditionalPluginDirectories
 import com.kitakkun.jetwhale.host.model.FailedPluginJar
 import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
 import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
@@ -42,7 +43,7 @@ class DefaultPluginTrustServiceTest {
         trustRepository = FakePluginTrustRepository()
         factoryRepository = FakePluginFactoryRepository()
         signer = FakeTrustRegistrySigner(keyPresent = false)
-        service = DefaultPluginTrustService(AppDataDirectoryProvider(), trustRepository, factoryRepository, signer)
+        service = DefaultPluginTrustService(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())), trustRepository, factoryRepository, signer)
     }
 
     @AfterTest
@@ -146,9 +147,9 @@ class DefaultPluginTrustServiceTest {
         val jar = File(pluginsDir, "plugin.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
         val diskSigner = FakeTrustRegistrySigner(keyPresent = false)
 
-        val diskRepository = DefaultPluginTrustRepository(AppDataDirectoryProvider(), diskSigner)
+        val diskRepository = DefaultPluginTrustRepository(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())), diskSigner)
         val diskFactory = FakePluginFactoryRepository()
-        val diskService = DefaultPluginTrustService(AppDataDirectoryProvider(), diskRepository, diskFactory, diskSigner)
+        val diskService = DefaultPluginTrustService(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())), diskRepository, diskFactory, diskSigner)
 
         // Approve with signing off: the registry is written unsigned.
         diskService.trustAndLoad(jar.absolutePath)
@@ -157,9 +158,9 @@ class DefaultPluginTrustServiceTest {
 
         // Fresh start with the same (now-present) key. Without the re-sign the unsigned registry would
         // verify INVALID and drop every plugin; re-signing lets it verify and load.
-        val reloadedRepository = DefaultPluginTrustRepository(AppDataDirectoryProvider(), diskSigner)
+        val reloadedRepository = DefaultPluginTrustRepository(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())), diskSigner)
         val reloadedFactory = FakePluginFactoryRepository()
-        val reloadedService = DefaultPluginTrustService(AppDataDirectoryProvider(), reloadedRepository, reloadedFactory, diskSigner)
+        val reloadedService = DefaultPluginTrustService(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())), reloadedRepository, reloadedFactory, diskSigner)
         reloadedService.loadTrustedPlugins()
 
         assertEquals(listOf(jar.absolutePath), reloadedFactory.loadedJarPaths)

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/AdditionalPluginDirectories.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/AdditionalPluginDirectories.kt
@@ -1,0 +1,16 @@
+package com.kitakkun.jetwhale.host.model
+
+/**
+ * Plugin directories named on the command line with `--plugin-dir`, loaded on top of the managed
+ * plugins directory.
+ *
+ * Their jars are **not** trust-gated, matching the existing `jetwhale.devPluginsDir` behaviour: the
+ * trust registry answers "did the person running this host approve this jar", and typing the
+ * directory on the command line is that approval. They are also not managed — they do not appear as
+ * installed plugins, and cannot be uninstalled, trusted or revoked from the UI, which all operate on
+ * the managed directory alone.
+ *
+ * Empty in normal usage, so production behaviour is unchanged.
+ */
+@JvmInline
+value class AdditionalPluginDirectories(val paths: List<String>)


### PR DESCRIPTION
Both options were parsed, validated into `JetWhaleCliOptions`, and then read by **nothing but tests** — while `docs/guide/host-settings.md:292-293` documented them as working. `--log-level FOO` failed startup for a flag that had no effect.

## `--plugin-dir`

Loads the jars in each named directory on top of the managed plugins directory.

**Not trust-gated**, and that is the interesting decision. The managed directory is gated: every jar needs a SHA-256 in the trust registry before `DefaultPluginTrustService` will load it. But `jetwhale.devPluginsDir` — the system property `runJetWhale` sets — already loads without any of that, because a developer building their own jar has approved it by building it.

`--plugin-dir` is the same posture: the registry answers *"did the person running this host approve this jar"*, and typing the directory on the command line **is** that approval. Gating it would also have meant inventing a UI flow rather than reusing one — `trustAndLoad` refuses anything outside the managed directory, so there is no way to approve such a jar from the window.

They are likewise **not managed**: not shown as installed, not uninstallable or revocable from the UI. All of that is defined over the managed directory alone. The docs now say so.

## `--log-level`

Sets the root logger — **and only when passed.**

The parser defaulted it to `WARN`, but `logback.xml` configures the root at `trace`. Wiring that default through would have quietly reduced what every launch logs, and so what the log viewer can show, for every caller who never asked for it. The option overrides; absent, the configured level stands.

The documented default is corrected from `WARN` to "the host's configured level", which is what it always actually was.

## Wiring

`AdditionalPluginDirectories` enters the graph through `JetWhaleAppGraph.Factory`, the way `ServerPortOverrides` and `McpPermissionOverride` already do — the command line is only readable from `main()`. `AppDataDirectoryProvider` takes it as a constructor parameter rather than reading yet another system property.

Its four test construction sites are updated explicitly rather than given a default argument. A default would have made the diff smaller and hidden the fact that the value now comes from the graph.

## Verification

Beyond `spotlessCheck check` (**BUILD SUCCESSFUL**), both options were exercised against a running host — headless, with `-PjetwhaleAppDataDir` pointing at a throwaway sandbox and `--plugin-dir` at a directory holding only the example plugin jar:

| | |
|---|---|
| `--plugin-dir <dir>` | `Loaded plugin: com.kitakkun.jetwhale.example` — 3 loads into an otherwise empty sandbox, so nothing else could have supplied them |
| `--log-level INFO` | 2 ktor `INFO` lines |
| `--log-level ERROR` | **0** `INFO` lines, plugins still loaded |

The ERROR run is the one that matters. A level that is merely accepted proves nothing; this one demonstrably filters.

## Also

`findAdbPath`'s KDoc promised a bare `"adb"` fallback while returning `adb.exe` on Windows — the one review comment left over from the merged #238.