### PR TITLE
feat(host): announce a connecting debug session with a Snackbar

### DIFF
--- a/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
@@ -12,6 +12,8 @@
     <string name="select_app">アプリを選択</string>
     <string name="session_secure_connection">暗号化された接続 (wss)</string>
     <string name="session_local_connection">ローカル接続 (ADB)</string>
+    <string name="session_connected_message">%1$s が接続されました</string>
+    <string name="sessions_connected_message">%1$d 件のセッションが接続されました</string>
     <string name="session_disconnected_message">%1$s が切断されました</string>
     <string name="sessions_disconnected_message">%1$d 件のセッションが切断されました</string>
     <string name="initializing">初期化中...</string>

--- a/jetwhale-host/app/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="select_app">Select App</string>
     <string name="session_secure_connection">Secure connection (wss)</string>
     <string name="session_local_connection">Local connection (ADB)</string>
+    <string name="session_connected_message">%1$s connected</string>
+    <string name="sessions_connected_message">%1$d sessions connected</string>
     <string name="session_disconnected_message">%1$s disconnected</string>
     <string name="sessions_disconnected_message">%1$d sessions disconnected</string>
     <string name="initializing">Initializing...</string>

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -36,6 +36,10 @@ sealed interface ToolingScaffoldScreenAction {
 sealed interface ToolingScaffoldScreenActionResult {
     /** Carries the sessions themselves, since a handler wants to name what went, not just its id. */
     data class SessionClosed(val closedSessions: ImmutableList<DebugSession>) : ToolingScaffoldScreenActionResult
+
+    /** Carries the sessions themselves, since a handler wants to name what arrived, not just its id. */
+    data class SessionConnected(val connectedSessions: ImmutableList<DebugSession>) : ToolingScaffoldScreenActionResult
+
     data class SetPluginEnabledFailed(val error: Throwable) : ToolingScaffoldScreenActionResult
 }
 
@@ -53,6 +57,20 @@ internal fun closedSessions(
 ): List<DebugSession> {
     val stillConnected = current.filter { it.isActive }.mapTo(mutableSetOf()) { it.id }
     return previouslyConnected.filterNot { it.id in stillConnected }
+}
+
+/**
+ * The sessions that are connected in [current] and were not in [previouslyConnected].
+ *
+ * "Connected" is what the diff is on, not "present": a disconnected session keeps its entry in the
+ * list, so an id reappearing as active is a genuine arrival and is announced — a reconnect included.
+ */
+internal fun newlyConnectedSessions(
+    previouslyConnected: List<DebugSession>,
+    current: List<DebugSession>,
+): List<DebugSession> {
+    val alreadyConnected = previouslyConnected.mapTo(mutableSetOf()) { it.id }
+    return current.filter { it.isActive && it.id !in alreadyConnected }
 }
 
 /**
@@ -139,12 +157,20 @@ fun toolingScaffoldPresenter(
         }
     }
 
-    var connectedSessions by remember { mutableStateOf<List<DebugSession>>(emptyList()) }
+    // Seeded from the sessions of the first composition so opening the window announces nothing:
+    // whoever was already connected is not an arrival. Read only inside the effect below, never
+    // during composition, so writing it back cannot drive a recomposition loop.
+    var connectedSessions by remember { mutableStateOf(debugSessions.filter { it.isActive }) }
     LaunchedEffect(debugSessions) {
         val closedSessions = closedSessions(previouslyConnected = connectedSessions, current = debugSessions)
+        val connectedSessionsToAnnounce = newlyConnectedSessions(previouslyConnected = connectedSessions, current = debugSessions)
         connectedSessions = debugSessions.filter { it.isActive }
-        if (closedSessions.isEmpty()) return@LaunchedEffect
-        screenChannel.emit(ToolingScaffoldScreenActionResult.SessionClosed(closedSessions.toImmutableList()))
+        if (closedSessions.isNotEmpty()) {
+            screenChannel.emit(ToolingScaffoldScreenActionResult.SessionClosed(closedSessions.toImmutableList()))
+        }
+        if (connectedSessionsToAnnounce.isNotEmpty()) {
+            screenChannel.emit(ToolingScaffoldScreenActionResult.SessionConnected(connectedSessionsToAnnounce.toImmutableList()))
+        }
     }
 
     ActionEffect(screenChannel) { action ->

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -14,7 +14,9 @@ import com.kitakkun.jetwhale.host.architecture.rememberScreenChannel
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.HostNavigationRequest
 import com.kitakkun.jetwhale.host.navigation.toPage
+import com.kitakkun.jetwhale.host.session_connected_message
 import com.kitakkun.jetwhale.host.session_disconnected_message
+import com.kitakkun.jetwhale.host.sessions_connected_message
 import com.kitakkun.jetwhale.host.sessions_disconnected_message
 import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import org.jetbrains.compose.resources.getString
@@ -64,6 +66,16 @@ fun ToolingScaffoldRoot(
                         val message = closedSessions.singleOrNull()
                             ?.let { getString(Res.string.session_disconnected_message, it.deviceAndAppDisplayName) }
                             ?: getString(Res.string.sessions_disconnected_message, closedSessions.size)
+                        snackbarHostState.showSnackbar(message = message, duration = SnackbarDuration.Short)
+                    }
+
+                    is ToolingScaffoldScreenActionResult.SessionConnected -> {
+                        // Same shape as the disconnect above: a single arrival names the session, a
+                        // simultaneous batch is collapsed into a count.
+                        val connectedSessions = result.connectedSessions
+                        val message = connectedSessions.singleOrNull()
+                            ?.let { getString(Res.string.session_connected_message, it.deviceAndAppDisplayName) }
+                            ?: getString(Res.string.sessions_connected_message, connectedSessions.size)
                         snackbarHostState.showSnackbar(message = message, duration = SnackbarDuration.Short)
                     }
 

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/drawer/NewlyConnectedSessionsTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/drawer/NewlyConnectedSessionsTest.kt
@@ -1,0 +1,67 @@
+package com.kitakkun.jetwhale.host.drawer
+
+import com.kitakkun.jetwhale.host.model.DebugSession
+import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NewlyConnectedSessionsTest {
+    @Test
+    fun `a session that appeared active is reported as connected`() {
+        val connected = newlyConnectedSessions(previouslyConnected = listOf(session("a")), current = listOf(session("a"), session("b")))
+
+        assertEquals(listOf("b"), connected.map { it.id })
+    }
+
+    @Test
+    fun `a session already connected before this update is not reported again`() {
+        val connected = newlyConnectedSessions(previouslyConnected = listOf(session("a")), current = listOf(session("a")))
+
+        assertTrue(connected.isEmpty(), "a was connected before this update and must not be re-reported")
+    }
+
+    @Test
+    fun `a session that reconnects is reported again`() {
+        // The disconnected entry stays in the list, so the diff is on "connected", not on "present".
+        val connected = newlyConnectedSessions(previouslyConnected = emptyList(), current = listOf(session("a")))
+
+        assertEquals(listOf("a"), connected.map { it.id })
+    }
+
+    @Test
+    fun `a session that only appeared inactive is not reported`() {
+        val connected = newlyConnectedSessions(previouslyConnected = emptyList(), current = listOf(session("a", isActive = false)))
+
+        assertTrue(connected.isEmpty(), "an inactive entry is not an arrival")
+    }
+
+    @Test
+    fun `sessions connecting together are all reported`() {
+        val connected = newlyConnectedSessions(
+            previouslyConnected = listOf(session("a")),
+            current = listOf(session("a"), session("b"), session("c")),
+        )
+
+        assertEquals(listOf("b", "c"), connected.map { it.id })
+    }
+
+    @Test
+    fun `sessions present from the start report nothing`() {
+        // The presenter seeds the previous snapshot from the first list, so opening the window is silent.
+        val initial = listOf(session("a"), session("b"))
+
+        val connected = newlyConnectedSessions(previouslyConnected = initial, current = initial)
+
+        assertTrue(connected.isEmpty(), "sessions present from the start have not just connected")
+    }
+
+    private fun session(id: String, isActive: Boolean = true) = DebugSession(
+        id = id,
+        name = id,
+        isActive = isActive,
+        transportSecurity = SessionTransportSecurity.LOOPBACK,
+        installedPlugins = persistentListOf(),
+    )
+}


### PR DESCRIPTION
## What

The host drawer already raises a Snackbar when a debug session disconnects. This adds the counterpart for a session connecting, with the same shape: a single arrival names the session via `deviceAndAppDisplayName`, a simultaneous batch collapses into a count. `session_connected_message` / `sessions_connected_message` are added to both `values` and `values-ja`.

## Why the connect path is not simply a copy of the disconnect path

A disconnect and a connect look symmetric in the UI but not in where the information comes from. A connect arrives from the network — nothing the user did produces it — so it has to be derived from the `debugSessions` list rather than raised at a call site. That forces three things, each of which the diff shows only as a small decision:

1. **"New" means "became active", not "appeared in the list".** `DefaultDebugSessionRepository.unregisterDebugSession` sets `isActive = false` instead of removing the entry, so the list is append-mostly and "an id I have not seen before" is the wrong test. The diff is therefore over the set of **active** session ids against the previously active set — mirroring `closedSessions`, which is already written this way for the same reason. A consequence, and the intended behaviour: a reconnect of the same session id announces itself again. The rule is a simple diff with no suppression window.

2. **Sessions already connected at first composition must stay silent.** The remembered snapshot is seeded from the `debugSessions` value of the first composition, not from an empty list, so opening the window does not announce everyone who was already attached. (The disconnect diff does not need this — seeding from an empty list happens to be correct there — so the seed is new behaviour that the shared state now carries.)

3. **`showSnackbar` suspends until the snackbar is dismissed.** Calling it from an effect keyed on `debugSessions` would let the next list emission cancel a snackbar that is still on screen, and a connect is exactly the event that changes `debugSessions`. The message is therefore queued rather than shown inline: it is emitted as a `ScreenChannel` result, and `ActionResultEffect` drains that buffered channel from a `LaunchedEffect` keyed on the channel — a collector that outlives every session list change. This is the existing serialization the disconnect message already relies on, which is why the connect message joins the same `when` in `ToolingScaffoldRoot` instead of growing a second queue beside it.

Note for reviewers who expect otherwise from the file: the disconnect message is *not* the result of a user action either. `SessionClosed` is already emitted from a `LaunchedEffect(debugSessions)` in `ToolingScaffoldPresenter`, so both directions are list-derived and share one snapshot (`connectedSessions`) and one effect. Adding a separate channel and drain loop in the Root would have duplicated infrastructure that `ScreenChannel` already provides.

The arrival diff is extracted as the pure `newlyConnectedSessions(previouslyConnected, current)` next to the existing `closedSessions`, and covered by `NewlyConnectedSessionsTest` (6 cases: arrival, no re-report, reconnect, inactive entry ignored, simultaneous batch, seeded first composition). Nothing about the diff needs a composition to test.

## Testing

- `./gradlew spotlessCheck` — BUILD SUCCESSFUL.
- `./gradlew check` — BUILD SUCCESSFUL (verified in the build log, not from the exit code). `ANDROID_HOME` had to be exported for `:demo:android:lintReportDebug`; unrelated to this change.
- `./gradlew :jetwhale-host:app:test` — the 6 new cases pass.
- `./gradlew :jetwhale-host:app:runHeadless` against a throwaway app data dir on ports 5095 / 5458 / 7115 — reaches `JetWhale headless: ready` with no exception, so nothing added here breaks startup.

**Not verified: the Snackbar itself.** Headless has no window, so it cannot render one, and no screenshot is attached. Confirming it needs a human to run `./gradlew :jetwhale-host:app:run`, connect an agent app (or reconnect one) while the window is open, and check that the Snackbar names the device and app once — and that opening the window with a session already attached shows nothing.
