### PR TITLE
fix: defects found in 1.0.0-alpha11 release QA

### DIFF
--- a/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/EndpointResolver.kt
+++ b/jetwhale-agent-runtime/src/commonMain/kotlin/com/kitakkun/jetwhale/agent/runtime/EndpointResolver.kt
@@ -3,8 +3,9 @@ package com.kitakkun.jetwhale.agent.runtime
 /**
  * A concrete address to dial — what resolution produces.
  *
- * [useWss] travels with the address rather than being read from `ssl { }` at dial time: `ssl { }`
- * still decides it for every endpoint but one, and `plainLoopback` is that one.
+ * [useWss] travels with the address rather than being read from `ssl { }` at dial time: every
+ * candidate in `endpoints { }` names its own scheme, so one list can hold both a plain loopback
+ * address and a wss one. `ssl { }` decides the scheme only for the deprecated `host`/`port` pair.
  */
 internal data class ResolvedEndpoint(val host: String, val port: Int, val useWss: Boolean) {
     override fun toString(): String = "${if (useWss) "wss" else "ws"}://$host:$port"

--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/DefaultDynamicPluginBridgeProvider.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/DefaultDynamicPluginBridgeProvider.kt
@@ -1,7 +1,10 @@
 package com.kitakkun.jetwhale.host.plugin
 
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
 import com.kitakkun.jetwhale.host.architecture.ExplicitScreenContextUsage
 import com.kitakkun.jetwhale.host.architecture.SoilDataBoundary
 import com.kitakkun.jetwhale.host.architecture.withScreenContext
@@ -41,8 +44,14 @@ class DefaultDynamicPluginBridgeProvider(
                             // Dynamic), not a luminance guess of the resolved surface.
                             LocalJetWhaleDarkTheme provides theme.colorScheme.isDarkTheme(),
                         ) {
-                            AppEnvironment(appearanceSettings.appLanguage) {
-                                content()
+                            // The scene has to carry its own background. On screen the host window
+                            // paints one behind it, but an off-screen MCP capture has nothing
+                            // behind it, so a plugin that draws no background of its own would be
+                            // captured transparent and read as white.
+                            Surface(modifier = Modifier.fillMaxSize()) {
+                                AppEnvironment(appearanceSettings.appLanguage) {
+                                    content()
+                                }
                             }
                         }
                     }

--- a/jetwhale-plugins/semantics/agent/build.gradle.kts
+++ b/jetwhale-plugins/semantics/agent/build.gradle.kts
@@ -46,7 +46,10 @@ kotlin {
         commonMain.dependencies {
             api(projects.jetwhalePlugins.semantics.protocol)
             api(projects.jetwhaleAgentSdk)
-            implementation(libs.jetbrainsComposeUi)
+            // SemanticsOwner is part of this module's public API: `registerSemanticsOwner` takes one,
+            // and `SemanticsOwnerNodeSource` is constructed with one. A consumer calling either needs
+            // compose-ui on its compile classpath from this artifact's POM.
+            api(libs.jetbrainsComposeUi)
             implementation(libs.kotlinxCoroutinesCore)
         }
         commonTest.dependencies {

--- a/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAgentOptions.kt
+++ b/tools/qa-agent/src/main/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAgentOptions.kt
@@ -8,6 +8,14 @@ internal const val DEFAULT_PLUGIN_VERSION = "1.0.0"
 internal const val DEFAULT_APP_NAME = "qa-agent"
 
 /**
+ * Id of the Network agent plugin every app carries so `/fire` has something to capture traffic with.
+ * A wire-level stand-in must never be registered under it: the two would claim the same id in one
+ * session, and the stand-in — which registers no request handlers — would shadow the real plugin's,
+ * leaving mocking unreachable. Pinned against the real plugin by `QaAgentOptionsTest`.
+ */
+internal const val BUILT_IN_NETWORK_PLUGIN_ID = "com.kitakkun.jetwhale.network"
+
+/**
  * What the agent impersonates and where it connects.
  *
  * @param apps names of the apps to connect as, one session each. Never empty.
@@ -31,6 +39,7 @@ internal val usage = """
       --plugin <id>[@<version>]  Register a raw-messaging plugin under this id, so /send and
                                  /request can drive its host counterpart. Registered for every app.
                                  Repeatable. Version defaults to $DEFAULT_PLUGIN_VERSION.
+                                 $BUILT_IN_NETWORK_PLUGIN_ID is rejected: it is always registered.
       --host <name>              JetWhale host to connect to (default: localhost).
       --port <n>                 Host debug port (default: $DEFAULT_HOST_PORT).
       --control-port <n>         Port for this agent's own control API (default: $DEFAULT_CONTROL_PORT).
@@ -61,6 +70,10 @@ internal fun parseArgs(args: Array<String>): QaAgentOptions {
             "--plugin" -> {
                 val (id, version) = valueOf(++i, arg).split("@", limit = 2).let {
                     it[0] to (it.getOrNull(1) ?: DEFAULT_PLUGIN_VERSION)
+                }
+                require(id != BUILT_IN_NETWORK_PLUGIN_ID) {
+                    "--plugin $id is already built in; registering it again would shadow its request " +
+                        "handlers and leave mocking unreachable. Drop the flag — the plugin is always on.\n\n$usage"
                 }
                 plugins[id] = version
             }

--- a/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAgentOptionsTest.kt
+++ b/tools/qa-agent/src/test/kotlin/com/kitakkun/jetwhale/tools/qaagent/QaAgentOptionsTest.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.tools.qaagent
 
+import com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -43,6 +44,20 @@ class QaAgentOptionsTest {
         assertEquals("localhost", options.hostName)
         assertEquals(DEFAULT_HOST_PORT, options.hostPort)
         assertEquals(DEFAULT_CONTROL_PORT, options.controlPort)
+    }
+
+    @Test
+    fun `the built-in network plugin cannot be registered again`() {
+        val failure = assertFailsWith<IllegalArgumentException> {
+            parseArgs(arrayOf("--plugin", BUILT_IN_NETWORK_PLUGIN_ID))
+        }
+
+        assertTrue(failure.message.orEmpty().contains(BUILT_IN_NETWORK_PLUGIN_ID), "the message should name the plugin")
+    }
+
+    @Test
+    fun `the built-in network plugin id matches the plugin the agent actually registers`() {
+        assertEquals(JetWhaleNetworkAgentPlugin().pluginId, BUILT_IN_NETWORK_PLUGIN_ID)
     }
 
     @Test


### PR DESCRIPTION
Four defects found while QA-ing `1.0.0-alpha10..main` for the 1.0.0-alpha11 release. Each was
reproduced against a running host before the fix and re-verified after it.

## A plugin scene had no background of its own

A plugin scene was composed with the theme applied but nothing painting a surface under it. On
screen that is invisible — the host window paints a background behind the scene. An off-screen MCP
capture has nothing behind it, so a plugin that draws no background of its own came back
transparent.

The Network Inspector is such a plugin: its root is a bare `Column`, so `jetwhale.screenshot`
returned a white page with a dark tab bar floating on it, while the same screen looks correct in the
window. Since alpha11 ships host-wide MCP tools as a headline feature, a screenshot that
misrepresents the UI is worth fixing on the release.

The surface now lives inside the scene, where both the window and the capture see it. Plugins that
already paint their own background (`nav3`, `semantics`, `example` — all `Scaffold`-based) render
byte-identically.

| before | after |
|---|---|
| white content area under a dark tab bar | matches the window |

## `--plugin` could shadow the QA agent's built-in Network plugin

Every QA-agent app registers `JetWhaleNetworkAgentPlugin` so `/fire` has something to capture with.
Naming the same id in `--plugin` registered a wire-level stand-in beside it, and both claimed the id
in one session. The stand-in registers no request handlers, so the real plugin's were shadowed:

- `com.kitakkun.jetwhale.network.addMockRule` failed with
  `No request handler registered for 'network/set_mock_rules'` — mocking was unreachable
- the id appeared twice in `jetwhale.listSessions`' `installedPlugins`

The flag is now rejected with a message that says why. Two tests cover it, one of them pinning the
constant against `JetWhaleNetworkAgentPlugin().pluginId` so the two cannot drift.

## `jetwhale-compose-semantics-inspector-agent` published compose-ui at runtime scope

`registerSemanticsOwner` takes a `SemanticsOwner` and `SemanticsOwnerNodeSource` is constructed with
one, so `androidx.compose.ui` is part of the module's public API. Declared as `implementation` it
landed in the POM at `runtime` scope, leaving a consumer that calls either to supply compose-ui
itself. This is a new artifact in alpha11, so it is worth correcting before it is published. The
generated POM now lists `org.jetbrains.compose.ui:ui-desktop` at `compile`.

Found by the ABI-validation work on `chore/abi-validation-plugins`, which touches the same build
file and will need a trivial merge.

## A stale KDoc reference

`EndpointResolver`'s KDoc explained per-endpoint `useWss` in terms of `plainLoopback`, which was
added and removed inside this release window. Each `endpoints { }` candidate names its own scheme;
`ssl { }` decides it only for the deprecated `host`/`port` pair.

## Verification

- `./gradlew check`, `-p jetwhale-agent-plugin check`, `-p jetwhale-gradle-plugin check`,
  `checkKotlinAbi` on the five public modules, and the Apple compile + `macosArm64Test` /
  `iosSimulatorArm64Test` jobs all pass.
- Reproduced and re-verified against a headless host driven over MCP, with the desktop demo and the
  QA agent connected: the Network Inspector screenshot now matches the window, `addMockRule` +
  `/fire` returns the mocked `201`, and `installedPlugins` no longer repeats the network id.

