### PR TITLE
ci: validate the ABI of the official plugin modules

### DIFF
--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -13,6 +13,10 @@ on:
       - 'jetwhale-agent-runtime/**'
       - 'jetwhale-annotations/**'
       - 'jetwhale-protocol/core/**'
+      # The official plugins are published artifacts too; `example` is a sample and is not.
+      - 'jetwhale-plugins/network/**'
+      - 'jetwhale-plugins/nav3/**'
+      - 'jetwhale-plugins/semantics/**'
       # Adding or removing a target here rewrites the `// Targets: [...]` header of every klib dump,
       # so a change confined to the convention would otherwise slip past unchecked.
       - 'gradle-conventions/**'
@@ -44,4 +48,15 @@ jobs:
             :jetwhale-agent-sdk:checkKotlinAbi \
             :jetwhale-agent-runtime:checkKotlinAbi \
             :jetwhale-annotations:checkKotlinAbi \
-            :jetwhale-protocol:core:checkKotlinAbi
+            :jetwhale-protocol:core:checkKotlinAbi \
+            :jetwhale-plugins:network:protocol:checkKotlinAbi \
+            :jetwhale-plugins:network:agent:checkKotlinAbi \
+            :jetwhale-plugins:network:agent-ktor:checkKotlinAbi \
+            :jetwhale-plugins:network:agent-okhttp:checkKotlinAbi \
+            :jetwhale-plugins:network:host:checkKotlinAbi \
+            :jetwhale-plugins:nav3:protocol:checkKotlinAbi \
+            :jetwhale-plugins:nav3:agent:checkKotlinAbi \
+            :jetwhale-plugins:nav3:host:checkKotlinAbi \
+            :jetwhale-plugins:semantics:protocol:checkKotlinAbi \
+            :jetwhale-plugins:semantics:agent:checkKotlinAbi \
+            :jetwhale-plugins:semantics:host:checkKotlinAbi

--- a/jetwhale-plugins/nav3/agent/api/agent.klib.api
+++ b/jetwhale-plugins/nav3/agent/api/agent.klib.api
@@ -1,0 +1,33 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.kitakkun.jetwhale.plugins.nav3:agent>
+final class <#A: androidx.navigation3.runtime/NavKey> com.kitakkun.jetwhale.plugins.nav3.agent/JetWhaleNav3AgentPlugin : com.kitakkun.jetwhale.agent.sdk/JetWhaleAgentPlugin { // com.kitakkun.jetwhale.plugins.nav3.agent/JetWhaleNav3AgentPlugin|null[0]
+    constructor <init>(com.kitakkun.jetwhale.plugins.nav3.agent/Nav3KeyCodec<#A>) // com.kitakkun.jetwhale.plugins.nav3.agent/JetWhaleNav3AgentPlugin.<init>|<init>(com.kitakkun.jetwhale.plugins.nav3.agent.Nav3KeyCodec<1:0>){}[0]
+
+    final val pluginId // com.kitakkun.jetwhale.plugins.nav3.agent/JetWhaleNav3AgentPlugin.pluginId|{}pluginId[0]
+        final fun <get-pluginId>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.agent/JetWhaleNav3AgentPlugin.pluginId.<get-pluginId>|<get-pluginId>(){}[0]
+    final val pluginVersion // com.kitakkun.jetwhale.plugins.nav3.agent/JetWhaleNav3AgentPlugin.pluginVersion|{}pluginVersion[0]
+        final fun <get-pluginVersion>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.agent/JetWhaleNav3AgentPlugin.pluginVersion.<get-pluginVersion>|<get-pluginVersion>(){}[0]
+
+    final fun registerBackStack(kotlin.collections/MutableList<#A>, kotlin/String = ...) // com.kitakkun.jetwhale.plugins.nav3.agent/JetWhaleNav3AgentPlugin.registerBackStack|registerBackStack(kotlin.collections.MutableList<1:0>;kotlin.String){}[0]
+    final fun unregisterBackStack(kotlin/String) // com.kitakkun.jetwhale.plugins.nav3.agent/JetWhaleNav3AgentPlugin.unregisterBackStack|unregisterBackStack(kotlin.String){}[0]
+}
+
+final class <#A: androidx.navigation3.runtime/NavKey> com.kitakkun.jetwhale.plugins.nav3.agent/Nav3KeyCodec { // com.kitakkun.jetwhale.plugins.nav3.agent/Nav3KeyCodec|null[0]
+    final object Companion { // com.kitakkun.jetwhale.plugins.nav3.agent/Nav3KeyCodec.Companion|null[0]
+        final fun <#A2: androidx.navigation3.runtime/NavKey> closedPolymorphic(kotlinx.serialization/KSerializer<#A2>): com.kitakkun.jetwhale.plugins.nav3.agent/Nav3KeyCodec<#A2> // com.kitakkun.jetwhale.plugins.nav3.agent/Nav3KeyCodec.Companion.closedPolymorphic|closedPolymorphic(kotlinx.serialization.KSerializer<0:0>){0§<androidx.navigation3.runtime.NavKey>}[0]
+        final fun openPolymorphic(kotlinx.serialization.modules/SerializersModule): com.kitakkun.jetwhale.plugins.nav3.agent/Nav3KeyCodec<androidx.navigation3.runtime/NavKey> // com.kitakkun.jetwhale.plugins.nav3.agent/Nav3KeyCodec.Companion.openPolymorphic|openPolymorphic(kotlinx.serialization.modules.SerializersModule){}[0]
+    }
+}
+
+final val com.kitakkun.jetwhale.plugins.nav3.agent/com_kitakkun_jetwhale_plugins_nav3_agent_JetWhaleNav3AgentPlugin$stableprop // com.kitakkun.jetwhale.plugins.nav3.agent/com_kitakkun_jetwhale_plugins_nav3_agent_JetWhaleNav3AgentPlugin$stableprop|#static{}com_kitakkun_jetwhale_plugins_nav3_agent_JetWhaleNav3AgentPlugin$stableprop[0]
+final val com.kitakkun.jetwhale.plugins.nav3.agent/com_kitakkun_jetwhale_plugins_nav3_agent_Nav3KeyCodec$stableprop // com.kitakkun.jetwhale.plugins.nav3.agent/com_kitakkun_jetwhale_plugins_nav3_agent_Nav3KeyCodec$stableprop|#static{}com_kitakkun_jetwhale_plugins_nav3_agent_Nav3KeyCodec$stableprop[0]
+
+final fun <#A: androidx.navigation3.runtime/NavKey> (com.kitakkun.jetwhale.plugins.nav3.agent/JetWhaleNav3AgentPlugin<#A>).com.kitakkun.jetwhale.plugins.nav3.agent/TrackNavBackStack(kotlin.collections/MutableList<#A>, kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kitakkun.jetwhale.plugins.nav3.agent/TrackNavBackStack|TrackNavBackStack@com.kitakkun.jetwhale.plugins.nav3.agent.JetWhaleNav3AgentPlugin<0:0>(kotlin.collections.MutableList<0:0>;kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){0§<androidx.navigation3.runtime.NavKey>}[0]
+final fun com.kitakkun.jetwhale.plugins.nav3.agent/com_kitakkun_jetwhale_plugins_nav3_agent_JetWhaleNav3AgentPlugin$stableprop_getter(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.agent/com_kitakkun_jetwhale_plugins_nav3_agent_JetWhaleNav3AgentPlugin$stableprop_getter|com_kitakkun_jetwhale_plugins_nav3_agent_JetWhaleNav3AgentPlugin$stableprop_getter(){}[0]
+final fun com.kitakkun.jetwhale.plugins.nav3.agent/com_kitakkun_jetwhale_plugins_nav3_agent_Nav3KeyCodec$stableprop_getter(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.agent/com_kitakkun_jetwhale_plugins_nav3_agent_Nav3KeyCodec$stableprop_getter|com_kitakkun_jetwhale_plugins_nav3_agent_Nav3KeyCodec$stableprop_getter(){}[0]

--- a/jetwhale-plugins/nav3/agent/api/jvm/agent.api
+++ b/jetwhale-plugins/nav3/agent/api/jvm/agent.api
@@ -1,0 +1,24 @@
+public final class com/kitakkun/jetwhale/plugins/nav3/agent/JetWhaleNav3AgentPlugin : com/kitakkun/jetwhale/agent/sdk/JetWhaleAgentPlugin {
+	public static final field $stable I
+	public fun <init> (Lcom/kitakkun/jetwhale/plugins/nav3/agent/Nav3KeyCodec;)V
+	public fun getPluginId ()Ljava/lang/String;
+	public fun getPluginVersion ()Ljava/lang/String;
+	public final fun registerBackStack (Ljava/util/List;Ljava/lang/String;)V
+	public static synthetic fun registerBackStack$default (Lcom/kitakkun/jetwhale/plugins/nav3/agent/JetWhaleNav3AgentPlugin;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun unregisterBackStack (Ljava/lang/String;)V
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/agent/Nav3KeyCodec {
+	public static final field $stable I
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/agent/Nav3KeyCodec$Companion;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/agent/Nav3KeyCodec$Companion {
+	public final fun closedPolymorphic (Lkotlinx/serialization/KSerializer;)Lcom/kitakkun/jetwhale/plugins/nav3/agent/Nav3KeyCodec;
+	public final fun openPolymorphic (Lkotlinx/serialization/modules/SerializersModule;)Lcom/kitakkun/jetwhale/plugins/nav3/agent/Nav3KeyCodec;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/agent/TrackNavBackStackKt {
+	public static final fun TrackNavBackStack (Lcom/kitakkun/jetwhale/plugins/nav3/agent/JetWhaleNav3AgentPlugin;Ljava/util/List;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/jetwhale-plugins/nav3/agent/build.gradle.kts
+++ b/jetwhale-plugins/nav3/agent/build.gradle.kts
@@ -1,6 +1,7 @@
-@file:OptIn(ExperimentalWasmDsl::class)
+@file:OptIn(ExperimentalWasmDsl::class, ExperimentalAbiValidation::class)
 
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -16,6 +17,9 @@ plugins {
 group = "com.kitakkun.jetwhale.plugins.nav3"
 
 kotlin {
+    abiValidation {
+    }
+
     android.namespace = "com.kitakkun.jetwhale.plugins.nav3.agent"
 }
 

--- a/jetwhale-plugins/nav3/host/api/host.api
+++ b/jetwhale-plugins/nav3/host/api/host.api
@@ -1,0 +1,21 @@
+public final class com/kitakkun/jetwhale/plugins/nav3/host/ComposableSingletons$Nav3NavigatorScreenKt {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/host/ComposableSingletons$Nav3NavigatorScreenKt;
+	public fun <init> ()V
+	public final fun getLambda$-1116830631$com_kitakkun_jetwhale_plugins_nav3_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1405533578$com_kitakkun_jetwhale_plugins_nav3_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1565653880$com_kitakkun_jetwhale_plugins_nav3_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1846595385$com_kitakkun_jetwhale_plugins_nav3_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1995684359$com_kitakkun_jetwhale_plugins_nav3_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-220944812$com_kitakkun_jetwhale_plugins_nav3_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-954273972$com_kitakkun_jetwhale_plugins_nav3_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1155875854$com_kitakkun_jetwhale_plugins_nav3_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1411848141$com_kitakkun_jetwhale_plugins_nav3_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1933186633$com_kitakkun_jetwhale_plugins_nav3_host ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/host/Nav3HostPluginFactory : com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginFactory {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun createPlugin ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
+}
+

--- a/jetwhale-plugins/nav3/host/build.gradle.kts
+++ b/jetwhale-plugins/nav3/host/build.gradle.kts
@@ -1,3 +1,7 @@
+@file:OptIn(ExperimentalAbiValidation::class)
+
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.composeCompiler)
@@ -7,6 +11,11 @@ plugins {
     // In-repo only: adds runJetWhaleLocal, which launches the local :jetwhale-host:app project.
     alias(libs.plugins.jetwhaleHostLaunch)
     alias(libs.plugins.publish)
+}
+
+kotlin {
+    abiValidation {
+    }
 }
 
 // Distinct group so this module's coordinates don't collide with the other plugins' `host` modules.

--- a/jetwhale-plugins/nav3/protocol/api/jvm/protocol.api
+++ b/jetwhale-plugins/nav3/protocol/api/jvm/protocol.api
@@ -1,0 +1,455 @@
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/BackStackChanged : com/kitakkun/jetwhale/protocol/messaging/JetWhaleEvent {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackChanged$Companion;
+	public fun <init> (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;)V
+	public final fun component1 ()Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;
+	public final fun copy (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackChanged;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackChanged;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackChanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSnapshot ()Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/BackStackChanged$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackChanged$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackChanged;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackChanged;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/BackStackChanged$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/BackStackUnregistered : com/kitakkun/jetwhale/protocol/messaging/JetWhaleEvent {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackUnregistered$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackUnregistered;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackUnregistered;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackUnregistered;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStackId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/BackStackUnregistered$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackUnregistered$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackUnregistered;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/BackStackUnregistered;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/BackStackUnregistered$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/GetNavState : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/GetNavState;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/MutateBackStack : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutateBackStack$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutateBackStack;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutateBackStack;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutateBackStack;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOperations ()Ljava/util/List;
+	public final fun getStackId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/MutateBackStack$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutateBackStack$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutateBackStack;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutateBackStack;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/MutateBackStack$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/MutationResult {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutationResult$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;
+	public final fun copy (Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutationResult;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutationResult;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutationResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/String;
+	public final fun getSnapshot ()Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/MutationResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutationResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutationResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/MutationResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/MutationResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/Nav3MessagesKt {
+	public static final field NAV3_PLUGIN_ID Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/Nav3ModelsKt {
+	public static final field DEFAULT_NAV_STACK_ID Ljava/lang/String;
+}
+
+public abstract interface class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Companion;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$MoveToTop : com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$MoveToTop$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$MoveToTop;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$MoveToTop;IILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$MoveToTop;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$MoveToTop$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$MoveToTop$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$MoveToTop;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$MoveToTop;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$MoveToTop$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Pop : com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Pop$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Pop;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Pop;IILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Pop;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Pop$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Pop$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Pop;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Pop;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Pop$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$PopTo : com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$PopTo$Companion;
+	public fun <init> (IZ)V
+	public final fun component1 ()I
+	public final fun component2 ()Z
+	public final fun copy (IZ)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$PopTo;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$PopTo;IZILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$PopTo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInclusive ()Z
+	public final fun getIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$PopTo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$PopTo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$PopTo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$PopTo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$PopTo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Push : com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Push$Companion;
+	public fun <init> (Lkotlinx/serialization/json/JsonElement;Ljava/lang/Integer;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun copy (Lkotlinx/serialization/json/JsonElement;Ljava/lang/Integer;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Push;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Push;Lkotlinx/serialization/json/JsonElement;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Push;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()Ljava/lang/Integer;
+	public final fun getKey ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Push$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Push$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Push;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Push;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$Push$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$RemoveAt : com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$RemoveAt$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$RemoveAt;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$RemoveAt;IILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$RemoveAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$RemoveAt$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$RemoveAt$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$RemoveAt;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$RemoveAt;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$RemoveAt$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$ReplaceAll : com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$ReplaceAll$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$ReplaceAll;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$ReplaceAll;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$ReplaceAll;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeys ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$ReplaceAll$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$ReplaceAll$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$ReplaceAll;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$ReplaceAll;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackOperation$ReplaceAll$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntries ()Ljava/util/List;
+	public final fun getStackId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavBackStackSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyFieldDescriptor {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyFieldDescriptor$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZ)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZZ)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyFieldDescriptor;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyFieldDescriptor;Ljava/lang/String;Ljava/lang/String;ZZILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyFieldDescriptor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNullable ()Z
+	public final fun getOptional ()Z
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyFieldDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyFieldDescriptor$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyFieldDescriptor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyFieldDescriptor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyFieldDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavKeySnapshot {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeySnapshot$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeySnapshot;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeySnapshot;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeySnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisplay ()Ljava/lang/String;
+	public final fun getKey ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getTypeName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavKeySnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeySnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeySnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeySnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavKeySnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyTypeDescriptor {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyTypeDescriptor$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyTypeDescriptor;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyTypeDescriptor;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyTypeDescriptor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFields ()Ljava/util/List;
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getTemplate ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyTypeDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyTypeDescriptor$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyTypeDescriptor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyTypeDescriptor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavKeyTypeDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavState {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavState$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavState;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavState;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyTypes ()Ljava/util/List;
+	public final fun getStacks ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/nav3/protocol/NavState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavState$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/nav3/protocol/NavState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/nav3/protocol/NavState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/jetwhale-plugins/nav3/protocol/api/protocol.klib.api
+++ b/jetwhale-plugins/nav3/protocol/api/protocol.klib.api
@@ -1,0 +1,466 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.kitakkun.jetwhale.plugins.nav3:protocol>
+sealed interface com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation|null[0]
+    final class MoveToTop : com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop|null[0]
+        constructor <init>(kotlin/Int) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.<init>|<init>(kotlin.Int){}[0]
+
+        final val index // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.index|{}index[0]
+            final fun <get-index>(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.index.<get-index>|<get-index>(){}[0]
+
+        final fun component1(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.component1|component1(){}[0]
+        final fun copy(kotlin/Int = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.copy|copy(kotlin.Int){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation.MoveToTop){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.MoveToTop.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class Pop : com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop|null[0]
+        constructor <init>(kotlin/Int) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.<init>|<init>(kotlin.Int){}[0]
+
+        final val count // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.count|{}count[0]
+            final fun <get-count>(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.count.<get-count>|<get-count>(){}[0]
+
+        final fun component1(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.component1|component1(){}[0]
+        final fun copy(kotlin/Int = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.copy|copy(kotlin.Int){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation.Pop){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Pop.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class PopTo : com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo|null[0]
+        constructor <init>(kotlin/Int, kotlin/Boolean) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.<init>|<init>(kotlin.Int;kotlin.Boolean){}[0]
+
+        final val inclusive // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.inclusive|{}inclusive[0]
+            final fun <get-inclusive>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.inclusive.<get-inclusive>|<get-inclusive>(){}[0]
+        final val index // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.index|{}index[0]
+            final fun <get-index>(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.index.<get-index>|<get-index>(){}[0]
+
+        final fun component1(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.component1|component1(){}[0]
+        final fun component2(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.component2|component2(){}[0]
+        final fun copy(kotlin/Int = ..., kotlin/Boolean = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.copy|copy(kotlin.Int;kotlin.Boolean){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation.PopTo){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.PopTo.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class Push : com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push|null[0]
+        constructor <init>(kotlinx.serialization.json/JsonElement, kotlin/Int?) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.<init>|<init>(kotlinx.serialization.json.JsonElement;kotlin.Int?){}[0]
+
+        final val index // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.index|{}index[0]
+            final fun <get-index>(): kotlin/Int? // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.index.<get-index>|<get-index>(){}[0]
+        final val key // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.key|{}key[0]
+            final fun <get-key>(): kotlinx.serialization.json/JsonElement // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.key.<get-key>|<get-key>(){}[0]
+
+        final fun component1(): kotlinx.serialization.json/JsonElement // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.component1|component1(){}[0]
+        final fun component2(): kotlin/Int? // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.component2|component2(){}[0]
+        final fun copy(kotlinx.serialization.json/JsonElement = ..., kotlin/Int? = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.copy|copy(kotlinx.serialization.json.JsonElement;kotlin.Int?){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation.Push){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Push.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class RemoveAt : com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt|null[0]
+        constructor <init>(kotlin/Int) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.<init>|<init>(kotlin.Int){}[0]
+
+        final val index // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.index|{}index[0]
+            final fun <get-index>(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.index.<get-index>|<get-index>(){}[0]
+
+        final fun component1(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.component1|component1(){}[0]
+        final fun copy(kotlin/Int = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.copy|copy(kotlin.Int){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation.RemoveAt){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.RemoveAt.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class ReplaceAll : com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll|null[0]
+        constructor <init>(kotlin.collections/List<kotlinx.serialization.json/JsonElement>) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.<init>|<init>(kotlin.collections.List<kotlinx.serialization.json.JsonElement>){}[0]
+
+        final val keys // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.keys|{}keys[0]
+            final fun <get-keys>(): kotlin.collections/List<kotlinx.serialization.json/JsonElement> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.keys.<get-keys>|<get-keys>(){}[0]
+
+        final fun component1(): kotlin.collections/List<kotlinx.serialization.json/JsonElement> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.component1|component1(){}[0]
+        final fun copy(kotlin.collections/List<kotlinx.serialization.json/JsonElement> = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.copy|copy(kotlin.collections.List<kotlinx.serialization.json.JsonElement>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation.ReplaceAll){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.Companion|null[0]
+            final val $childSerializers // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.Companion.$childSerializers|{}$childSerializers[0]
+
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.ReplaceAll.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged : com.kitakkun.jetwhale.protocol.messaging/JetWhaleEvent { // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged|null[0]
+    constructor <init>(com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot) // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.<init>|<init>(com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackSnapshot){}[0]
+
+    final val snapshot // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.snapshot|{}snapshot[0]
+        final fun <get-snapshot>(): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.snapshot.<get-snapshot>|<get-snapshot>(){}[0]
+
+    final fun component1(): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.component1|component1(){}[0]
+    final fun copy(com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.copy|copy(com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackSnapshot){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged> { // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged) // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.BackStackChanged){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged> // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackChanged.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered : com.kitakkun.jetwhale.protocol.messaging/JetWhaleEvent { // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered|null[0]
+    constructor <init>(kotlin/String) // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.<init>|<init>(kotlin.String){}[0]
+
+    final val stackId // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.stackId|{}stackId[0]
+        final fun <get-stackId>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.stackId.<get-stackId>|<get-stackId>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.component1|component1(){}[0]
+    final fun copy(kotlin/String = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.copy|copy(kotlin.String){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered> { // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered) // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.BackStackUnregistered){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered> // com.kitakkun.jetwhale.plugins.nav3.protocol/BackStackUnregistered.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult> { // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack|null[0]
+    constructor <init>(kotlin/String, kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation>) // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.<init>|<init>(kotlin.String;kotlin.collections.List<com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation>){}[0]
+
+    final val operations // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.operations|{}operations[0]
+        final fun <get-operations>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation> // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.operations.<get-operations>|<get-operations>(){}[0]
+    final val stackId // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.stackId|{}stackId[0]
+        final fun <get-stackId>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.stackId.<get-stackId>|<get-stackId>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation> // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackOperation> = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.copy|copy(kotlin.String;kotlin.collections.List<com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack> { // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack) // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.MutateBackStack){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack> // com.kitakkun.jetwhale.plugins.nav3.protocol/MutateBackStack.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult { // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult|null[0]
+    constructor <init>(kotlin/String?, com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot?) // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.<init>|<init>(kotlin.String?;com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackSnapshot?){}[0]
+
+    final val error // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.error|{}error[0]
+        final fun <get-error>(): kotlin/String? // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.error.<get-error>|<get-error>(){}[0]
+    final val snapshot // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.snapshot|{}snapshot[0]
+        final fun <get-snapshot>(): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot? // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.snapshot.<get-snapshot>|<get-snapshot>(){}[0]
+
+    final fun component1(): kotlin/String? // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.component1|component1(){}[0]
+    final fun component2(): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot? // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.component2|component2(){}[0]
+    final fun copy(kotlin/String? = ..., com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot? = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.copy|copy(kotlin.String?;com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackSnapshot?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult> { // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult) // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.MutationResult){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult> // com.kitakkun.jetwhale.plugins.nav3.protocol/MutationResult.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot|null[0]
+    constructor <init>(kotlin/String, kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot>) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.<init>|<init>(kotlin.String;kotlin.collections.List<com.kitakkun.jetwhale.plugins.nav3.protocol.NavKeySnapshot>){}[0]
+
+    final val entries // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.entries|{}entries[0]
+        final fun <get-entries>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.entries.<get-entries>|<get-entries>(){}[0]
+    final val stackId // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.stackId|{}stackId[0]
+        final fun <get-stackId>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.stackId.<get-stackId>|<get-stackId>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot> = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.copy|copy(kotlin.String;kotlin.collections.List<com.kitakkun.jetwhale.plugins.nav3.protocol.NavKeySnapshot>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackSnapshot){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor|null[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/Boolean, kotlin/Boolean) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.<init>|<init>(kotlin.String;kotlin.String;kotlin.Boolean;kotlin.Boolean){}[0]
+
+    final val name // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.name|{}name[0]
+        final fun <get-name>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.name.<get-name>|<get-name>(){}[0]
+    final val nullable // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.nullable|{}nullable[0]
+        final fun <get-nullable>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.nullable.<get-nullable>|<get-nullable>(){}[0]
+    final val optional // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.optional|{}optional[0]
+        final fun <get-optional>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.optional.<get-optional>|<get-optional>(){}[0]
+    final val type // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.type|{}type[0]
+        final fun <get-type>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.type.<get-type>|<get-type>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.component1|component1(){}[0]
+    final fun component2(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.component2|component2(){}[0]
+    final fun component3(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.component3|component3(){}[0]
+    final fun component4(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.component4|component4(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/Boolean = ..., kotlin/Boolean = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.copy|copy(kotlin.String;kotlin.String;kotlin.Boolean;kotlin.Boolean){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavKeyFieldDescriptor){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot|null[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlinx.serialization.json/JsonElement?) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.<init>|<init>(kotlin.String;kotlin.String;kotlinx.serialization.json.JsonElement?){}[0]
+
+    final val display // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.display|{}display[0]
+        final fun <get-display>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.display.<get-display>|<get-display>(){}[0]
+    final val key // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.key|{}key[0]
+        final fun <get-key>(): kotlinx.serialization.json/JsonElement? // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.key.<get-key>|<get-key>(){}[0]
+    final val typeName // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.typeName|{}typeName[0]
+        final fun <get-typeName>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.typeName.<get-typeName>|<get-typeName>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.component1|component1(){}[0]
+    final fun component2(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.component2|component2(){}[0]
+    final fun component3(): kotlinx.serialization.json/JsonElement? // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.component3|component3(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlinx.serialization.json/JsonElement? = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.copy|copy(kotlin.String;kotlin.String;kotlinx.serialization.json.JsonElement?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavKeySnapshot){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeySnapshot.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor|null[0]
+    constructor <init>(kotlin/String, kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor>, kotlinx.serialization.json/JsonElement) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.<init>|<init>(kotlin.String;kotlin.collections.List<com.kitakkun.jetwhale.plugins.nav3.protocol.NavKeyFieldDescriptor>;kotlinx.serialization.json.JsonElement){}[0]
+
+    final val fields // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.fields|{}fields[0]
+        final fun <get-fields>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.fields.<get-fields>|<get-fields>(){}[0]
+    final val serialName // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.serialName|{}serialName[0]
+        final fun <get-serialName>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.serialName.<get-serialName>|<get-serialName>(){}[0]
+    final val template // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.template|{}template[0]
+        final fun <get-template>(): kotlinx.serialization.json/JsonElement // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.template.<get-template>|<get-template>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.component2|component2(){}[0]
+    final fun component3(): kotlinx.serialization.json/JsonElement // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.component3|component3(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyFieldDescriptor> = ..., kotlinx.serialization.json/JsonElement = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.copy|copy(kotlin.String;kotlin.collections.List<com.kitakkun.jetwhale.plugins.nav3.protocol.NavKeyFieldDescriptor>;kotlinx.serialization.json.JsonElement){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavKeyTypeDescriptor){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.nav3.protocol/NavState { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState|null[0]
+    constructor <init>(kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot>, kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor>) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.<init>|<init>(kotlin.collections.List<com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackSnapshot>;kotlin.collections.List<com.kitakkun.jetwhale.plugins.nav3.protocol.NavKeyTypeDescriptor>){}[0]
+
+    final val keyTypes // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.keyTypes|{}keyTypes[0]
+        final fun <get-keyTypes>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.keyTypes.<get-keyTypes>|<get-keyTypes>(){}[0]
+    final val stacks // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.stacks|{}stacks[0]
+        final fun <get-stacks>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.stacks.<get-stacks>|<get-stacks>(){}[0]
+
+    final fun component1(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.component2|component2(){}[0]
+    final fun copy(kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavBackStackSnapshot> = ..., kotlin.collections/List<com.kitakkun.jetwhale.plugins.nav3.protocol/NavKeyTypeDescriptor> = ...): com.kitakkun.jetwhale.plugins.nav3.protocol/NavState // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.copy|copy(kotlin.collections.List<com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackSnapshot>;kotlin.collections.List<com.kitakkun.jetwhale.plugins.nav3.protocol.NavKeyTypeDescriptor>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavState> { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.nav3.protocol/NavState // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.nav3.protocol/NavState) // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.nav3.protocol.NavState){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/NavState> // com.kitakkun.jetwhale.plugins.nav3.protocol/NavState.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final object com.kitakkun.jetwhale.plugins.nav3.protocol/GetNavState : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.nav3.protocol/NavState>, kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.nav3.protocol/GetNavState|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.nav3.protocol/GetNavState.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.nav3.protocol/GetNavState.hashCode|hashCode(){}[0]
+    final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.nav3.protocol/GetNavState> // com.kitakkun.jetwhale.plugins.nav3.protocol/GetNavState.serializer|serializer(){}[0]
+    final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.nav3.protocol/GetNavState.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/GetNavState.toString|toString(){}[0]
+}
+
+final const val com.kitakkun.jetwhale.plugins.nav3.protocol/DEFAULT_NAV_STACK_ID // com.kitakkun.jetwhale.plugins.nav3.protocol/DEFAULT_NAV_STACK_ID|{}DEFAULT_NAV_STACK_ID[0]
+    final fun <get-DEFAULT_NAV_STACK_ID>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/DEFAULT_NAV_STACK_ID.<get-DEFAULT_NAV_STACK_ID>|<get-DEFAULT_NAV_STACK_ID>(){}[0]
+final const val com.kitakkun.jetwhale.plugins.nav3.protocol/NAV3_PLUGIN_ID // com.kitakkun.jetwhale.plugins.nav3.protocol/NAV3_PLUGIN_ID|{}NAV3_PLUGIN_ID[0]
+    final fun <get-NAV3_PLUGIN_ID>(): kotlin/String // com.kitakkun.jetwhale.plugins.nav3.protocol/NAV3_PLUGIN_ID.<get-NAV3_PLUGIN_ID>|<get-NAV3_PLUGIN_ID>(){}[0]

--- a/jetwhale-plugins/nav3/protocol/build.gradle.kts
+++ b/jetwhale-plugins/nav3/protocol/build.gradle.kts
@@ -1,6 +1,7 @@
-@file:OptIn(ExperimentalWasmDsl::class)
+@file:OptIn(ExperimentalWasmDsl::class, ExperimentalAbiValidation::class)
 
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -14,6 +15,9 @@ plugins {
 group = "com.kitakkun.jetwhale.plugins.nav3"
 
 kotlin {
+    abiValidation {
+    }
+
     android.namespace = "com.kitakkun.jetwhale.plugins.nav3.protocol"
 }
 

--- a/jetwhale-plugins/network/agent-ktor/api/agent-ktor.klib.api
+++ b/jetwhale-plugins/network/agent-ktor/api/agent-ktor.klib.api
@@ -1,0 +1,10 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.kitakkun.jetwhale.plugins.network:agent-ktor>
+final fun (com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin).com.kitakkun.jetwhale.plugins.network.agent.ktor/ktorClientPlugin(kotlin/Int = ...): io.ktor.client.plugins.api/ClientPlugin<kotlin/Unit> // com.kitakkun.jetwhale.plugins.network.agent.ktor/ktorClientPlugin|ktorClientPlugin@com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin(kotlin.Int){}[0]
+final fun (com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin).com.kitakkun.jetwhale.plugins.network.agent.ktor/ktorSendInterceptor(io.ktor.client/HttpClient, kotlin/Int = ...): kotlin.coroutines/SuspendFunction2<io.ktor.client.plugins/Sender, io.ktor.client.request/HttpRequestBuilder, io.ktor.client.call/HttpClientCall> // com.kitakkun.jetwhale.plugins.network.agent.ktor/ktorSendInterceptor|ktorSendInterceptor@com.kitakkun.jetwhale.plugins.network.agent.JetWhaleNetworkAgentPlugin(io.ktor.client.HttpClient;kotlin.Int){}[0]

--- a/jetwhale-plugins/network/agent-ktor/api/jvm/agent-ktor.api
+++ b/jetwhale-plugins/network/agent-ktor/api/jvm/agent-ktor.api
@@ -1,0 +1,10 @@
+public final class com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginKt {
+	public static final fun ktorClientPlugin (Lcom/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin;I)Lio/ktor/client/plugins/api/ClientPlugin;
+	public static synthetic fun ktorClientPlugin$default (Lcom/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin;IILjava/lang/Object;)Lio/ktor/client/plugins/api/ClientPlugin;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorSendInterceptorKt {
+	public static final fun ktorSendInterceptor (Lcom/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin;Lio/ktor/client/HttpClient;I)Lkotlin/jvm/functions/Function3;
+	public static synthetic fun ktorSendInterceptor$default (Lcom/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin;Lio/ktor/client/HttpClient;IILjava/lang/Object;)Lkotlin/jvm/functions/Function3;
+}
+

--- a/jetwhale-plugins/network/agent-ktor/build.gradle.kts
+++ b/jetwhale-plugins/network/agent-ktor/build.gradle.kts
@@ -1,6 +1,7 @@
-@file:OptIn(ExperimentalWasmDsl::class)
+@file:OptIn(ExperimentalWasmDsl::class, ExperimentalAbiValidation::class)
 
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -10,6 +11,9 @@ plugins {
 group = "com.kitakkun.jetwhale.plugins.network"
 
 kotlin {
+    abiValidation {
+    }
+
     android.namespace = "com.kitakkun.jetwhale.plugins.network.agent.ktor"
 }
 

--- a/jetwhale-plugins/network/agent-okhttp/api/agent-okhttp.api
+++ b/jetwhale-plugins/network/agent-okhttp/api/agent-okhttp.api
@@ -1,0 +1,5 @@
+public final class com/kitakkun/jetwhale/plugins/network/agent/okhttp/JetWhaleNetworkOkHttpInterceptorKt {
+	public static final fun okHttpInterceptor (Lcom/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin;I)Lokhttp3/Interceptor;
+	public static synthetic fun okHttpInterceptor$default (Lcom/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin;IILjava/lang/Object;)Lokhttp3/Interceptor;
+}
+

--- a/jetwhale-plugins/network/agent-okhttp/build.gradle.kts
+++ b/jetwhale-plugins/network/agent-okhttp/build.gradle.kts
@@ -1,6 +1,15 @@
+@file:OptIn(ExperimentalAbiValidation::class)
+
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.publish)
+}
+
+kotlin {
+    abiValidation {
+    }
 }
 
 // Distinct group so this module doesn't collide with other leaf-name-sharing modules.

--- a/jetwhale-plugins/network/agent/api/agent.klib.api
+++ b/jetwhale-plugins/network/agent/api/agent.klib.api
@@ -1,0 +1,48 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.kitakkun.jetwhale.plugins.network:agent>
+final class com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin : com.kitakkun.jetwhale.agent.sdk/JetWhaleAgentPlugin { // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin|null[0]
+    constructor <init>(com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules = ...) // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.<init>|<init>(com.kitakkun.jetwhale.plugins.network.agent.NetworkRedactionRules){}[0]
+
+    final val pluginId // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.pluginId|{}pluginId[0]
+        final fun <get-pluginId>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.pluginId.<get-pluginId>|<get-pluginId>(){}[0]
+    final val pluginVersion // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.pluginVersion|{}pluginVersion[0]
+        final fun <get-pluginVersion>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.pluginVersion.<get-pluginVersion>|<get-pluginVersion>(){}[0]
+
+    final fun findMock(kotlin/String, kotlin/String): com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec? // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.findMock|findMock(kotlin.String;kotlin.String){}[0]
+    final fun newTransactionId(): kotlin/String // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.newTransactionId|newTransactionId(){}[0]
+    final fun recordFailure(com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure) // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.recordFailure|recordFailure(com.kitakkun.jetwhale.plugins.network.protocol.HttpRequestFailure){}[0]
+    final fun recordRequest(com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest) // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.recordRequest|recordRequest(com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest){}[0]
+    final fun recordResponse(com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse) // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.recordResponse|recordResponse(com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse){}[0]
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.Companion|null[0]
+        final const val PLUGIN_ID // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.Companion.PLUGIN_ID|{}PLUGIN_ID[0]
+            final fun <get-PLUGIN_ID>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.agent/JetWhaleNetworkAgentPlugin.Companion.PLUGIN_ID.<get-PLUGIN_ID>|<get-PLUGIN_ID>(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules { // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules|null[0]
+    final val mcpOnlyRules // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.mcpOnlyRules|{}mcpOnlyRules[0]
+        final fun <get-mcpOnlyRules>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule> // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.mcpOnlyRules.<get-mcpOnlyRules>|<get-mcpOnlyRules>(){}[0]
+
+    final fun redactAtCapture(com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.redactAtCapture|redactAtCapture(com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest){}[0]
+    final fun redactAtCapture(com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.redactAtCapture|redactAtCapture(com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse){}[0]
+
+    final class Builder { // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.Builder|null[0]
+        final fun bodyJsonField(kotlin/Array<out kotlin/String>..., com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope = ..., com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy = ...) // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.Builder.bodyJsonField|bodyJsonField(kotlin.Array<out|kotlin.String>...;com.kitakkun.jetwhale.plugins.network.protocol.RedactionScope;com.kitakkun.jetwhale.plugins.network.protocol.RedactionStrategy){}[0]
+        final fun header(kotlin/Array<out kotlin/String>..., com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope = ..., com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy = ...) // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.Builder.header|header(kotlin.Array<out|kotlin.String>...;com.kitakkun.jetwhale.plugins.network.protocol.RedactionScope;com.kitakkun.jetwhale.plugins.network.protocol.RedactionStrategy){}[0]
+        final fun urlQueryParam(kotlin/Array<out kotlin/String>..., com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope = ..., com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy = ...) // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.Builder.urlQueryParam|urlQueryParam(kotlin.Array<out|kotlin.String>...;com.kitakkun.jetwhale.plugins.network.protocol.RedactionScope;com.kitakkun.jetwhale.plugins.network.protocol.RedactionStrategy){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.Companion|null[0]
+        final val None // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.Companion.None|{}None[0]
+            final fun <get-None>(): com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.Companion.None.<get-None>|<get-None>(){}[0]
+    }
+}
+
+final fun com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules(kotlin/Function1<com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules.Builder, kotlin/Unit>): com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules // com.kitakkun.jetwhale.plugins.network.agent/NetworkRedactionRules|NetworkRedactionRules(kotlin.Function1<com.kitakkun.jetwhale.plugins.network.agent.NetworkRedactionRules.Builder,kotlin.Unit>){}[0]

--- a/jetwhale-plugins/network/agent/api/jvm/agent.api
+++ b/jetwhale-plugins/network/agent/api/jvm/agent.api
@@ -1,0 +1,42 @@
+public final class com/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin : com/kitakkun/jetwhale/agent/sdk/JetWhaleAgentPlugin {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin$Companion;
+	public static final field PLUGIN_ID Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Lcom/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules;)V
+	public synthetic fun <init> (Lcom/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun findMock (Ljava/lang/String;Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;
+	public fun getPluginId ()Ljava/lang/String;
+	public fun getPluginVersion ()Ljava/lang/String;
+	public final fun newTransactionId ()Ljava/lang/String;
+	public final fun recordFailure (Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;)V
+	public final fun recordRequest (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;)V
+	public final fun recordResponse (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;)V
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin$Companion {
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules$Companion;
+	public final fun getMcpOnlyRules ()Ljava/util/List;
+	public final fun redactAtCapture (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;)Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;
+	public final fun redactAtCapture (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;)Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules$Builder {
+	public final fun bodyJsonField ([Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;)V
+	public static synthetic fun bodyJsonField$default (Lcom/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules$Builder;[Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;ILjava/lang/Object;)V
+	public final fun header ([Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;)V
+	public static synthetic fun header$default (Lcom/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules$Builder;[Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;ILjava/lang/Object;)V
+	public final fun urlQueryParam ([Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;)V
+	public static synthetic fun urlQueryParam$default (Lcom/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules$Builder;[Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;ILjava/lang/Object;)V
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules$Companion {
+	public final fun getNone ()Lcom/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRulesKt {
+	public static final fun NetworkRedactionRules (Lkotlin/jvm/functions/Function1;)Lcom/kitakkun/jetwhale/plugins/network/agent/NetworkRedactionRules;
+}
+

--- a/jetwhale-plugins/network/agent/build.gradle.kts
+++ b/jetwhale-plugins/network/agent/build.gradle.kts
@@ -1,6 +1,7 @@
-@file:OptIn(ExperimentalWasmDsl::class)
+@file:OptIn(ExperimentalWasmDsl::class, ExperimentalAbiValidation::class)
 
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -13,6 +14,9 @@ plugins {
 group = "com.kitakkun.jetwhale.plugins.network"
 
 kotlin {
+    abiValidation {
+    }
+
     android.namespace = "com.kitakkun.jetwhale.plugins.network.agent"
 }
 

--- a/jetwhale-plugins/network/host/api/host.api
+++ b/jetwhale-plugins/network/host/api/host.api
@@ -1,0 +1,63 @@
+public final class com/kitakkun/jetwhale/plugins/network/host/ComposableSingletons$JsonBodyViewKt {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/host/ComposableSingletons$JsonBodyViewKt;
+	public fun <init> ()V
+	public final fun getLambda$1483551591$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$164796560$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/host/ComposableSingletons$MocksViewKt {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/host/ComposableSingletons$MocksViewKt;
+	public fun <init> ()V
+	public final fun getLambda$-1046226545$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1273530357$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1463188833$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1891923305$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-61737784$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-815177313$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-855641655$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-882214116$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1882639474$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$189459121$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$646412787$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$836412836$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$952251840$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/host/ComposableSingletons$TrafficViewKt {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/host/ComposableSingletons$TrafficViewKt;
+	public fun <init> ()V
+	public final fun getLambda$-1054845750$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-2057655576$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-933537792$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$558337446$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$96535872$com_kitakkun_jetwhale_plugins_network_host ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/host/HttpTransaction {
+	public static final field $stable I
+	public fun <init> (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;)V
+	public synthetic fun <init> (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;
+	public final fun component2 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;
+	public final fun component3 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;
+	public final fun copy (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;)Lcom/kitakkun/jetwhale/plugins/network/host/HttpTransaction;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/host/HttpTransaction;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/host/HttpTransaction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFailure ()Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;
+	public final fun getRequest ()Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;
+	public final fun getResponse ()Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;
+	public final fun getTxId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory : com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginFactory {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun createPlugin ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/host/NetworkInspectorScreenKt {
+	public static final fun NetworkInspectorScreen (Ljava/util/List;Ljava/util/List;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+}
+

--- a/jetwhale-plugins/network/host/build.gradle.kts
+++ b/jetwhale-plugins/network/host/build.gradle.kts
@@ -1,3 +1,7 @@
+@file:OptIn(ExperimentalAbiValidation::class)
+
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.composeCompiler)
@@ -7,6 +11,11 @@ plugins {
     // In-repo only: adds runJetWhaleLocal, which launches the local :jetwhale-host:app project.
     alias(libs.plugins.jetwhaleHostLaunch)
     alias(libs.plugins.publish)
+}
+
+kotlin {
+    abiValidation {
+    }
 }
 
 // Distinct group so this module's coordinates don't collide with `example:host`.

--- a/jetwhale-plugins/network/protocol/api/jvm/protocol.api
+++ b/jetwhale-plugins/network/protocol/api/jvm/protocol.api
@@ -1,0 +1,528 @@
+public final class com/kitakkun/jetwhale/plugins/network/protocol/Ack {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/Ack;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ZJ)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ZJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ZJ)Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ZJILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBody ()Ljava/lang/String;
+	public final fun getBodyTruncated ()Z
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun getTimestampMs ()J
+	public final fun getTxId ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse$Companion;
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/util/Map;Ljava/lang/String;ZJZ)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/util/Map;Ljava/lang/String;ZJZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()J
+	public final fun component8 ()Z
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;Ljava/util/Map;Ljava/lang/String;ZJZ)Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;Ljava/lang/String;ILjava/lang/String;Ljava/util/Map;Ljava/lang/String;ZJZILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBody ()Ljava/lang/String;
+	public final fun getBodyTruncated ()Z
+	public final fun getDurationMs ()J
+	public final fun getFromMock ()Z
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getStatusCode ()I
+	public final fun getStatusDescription ()Ljava/lang/String;
+	public final fun getTxId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/GetMockConfig : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/GetMockConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/GetRedactionConfig : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/GetRedactionConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;J)Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDurationMs ()J
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getTxId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockConfig {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/MockConfig$Companion;
+	public fun <init> (ZLjava/util/List;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (ZLjava/util/List;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockConfig;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/MockConfig;ZLjava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Z
+	public final fun getRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/MockConfig$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/MockConfig$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockConfig;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockConfig;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockConfig$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockMatchType : java/lang/Enum {
+	public static final field CONTAINS Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType$Companion;
+	public static final field EXACT Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;
+	public static final field REGEX Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;
+	public static fun values ()[Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockMatchType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockMatcher {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMatchType ()Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatchType;
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun getUrlPattern ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/MockMatcher$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockMatcher$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockModelsKt {
+	public static final fun findMatching (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Z)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec$Companion;
+	public fun <init> ()V
+	public fun <init> (ILjava/util/Map;Ljava/lang/String;J)V
+	public synthetic fun <init> (ILjava/util/Map;Ljava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()J
+	public final fun copy (ILjava/util/Map;Ljava/lang/String;J)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;ILjava/util/Map;Ljava/lang/String;JILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBody ()Ljava/lang/String;
+	public final fun getDelayMs ()J
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getStatusCode ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockRule {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/MockRule$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;
+	public final fun component5 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockRule;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/MockRule;Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMatcher ()Lcom/kitakkun/jetwhale/plugins/network/protocol/MockMatcher;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getResponse ()Lcom/kitakkun/jetwhale/plugins/network/protocol/MockResponseSpec;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/MockRule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/MockRule$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/MockRule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/MockRule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/MockRule$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionConfig {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionConfig$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionConfig;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionConfig;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMcpOnlyRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/RedactionConfig$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionConfig$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionConfig;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionConfig;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionConfig$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionModelsKt {
+	public static final field REDACTED_PLACEHOLDER Ljava/lang/String;
+	public static final fun redact (Ljava/util/List;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;)Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;
+	public static final fun redact (Ljava/util/List;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;)Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionRule {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionRule$Companion;
+	public fun <init> (Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;)V
+	public final fun component1 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;
+	public final fun component4 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;
+	public final fun copy (Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionRule;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionRule;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getScope ()Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;
+	public final fun getStrategy ()Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;
+	public final fun getTarget ()Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/RedactionRule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionRule$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionRule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionRule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionRule$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionScope : java/lang/Enum {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope$Companion;
+	public static final field EVERYWHERE Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;
+	public static final field MCP_ONLY Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;
+	public static fun values ()[Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionScope;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionScope$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy : java/lang/Enum {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy$Companion;
+	public static final field MASK Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;
+	public static final field PLACEHOLDER Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;
+	public static fun values ()[Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionStrategy$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget : java/lang/Enum {
+	public static final field BODY_JSON_FIELD Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget;
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget$Companion;
+	public static final field HEADER Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget;
+	public static final field URL_QUERY_PARAM Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget;
+	public static fun values ()[Lcom/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RedactionTarget$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RequestFailed : com/kitakkun/jetwhale/protocol/messaging/JetWhaleEvent {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestFailed$Companion;
+	public fun <init> (Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;)V
+	public final fun component1 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;
+	public final fun copy (Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestFailed;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestFailed;Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFailure ()Lcom/kitakkun/jetwhale/plugins/network/protocol/HttpRequestFailure;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/RequestFailed$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestFailed$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestFailed;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestFailed;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RequestFailed$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RequestSent : com/kitakkun/jetwhale/protocol/messaging/JetWhaleEvent {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestSent$Companion;
+	public fun <init> (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;)V
+	public final fun component1 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;
+	public final fun copy (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestSent;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestSent;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestSent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequest ()Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/RequestSent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestSent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestSent;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/RequestSent;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/RequestSent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/ResponseReceived : com/kitakkun/jetwhale/protocol/messaging/JetWhaleEvent {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/ResponseReceived$Companion;
+	public fun <init> (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;)V
+	public final fun component1 ()Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;
+	public final fun copy (Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;)Lcom/kitakkun/jetwhale/plugins/network/protocol/ResponseReceived;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/ResponseReceived;Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/ResponseReceived;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResponse ()Lcom/kitakkun/jetwhale/plugins/network/protocol/CapturedHttpResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/ResponseReceived$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/ResponseReceived$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/ResponseReceived;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/ResponseReceived;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/ResponseReceived$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/SetMockRules : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockRules$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockRules;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockRules;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockRules;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/SetMockRules$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockRules$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockRules;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockRules;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/SetMockRules$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/SetMockingEnabled : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockingEnabled$Companion;
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockingEnabled;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockingEnabled;ZILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockingEnabled;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/network/protocol/SetMockingEnabled$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockingEnabled$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockingEnabled;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/network/protocol/SetMockingEnabled;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/network/protocol/SetMockingEnabled$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/jetwhale-plugins/network/protocol/api/protocol.klib.api
+++ b/jetwhale-plugins/network/protocol/api/protocol.klib.api
@@ -1,0 +1,568 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.kitakkun.jetwhale.plugins.network:protocol>
+final enum class com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType : kotlin/Enum<com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType> { // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType|null[0]
+    enum entry CONTAINS // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType.CONTAINS|null[0]
+    enum entry EXACT // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType.EXACT|null[0]
+    enum entry REGEX // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType.REGEX|null[0]
+
+    final val entries // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType> // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType> // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType> // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
+final enum class com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope : kotlin/Enum<com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope> { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope|null[0]
+    enum entry EVERYWHERE // com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope.EVERYWHERE|null[0]
+    enum entry MCP_ONLY // com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope.MCP_ONLY|null[0]
+
+    final val entries // com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope // com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
+final enum class com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy : kotlin/Enum<com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy> { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy|null[0]
+    enum entry MASK // com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy.MASK|null[0]
+    enum entry PLACEHOLDER // com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy.PLACEHOLDER|null[0]
+
+    final val entries // com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy // com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
+final enum class com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget : kotlin/Enum<com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget> { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget|null[0]
+    enum entry BODY_JSON_FIELD // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget.BODY_JSON_FIELD|null[0]
+    enum entry HEADER // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget.HEADER|null[0]
+    enum entry URL_QUERY_PARAM // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget.URL_QUERY_PARAM|null[0]
+
+    final val entries // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest { // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest|null[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/String, kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>> = ..., kotlin/String? = ..., kotlin/Boolean = ..., kotlin/Long) // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.collections.List<kotlin.String>>;kotlin.String?;kotlin.Boolean;kotlin.Long){}[0]
+
+    final val body // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.body|{}body[0]
+        final fun <get-body>(): kotlin/String? // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.body.<get-body>|<get-body>(){}[0]
+    final val bodyTruncated // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.bodyTruncated|{}bodyTruncated[0]
+        final fun <get-bodyTruncated>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.bodyTruncated.<get-bodyTruncated>|<get-bodyTruncated>(){}[0]
+    final val headers // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.headers|{}headers[0]
+        final fun <get-headers>(): kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>> // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.headers.<get-headers>|<get-headers>(){}[0]
+    final val method // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.method|{}method[0]
+        final fun <get-method>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.method.<get-method>|<get-method>(){}[0]
+    final val timestampMs // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.timestampMs|{}timestampMs[0]
+        final fun <get-timestampMs>(): kotlin/Long // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.timestampMs.<get-timestampMs>|<get-timestampMs>(){}[0]
+    final val txId // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.txId|{}txId[0]
+        final fun <get-txId>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.txId.<get-txId>|<get-txId>(){}[0]
+    final val url // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.url|{}url[0]
+        final fun <get-url>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.url.<get-url>|<get-url>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.component1|component1(){}[0]
+    final fun component2(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.component2|component2(){}[0]
+    final fun component3(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>> // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.component4|component4(){}[0]
+    final fun component5(): kotlin/String? // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.component5|component5(){}[0]
+    final fun component6(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.component6|component6(){}[0]
+    final fun component7(): kotlin/Long // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.component7|component7(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>> = ..., kotlin/String? = ..., kotlin/Boolean = ..., kotlin/Long = ...): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.copy|copy(kotlin.String;kotlin.String;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.collections.List<kotlin.String>>;kotlin.String?;kotlin.Boolean;kotlin.Long){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest> { // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest) // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest> // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse { // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse|null[0]
+    constructor <init>(kotlin/String, kotlin/Int, kotlin/String = ..., kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>> = ..., kotlin/String? = ..., kotlin/Boolean = ..., kotlin/Long, kotlin/Boolean = ...) // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.<init>|<init>(kotlin.String;kotlin.Int;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.collections.List<kotlin.String>>;kotlin.String?;kotlin.Boolean;kotlin.Long;kotlin.Boolean){}[0]
+
+    final val body // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.body|{}body[0]
+        final fun <get-body>(): kotlin/String? // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.body.<get-body>|<get-body>(){}[0]
+    final val bodyTruncated // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.bodyTruncated|{}bodyTruncated[0]
+        final fun <get-bodyTruncated>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.bodyTruncated.<get-bodyTruncated>|<get-bodyTruncated>(){}[0]
+    final val durationMs // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.durationMs|{}durationMs[0]
+        final fun <get-durationMs>(): kotlin/Long // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.durationMs.<get-durationMs>|<get-durationMs>(){}[0]
+    final val fromMock // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.fromMock|{}fromMock[0]
+        final fun <get-fromMock>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.fromMock.<get-fromMock>|<get-fromMock>(){}[0]
+    final val headers // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.headers|{}headers[0]
+        final fun <get-headers>(): kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>> // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.headers.<get-headers>|<get-headers>(){}[0]
+    final val statusCode // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.statusCode|{}statusCode[0]
+        final fun <get-statusCode>(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.statusCode.<get-statusCode>|<get-statusCode>(){}[0]
+    final val statusDescription // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.statusDescription|{}statusDescription[0]
+        final fun <get-statusDescription>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.statusDescription.<get-statusDescription>|<get-statusDescription>(){}[0]
+    final val txId // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.txId|{}txId[0]
+        final fun <get-txId>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.txId.<get-txId>|<get-txId>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.component2|component2(){}[0]
+    final fun component3(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>> // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.component4|component4(){}[0]
+    final fun component5(): kotlin/String? // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.component5|component5(){}[0]
+    final fun component6(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.component6|component6(){}[0]
+    final fun component7(): kotlin/Long // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.component7|component7(){}[0]
+    final fun component8(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.component8|component8(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Int = ..., kotlin/String = ..., kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>> = ..., kotlin/String? = ..., kotlin/Boolean = ..., kotlin/Long = ..., kotlin/Boolean = ...): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.copy|copy(kotlin.String;kotlin.Int;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.collections.List<kotlin.String>>;kotlin.String?;kotlin.Boolean;kotlin.Long;kotlin.Boolean){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse> { // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse) // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse> // com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure { // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure|null[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/Long) // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.<init>|<init>(kotlin.String;kotlin.String;kotlin.Long){}[0]
+
+    final val durationMs // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.durationMs|{}durationMs[0]
+        final fun <get-durationMs>(): kotlin/Long // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.durationMs.<get-durationMs>|<get-durationMs>(){}[0]
+    final val message // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.message|{}message[0]
+        final fun <get-message>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.message.<get-message>|<get-message>(){}[0]
+    final val txId // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.txId|{}txId[0]
+        final fun <get-txId>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.txId.<get-txId>|<get-txId>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.component1|component1(){}[0]
+    final fun component2(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.component2|component2(){}[0]
+    final fun component3(): kotlin/Long // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.component3|component3(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/Long = ...): com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.copy|copy(kotlin.String;kotlin.String;kotlin.Long){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure> { // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure) // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.HttpRequestFailure){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure> // com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/MockConfig { // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig|null[0]
+    constructor <init>(kotlin/Boolean, kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/MockRule>) // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.<init>|<init>(kotlin.Boolean;kotlin.collections.List<com.kitakkun.jetwhale.plugins.network.protocol.MockRule>){}[0]
+
+    final val enabled // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.enabled|{}enabled[0]
+        final fun <get-enabled>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.enabled.<get-enabled>|<get-enabled>(){}[0]
+    final val rules // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.rules|{}rules[0]
+        final fun <get-rules>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/MockRule> // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.rules.<get-rules>|<get-rules>(){}[0]
+
+    final fun component1(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/MockRule> // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.component2|component2(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/MockRule> = ...): com.kitakkun.jetwhale.plugins.network.protocol/MockConfig // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.copy|copy(kotlin.Boolean;kotlin.collections.List<com.kitakkun.jetwhale.plugins.network.protocol.MockRule>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/MockConfig> { // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/MockConfig // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/MockConfig) // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.MockConfig){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/MockConfig> // com.kitakkun.jetwhale.plugins.network.protocol/MockConfig.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher { // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin/String, com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType = ...) // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.<init>|<init>(kotlin.String?;kotlin.String;com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType){}[0]
+
+    final val matchType // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.matchType|{}matchType[0]
+        final fun <get-matchType>(): com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.matchType.<get-matchType>|<get-matchType>(){}[0]
+    final val method // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.method|{}method[0]
+        final fun <get-method>(): kotlin/String? // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.method.<get-method>|<get-method>(){}[0]
+    final val urlPattern // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.urlPattern|{}urlPattern[0]
+        final fun <get-urlPattern>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.urlPattern.<get-urlPattern>|<get-urlPattern>(){}[0]
+
+    final fun component1(): kotlin/String? // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.component1|component1(){}[0]
+    final fun component2(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.component2|component2(){}[0]
+    final fun component3(): com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.component3|component3(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/String = ..., com.kitakkun.jetwhale.plugins.network.protocol/MockMatchType = ...): com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.copy|copy(kotlin.String?;kotlin.String;com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher> { // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher) // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher> // com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec { // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec|null[0]
+    constructor <init>(kotlin/Int = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ..., kotlin/String = ..., kotlin/Long = ...) // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.<init>|<init>(kotlin.Int;kotlin.collections.Map<kotlin.String,kotlin.String>;kotlin.String;kotlin.Long){}[0]
+
+    final val body // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.body|{}body[0]
+        final fun <get-body>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.body.<get-body>|<get-body>(){}[0]
+    final val delayMs // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.delayMs|{}delayMs[0]
+        final fun <get-delayMs>(): kotlin/Long // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.delayMs.<get-delayMs>|<get-delayMs>(){}[0]
+    final val headers // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.headers|{}headers[0]
+        final fun <get-headers>(): kotlin.collections/Map<kotlin/String, kotlin/String> // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.headers.<get-headers>|<get-headers>(){}[0]
+    final val statusCode // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.statusCode|{}statusCode[0]
+        final fun <get-statusCode>(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.statusCode.<get-statusCode>|<get-statusCode>(){}[0]
+
+    final fun component1(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/String, kotlin/String> // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.component2|component2(){}[0]
+    final fun component3(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.component3|component3(){}[0]
+    final fun component4(): kotlin/Long // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.component4|component4(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ..., kotlin/String = ..., kotlin/Long = ...): com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.copy|copy(kotlin.Int;kotlin.collections.Map<kotlin.String,kotlin.String>;kotlin.String;kotlin.Long){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec> { // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec) // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec> // com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/MockRule { // com.kitakkun.jetwhale.plugins.network.protocol/MockRule|null[0]
+    constructor <init>(kotlin/String, kotlin/String = ..., kotlin/Boolean = ..., com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher, com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec) // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.<init>|<init>(kotlin.String;kotlin.String;kotlin.Boolean;com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher;com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec){}[0]
+
+    final val enabled // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.enabled|{}enabled[0]
+        final fun <get-enabled>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.enabled.<get-enabled>|<get-enabled>(){}[0]
+    final val id // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.id|{}id[0]
+        final fun <get-id>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.id.<get-id>|<get-id>(){}[0]
+    final val matcher // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.matcher|{}matcher[0]
+        final fun <get-matcher>(): com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.matcher.<get-matcher>|<get-matcher>(){}[0]
+    final val name // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.name|{}name[0]
+        final fun <get-name>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.name.<get-name>|<get-name>(){}[0]
+    final val response // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.response|{}response[0]
+        final fun <get-response>(): com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.response.<get-response>|<get-response>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.component1|component1(){}[0]
+    final fun component2(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.component2|component2(){}[0]
+    final fun component3(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.component3|component3(){}[0]
+    final fun component4(): com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.component4|component4(){}[0]
+    final fun component5(): com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.component5|component5(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/Boolean = ..., com.kitakkun.jetwhale.plugins.network.protocol/MockMatcher = ..., com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec = ...): com.kitakkun.jetwhale.plugins.network.protocol/MockRule // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.copy|copy(kotlin.String;kotlin.String;kotlin.Boolean;com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher;com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/MockRule> { // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/MockRule // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/MockRule) // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.MockRule){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/MockRule> // com.kitakkun.jetwhale.plugins.network.protocol/MockRule.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig|null[0]
+    constructor <init>(kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule>) // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.<init>|<init>(kotlin.collections.List<com.kitakkun.jetwhale.plugins.network.protocol.RedactionRule>){}[0]
+
+    final val mcpOnlyRules // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.mcpOnlyRules|{}mcpOnlyRules[0]
+        final fun <get-mcpOnlyRules>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.mcpOnlyRules.<get-mcpOnlyRules>|<get-mcpOnlyRules>(){}[0]
+
+    final fun component1(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.component1|component1(){}[0]
+    final fun copy(kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule> = ...): com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.copy|copy(kotlin.collections.List<com.kitakkun.jetwhale.plugins.network.protocol.RedactionRule>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig> { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig) // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.RedactionConfig){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule|null[0]
+    constructor <init>(com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget, kotlin/String, com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope, com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy) // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.<init>|<init>(com.kitakkun.jetwhale.plugins.network.protocol.RedactionTarget;kotlin.String;com.kitakkun.jetwhale.plugins.network.protocol.RedactionScope;com.kitakkun.jetwhale.plugins.network.protocol.RedactionStrategy){}[0]
+
+    final val name // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.name|{}name[0]
+        final fun <get-name>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.name.<get-name>|<get-name>(){}[0]
+    final val scope // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.scope|{}scope[0]
+        final fun <get-scope>(): com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.scope.<get-scope>|<get-scope>(){}[0]
+    final val strategy // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.strategy|{}strategy[0]
+        final fun <get-strategy>(): com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.strategy.<get-strategy>|<get-strategy>(){}[0]
+    final val target // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.target|{}target[0]
+        final fun <get-target>(): com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.target.<get-target>|<get-target>(){}[0]
+
+    final fun component1(): com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.component1|component1(){}[0]
+    final fun component2(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.component2|component2(){}[0]
+    final fun component3(): com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.component3|component3(){}[0]
+    final fun component4(): com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.component4|component4(){}[0]
+    final fun copy(com.kitakkun.jetwhale.plugins.network.protocol/RedactionTarget = ..., kotlin/String = ..., com.kitakkun.jetwhale.plugins.network.protocol/RedactionScope = ..., com.kitakkun.jetwhale.plugins.network.protocol/RedactionStrategy = ...): com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.copy|copy(com.kitakkun.jetwhale.plugins.network.protocol.RedactionTarget;kotlin.String;com.kitakkun.jetwhale.plugins.network.protocol.RedactionScope;com.kitakkun.jetwhale.plugins.network.protocol.RedactionStrategy){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule> { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule) // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.RedactionRule){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule> // com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed : com.kitakkun.jetwhale.protocol.messaging/JetWhaleEvent { // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed|null[0]
+    constructor <init>(com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure) // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.<init>|<init>(com.kitakkun.jetwhale.plugins.network.protocol.HttpRequestFailure){}[0]
+
+    final val failure // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.failure|{}failure[0]
+        final fun <get-failure>(): com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.failure.<get-failure>|<get-failure>(){}[0]
+
+    final fun component1(): com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.component1|component1(){}[0]
+    final fun copy(com.kitakkun.jetwhale.plugins.network.protocol/HttpRequestFailure = ...): com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.copy|copy(com.kitakkun.jetwhale.plugins.network.protocol.HttpRequestFailure){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed> { // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed) // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.RequestFailed){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed> // com.kitakkun.jetwhale.plugins.network.protocol/RequestFailed.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/RequestSent : com.kitakkun.jetwhale.protocol.messaging/JetWhaleEvent { // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent|null[0]
+    constructor <init>(com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest) // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.<init>|<init>(com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest){}[0]
+
+    final val request // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.request|{}request[0]
+        final fun <get-request>(): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.request.<get-request>|<get-request>(){}[0]
+
+    final fun component1(): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.component1|component1(){}[0]
+    final fun copy(com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest = ...): com.kitakkun.jetwhale.plugins.network.protocol/RequestSent // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.copy|copy(com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RequestSent> { // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/RequestSent // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/RequestSent) // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.RequestSent){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/RequestSent> // com.kitakkun.jetwhale.plugins.network.protocol/RequestSent.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived : com.kitakkun.jetwhale.protocol.messaging/JetWhaleEvent { // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived|null[0]
+    constructor <init>(com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse) // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.<init>|<init>(com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse){}[0]
+
+    final val response // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.response|{}response[0]
+        final fun <get-response>(): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.response.<get-response>|<get-response>(){}[0]
+
+    final fun component1(): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.component1|component1(){}[0]
+    final fun copy(com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse = ...): com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.copy|copy(com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived> { // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived) // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.ResponseReceived){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived> // com.kitakkun.jetwhale.plugins.network.protocol/ResponseReceived.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.network.protocol/Ack> { // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules|null[0]
+    constructor <init>(kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/MockRule>) // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.<init>|<init>(kotlin.collections.List<com.kitakkun.jetwhale.plugins.network.protocol.MockRule>){}[0]
+
+    final val rules // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.rules|{}rules[0]
+        final fun <get-rules>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/MockRule> // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.rules.<get-rules>|<get-rules>(){}[0]
+
+    final fun component1(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/MockRule> // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.component1|component1(){}[0]
+    final fun copy(kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/MockRule> = ...): com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.copy|copy(kotlin.collections.List<com.kitakkun.jetwhale.plugins.network.protocol.MockRule>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules> { // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules) // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.SetMockRules){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules> // com.kitakkun.jetwhale.plugins.network.protocol/SetMockRules.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.network.protocol/Ack> { // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled|null[0]
+    constructor <init>(kotlin/Boolean) // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.<init>|<init>(kotlin.Boolean){}[0]
+
+    final val enabled // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.enabled|{}enabled[0]
+        final fun <get-enabled>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.enabled.<get-enabled>|<get-enabled>(){}[0]
+
+    final fun component1(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.component1|component1(){}[0]
+    final fun copy(kotlin/Boolean = ...): com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.copy|copy(kotlin.Boolean){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled> { // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled) // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.network.protocol.SetMockingEnabled){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled> // com.kitakkun.jetwhale.plugins.network.protocol/SetMockingEnabled.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final object com.kitakkun.jetwhale.plugins.network.protocol/Ack : kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.network.protocol/Ack|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/Ack.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/Ack.hashCode|hashCode(){}[0]
+    final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/Ack> // com.kitakkun.jetwhale.plugins.network.protocol/Ack.serializer|serializer(){}[0]
+    final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.network.protocol/Ack.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/Ack.toString|toString(){}[0]
+}
+
+final object com.kitakkun.jetwhale.plugins.network.protocol/GetMockConfig : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.network.protocol/MockConfig>, kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.network.protocol/GetMockConfig|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/GetMockConfig.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/GetMockConfig.hashCode|hashCode(){}[0]
+    final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/GetMockConfig> // com.kitakkun.jetwhale.plugins.network.protocol/GetMockConfig.serializer|serializer(){}[0]
+    final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.network.protocol/GetMockConfig.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/GetMockConfig.toString|toString(){}[0]
+}
+
+final object com.kitakkun.jetwhale.plugins.network.protocol/GetRedactionConfig : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.network.protocol/RedactionConfig>, kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.network.protocol/GetRedactionConfig|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.network.protocol/GetRedactionConfig.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.network.protocol/GetRedactionConfig.hashCode|hashCode(){}[0]
+    final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.network.protocol/GetRedactionConfig> // com.kitakkun.jetwhale.plugins.network.protocol/GetRedactionConfig.serializer|serializer(){}[0]
+    final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.network.protocol/GetRedactionConfig.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/GetRedactionConfig.toString|toString(){}[0]
+}
+
+final const val com.kitakkun.jetwhale.plugins.network.protocol/REDACTED_PLACEHOLDER // com.kitakkun.jetwhale.plugins.network.protocol/REDACTED_PLACEHOLDER|{}REDACTED_PLACEHOLDER[0]
+    final fun <get-REDACTED_PLACEHOLDER>(): kotlin/String // com.kitakkun.jetwhale.plugins.network.protocol/REDACTED_PLACEHOLDER.<get-REDACTED_PLACEHOLDER>|<get-REDACTED_PLACEHOLDER>(){}[0]
+
+final fun (kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/MockRule>).com.kitakkun.jetwhale.plugins.network.protocol/findMatching(kotlin/String, kotlin/String, kotlin/Boolean): com.kitakkun.jetwhale.plugins.network.protocol/MockResponseSpec? // com.kitakkun.jetwhale.plugins.network.protocol/findMatching|findMatching@kotlin.collections.List<com.kitakkun.jetwhale.plugins.network.protocol.MockRule>(kotlin.String;kotlin.String;kotlin.Boolean){}[0]
+final fun (kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule>).com.kitakkun.jetwhale.plugins.network.protocol/redact(com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpRequest // com.kitakkun.jetwhale.plugins.network.protocol/redact|redact@kotlin.collections.List<com.kitakkun.jetwhale.plugins.network.protocol.RedactionRule>(com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest){}[0]
+final fun (kotlin.collections/List<com.kitakkun.jetwhale.plugins.network.protocol/RedactionRule>).com.kitakkun.jetwhale.plugins.network.protocol/redact(com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse): com.kitakkun.jetwhale.plugins.network.protocol/CapturedHttpResponse // com.kitakkun.jetwhale.plugins.network.protocol/redact|redact@kotlin.collections.List<com.kitakkun.jetwhale.plugins.network.protocol.RedactionRule>(com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpResponse){}[0]

--- a/jetwhale-plugins/network/protocol/build.gradle.kts
+++ b/jetwhale-plugins/network/protocol/build.gradle.kts
@@ -1,6 +1,7 @@
-@file:OptIn(ExperimentalWasmDsl::class)
+@file:OptIn(ExperimentalWasmDsl::class, ExperimentalAbiValidation::class)
 
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -12,6 +13,9 @@ plugins {
 group = "com.kitakkun.jetwhale.plugins.network"
 
 kotlin {
+    abiValidation {
+    }
+
     android.namespace = "com.kitakkun.jetwhale.plugins.network.protocol"
 }
 

--- a/jetwhale-plugins/semantics/agent/api/agent.klib.api
+++ b/jetwhale-plugins/semantics/agent/api/agent.klib.api
@@ -1,0 +1,72 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.kitakkun.jetwhale.plugins.semantics:agent>
+abstract interface com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSource { // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSource|null[0]
+    abstract val sourceId // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSource.sourceId|{}sourceId[0]
+        abstract fun <get-sourceId>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSource.sourceId.<get-sourceId>|<get-sourceId>(){}[0]
+
+    abstract suspend fun capture(com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions): com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot? // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSource.capture|capture(com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions){}[0]
+    abstract suspend fun performAction(com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSource.performAction|performAction(com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction){}[0]
+}
+
+abstract interface com.kitakkun.jetwhale.plugins.semantics.agent/ComposeUiThread { // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeUiThread|null[0]
+    abstract suspend fun <#A1: kotlin/Any?> await(kotlin/Function0<#A1>): #A1 // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeUiThread.await|await(kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin : com.kitakkun.jetwhale.agent.sdk/JetWhaleAgentPlugin { // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin|null[0]
+    constructor <init>() // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin.<init>|<init>(){}[0]
+
+    final val pluginId // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin.pluginId|{}pluginId[0]
+        final fun <get-pluginId>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin.pluginId.<get-pluginId>|<get-pluginId>(){}[0]
+    final val pluginVersion // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin.pluginVersion|{}pluginVersion[0]
+        final fun <get-pluginVersion>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin.pluginVersion.<get-pluginVersion>|<get-pluginVersion>(){}[0]
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin.Companion|null[0]
+        final const val PLUGIN_ID // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin.Companion.PLUGIN_ID|{}PLUGIN_ID[0]
+            final fun <get-PLUGIN_ID>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin.Companion.PLUGIN_ID.<get-PLUGIN_ID>|<get-PLUGIN_ID>(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.agent/SemanticsOwnerNodeSource : com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSource { // com.kitakkun.jetwhale.plugins.semantics.agent/SemanticsOwnerNodeSource|null[0]
+    constructor <init>(kotlin/String, kotlin/Function0<androidx.compose.ui.semantics/SemanticsOwner?>, kotlin/Function0<kotlin/String>, kotlin/Function0<kotlin/Float>, kotlin/Function0<androidx.compose.ui.geometry/Offset> = ..., com.kitakkun.jetwhale.plugins.semantics.agent/ComposeUiThread = ...) // com.kitakkun.jetwhale.plugins.semantics.agent/SemanticsOwnerNodeSource.<init>|<init>(kotlin.String;kotlin.Function0<androidx.compose.ui.semantics.SemanticsOwner?>;kotlin.Function0<kotlin.String>;kotlin.Function0<kotlin.Float>;kotlin.Function0<androidx.compose.ui.geometry.Offset>;com.kitakkun.jetwhale.plugins.semantics.agent.ComposeUiThread){}[0]
+
+    final val sourceId // com.kitakkun.jetwhale.plugins.semantics.agent/SemanticsOwnerNodeSource.sourceId|{}sourceId[0]
+        final fun <get-sourceId>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.agent/SemanticsOwnerNodeSource.sourceId.<get-sourceId>|<get-sourceId>(){}[0]
+
+    final suspend fun capture(com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions): com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot? // com.kitakkun.jetwhale.plugins.semantics.agent/SemanticsOwnerNodeSource.capture|capture(com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions){}[0]
+    final suspend fun performAction(com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult // com.kitakkun.jetwhale.plugins.semantics.agent/SemanticsOwnerNodeSource.performAction|performAction(com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction){}[0]
+}
+
+final object com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry { // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry|null[0]
+    final val sources // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry.sources|{}sources[0]
+        final fun <get-sources>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSource> // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry.sources.<get-sources>|<get-sources>(){}[0]
+
+    final fun clear() // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry.clear|clear(){}[0]
+    final fun register(com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSource): com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry.Registration // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry.register|register(com.kitakkun.jetwhale.plugins.semantics.agent.ComposeNodeSource){}[0]
+
+    final class Registration : kotlin/AutoCloseable { // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry.Registration|null[0]
+        final fun close() // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry.Registration.close|close(){}[0]
+    }
+}
+
+final object com.kitakkun.jetwhale.plugins.semantics.agent/MainDispatcherComposeUiThread : com.kitakkun.jetwhale.plugins.semantics.agent/ComposeUiThread { // com.kitakkun.jetwhale.plugins.semantics.agent/MainDispatcherComposeUiThread|null[0]
+    final suspend fun <#A1: kotlin/Any?> await(kotlin/Function0<#A1>): #A1 // com.kitakkun.jetwhale.plugins.semantics.agent/MainDispatcherComposeUiThread.await|await(kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
+}
+
+final val com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry$stableprop // com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry$stableprop|#static{}com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry$stableprop[0]
+final val com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry_Registration$stableprop // com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry_Registration$stableprop|#static{}com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry_Registration$stableprop[0]
+final val com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_JetWhaleSemanticsAgentPlugin$stableprop // com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_JetWhaleSemanticsAgentPlugin$stableprop|#static{}com_kitakkun_jetwhale_plugins_semantics_agent_JetWhaleSemanticsAgentPlugin$stableprop[0]
+final val com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_MainDispatcherComposeUiThread$stableprop // com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_MainDispatcherComposeUiThread$stableprop|#static{}com_kitakkun_jetwhale_plugins_semantics_agent_MainDispatcherComposeUiThread$stableprop[0]
+final val com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_SemanticsOwnerNodeSource$stableprop // com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_SemanticsOwnerNodeSource$stableprop|#static{}com_kitakkun_jetwhale_plugins_semantics_agent_SemanticsOwnerNodeSource$stableprop[0]
+
+final fun (com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry).com.kitakkun.jetwhale.plugins.semantics.agent/registerSemanticsOwner(androidx.compose.ui.semantics/SemanticsOwner, kotlin/String, kotlin/String, kotlin/Float, kotlin/Function0<androidx.compose.ui.geometry/Offset> = ..., com.kitakkun.jetwhale.plugins.semantics.agent/ComposeUiThread = ...): com.kitakkun.jetwhale.plugins.semantics.agent/ComposeNodeSourceRegistry.Registration // com.kitakkun.jetwhale.plugins.semantics.agent/registerSemanticsOwner|registerSemanticsOwner@com.kitakkun.jetwhale.plugins.semantics.agent.ComposeNodeSourceRegistry(androidx.compose.ui.semantics.SemanticsOwner;kotlin.String;kotlin.String;kotlin.Float;kotlin.Function0<androidx.compose.ui.geometry.Offset>;com.kitakkun.jetwhale.plugins.semantics.agent.ComposeUiThread){}[0]
+final fun com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry$stableprop_getter(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry$stableprop_getter|com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry$stableprop_getter(){}[0]
+final fun com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry_Registration$stableprop_getter(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry_Registration$stableprop_getter|com_kitakkun_jetwhale_plugins_semantics_agent_ComposeNodeSourceRegistry_Registration$stableprop_getter(){}[0]
+final fun com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_JetWhaleSemanticsAgentPlugin$stableprop_getter(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_JetWhaleSemanticsAgentPlugin$stableprop_getter|com_kitakkun_jetwhale_plugins_semantics_agent_JetWhaleSemanticsAgentPlugin$stableprop_getter(){}[0]
+final fun com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_MainDispatcherComposeUiThread$stableprop_getter(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_MainDispatcherComposeUiThread$stableprop_getter|com_kitakkun_jetwhale_plugins_semantics_agent_MainDispatcherComposeUiThread$stableprop_getter(){}[0]
+final fun com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_SemanticsOwnerNodeSource$stableprop_getter(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.agent/com_kitakkun_jetwhale_plugins_semantics_agent_SemanticsOwnerNodeSource$stableprop_getter|com_kitakkun_jetwhale_plugins_semantics_agent_SemanticsOwnerNodeSource$stableprop_getter(){}[0]

--- a/jetwhale-plugins/semantics/agent/api/jvm/agent.api
+++ b/jetwhale-plugins/semantics/agent/api/jvm/agent.api
@@ -1,0 +1,59 @@
+public abstract interface class com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSource {
+	public abstract fun capture (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getSourceId ()Ljava/lang/String;
+	public abstract fun performAction (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry;
+	public final fun clear ()V
+	public final fun getSources ()Ljava/util/List;
+	public final fun register (Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSource;)Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry$Registration;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry$Registration : java/lang/AutoCloseable {
+	public static final field $stable I
+	public fun close ()V
+}
+
+public abstract interface class com/kitakkun/jetwhale/plugins/semantics/agent/ComposeUiThread {
+	public abstract fun await (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/agent/DesktopSemanticsProbeKt {
+	public static final fun JetWhaleSemanticsProbe (Landroidx/compose/ui/window/FrameWindowScope;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/agent/JetWhaleSemanticsAgentPlugin : com/kitakkun/jetwhale/agent/sdk/JetWhaleAgentPlugin {
+	public static final field $stable I
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/agent/JetWhaleSemanticsAgentPlugin$Companion;
+	public static final field PLUGIN_ID Ljava/lang/String;
+	public fun <init> ()V
+	public fun getPluginId ()Ljava/lang/String;
+	public fun getPluginVersion ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/agent/JetWhaleSemanticsAgentPlugin$Companion {
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/agent/MainDispatcherComposeUiThread : com/kitakkun/jetwhale/plugins/semantics/agent/ComposeUiThread {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/agent/MainDispatcherComposeUiThread;
+	public fun await (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsOwnerNodeSource : com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSource {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeUiThread;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeUiThread;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun capture (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getSourceId ()Ljava/lang/String;
+	public fun performAction (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsOwnerNodeSourceKt {
+	public static final fun registerSemanticsOwner (Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry;Landroidx/compose/ui/semantics/SemanticsOwner;Ljava/lang/String;Ljava/lang/String;FLkotlin/jvm/functions/Function0;Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeUiThread;)Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry$Registration;
+	public static synthetic fun registerSemanticsOwner$default (Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry;Landroidx/compose/ui/semantics/SemanticsOwner;Ljava/lang/String;Ljava/lang/String;FLkotlin/jvm/functions/Function0;Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeUiThread;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry$Registration;
+}
+

--- a/jetwhale-plugins/semantics/agent/build.gradle.kts
+++ b/jetwhale-plugins/semantics/agent/build.gradle.kts
@@ -1,6 +1,7 @@
-@file:OptIn(ExperimentalWasmDsl::class)
+@file:OptIn(ExperimentalWasmDsl::class, ExperimentalAbiValidation::class)
 
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -19,6 +20,9 @@ group = "com.kitakkun.jetwhale.plugins.semantics"
 // target Compose does not run on has no node tree to read in the first place. macOS is left out
 // too: Compose rejects it unless the whole build opts into its experimental macOS support.
 kotlin {
+    abiValidation {
+    }
+
     jvm()
     jvmToolchain(17)
 

--- a/jetwhale-plugins/semantics/host/api/host.api
+++ b/jetwhale-plugins/semantics/host/api/host.api
@@ -1,0 +1,17 @@
+public final class com/kitakkun/jetwhale/plugins/semantics/host/ComposableSingletons$ComposeSemanticsInspectorScreenKt {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/host/ComposableSingletons$ComposeSemanticsInspectorScreenKt;
+	public fun <init> ()V
+	public final fun getLambda$1043987052$com_kitakkun_jetwhale_plugins_semantics_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1172912206$com_kitakkun_jetwhale_plugins_semantics_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$119651336$com_kitakkun_jetwhale_plugins_semantics_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1828601466$com_kitakkun_jetwhale_plugins_semantics_host ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1946299614$com_kitakkun_jetwhale_plugins_semantics_host ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$356591191$com_kitakkun_jetwhale_plugins_semantics_host ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory : com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginFactory {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun createPlugin ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
+}
+

--- a/jetwhale-plugins/semantics/host/build.gradle.kts
+++ b/jetwhale-plugins/semantics/host/build.gradle.kts
@@ -1,3 +1,7 @@
+@file:OptIn(ExperimentalAbiValidation::class)
+
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.composeCompiler)
@@ -7,6 +11,11 @@ plugins {
     // In-repo only: adds runJetWhaleLocal, which launches the local :jetwhale-host:app project.
     alias(libs.plugins.jetwhaleHostLaunch)
     alias(libs.plugins.publish)
+}
+
+kotlin {
+    abiValidation {
+    }
 }
 
 // Distinct group so this module's coordinates don't collide with the other plugins' `host`.

--- a/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
+++ b/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
@@ -1,0 +1,326 @@
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/CaptureNodeTree : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/CaptureNodeTree$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;)V
+	public synthetic fun <init> (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;
+	public final fun copy (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/CaptureNodeTree;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/CaptureNodeTree;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/CaptureNodeTree;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOptions ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/CaptureNodeTree$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/CaptureNodeTree$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/CaptureNodeTree;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/CaptureNodeTree;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/CaptureNodeTree$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode$Companion;
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;Ljava/util/List;ZZZZZZZLjava/util/List;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;Ljava/util/List;ZZZZZZZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Z
+	public final fun component13 ()Z
+	public final fun component14 ()Z
+	public final fun component15 ()Z
+	public final fun component16 ()Z
+	public final fun component17 ()Z
+	public final fun component18 ()Z
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;Ljava/util/List;ZZZZZZZLjava/util/List;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;Ljava/util/List;ZZZZZZZLjava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActions ()Ljava/util/List;
+	public final fun getBounds ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;
+	public final fun getBoundsInScreen ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getContentDescription ()Ljava/lang/String;
+	public final fun getEditableText ()Ljava/lang/String;
+	public final fun getId ()I
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getStateDescription ()Ljava/lang/String;
+	public final fun getTestTag ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getToggleableState ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isClickable ()Z
+	public final fun isEditable ()Z
+	public final fun isEnabled ()Z
+	public final fun isFocused ()Z
+	public final fun isScrollable ()Z
+	public final fun isSelected ()Z
+	public final fun isVisible ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;FFFLcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()F
+	public final fun component4 ()F
+	public final fun component5 ()F
+	public final fun component6 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;FFFLcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot;Ljava/lang/String;Ljava/lang/String;FFFLcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDensity ()F
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getNode ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNode;
+	public final fun getRootId ()Ljava/lang/String;
+	public final fun getWindowOffsetX ()F
+	public final fun getWindowOffsetY ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction : java/lang/Enum {
+	public static final field Click Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static final field Collapse Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction$Companion;
+	public static final field Dismiss Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static final field Expand Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static final field ImeAction Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static final field InsertText Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static final field LongClick Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static final field RequestFocus Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static final field ScrollBy Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static final field SetText Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static fun values ()[Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeActionResult {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeActionResult$Companion;
+	public fun <init> (ZLjava/lang/String;)V
+	public synthetic fun <init> (ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeActionResult;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeActionResult;ZLjava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeActionResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getPerformed ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeActionResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeActionResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeActionResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeActionResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeActionResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds$Companion;
+	public fun <init> (FFFF)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun component3 ()F
+	public final fun component4 ()F
+	public final fun copy (FFFF)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;FFFFILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()F
+	public final fun getCenterX ()F
+	public final fun getCenterY ()F
+	public final fun getHeight ()F
+	public final fun getLeft ()F
+	public final fun getRight ()F
+	public final fun getTop ()F
+	public final fun getWidth ()F
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeBounds$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (ZZLjava/lang/Integer;)V
+	public synthetic fun <init> (ZZLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (ZZLjava/lang/Integer;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;ZZLjava/lang/Integer;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeInvisible ()Z
+	public final fun getMaxDepth ()Ljava/lang/Integer;
+	public final fun getMerged ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnapshot {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnapshot$Companion;
+	public fun <init> (JJLcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (JJLcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (JJLcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;Ljava/util/List;Ljava/util/List;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnapshot;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnapshot;JJLcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaptureDurationMs ()J
+	public final fun getCapturedAtMs ()J
+	public final fun getOptions ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeCaptureOptions;
+	public final fun getRoots ()Ljava/util/List;
+	public final fun getWarnings ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction$Companion;
+	public fun <init> (Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FF)V
+	public synthetic fun <init> (Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()F
+	public final fun component6 ()F
+	public final fun copy (Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FF)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FFILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public final fun getNodeId ()I
+	public final fun getRootId ()Ljava/lang/String;
+	public final fun getScrollX ()F
+	public final fun getScrollY ()F
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
+++ b/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
@@ -1,0 +1,369 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.kitakkun.jetwhale.plugins.semantics:protocol>
+final enum class com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction : kotlin/Enum<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction> { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction|null[0]
+    enum entry Click // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.Click|null[0]
+    enum entry Collapse // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.Collapse|null[0]
+    enum entry Dismiss // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.Dismiss|null[0]
+    enum entry Expand // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.Expand|null[0]
+    enum entry ImeAction // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.ImeAction|null[0]
+    enum entry InsertText // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.InsertText|null[0]
+    enum entry LongClick // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.LongClick|null[0]
+    enum entry RequestFocus // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.RequestFocus|null[0]
+    enum entry ScrollBy // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.ScrollBy|null[0]
+    enum entry SetText // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.SetText|null[0]
+
+    final val entries // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot> { // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree|null[0]
+    constructor <init>(com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.<init>|<init>(com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions){}[0]
+
+    final val options // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.options|{}options[0]
+        final fun <get-options>(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.options.<get-options>|<get-options>(){}[0]
+
+    final fun component1(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.component1|component1(){}[0]
+    final fun copy(com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.copy|copy(com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree> { // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree) // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.CaptureNodeTree){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree> // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode { // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode|null[0]
+    constructor <init>(kotlin/Int, kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds, com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds, kotlin.collections/List<kotlin/String> = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode> = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.<init>|<init>(kotlin.Int;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds;kotlin.collections.List<kotlin.String>;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.collections.List<com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode>){}[0]
+
+    final val actions // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.actions|{}actions[0]
+        final fun <get-actions>(): kotlin.collections/List<kotlin/String> // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.actions.<get-actions>|<get-actions>(){}[0]
+    final val bounds // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.bounds|{}bounds[0]
+        final fun <get-bounds>(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.bounds.<get-bounds>|<get-bounds>(){}[0]
+    final val boundsInScreen // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.boundsInScreen|{}boundsInScreen[0]
+        final fun <get-boundsInScreen>(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.boundsInScreen.<get-boundsInScreen>|<get-boundsInScreen>(){}[0]
+    final val children // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.children|{}children[0]
+        final fun <get-children>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode> // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.children.<get-children>|<get-children>(){}[0]
+    final val contentDescription // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.contentDescription|{}contentDescription[0]
+        final fun <get-contentDescription>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.contentDescription.<get-contentDescription>|<get-contentDescription>(){}[0]
+    final val editableText // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.editableText|{}editableText[0]
+        final fun <get-editableText>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.editableText.<get-editableText>|<get-editableText>(){}[0]
+    final val id // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.id|{}id[0]
+        final fun <get-id>(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.id.<get-id>|<get-id>(){}[0]
+    final val isClickable // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isClickable|{}isClickable[0]
+        final fun <get-isClickable>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isClickable.<get-isClickable>|<get-isClickable>(){}[0]
+    final val isEditable // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isEditable|{}isEditable[0]
+        final fun <get-isEditable>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isEditable.<get-isEditable>|<get-isEditable>(){}[0]
+    final val isEnabled // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isEnabled|{}isEnabled[0]
+        final fun <get-isEnabled>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isEnabled.<get-isEnabled>|<get-isEnabled>(){}[0]
+    final val isFocused // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isFocused|{}isFocused[0]
+        final fun <get-isFocused>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isFocused.<get-isFocused>|<get-isFocused>(){}[0]
+    final val isScrollable // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isScrollable|{}isScrollable[0]
+        final fun <get-isScrollable>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isScrollable.<get-isScrollable>|<get-isScrollable>(){}[0]
+    final val isSelected // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isSelected|{}isSelected[0]
+        final fun <get-isSelected>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isSelected.<get-isSelected>|<get-isSelected>(){}[0]
+    final val isVisible // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isVisible|{}isVisible[0]
+        final fun <get-isVisible>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.isVisible.<get-isVisible>|<get-isVisible>(){}[0]
+    final val role // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.role|{}role[0]
+        final fun <get-role>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.role.<get-role>|<get-role>(){}[0]
+    final val stateDescription // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.stateDescription|{}stateDescription[0]
+        final fun <get-stateDescription>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.stateDescription.<get-stateDescription>|<get-stateDescription>(){}[0]
+    final val testTag // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.testTag|{}testTag[0]
+        final fun <get-testTag>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.testTag.<get-testTag>|<get-testTag>(){}[0]
+    final val text // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.text|{}text[0]
+        final fun <get-text>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.text.<get-text>|<get-text>(){}[0]
+    final val toggleableState // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.toggleableState|{}toggleableState[0]
+        final fun <get-toggleableState>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.toggleableState.<get-toggleableState>|<get-toggleableState>(){}[0]
+
+    final fun component1(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component1|component1(){}[0]
+    final fun component10(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component10|component10(){}[0]
+    final fun component11(): kotlin.collections/List<kotlin/String> // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component11|component11(){}[0]
+    final fun component12(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component12|component12(){}[0]
+    final fun component13(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component13|component13(){}[0]
+    final fun component14(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component14|component14(){}[0]
+    final fun component15(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component15|component15(){}[0]
+    final fun component16(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component16|component16(){}[0]
+    final fun component17(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component17|component17(){}[0]
+    final fun component18(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component18|component18(){}[0]
+    final fun component19(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode> // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component19|component19(){}[0]
+    final fun component2(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component2|component2(){}[0]
+    final fun component3(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component3|component3(){}[0]
+    final fun component4(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component4|component4(){}[0]
+    final fun component5(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component5|component5(){}[0]
+    final fun component6(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component6|component6(){}[0]
+    final fun component7(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component7|component7(){}[0]
+    final fun component8(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component8|component8(){}[0]
+    final fun component9(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.component9|component9(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds = ..., kotlin.collections/List<kotlin/String> = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode> = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.copy|copy(kotlin.Int;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds;kotlin.collections.List<kotlin.String>;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.collections.List<com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode) // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode> // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot { // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot|null[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/Float, kotlin/Float, kotlin/Float, com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode?) // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.<init>|<init>(kotlin.String;kotlin.String;kotlin.Float;kotlin.Float;kotlin.Float;com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode?){}[0]
+
+    final val density // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.density|{}density[0]
+        final fun <get-density>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.density.<get-density>|<get-density>(){}[0]
+    final val label // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.label|{}label[0]
+        final fun <get-label>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.label.<get-label>|<get-label>(){}[0]
+    final val node // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.node|{}node[0]
+        final fun <get-node>(): com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.node.<get-node>|<get-node>(){}[0]
+    final val rootId // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.rootId|{}rootId[0]
+        final fun <get-rootId>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.rootId.<get-rootId>|<get-rootId>(){}[0]
+    final val windowOffsetX // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.windowOffsetX|{}windowOffsetX[0]
+        final fun <get-windowOffsetX>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.windowOffsetX.<get-windowOffsetX>|<get-windowOffsetX>(){}[0]
+    final val windowOffsetY // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.windowOffsetY|{}windowOffsetY[0]
+        final fun <get-windowOffsetY>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.windowOffsetY.<get-windowOffsetY>|<get-windowOffsetY>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.component1|component1(){}[0]
+    final fun component2(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.component2|component2(){}[0]
+    final fun component3(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.component3|component3(){}[0]
+    final fun component4(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.component4|component4(){}[0]
+    final fun component5(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.component5|component5(){}[0]
+    final fun component6(): com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode? // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.component6|component6(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/Float = ..., kotlin/Float = ..., kotlin/Float = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeNode? = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.copy|copy(kotlin.String;kotlin.String;kotlin.Float;kotlin.Float;kotlin.Float;com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot) // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot> // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult|null[0]
+    constructor <init>(kotlin/Boolean, kotlin/String? = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.<init>|<init>(kotlin.Boolean;kotlin.String?){}[0]
+
+    final val message // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.message|{}message[0]
+        final fun <get-message>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.message.<get-message>|<get-message>(){}[0]
+    final val performed // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.performed|{}performed[0]
+        final fun <get-performed>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.performed.<get-performed>|<get-performed>(){}[0]
+
+    final fun component1(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.component2|component2(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin/String? = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.copy|copy(kotlin.Boolean;kotlin.String?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult> { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult) // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds|null[0]
+    constructor <init>(kotlin/Float, kotlin/Float, kotlin/Float, kotlin/Float) // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.<init>|<init>(kotlin.Float;kotlin.Float;kotlin.Float;kotlin.Float){}[0]
+
+    final val bottom // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.bottom|{}bottom[0]
+        final fun <get-bottom>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.bottom.<get-bottom>|<get-bottom>(){}[0]
+    final val centerX // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.centerX|{}centerX[0]
+        final fun <get-centerX>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.centerX.<get-centerX>|<get-centerX>(){}[0]
+    final val centerY // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.centerY|{}centerY[0]
+        final fun <get-centerY>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.centerY.<get-centerY>|<get-centerY>(){}[0]
+    final val height // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.height|{}height[0]
+        final fun <get-height>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.height.<get-height>|<get-height>(){}[0]
+    final val isEmpty // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.isEmpty|{}isEmpty[0]
+        final fun <get-isEmpty>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.isEmpty.<get-isEmpty>|<get-isEmpty>(){}[0]
+    final val left // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.left|{}left[0]
+        final fun <get-left>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.left.<get-left>|<get-left>(){}[0]
+    final val right // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.right|{}right[0]
+        final fun <get-right>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.right.<get-right>|<get-right>(){}[0]
+    final val top // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.top|{}top[0]
+        final fun <get-top>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.top.<get-top>|<get-top>(){}[0]
+    final val width // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.width|{}width[0]
+        final fun <get-width>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.width.<get-width>|<get-width>(){}[0]
+
+    final fun component1(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.component1|component1(){}[0]
+    final fun component2(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.component2|component2(){}[0]
+    final fun component3(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.component3|component3(){}[0]
+    final fun component4(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.component4|component4(){}[0]
+    final fun copy(kotlin/Float = ..., kotlin/Float = ..., kotlin/Float = ..., kotlin/Float = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.copy|copy(kotlin.Float;kotlin.Float;kotlin.Float;kotlin.Float){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds> { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds) // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeBounds.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions|null[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Int? = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Int?){}[0]
+
+    final val includeInvisible // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.includeInvisible|{}includeInvisible[0]
+        final fun <get-includeInvisible>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.includeInvisible.<get-includeInvisible>|<get-includeInvisible>(){}[0]
+    final val maxDepth // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.maxDepth|{}maxDepth[0]
+        final fun <get-maxDepth>(): kotlin/Int? // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.maxDepth.<get-maxDepth>|<get-maxDepth>(){}[0]
+    final val merged // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.merged|{}merged[0]
+        final fun <get-merged>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.merged.<get-merged>|<get-merged>(){}[0]
+
+    final fun component1(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.component1|component1(){}[0]
+    final fun component2(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.component2|component2(){}[0]
+    final fun component3(): kotlin/Int? // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.component3|component3(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Int? = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.copy|copy(kotlin.Boolean;kotlin.Boolean;kotlin.Int?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions> { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions) // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot|null[0]
+    constructor <init>(kotlin/Long, kotlin/Long, com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions, kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot>, kotlin.collections/List<kotlin/String> = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.<init>|<init>(kotlin.Long;kotlin.Long;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions;kotlin.collections.List<com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot>;kotlin.collections.List<kotlin.String>){}[0]
+
+    final val captureDurationMs // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.captureDurationMs|{}captureDurationMs[0]
+        final fun <get-captureDurationMs>(): kotlin/Long // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.captureDurationMs.<get-captureDurationMs>|<get-captureDurationMs>(){}[0]
+    final val capturedAtMs // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.capturedAtMs|{}capturedAtMs[0]
+        final fun <get-capturedAtMs>(): kotlin/Long // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.capturedAtMs.<get-capturedAtMs>|<get-capturedAtMs>(){}[0]
+    final val options // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.options|{}options[0]
+        final fun <get-options>(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.options.<get-options>|<get-options>(){}[0]
+    final val roots // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.roots|{}roots[0]
+        final fun <get-roots>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.roots.<get-roots>|<get-roots>(){}[0]
+    final val warnings // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.warnings|{}warnings[0]
+        final fun <get-warnings>(): kotlin.collections/List<kotlin/String> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.warnings.<get-warnings>|<get-warnings>(){}[0]
+
+    final fun component1(): kotlin/Long // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.component1|component1(){}[0]
+    final fun component2(): kotlin/Long // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.component2|component2(){}[0]
+    final fun component3(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.component4|component4(){}[0]
+    final fun component5(): kotlin.collections/List<kotlin/String> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.component5|component5(){}[0]
+    final fun copy(kotlin/Long = ..., kotlin/Long = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions = ..., kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot> = ..., kotlin.collections/List<kotlin/String> = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.copy|copy(kotlin.Long;kotlin.Long;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions;kotlin.collections.List<com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot>;kotlin.collections.List<kotlin.String>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot> { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot) // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot> // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult> { // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction|null[0]
+    constructor <init>(kotlin/String, kotlin/Int, com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction, kotlin/String? = ..., kotlin/Float = ..., kotlin/Float = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.<init>|<init>(kotlin.String;kotlin.Int;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction;kotlin.String?;kotlin.Float;kotlin.Float){}[0]
+
+    final val action // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.action|{}action[0]
+        final fun <get-action>(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.action.<get-action>|<get-action>(){}[0]
+    final val nodeId // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.nodeId|{}nodeId[0]
+        final fun <get-nodeId>(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.nodeId.<get-nodeId>|<get-nodeId>(){}[0]
+    final val rootId // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.rootId|{}rootId[0]
+        final fun <get-rootId>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.rootId.<get-rootId>|<get-rootId>(){}[0]
+    final val scrollX // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.scrollX|{}scrollX[0]
+        final fun <get-scrollX>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.scrollX.<get-scrollX>|<get-scrollX>(){}[0]
+    final val scrollY // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.scrollY|{}scrollY[0]
+        final fun <get-scrollY>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.scrollY.<get-scrollY>|<get-scrollY>(){}[0]
+    final val text // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.text|{}text[0]
+        final fun <get-text>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.text.<get-text>|<get-text>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.component2|component2(){}[0]
+    final fun component3(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.component3|component3(){}[0]
+    final fun component4(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.component4|component4(){}[0]
+    final fun component5(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.component5|component5(){}[0]
+    final fun component6(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.component6|component6(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Int = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction = ..., kotlin/String? = ..., kotlin/Float = ..., kotlin/Float = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.copy|copy(kotlin.String;kotlin.Int;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction;kotlin.String?;kotlin.Float;kotlin.Float){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction> { // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction) // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction> // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.Companion.serializer|serializer(){}[0]
+    }
+}

--- a/jetwhale-plugins/semantics/protocol/build.gradle.kts
+++ b/jetwhale-plugins/semantics/protocol/build.gradle.kts
@@ -1,6 +1,7 @@
-@file:OptIn(ExperimentalWasmDsl::class)
+@file:OptIn(ExperimentalWasmDsl::class, ExperimentalAbiValidation::class)
 
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -12,6 +13,9 @@ plugins {
 group = "com.kitakkun.jetwhale.plugins.semantics"
 
 kotlin {
+    abiValidation {
+    }
+
     android.namespace = "com.kitakkun.jetwhale.plugins.semantics.protocol"
 }
 


### PR DESCRIPTION
Kotlin ABI validation covered the five public modules — `jetwhale-host-sdk`, `jetwhale-agent-sdk`,
`jetwhale-agent-runtime`, `jetwhale-annotations`, `jetwhale-protocol:core` — but not the official
plugins, which are published artifacts that out-of-tree consumers compile against. This extends it
to all eleven of them.

| Module | Kind | Dumps |
|---|---|---|
| `network/protocol`, `network/agent`, `network/agent-ktor` | multiplatform | `api/<name>.klib.api` + `api/jvm/<name>.api` |
| `network/agent-okhttp`, `network/host` | JVM | `api/<name>.api` |
| `nav3/protocol`, `nav3/agent` | multiplatform | klib + jvm |
| `nav3/host` | JVM | `api/host.api` |
| `semantics/protocol`, `semantics/agent` | multiplatform | klib + jvm |
| `semantics/host` | JVM | `api/host.api` |

The JVM-only modules take the same DSL unchanged: `abiValidation { }` lives on the Kotlin *base*
extension rather than the multiplatform one, which is how the JVM-only `:jetwhale-host-sdk` already
does it. They simply had no `kotlin { }` block before. No module had to be skipped.

`jetwhale-plugins/example/*` is left out: none of its three modules declare a `jetwhalePublish`
block, so it is an unpublished sample.

Dumps follow the shape settled in 6d0654a7 — only `<name>.klib.api` and `jvm/<name>.api`, no
`api/android/`. Regenerating wrote nothing under `android/`, so that commit's finding still holds.

`abi-check.yml` runs the eleven new tasks, and its `paths:` filter gains
`jetwhale-plugins/{network,nav3,semantics}/**` — a plugin source change previously reached the job
only incidentally, through the `**/build.gradle.kts` glob.

## What the dumps surfaced

**`:semantics:agent` published compose-ui at the wrong scope.** `registerSemanticsOwner` takes a
`SemanticsOwner` and `SemanticsOwnerNodeSource` is constructed with one, so `androidx.compose.ui` is
part of the module's public API, but it was declared `implementation`. Fixed separately in #241,
which touches the same build file — expect a trivial conflict.

**The `host` modules export more than the factory.** Only the `*PluginFactory` is loaded reflectively
by the host, yet `:network:host` also exports `HttpTransaction` and the `NetworkInspectorScreen`
composable. Not a break risk — nothing compiles against a host plugin jar — but it is now frozen
into a checked baseline, so it is worth deciding whether those should be `internal`.

**Compose lambda keys are stable.** Every host dump is mostly compiler-generated
`ComposableSingletons$*.getLambda$<key>$<module>` entries — `:network:host` is 63 lines, ~40 of them
these. Inserting a line above a composable and regenerating produced a byte-identical dump, so
incidental edits will not churn the baseline; adding or removing a composable lambda still will. No
`filters { }` exclusion was added since no module in the repo uses filters today, but excluding
`**.ComposableSingletons**` would make those three dumps readable if the churn becomes annoying.

**No unintended leaks elsewhere.** The protocol and agent surfaces are deliberate: message/model
classes with their generated `$$serializer`/`$Companion` pairs, and the sealed `NavBackStackOperation`
hierarchy. `ComposeNodeSourceRegistry.clear()` is public but documented as intended for tests and
teardown.

## Verification

`checkKotlinAbi` passes on all sixteen modules (five existing, eleven new) and `spotlessCheck` is
clean.
