### PR TITLE
feat(host): host-scoped plugins, plugin context, and rich MCP results

### DIFF
--- a/docs/guide/developing-plugins.md
+++ b/docs/guide/developing-plugins.md
@@ -85,8 +85,10 @@ Implement `JetWhaleHostPluginFactory` and declare it in a plugin manifest. The h
 by instantiating the `factoryClass` named in the manifest. See `jetwhale-plugins/example/host` for a
 complete, working example:
 
-- `src/main/kotlin/.../MyPluginFactory.kt` — a `JetWhaleHostPluginFactory` returning your
-  `JetWhaleHostPlugin`. It needs a public no-arg constructor so the host can instantiate it.
+- `src/main/kotlin/.../MyPluginFactory.kt` — a `JetWhaleHostPluginFactory` whose
+  `createPlugin(context)` returns your `JetWhaleHostPlugin`. It needs a public no-arg constructor so
+  the host can instantiate it; `context` is the [host services](#host-services-jetwhalehostplugincontext)
+  the instance may keep.
 - `src/main/resources/META-INF/jetwhale/plugin-manifest.json` — one entry per plugin under `plugins`,
   each with `pluginId`, `pluginName`, `version`, and `factoryClass` (the fully-qualified name of the
   factory above):
@@ -118,6 +120,7 @@ in the IDE.
 | `version` | ✅ | — | Your plugin's version. |
 | `factoryClass` | ✅ | — | Fully-qualified `JetWhaleHostPluginFactory` the host instantiates. Needs a public no-arg constructor. |
 | `requiresAgent` | | `true` | `false` makes the plugin [host-only](#host-only-plugins-no-agent-no-messaging): no agent counterpart, no messaging, instantiated for every active session. |
+| `scope` | | `"session"` | `"host"` makes the plugin [host-scoped](#host-scoped-plugins-one-instance-for-the-whole-host): a single instance for the whole debug tool, created before any app connects, whose MCP tools take no `sessionId`. Requires `"requiresAgent": false`. |
 | `agentVersionRange` | | none | `{ "min": …, "max": … }`, both **inclusive** and both nullable. An agent plugin whose `pluginVersion` falls outside the range is reported back to the agent as *incompatible* and never paired. Omit the object to accept any agent version. |
 | `icon` | | none | `{ "activePath": …, "inactivePath": … }` — see below. |
 
@@ -293,6 +296,63 @@ own capabilities — extend the plain `JetWhaleHostPlugin` (not `JetWhaleMessagi
 `messenger`; it is made available for every active session. See
 `ExampleHostOnlyPlugin` in `jetwhale-plugins/example/host`.
 
+#### Host-scoped plugins (one instance for the whole host)
+
+A host-only plugin still gets **one instance per connected session**. When the plugin has nothing to
+do with any particular app — it drives a device over adb, watches a directory, talks to a service —
+declare `"scope": "host"` alongside `"requiresAgent": false` and the host holds exactly **one**
+instance of it instead:
+
+```json
+{
+  "pluginId": "com.example.devicecontrol",
+  "pluginName": "Device Control",
+  "version": "1.0.0",
+  "factoryClass": "com.example.DeviceControlFactory",
+  "requiresAgent": false,
+  "scope": "host"
+}
+```
+
+What changes:
+
+- The instance is created as soon as the plugin is **enabled and loaded** — with no app connected and
+  no session in existence — and disposed when the plugin is disabled, unloaded or reloaded. Closing a
+  session never touches it.
+- Its **MCP tools take no `sessionId`**: there is nothing to route, so a call reaches the single
+  instance directly. (Session-scoped plugin tools still get the injected `sessionId`.)
+- Its factory must return a plain `JetWhaleHostPlugin`, never a `JetWhaleMessagingHostPlugin`: with
+  no session there is no agent to talk to, and the host refuses to create such an instance.
+  Declaring `"scope": "host"` together with `"requiresAgent": true` is a manifest error, and the jar
+  fails to load.
+- It may still implement `JetWhaleHostPluginUi`; its scene is opened from the drawer without a
+  session being selected. A host-scoped plugin with no UI shows the usual headless screen.
+
+See `ExampleHostScopedPlugin` in `jetwhale-plugins/example/host`.
+
+#### Host services: `JetWhaleHostPluginContext`
+
+`createPlugin(context)` hands every plugin the host's own capabilities. The object stays valid for
+the life of the instance, so keep whatever the plugin needs:
+
+```kotlin
+class DeviceControlFactory : JetWhaleHostPluginFactory {
+    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin =
+        DeviceControlPlugin(context.adb)
+}
+```
+
+- **`context.adb`** — the adb executable the host resolved, as one runner shared with the debug
+  tool's own port wiring, so a plugin never has to find an SDK of its own. `adb.run(vararg args,
+  timeout)` returns a `JetWhaleAdbResult` (exit code plus combined stdout/stderr; a non-zero exit is
+  a result, not an exception), and `adb.runStreaming(vararg args, timeout) { stream -> … }` hands you
+  raw stdout for binary or unbounded output such as `exec-out screencap -p` or `logcat`. Both throw
+  `JetWhaleAdbUnavailableException` when adb cannot be launched at all — catch it and say so, since
+  no amount of retrying brings a missing SDK back. `adb.executable` is the path (or bare name) in use.
+- **`context.sessions`** — `sessions.active` is a `StateFlow` of the currently connected sessions
+  (`sessionId`, `appName`, `deviceId`, `deviceName`, `installedPluginIds`). This is how a host-scoped
+  plugin learns that an app has arrived.
+
 ## Exposing MCP tools <Badge type="warning" text="experimental" />
 
 A host plugin can contribute tools to the host's [MCP server](/guide/mcp-server) by implementing
@@ -311,8 +371,8 @@ class InspectWidgetCommand(private val widgets: WidgetStore) : JetWhaleMcpComman
     private val widgetId by string("The widget ID")
     private val verbose by booleanOrNull("Include layout details.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
-        return widgets.describeAsJson(id = arguments[widgetId], verbose = arguments[verbose] ?: false)
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
+        return JetWhaleMcpResult.text(widgets.describeAsJson(id = arguments[widgetId], verbose = arguments[verbose] ?: false))
     }
 }
 
@@ -325,10 +385,16 @@ Things to know:
 
 - **Names must be globally unique** — prefix them with your `pluginId` by convention.
 - **`sessionId` is injected for you.** JetWhale adds a required `sessionId` parameter to every
-  plugin tool's schema and routes the call to the right plugin instance, so your command runs
-  against the correct session without handling it yourself.
-- **`execute` returns a string** (plain text or JSON). Throw `JetWhaleMcpArgumentException` for
-  caller mistakes — it is rendered as an `{"error": ...}` payload instead of failing the server.
+  session-scoped plugin tool's schema and routes the call to the right plugin instance, so your
+  command runs against the correct session without handling it yourself. A
+  [host-scoped](#host-scoped-plugins-one-instance-for-the-whole-host) plugin's tools take no
+  `sessionId` at all — the single instance is the target.
+- **`execute` returns a `JetWhaleMcpResult`.** `JetWhaleMcpResult.text(…)` for plain text or JSON,
+  `JetWhaleMcpResult.image(bytes, mimeType)` for a screenshot or other image the agent should see —
+  the host base64-encodes it for the protocol, so hand over raw bytes. A result may also carry
+  several blocks: `JetWhaleMcpResult(listOf(JetWhaleMcpContent.Text(…), JetWhaleMcpContent.Image(…)))`.
+  Throw `JetWhaleMcpArgumentException` for caller mistakes — it is rendered as an `{"error": ...}`
+  payload instead of failing the server.
 - **Messaging works from tool handlers.** `messenger` is valid for the whole instance lifetime, so
   a command can `request` the agent directly.
 - **Declare parameters as properties, never inside `execute`.** The list is read once, and declaring

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -262,7 +262,9 @@ Installing does not enable: the sequence is
 Host plugins can expose their own MCP tools by implementing `JetWhaleMcpCapablePlugin`. Their tools
 are registered alongside the built-ins; JetWhale automatically injects a required `sessionId`
 parameter into each plugin tool's schema so an AI agent can target a specific connected device with
-your custom debugging features too. See
+your custom debugging features too. A **host-scoped** plugin is the exception: it has a single
+instance that belongs to no session, so its tools take **no `sessionId`** and work with nothing
+connected at all. See
 [Developing Plugins → Exposing MCP tools](/guide/developing-plugins#exposing-mcp-tools) for how to
 write one.
 

--- a/jetwhale-host-sdk/api/jetwhale-host-sdk.api
+++ b/jetwhale-host-sdk/api/jetwhale-host-sdk.api
@@ -9,6 +9,24 @@ public final class com/kitakkun/jetwhale/host/sdk/DefaultArgumentJsonKt {
 public abstract interface annotation class com/kitakkun/jetwhale/host/sdk/InternalJetWhaleHostApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleAdb {
+	public abstract fun getExecutable ()Ljava/lang/String;
+	public abstract fun run-8Mi8wO0 ([Ljava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun runStreaming-dWUq8MI ([Ljava/lang/String;JLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleAdbResult {
+	public static final field $stable I
+	public fun <init> (ILjava/lang/String;)V
+	public final fun getExitCode ()I
+	public final fun getOutput ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleAdbUnavailableException : java/lang/Exception {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
 public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin {
 	public static final field $stable I
 	public fun <init> ()V
@@ -25,24 +43,30 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin {
 	protected fun onStorageMigrate (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginContext {
+	public abstract fun getAdb ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleAdb;
+	public abstract fun getSessions ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleSessions;
+}
+
 public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginFactory {
-	public abstract fun createPlugin ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
+	public abstract fun createPlugin (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginContext;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
 }
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest {
 	public static final field $stable I
 	public static final field Companion Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Z
-	public final fun component6 ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;
-	public final fun component7 ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;
-	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;
+	public final fun component6 ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope;
+	public final fun component7 ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;
+	public final fun component8 ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$Icon;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAgentVersionRange ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest$AgentVersionRange;
 	public final fun getFactoryClass ()Ljava/lang/String;
@@ -50,6 +74,7 @@ public final class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest {
 	public final fun getPluginId ()Ljava/lang/String;
 	public final fun getPluginName ()Ljava/lang/String;
 	public final fun getRequiresAgent ()Z
+	public final fun getScope ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -166,6 +191,19 @@ public final class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifestFile
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope : java/lang/Enum {
+	public static final field Companion Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope$Companion;
+	public static final field HOST Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope;
+	public static final field SESSION Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope;
+	public static fun values ()[Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginScope$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginUi {
 	public abstract fun Content (Landroidx/compose/runtime/Composer;I)V
 }
@@ -237,6 +275,22 @@ public abstract class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand {
 	public final fun toDescriptor ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor;
 }
 
+public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent {
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Image : com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent {
+	public static final field $stable I
+	public fun <init> ([BLjava/lang/String;)V
+	public final fun getData ()[B
+	public final fun getMimeType ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent$Text : com/kitakkun/jetwhale/host/sdk/JetWhaleMcpContent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getText ()Ljava/lang/String;
+}
+
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameter {
 	public static final field $stable I
 	public final fun getDescription ()Ljava/lang/String;
@@ -266,6 +320,18 @@ public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpParameterDescriptor
 	public final fun getSchema ()Lkotlinx/serialization/json/JsonObject;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult {
+	public static final field $stable I
+	public static final field Companion Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun getContent ()Ljava/util/List;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult$Companion {
+	public final fun image ([BLjava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult;
+	public final fun text (Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult;
 }
 
 public final class com/kitakkun/jetwhale/host/sdk/JetWhaleMcpToolDescriptor {
@@ -306,6 +372,20 @@ public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhalePluginSto
 	public abstract fun getKeysFlow ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun put (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun remove (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/kitakkun/jetwhale/host/sdk/JetWhaleSessionInfo {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public final fun getAppName ()Ljava/lang/String;
+	public final fun getDeviceId ()Ljava/lang/String;
+	public final fun getDeviceName ()Ljava/lang/String;
+	public final fun getInstalledPluginIds ()Ljava/util/List;
+	public final fun getSessionId ()Ljava/lang/String;
+}
+
+public abstract interface class com/kitakkun/jetwhale/host/sdk/JetWhaleSessions {
+	public abstract fun getActive ()Lkotlinx/coroutines/flow/StateFlow;
 }
 
 public final class com/kitakkun/jetwhale/host/sdk/McpCaptureKt {

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginContext.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginContext.kt
@@ -1,0 +1,69 @@
+package com.kitakkun.jetwhale.host.sdk
+
+import kotlinx.coroutines.flow.StateFlow
+import java.io.InputStream
+import kotlin.time.Duration
+
+/**
+ * The host services a plugin instance is handed when it is created. It is the only way into the
+ * debug tool's own capabilities — a plugin never resolves them itself, so the host stays the single
+ * owner of the adb executable it resolved and of the sessions it knows about.
+ */
+public interface JetWhaleHostPluginContext {
+    public val adb: JetWhaleAdb
+    public val sessions: JetWhaleSessions
+}
+
+/**
+ * Runs adb commands through the same executable the host itself uses, so a plugin never has to
+ * resolve one of its own (and never disagrees with the host about which SDK is meant).
+ */
+public interface JetWhaleAdb {
+    /** Absolute path to the adb executable, or the bare executable name when the host fell back to PATH. */
+    public val executable: String
+
+    /**
+     * Runs `adb <args>` to completion and returns its exit code together with its combined
+     * stdout/stderr text. A non-zero exit is a result, not an exception.
+     *
+     * @throws JetWhaleAdbUnavailableException when adb itself cannot be launched.
+     */
+    public suspend fun run(vararg args: String, timeout: Duration): JetWhaleAdbResult
+
+    /**
+     * Runs `adb <args>` and hands its raw stdout to [consume], for commands whose output is binary
+     * or unbounded (`exec-out screencap -p`, `logcat`). The process is destroyed once [consume]
+     * returns, so a long-running command ends with the consumer.
+     *
+     * @throws JetWhaleAdbUnavailableException when adb itself cannot be launched.
+     */
+    public suspend fun <T> runStreaming(vararg args: String, timeout: Duration, consume: suspend (InputStream) -> T): T
+}
+
+/** Exit code and combined stdout/stderr text of a finished adb command. */
+public class JetWhaleAdbResult(
+    public val exitCode: Int,
+    public val output: String,
+)
+
+/** The adb executable could not be launched — no Android SDK on this machine, or it moved. */
+public class JetWhaleAdbUnavailableException(
+    message: String,
+    cause: Throwable?,
+) : Exception(message, cause)
+
+/** The debug sessions the host currently knows about. */
+public interface JetWhaleSessions {
+    /** The sessions that are connected right now; empty when no app is attached. */
+    public val active: StateFlow<List<JetWhaleSessionInfo>>
+}
+
+/** One connected debug session, as a host-scoped plugin sees it. */
+public class JetWhaleSessionInfo(
+    public val sessionId: String,
+    public val appName: String?,
+    public val deviceId: String?,
+    public val deviceName: String?,
+    /** The pluginIds this session's agent advertised during negotiation. */
+    public val installedPluginIds: List<String>,
+)

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginFactory.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginFactory.kt
@@ -3,7 +3,10 @@ package com.kitakkun.jetwhale.host.sdk
 public interface JetWhaleHostPluginFactory {
     /**
      * Creates an instance of the plugin.
+     *
+     * @param context The host services available to the instance (adb, sessions). Hold it if the
+     *   plugin needs it later; it stays valid for the life of the instance.
      * @return An instance of [JetWhaleHostPlugin].
      */
-    public fun createPlugin(): JetWhaleHostPlugin
+    public fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin
 }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginManifest.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.sdk
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -32,6 +33,13 @@ public data class JetWhaleHostPluginManifest(
      * (not a [JetWhaleMessagingHostPlugin]).
      */
     public val requiresAgent: Boolean = true,
+    /**
+     * Whether this plugin gets one instance per debug session ([JetWhaleHostPluginScope.SESSION],
+     * the default) or a single instance for the whole host ([JetWhaleHostPluginScope.HOST]).
+     * A host-scoped plugin must declare `"requiresAgent": false` — there is no session, so there is
+     * no agent to talk to.
+     */
+    public val scope: JetWhaleHostPluginScope = JetWhaleHostPluginScope.SESSION,
     public val agentVersionRange: AgentVersionRange? = null,
     public val icon: Icon? = null,
 ) {
@@ -51,4 +59,19 @@ public data class JetWhaleHostPluginManifest(
         public val activePath: String? = null,
         public val inactivePath: String? = null,
     )
+}
+
+/** How many instances of a plugin the host creates, and what each one is tied to. */
+@Serializable
+public enum class JetWhaleHostPluginScope {
+    /** One instance per active debug session; its tools take a `sessionId`. */
+    @SerialName("session")
+    SESSION,
+
+    /**
+     * A single instance for the whole host, created as soon as the plugin is enabled and loaded —
+     * before (and without) any session. Its MCP tools take no `sessionId`.
+     */
+    @SerialName("host")
+    HOST,
 }

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCapablePlugin.kt
@@ -9,8 +9,10 @@ import kotlinx.serialization.json.JsonObject
  *
  * The MCP server queries all active plugin instances for this interface as sessions come up,
  * registers each command's descriptor, and dispatches invocations to the matching command on the
- * correct plugin instance (keyed by pluginId + sessionId). A [JetWhaleMcpArgumentException]
- * thrown by a command is rendered as an `{"error": ...}` payload instead of failing the server.
+ * correct plugin instance — keyed by pluginId + sessionId for a session-scoped plugin, and by
+ * pluginId alone for a host-scoped one, whose tools therefore take no `sessionId`. A
+ * [JetWhaleMcpArgumentException] thrown by a command is rendered as an `{"error": ...}` payload
+ * instead of failing the server.
  *
  * Usage:
  * ```kotlin

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpCommand.kt
@@ -33,8 +33,8 @@ import kotlin.reflect.KProperty
  *     private val widgetId by string("The widget ID")
  *     private val verbose by booleanOrNull("Include layout details.")
  *
- *     override suspend fun execute(arguments: JetWhaleMcpArguments): String {
- *         return widgets.describeAsJson(id = arguments[widgetId], verbose = arguments[verbose] ?: false)
+ *     override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
+ *         return JetWhaleMcpResult.text(widgets.describeAsJson(id = arguments[widgetId], verbose = arguments[verbose] ?: false))
  *     }
  * }
  * ```
@@ -77,9 +77,10 @@ public abstract class JetWhaleMcpCommand(
     /**
      * Executes the tool.
      *
-     * @return A result string (plain text or JSON).
+     * @return The tool's result: [JetWhaleMcpResult.text] for plain text or JSON,
+     *   [JetWhaleMcpResult.image] for a screenshot or other binary image the agent should see.
      */
-    public abstract suspend fun execute(arguments: JetWhaleMcpArguments): String
+    public abstract suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult
 
     public fun toDescriptor(): JetWhaleMcpToolDescriptor {
         parametersSealed = true

--- a/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult.kt
+++ b/jetwhale-host-sdk/src/main/kotlin/com/kitakkun/jetwhale/host/sdk/JetWhaleMcpResult.kt
@@ -1,0 +1,31 @@
+package com.kitakkun.jetwhale.host.sdk
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+
+/** One block of an MCP tool result. */
+@ExperimentalJetWhaleApi
+public sealed interface JetWhaleMcpContent {
+    /** Plain text or JSON, shown to the AI agent as-is. */
+    public class Text(public val text: String) : JetWhaleMcpContent
+
+    /** Raw image bytes; the host base64-encodes them for the MCP protocol. */
+    public class Image(
+        public val data: ByteArray,
+        public val mimeType: String,
+    ) : JetWhaleMcpContent
+}
+
+/**
+ * What a [JetWhaleMcpCommand] returns: one or more content blocks. Most commands answer with a
+ * single block, for which [text] and [image] are the shorthands.
+ */
+@ExperimentalJetWhaleApi
+public class JetWhaleMcpResult(
+    public val content: List<JetWhaleMcpContent>,
+) {
+    public companion object {
+        public fun text(text: String): JetWhaleMcpResult = JetWhaleMcpResult(listOf(JetWhaleMcpContent.Text(text)))
+
+        public fun image(data: ByteArray, mimeType: String): JetWhaleMcpResult = JetWhaleMcpResult(listOf(JetWhaleMcpContent.Image(data, mimeType)))
+    }
+}

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/DrawerPluginItemUiState.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/DrawerPluginItemUiState.kt
@@ -15,4 +15,6 @@ data class DrawerPluginItemUiState(
     val exposesMcpTools: Boolean,
     /** True when this plugin renders no UI in the selected session, so opening it shows nothing. */
     val isHeadless: Boolean,
+    /** True when a single instance serves the whole host, so the plugin needs no session to be usable. */
+    val isHostScoped: Boolean,
 )

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -20,6 +20,7 @@ import com.kitakkun.jetwhale.host.model.McpToolInvocation
 import com.kitakkun.jetwhale.host.model.PluginAvailability
 import com.kitakkun.jetwhale.host.model.PluginMetaData
 import com.kitakkun.jetwhale.host.model.SetPluginEnabledParams
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginScope
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import soil.query.compose.rememberMutation
@@ -126,6 +127,7 @@ fun toolingScaffoldPresenter(
             loadedPlugins.map { metaData ->
                 val isInstalledOnAgent = selectedSession?.installedPlugins?.any { installed -> installed.pluginId == metaData.id } == true
                 val isEnabledInSettings = enabledPluginIds.contains(metaData.id)
+                val isHostScoped = metaData.scope == JetWhaleHostPluginScope.HOST
 
                 DrawerPluginItemUiState(
                     id = metaData.id,
@@ -133,6 +135,12 @@ fun toolingScaffoldPresenter(
                     activeIconResource = metaData.activeIconResource,
                     inactiveIconResource = metaData.inactiveIconResource,
                     pluginAvailability = when {
+                        // A host-scoped plugin runs against the host itself, so whether it is usable
+                        // never depends on a session being selected.
+                        isHostScoped && isEnabledInSettings -> PluginAvailability.Enabled
+
+                        isHostScoped -> PluginAvailability.Disabled
+
                         selectedSession == null -> PluginAvailability.Unavailable
 
                         // Host-only plugins (no agent) are available for any active session; agent-backed
@@ -146,6 +154,7 @@ fun toolingScaffoldPresenter(
                     underAiControl = aiControlledPluginId == metaData.id,
                     exposesMcpTools = mcpCapablePlugins.toolsFor(selectedSession?.id, metaData.id).isNotEmpty(),
                     isHeadless = headlessPlugins.isHeadless(selectedSession?.id, metaData.id),
+                    isHostScoped = isHostScoped,
                 )
             }.toImmutableList()
         }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldRoot.kt
@@ -28,7 +28,7 @@ fun ToolingScaffoldRoot(
     onClickSettings: () -> Unit,
     onClickPluginSettings: () -> Unit,
     onClickInfo: () -> Unit,
-    onClickPlugin: (pluginId: String, sessionId: String) -> Unit,
+    onClickPlugin: (pluginId: String, sessionId: String?) -> Unit,
     onOpenMcpTools: (pluginId: String?, sessionId: String?) -> Unit,
     onClickPopout: (pluginId: String, pluginName: String, sessionId: String) -> Unit,
     isPoppedOut: (pluginId: String, sessionId: String) -> Boolean,
@@ -156,10 +156,16 @@ fun ToolingScaffoldRoot(
                 onClickSettings = onClickSettings,
                 onClickPluginSettings = onClickPluginSettings,
                 onClickInfo = onClickInfo,
-                onClickPlugin = {
-                    val selectedSession = uiState.selectedSession ?: return@ToolingScaffold
-                    screenChannel.send(ToolingScaffoldScreenAction.UpdateSelectedPlugin(it))
-                    onClickPlugin(it, selectedSession.id)
+                onClickPlugin = { pluginId ->
+                    // A host-scoped plugin opens against the host itself, so it needs no session —
+                    // and must not wait for one to be selected.
+                    val isHostScoped = uiState.plugins.any { it.id == pluginId && it.isHostScoped }
+                    val sessionId = when {
+                        isHostScoped -> null
+                        else -> uiState.selectedSession?.id ?: return@ToolingScaffold
+                    }
+                    screenChannel.send(ToolingScaffoldScreenAction.UpdateSelectedPlugin(pluginId))
+                    onClickPlugin(pluginId, sessionId)
                 },
                 // The browser tolerates a missing session, so the badge stays usable while no session
                 // is selected: it simply opens with the session filter on "All".

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
@@ -18,10 +18,11 @@ data object LicensesNavKey : NavKey
 @Serializable
 data object InfoNavKey : NavKey
 
+/** A plugin screen. [sessionId] is null for a host-scoped plugin, which belongs to no session. */
 @Serializable
 data class PluginNavKey(
     val pluginId: String,
-    val sessionId: String,
+    val sessionId: String?,
 ) : NavKey
 
 @Serializable

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
@@ -28,9 +28,10 @@ fun NavBackStack<NavKey>.openMcpTools(pluginId: String?, sessionId: String?) {
 }
 
 /**
- * Whether the given plugin is currently shown in a separate popout window for [sessionId].
+ * Whether the given plugin is currently shown in a separate popout window for [sessionId]. A
+ * host-scoped plugin (null [sessionId]) is never popped out: popouts are opened per session.
  */
-fun NavBackStack<NavKey>.isPluginPoppedOut(pluginId: String, sessionId: String): Boolean = any {
+fun NavBackStack<NavKey>.isPluginPoppedOut(pluginId: String, sessionId: String?): Boolean = any {
     it is PluginPopoutNavKey &&
         it.pluginId == pluginId &&
         it.sessionId == sessionId
@@ -39,7 +40,7 @@ fun NavBackStack<NavKey>.isPluginPoppedOut(pluginId: String, sessionId: String):
 /**
  * Docks a popped-out plugin: shows it in the main window and closes its popout window.
  */
-fun NavBackStack<NavKey>.bringPluginBackToMainWindow(pluginId: String, sessionId: String) {
+fun NavBackStack<NavKey>.bringPluginBackToMainWindow(pluginId: String, sessionId: String?) {
     addSingleTop(
         PluginNavKey(
             pluginId = pluginId,
@@ -56,6 +57,8 @@ fun NavBackStack<NavKey>.bringPluginBackToMainWindow(pluginId: String, sessionId
 /**
  * Makes the plugin screen currently on top of the back stack follow a session switch.
  *
+ * A host-scoped plugin's screen is left where it is: it has no session to follow.
+ *
  * If the top entry is a [PluginNavKey] targeting a different session, it is replaced with a
  * [PluginNavKey] for [newSessionId] so the same plugin is shown for the newly-selected session.
  * If the plugin is not available on the new session (per [isPluginAvailableOnNewSession]), the old
@@ -69,7 +72,8 @@ fun NavBackStack<NavKey>.followPluginToSession(
     isPluginAvailableOnNewSession: (pluginId: String) -> Boolean,
 ) {
     val top = lastOrNull() as? PluginNavKey ?: return
-    if (top.sessionId == newSessionId) return
+    // A host-scoped plugin's screen belongs to no session, so a session switch leaves it alone.
+    if (top.sessionId == null || top.sessionId == newSessionId) return
 
     removeLastOrNull()
     if (isPluginAvailableOnNewSession(top.pluginId)) {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavEntries.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavEntries.kt
@@ -45,8 +45,8 @@ fun EntryProviderScope<NavKey>.emptyPluginEntry() {
 
 context(appGraph: JetWhaleAppGraph)
 fun EntryProviderScope<NavKey>.pluginEntries(
-    isOpenedOnPopout: (pluginId: String, sessionId: String) -> Boolean,
-    onBringbackToMainWindow: (pluginId: String, sessionId: String) -> Unit,
+    isOpenedOnPopout: (pluginId: String, sessionId: String?) -> Boolean,
+    onBringbackToMainWindow: (pluginId: String, sessionId: String?) -> Unit,
 ) {
     entry<PluginNavKey> { navKey ->
         context(

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/adb/DefaultJetWhaleAdb.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/adb/DefaultJetWhaleAdb.kt
@@ -1,0 +1,76 @@
+package com.kitakkun.jetwhale.host.data.adb
+
+import com.kitakkun.jetwhale.host.data.util.findAdbPath
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdbResult
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdbUnavailableException
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import java.io.IOException
+import java.io.InputStream
+import kotlin.time.Duration
+
+/**
+ * The host's single adb runner: every adb invocation in the debug tool — its own port wiring and
+ * anything a plugin asks for through [com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext] —
+ * goes through this one executable, resolved once by [findAdbPath].
+ */
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultJetWhaleAdb : JetWhaleAdb {
+    override val executable: String by lazy { findAdbPath() }
+
+    override suspend fun run(vararg args: String, timeout: Duration): JetWhaleAdbResult = withProcess(args, timeout) { process ->
+        // stderr is merged into stdout, so a diagnostic adb printed there is part of the result
+        // rather than being lost.
+        val output = process.inputStream.bufferedReader().readText()
+        JetWhaleAdbResult(exitCode = process.waitFor(), output = output.trim())
+    }
+
+    override suspend fun <T> runStreaming(vararg args: String, timeout: Duration, consume: suspend (InputStream) -> T): T = withProcess(args, timeout) { process ->
+        consume(process.inputStream)
+    }
+
+    /**
+     * Starts adb, runs [body] against the process, and makes sure the process is gone afterwards.
+     *
+     * A read from the process' stream blocks and does not observe cancellation, so a cancelled or
+     * timed-out call is ended by destroying the process — which is what unblocks the read. The
+     * guard child does that as soon as the scope is cancelled, while [body] is still blocked.
+     */
+    private suspend fun <T> withProcess(args: Array<out String>, timeout: Duration, body: suspend (Process) -> T): T = withContext(Dispatchers.IO) {
+        val process = try {
+            ProcessBuilder(listOf(executable) + args)
+                .redirectErrorStream(true)
+                .start()
+        } catch (e: IOException) {
+            throw JetWhaleAdbUnavailableException("adb could not be launched from \"$executable\": ${e.message}", e)
+        }
+        try {
+            withTimeout(timeout) {
+                val guard = launch {
+                    try {
+                        awaitCancellation()
+                    } finally {
+                        process.destroyForcibly()
+                    }
+                }
+                try {
+                    body(process)
+                } finally {
+                    guard.cancel()
+                }
+            }
+        } finally {
+            process.destroyForcibly()
+        }
+    }
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/adb/DefaultJetWhaleHostPluginContext.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/adb/DefaultJetWhaleHostPluginContext.kt
@@ -1,0 +1,52 @@
+package com.kitakkun.jetwhale.host.data.adb
+
+import com.kitakkun.jetwhale.host.model.DebugSessionRepository
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
+import com.kitakkun.jetwhale.host.sdk.JetWhaleSessionInfo
+import com.kitakkun.jetwhale.host.sdk.JetWhaleSessions
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * The host services handed to every plugin instance. One object serves them all: it exposes only
+ * host-wide capabilities, so nothing in it is scoped to a single plugin or session.
+ */
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultJetWhaleHostPluginContext(
+    override val adb: JetWhaleAdb,
+    debugSessionRepository: DebugSessionRepository,
+) : JetWhaleHostPluginContext {
+    override val sessions: JetWhaleSessions = DefaultJetWhaleSessions(debugSessionRepository)
+}
+
+private class DefaultJetWhaleSessions(debugSessionRepository: DebugSessionRepository) : JetWhaleSessions {
+    // Lives as long as the host itself; the flow it shares is read by plugin instances that come and
+    // go, so it is kept hot rather than restarted per subscriber.
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    override val active: StateFlow<List<JetWhaleSessionInfo>> = debugSessionRepository.debugSessionsFlow
+        .map { sessions ->
+            sessions.filter { it.isActive }.map { session ->
+                JetWhaleSessionInfo(
+                    sessionId = session.id,
+                    appName = session.appName,
+                    deviceId = session.deviceId,
+                    deviceName = session.deviceName,
+                    installedPluginIds = session.installedPlugins.map { it.pluginId },
+                )
+            }
+        }
+        .stateIn(scope, SharingStarted.Eagerly, emptyList())
+}

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultLoadedPluginMetaDataSubscriptionKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultLoadedPluginMetaDataSubscriptionKey.kt
@@ -27,6 +27,7 @@ class DefaultLoadedPluginMetaDataSubscriptionKey(
                     id = loaded.manifest.pluginId,
                     version = loaded.manifest.version,
                     requiresAgent = loaded.manifest.requiresAgent,
+                    scope = loaded.manifest.scope,
                     activeIconResource = loaded.manifest.icon?.activePath?.let {
                         val resource = classLoader.getResource(it) ?: return@let null
                         PluginIconResource(resource)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneQueryKeyFactory.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneQueryKeyFactory.kt
@@ -18,7 +18,7 @@ class DefaultPluginComposeSceneQueryKeyFactory(
     private val pluginComposeSceneService: PluginComposeSceneService,
 ) : PluginComposeSceneQueryKeyFactory {
     @OptIn(InternalComposeUiApi::class)
-    override fun create(pluginId: String, sessionId: String): PluginComposeSceneQueryKey = object : PluginComposeSceneQueryKey by buildQueryKey(
+    override fun create(pluginId: String, sessionId: String?): PluginComposeSceneQueryKey = object : PluginComposeSceneQueryKey by buildQueryKey(
         id = QueryId("PluginComposeScene:$pluginId:$sessionId"),
         fetch = {
             pluginComposeSceneService.getOrCreatePluginScene(

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginComposeSceneService.kt
@@ -45,7 +45,10 @@ class DefaultPluginComposeSceneService(
         val scene: PluginComposeScene,
     )
 
-    private val pluginScenes = mutableMapOf<String, CachedScene>()
+    /** Identifies a scene. [sessionId] is null for the single scene of a host-scoped plugin. */
+    private data class SceneKey(val pluginId: String, val sessionId: String?)
+
+    private val pluginScenes = mutableMapOf<SceneKey, CachedScene>()
 
     // Written from the host's composition and read when a scene is created; both happen on the main
     // thread. Falls back to the ComposeScene default until the window has reported its density.
@@ -57,16 +60,16 @@ class DefaultPluginComposeSceneService(
 
     override suspend fun getOrCreatePluginScene(
         pluginId: String,
-        sessionId: String,
+        sessionId: String?,
     ): PluginComposeScene {
-        val pluginInstance = pluginInstanceService.getPluginInstanceForSession(
-            pluginId = pluginId,
-            sessionId = sessionId,
-        ) ?: run {
+        val pluginInstance = when (sessionId) {
+            null -> pluginInstanceService.getHostScopedInstance(pluginId)
+            else -> pluginInstanceService.getPluginInstanceForSession(pluginId = pluginId, sessionId = sessionId)
+        } ?: run {
             error("Plugin instance not found for pluginId=$pluginId, sessionId=$sessionId")
         }
         return withContext(Dispatchers.Main) {
-            val sceneKey = "$pluginId:$sessionId"
+            val sceneKey = SceneKey(pluginId, sessionId)
             val cached = pluginScenes[sceneKey]
             if (cached != null && cached.pluginInstance === pluginInstance) return@withContext cached.scene
             // A reinstalled or reloaded plugin is served by a new instance from a new classloader; a
@@ -107,7 +110,7 @@ class DefaultPluginComposeSceneService(
     }
 
     override fun disposePluginSceneForSession(sessionId: String) {
-        val keysToRemove = pluginScenes.keys.filter { it.endsWith(":$sessionId") }
+        val keysToRemove = pluginScenes.keys.filter { it.sessionId == sessionId }
         for (key in keysToRemove) {
             pluginScenes[key]?.scene?.composeScene?.close()
             pluginScenes.remove(key)
@@ -115,7 +118,7 @@ class DefaultPluginComposeSceneService(
     }
 
     override fun disposePluginScenesForPlugin(pluginId: String) {
-        val keysToRemove = pluginScenes.keys.filter { it.startsWith("$pluginId:") }
+        val keysToRemove = pluginScenes.keys.filter { it.pluginId == pluginId }
         for (key in keysToRemove) {
             pluginScenes[key]?.scene?.composeScene?.close()
             pluginScenes.remove(key)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepository.kt
@@ -6,6 +6,7 @@ import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
 import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifestFile
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginScope
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -172,8 +173,9 @@ class DefaultPluginFactoryRepository(
      * Reads the manifest from [classLoader] and instantiates every plugin the jar declares, pairing
      * each manifest entry with the factory class it names (no ServiceLoader) — which is what lets a
      * single jar provide several plugins. Throws on any problem (manifest missing, empty, or with
-     * duplicate ids; a factory class that is missing, lacks a public no-arg constructor, or is not a
-     * [JetWhaleHostPluginFactory]). The caller owns [classLoader]'s lifecycle.
+     * duplicate ids; an entry combining `scope: host` with `requiresAgent: true`; a factory class
+     * that is missing, lacks a public no-arg constructor, or is not a [JetWhaleHostPluginFactory]).
+     * The caller owns [classLoader]'s lifecycle.
      */
     private fun loadDeclaredPlugins(pluginJarPath: String, classLoader: ClassLoader): List<LoadedHostPlugin> {
         val manifestJson = classLoader.getResourceAsStream(MANIFEST_PATH)?.bufferedReader()?.use { it.readText() }
@@ -195,6 +197,16 @@ class DefaultPluginFactoryRepository(
         }
 
         return manifests.map { manifest ->
+            // A host-scoped plugin has a single instance and no session, so there is no connection an
+            // agent counterpart could arrive on. Declaring both is a manifest mistake, not a
+            // degraded mode.
+            if (manifest.scope == JetWhaleHostPluginScope.HOST && manifest.requiresAgent) {
+                throw PluginManifestParseException(
+                    "Plugin '${manifest.pluginId}' in $pluginJarPath declares \"scope\": \"host\" together with " +
+                        "\"requiresAgent\": true. A host-scoped plugin belongs to no session and has no agent " +
+                        "counterpart, so it must declare \"requiresAgent\": false.",
+                )
+            }
             val factory = try {
                 // getConstructor (not getDeclaredConstructor): the contract is a *public* no-arg
                 // constructor, so a non-public/missing one fails clearly with NoSuchMethodException.
@@ -346,5 +358,6 @@ class DefaultPluginFactoryRepository(
 /** The jar's plugin manifest exists but could not be parsed (malformed or incompatible schema). */
 class PluginManifestParseException(
     message: String,
+    // Defaulted because most manifest problems are detected by this code itself and have no cause.
     cause: Throwable? = null,
 ) : Exception(message, cause)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginHotReloadService.kt
@@ -199,11 +199,21 @@ class DefaultPluginHotReloadService(
     }
 
     /**
-     * Recreates plugin instances for the active sessions that have the plugin installed, so that the
-     * UI can immediately render the freshly loaded code. Only runs when the plugin is enabled.
+     * Recreates plugin instances — the host-scoped one, or one per active session that has the
+     * plugin installed — so that the UI can immediately render the freshly loaded code. Only runs
+     * when the plugin is enabled.
      */
     private suspend fun reinitializeInstances(pluginId: String) {
         if (!enabledPluginsRepository.isPluginEnabled(pluginId)) return
+
+        // A host-scoped plugin has a single instance and no sessions to target, so it is re-created
+        // on its own path.
+        if (reconciliationService.isHostScoped(pluginId)) {
+            withContext(Dispatchers.Main) {
+                pluginInstanceService.initializeHostScopedInstanceIfNeeded(pluginId)
+            }
+            return
+        }
 
         // The target-session rule (host-only vs agent-backed) lives in the reconciliation service.
         val activeSessions = debugSessionRepository.debugSessionsFlow.first().filter { it.isActive }

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstanceService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstanceService.kt
@@ -10,7 +10,9 @@ import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.sdk.InternalJetWhaleHostApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginScope
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMessagingHostPlugin
 import com.kitakkun.jetwhale.protocol.messaging.JetWhalePluginPeer
@@ -39,7 +41,8 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Level
 import java.util.logging.Logger
 
-private data class PluginInstanceKey(val pluginId: String, val sessionId: String)
+/** Identifies one plugin instance. [sessionId] is null for the single instance of a host-scoped plugin. */
+private data class PluginInstanceKey(val pluginId: String, val sessionId: String?)
 
 /**
  * A plugin instance paired with the messaging peer that delivers its frames. The peer's outbound
@@ -65,6 +68,7 @@ class DefaultPluginInstanceService(
     private val pluginFactoryRepository: PluginFactoryRepository,
     private val frameSender: HostPluginFrameSender,
     private val pluginDataStoreRepository: PluginDataStoreRepository,
+    private val hostPluginContext: JetWhaleHostPluginContext,
 ) : PluginInstanceService {
     private val logger = Logger.getLogger(DefaultPluginInstanceService::class.java.name)
 
@@ -85,25 +89,58 @@ class DefaultPluginInstanceService(
 
     override fun getPluginInstanceForSession(pluginId: String, sessionId: String): JetWhaleHostPlugin? = loadedPlugins[PluginInstanceKey(pluginId, sessionId)]?.plugin
 
-    override fun initializePluginInstancesForSessionsIfNeeded(pluginId: String, sessionIds: Set<String>): Set<String> {
-        val loaded = pluginFactoryRepository.loadedPlugins[pluginId] ?: return emptySet()
+    override fun getHostScopedInstance(pluginId: String): JetWhaleHostPlugin? = loadedPlugins[PluginInstanceKey(pluginId, null)]?.plugin
 
-        // Reinstalling or reloading a jar yields a new factory behind a new classloader; instances the
-        // previous factory produced hold classes from a classloader that is already closed, so drop
-        // them and let the loop below rebuild them from the current code.
+    override fun initializeHostScopedInstanceIfNeeded(pluginId: String): Boolean {
+        val loaded = pluginFactoryRepository.loadedPlugins[pluginId] ?: return false
+        dropInstancesFromStaleFactories(pluginId, loaded)
+
+        val key = PluginInstanceKey(pluginId, sessionId = null)
+        var created = false
+        try {
+            // compute, not computeIfAbsent: a refused instance (a messaging plugin declared
+            // host-scoped) maps to no entry at all, which computeIfAbsent cannot express.
+            loadedPlugins.compute(key) { _, existing ->
+                existing ?: createInstance(pluginId, sessionId = null, loaded = loaded)?.also { created = true }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logger.log(Level.WARNING, "Creating the host-scoped instance of plugin '$pluginId' failed", e)
+            return false
+        }
+
+        publishHeadlessPlugins()
+        if (created) emitEvent(PluginInstanceEvent.Ready(pluginId, sessionId = null))
+        return created
+    }
+
+    /**
+     * Drops the instances a previous factory generation produced. Reinstalling or reloading a jar
+     * yields a new factory behind a new classloader, and instances the previous factory produced hold
+     * classes from a classloader that is already closed.
+     */
+    private fun dropInstancesFromStaleFactories(pluginId: String, loaded: LoadedHostPlugin) {
         loadedPlugins.entries
             .filter { (key, instance) -> key.pluginId == pluginId && instance.factory !== loaded.factory }
             .map { it.key }
             .forEach { disposeInstance(it) }
+    }
+
+    override fun initializePluginInstancesForSessionsIfNeeded(pluginId: String, sessionIds: Set<String>): Set<String> {
+        val loaded = pluginFactoryRepository.loadedPlugins[pluginId] ?: return emptySet()
+
+        // Drop the instances of a previous factory generation so the loop below rebuilds them from
+        // the current code.
+        dropInstancesFromStaleFactories(pluginId, loaded)
 
         val newlyInitializedSessions = mutableSetOf<String>()
         for (sessionId in sessionIds) {
             val key = PluginInstanceKey(pluginId, sessionId)
             var created = false
             try {
-                loadedPlugins.computeIfAbsent(key) {
-                    created = true
-                    createInstance(pluginId, sessionId, loaded)
+                loadedPlugins.compute(key) { _, existing ->
+                    existing ?: createInstance(pluginId, sessionId, loaded)?.also { created = true }
                 }
             } catch (e: CancellationException) {
                 throw e
@@ -123,8 +160,18 @@ class DefaultPluginInstanceService(
         return newlyInitializedSessions
     }
 
-    private fun createInstance(pluginId: String, sessionId: String, loaded: LoadedHostPlugin): LoadedInstance {
-        val plugin = loaded.factory.createPlugin()
+    private fun createInstance(pluginId: String, sessionId: String?, loaded: LoadedHostPlugin): LoadedInstance? {
+        val plugin = loaded.factory.createPlugin(hostPluginContext)
+        if (loaded.manifest.scope == JetWhaleHostPluginScope.HOST && plugin is JetWhaleMessagingHostPlugin) {
+            // A host-scoped instance belongs to no session, so there is no connection its messenger
+            // could ever reach. Skipping the instance surfaces the misconfiguration instead of
+            // running a plugin whose every request times out.
+            logger.warning(
+                "Plugin '$pluginId' declares scope=host but its factory returns a JetWhaleMessagingHostPlugin; " +
+                    "a host-scoped plugin has no agent to talk to, so no instance was created.",
+            )
+            return null
+        }
         if (!loaded.manifest.requiresAgent && plugin is JetWhaleMessagingHostPlugin) {
             // A messaging plugin without an agent counterpart waits out its prepare timeout on every
             // session and gets "not active" failures for every request — surface the misconfiguration
@@ -141,13 +188,14 @@ class DefaultPluginInstanceService(
         // name or reach another plugin's data.
         plugin.bindStorage(pluginDataStoreRepository.storageFor(pluginId))
 
-        val descriptor = "plugin '$pluginId' in session '$sessionId'"
+        val descriptor = if (sessionId == null) "host-scoped plugin '$pluginId'" else "plugin '$pluginId' in session '$sessionId'"
 
         // User code below (registerHandlers, onCreate) is guarded: this runs inside the map's
         // computeIfAbsent, and a throwing plugin must neither leak the just-created peer/scope nor
         // abort loading for the caller.
-        // Only messaging plugins get a peer; a pure plugin pays none of the messaging cost.
-        val peer = if (plugin is JetWhaleMessagingHostPlugin) {
+        // Only messaging plugins get a peer; a pure plugin pays none of the messaging cost. A
+        // host-scoped plugin is never a messaging one (refused above), so it never reaches this.
+        val peer = if (plugin is JetWhaleMessagingHostPlugin && sessionId != null) {
             val newPeer = JetWhalePluginPeer(
                 pluginId = pluginId,
                 parentScope = scope,
@@ -176,7 +224,7 @@ class DefaultPluginInstanceService(
         try {
             plugin.dispatchCreate()
         } catch (e: Throwable) {
-            logger.warning("onCreate for plugin '$pluginId' in session '$sessionId' failed: ${e.message}")
+            logger.warning("onCreate for $descriptor failed: ${e.message}")
         }
         val prepareJob = if (peer != null && plugin is JetWhaleMessagingHostPlugin) {
             instanceScope.launchPeerPreparation(
@@ -211,6 +259,7 @@ class DefaultPluginInstanceService(
     }
 
     override fun unloadPluginInstanceForSession(sessionId: String) {
+        // A host-scoped instance carries a null sessionId and outlives every session, so it never matches.
         loadedPlugins.keys.filter { it.sessionId == sessionId }.forEach { disposeInstance(it) }
     }
 
@@ -229,7 +278,7 @@ class DefaultPluginInstanceService(
         } catch (e: Throwable) {
             // A throwing onDispose must not leak the scope/peer, nor abort disposing the session's
             // other plugins from the callers' forEach loops.
-            logger.warning("onDispose for plugin '${key.pluginId}' in session '${key.sessionId}' failed: ${e.message}")
+            logger.warning("onDispose for plugin '${key.pluginId}' (session '${key.sessionId}') failed: ${e.message}")
         } finally {
             removed.instanceScope.cancel()
             // close() suspends (it fails pending requests under a mutex), so run it off the caller.
@@ -252,11 +301,13 @@ class DefaultPluginInstanceService(
      * an instance from a new classloader that may not answer the same way.
      */
     private fun publishHeadlessPlugins() {
+        val headless = loadedPlugins.entries.filter { (_, instance) -> instance.plugin !is JetWhaleHostPluginUi }.map { it.key }
         headlessPluginsFlow.value = HeadlessPlugins(
-            loadedPlugins.entries
-                .filter { (_, instance) -> instance.plugin !is JetWhaleHostPluginUi }
-                .groupBy({ it.key.sessionId }, { it.key.pluginId })
+            pluginIdsBySession = headless
+                .mapNotNull { key -> key.sessionId?.let { it to key.pluginId } }
+                .groupBy({ it.first }, { it.second })
                 .mapValues { (_, pluginIds) -> pluginIds.toSet() },
+            hostScopedPluginIds = headless.filter { it.sessionId == null }.mapTo(mutableSetOf()) { it.pluginId },
         )
     }
 

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationService.kt
@@ -7,6 +7,7 @@ import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.model.PluginReconciliationEvent
 import com.kitakkun.jetwhale.host.model.PluginSessionReconciliationService
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginScope
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -29,13 +30,18 @@ class DefaultPluginSessionReconciliationService(
 ) : PluginSessionReconciliationService {
     override fun requiresAgent(pluginId: String): Boolean = pluginFactoryRepository.loadedPlugins[pluginId]?.manifest?.requiresAgent ?: true
 
-    override fun targetSessionIds(pluginId: String, sessions: List<DebugSession>): Set<String> = if (requiresAgent(pluginId)) {
-        sessions
-            .filter { session -> session.installedPlugins.any { it.pluginId == pluginId } }
-            .map { it.id }
-            .toSet()
-    } else {
-        sessions.map { it.id }.toSet()
+    override fun isHostScoped(pluginId: String): Boolean = pluginFactoryRepository.loadedPlugins[pluginId]?.manifest?.scope == JetWhaleHostPluginScope.HOST
+
+    override fun targetSessionIds(pluginId: String, sessions: List<DebugSession>): Set<String> = when {
+        isHostScoped(pluginId) -> emptySet()
+
+        requiresAgent(pluginId) ->
+            sessions
+                .filter { session -> session.installedPlugins.any { it.pluginId == pluginId } }
+                .map { it.id }
+                .toSet()
+
+        else -> sessions.map { it.id }.toSet()
     }
 
     override fun reconciliationEvents(): Flow<PluginReconciliationEvent> = channelFlow {
@@ -55,6 +61,13 @@ class DefaultPluginSessionReconciliationService(
             ) { enabledPluginIds, activeSessions, _ -> enabledPluginIds to activeSessions }
                 .collect { (enabledPluginIds, activeSessions) ->
                     enabledPluginIds.forEach { pluginId ->
+                        // A host-scoped plugin holds a single instance that belongs to no session, so
+                        // it is created as soon as the plugin is enabled and loaded — with zero
+                        // sessions connected included.
+                        if (isHostScoped(pluginId)) {
+                            pluginInstanceService.initializeHostScopedInstanceIfNeeded(pluginId)
+                            return@forEach
+                        }
                         val activatedSessionIds = pluginInstanceService.initializePluginInstancesForSessionsIfNeeded(
                             pluginId = pluginId,
                             sessionIds = targetSessionIds(pluginId, activeSessions),

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultADBAutoWiringService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/server/DefaultADBAutoWiringService.kt
@@ -1,7 +1,8 @@
 package com.kitakkun.jetwhale.host.data.server
 
-import com.kitakkun.jetwhale.host.data.util.findAdbPath
 import com.kitakkun.jetwhale.host.model.ADBAutoWiringService
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdbUnavailableException
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -10,24 +11,27 @@ import io.ktor.util.collections.ConcurrentSet
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import java.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 // How long to wait before re-attaching `adb track-devices` after the tracking stream ends or errors
 // (e.g. another tool ran `adb kill-server`, or adb restarted because of a client/server version mismatch).
 private const val RECONNECT_DELAY_MS = 2_000L
 
+/** Ample for a local `adb reverse`, which either answers at once or is not going to answer at all. */
+private val WIRING_TIMEOUT = 10.seconds
+
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 @Inject
-class DefaultADBAutoWiringService : ADBAutoWiringService {
+class DefaultADBAutoWiringService(
+    private val adb: JetWhaleAdb,
+) : ADBAutoWiringService {
     private val coroutineScope = CoroutineScope(Dispatchers.IO)
     private val wiredDevices = ConcurrentSet<String>()
 
@@ -35,12 +39,14 @@ class DefaultADBAutoWiringService : ADBAutoWiringService {
     // device-tracking job serves all of them.
     private val wiredPorts = ConcurrentSet<Int>()
     private var wiringJob: Job? = null
-    private val adbPath: String by lazy { findAdbPath() }
 
     override fun startAutoWiring(port: Int) {
         if (wiredPorts.add(port)) {
             // Devices that connected before this port was registered still need the new forwarding.
-            wiredDevices.forEach { serial -> wire(serial, port) }
+            val serials = wiredDevices.toList()
+            coroutineScope.launch {
+                serials.forEach { serial -> wire(serial, port) }
+            }
         }
 
         // A job that has finished — it stood down over a missing adb — must not read as running, or
@@ -50,20 +56,15 @@ class DefaultADBAutoWiringService : ADBAutoWiringService {
 
         wiringJob = coroutineScope.launch {
             // `adb track-devices` can end at any time (adb server restart/crash, USB hiccup, version
-            // mismatch). When it does, the flow completes; without this loop the service would silently
+            // mismatch). When it does, the call returns; without this loop the service would silently
             // stop wiring until the host is restarted. Re-attach with a small backoff instead.
             while (isActive) {
                 try {
-                    deviceEventFlow().collect { event ->
-                        when (event) {
-                            is DeviceEvent.Connected -> wiredPorts.forEach { wire(event.serial, it) }
-                            is DeviceEvent.Disconnected -> wiredPorts.forEach { unwire(event.serial, it) }
-                        }
-                    }
+                    trackDevices()
                     System.err.println("ADB device tracking ended; re-attaching in ${RECONNECT_DELAY_MS}ms")
                 } catch (e: CancellationException) {
                     throw e
-                } catch (e: AdbUnavailableException) {
+                } catch (e: JetWhaleAdbUnavailableException) {
                     // Auto wiring is on by default, so a machine with no Android SDK would otherwise
                     // retry a binary that will never appear, every RECONNECT_DELAY_MS, forever.
                     // Report once and stand down until the next startAutoWiring call.
@@ -77,65 +78,49 @@ class DefaultADBAutoWiringService : ADBAutoWiringService {
         }
     }
 
-    private fun deviceEventFlow(): Flow<DeviceEvent> = callbackFlow {
-        val deviceTrackingProcess = try {
-            ProcessBuilder(adbPath, "track-devices")
-                .redirectErrorStream(true)
-                .start()
-        } catch (e: IOException) {
-            throw AdbUnavailableException(adbPath, e)
-        }
-
-        launch {
-            deviceTrackingProcess.inputStream
-                .bufferedReader()
-                .useLines { lines ->
-                    lines.forEach { line ->
-                        val serial = line.substringBefore("\t")
-                            // Remove 4-digit hex prefix
-                            .replaceFirst(Regex("^[0-9a-fA-F]{4}"), "")
-                        val event = line.substringAfter("\t")
-
-                        when (event) {
-                            "device" -> trySend(DeviceEvent.Connected(serial))
-                            "offline" -> trySend(DeviceEvent.Disconnected(serial))
-                        }
+    /** Reads `adb track-devices` until the stream ends, wiring and unwiring devices as they appear. */
+    private suspend fun trackDevices() {
+        adb.runStreaming("track-devices", timeout = Duration.INFINITE) { stream ->
+            stream.bufferedReader().useLines { lines ->
+                for (line in lines) {
+                    val serial = line.substringBefore("\t")
+                        // Remove 4-digit hex prefix
+                        .replaceFirst(Regex("^[0-9a-fA-F]{4}"), "")
+                    when (line.substringAfter("\t")) {
+                        "device" -> wiredPorts.forEach { port -> wire(serial, port) }
+                        "offline" -> wiredPorts.forEach { port -> unwire(serial, port) }
                     }
                 }
-            // track-devices reached EOF (the process exited): complete the flow so startAutoWiring re-attaches.
-            close()
-        }
-
-        awaitClose {
-            deviceTrackingProcess.destroy()
+            }
         }
     }
 
-    private fun wire(serial: String, port: Int) {
+    private suspend fun wire(serial: String, port: Int) {
         println("Wiring ADB reverse for device $serial on port $port")
-        val (exitCode, output) = runAdb("-s", serial, "reverse", "tcp:$port", "tcp:$port")
-        if (exitCode == 0) {
+        val result = runAdb("-s", serial, "reverse", "tcp:$port", "tcp:$port")
+        if (result != null && result.exitCode == 0) {
             wiredDevices.add(serial)
         } else {
             // e.g. "device offline" right after it turns ready, or an adb server version mismatch.
             // Surface it instead of recording a false success.
-            System.err.println("Failed to wire ADB reverse for device $serial on port $port (exit=$exitCode): $output")
+            System.err.println("Failed to wire ADB reverse for device $serial on port $port: ${result?.let { "exit=${it.exitCode}: ${it.output}" } ?: "adb unavailable"}")
         }
     }
 
-    private fun unwire(serial: String, port: Int) {
+    private suspend fun unwire(serial: String, port: Int) {
         println("Unwiring ADB reverse for device $serial on port $port")
-        val (exitCode, output) = runAdb("-s", serial, "reverse", "--remove", "tcp:$port")
-        if (exitCode != 0) {
-            System.err.println("Failed to unwire ADB reverse for device $serial on port $port (exit=$exitCode): $output")
+        val result = runAdb("-s", serial, "reverse", "--remove", "tcp:$port")
+        if (result == null || result.exitCode != 0) {
+            System.err.println("Failed to unwire ADB reverse for device $serial on port $port: ${result?.let { "exit=${it.exitCode}: ${it.output}" } ?: "adb unavailable"}")
         }
         wiredDevices.remove(serial)
     }
 
     override fun stopAutoWiring(port: Int) {
         wiredPorts.remove(port)
-        wiredDevices.forEach { serial ->
-            runAdb("-s", serial, "reverse", "--remove", "tcp:$port")
+        val serials = wiredDevices.toList()
+        coroutineScope.launch {
+            serials.forEach { serial -> runAdb("-s", serial, "reverse", "--remove", "tcp:$port") }
         }
         // Keep tracking as long as any port is still wired (e.g. only wss was turned off).
         if (wiredPorts.isEmpty()) {
@@ -146,32 +131,15 @@ class DefaultADBAutoWiringService : ADBAutoWiringService {
     }
 
     /**
-     * Runs an adb command to completion and returns its exit code together with its merged output.
-     *
-     * A failure to launch adb at all is reported as a non-zero exit rather than thrown. The wiring
-     * job catches everything, but teardown does not run inside it — [stopAutoWiring] and [unwire]
-     * call this directly, and an adb that has been uninstalled or unmounted since wiring would
-     * otherwise throw IOException out of a shutdown path, where nothing is waiting to handle it.
-     * Callers already treat a non-zero exit as a failure to report.
+     * Runs an adb command to completion, reporting an adb that cannot be launched as `null` rather
+     * than throwing: teardown ([stopAutoWiring], [unwire]) runs outside the wiring job, where an adb
+     * that has been uninstalled or unmounted since wiring would otherwise throw into a shutdown path
+     * with nothing waiting to handle it.
      */
-    private fun runAdb(vararg args: String): Pair<Int, String> = try {
-        val process = ProcessBuilder(adbPath, *args)
-            .redirectErrorStream(true)
-            .start()
-        val output = process.inputStream.bufferedReader().readText().trim()
-        process.waitFor() to output
-    } catch (e: IOException) {
-        ADB_LAUNCH_FAILED to "adb could not be launched from \"$adbPath\": ${e.message}"
+    private suspend fun runAdb(vararg args: String) = try {
+        adb.run(*args, timeout = WIRING_TIMEOUT)
+    } catch (e: JetWhaleAdbUnavailableException) {
+        System.err.println(e.message)
+        null
     }
-}
-
-/** The adb executable itself could not be launched — no amount of retrying will bring it back. */
-// Distinct from any exit code adb itself returns, which are small positive integers.
-private const val ADB_LAUNCH_FAILED = -1
-
-private class AdbUnavailableException(adbPath: String, cause: IOException) : Exception("adb could not be launched from \"$adbPath\": ${cause.message}", cause)
-
-private sealed interface DeviceEvent {
-    data class Connected(val serial: String) : DeviceEvent
-    data class Disconnected(val serial: String) : DeviceEvent
 }

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepositoryManifestTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginFactoryRepositoryManifestTest.kt
@@ -1,0 +1,78 @@
+package com.kitakkun.jetwhale.host.data.plugin
+
+import com.kitakkun.jetwhale.host.data.AppDataDirectoryProvider
+import com.kitakkun.jetwhale.host.model.AdditionalPluginDirectories
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Referenced by the manifests below; the jars under test carry no classes of their own. */
+class ManifestTestPluginFactory : JetWhaleHostPluginFactory {
+    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = object : JetWhaleHostPlugin() {}
+}
+
+class DefaultPluginFactoryRepositoryManifestTest {
+    private val repository = DefaultPluginFactoryRepository(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())))
+
+    @Test
+    fun `a host-scoped plugin that also requires an agent is rejected`() = runBlocking {
+        val jar = jarWithManifest(scope = "host", requiresAgent = true)
+
+        repository.loadPlugin(jar.absolutePath)
+
+        assertTrue(repository.loadedPlugins.isEmpty())
+        val failure = repository.failedJarsFlow.first().single()
+        assertEquals(jar.absolutePath, failure.jarPath)
+        assertTrue("requiresAgent" in failure.reason, "Expected the reason to name the offending field, but was: ${failure.reason}")
+    }
+
+    @Test
+    fun `a host-scoped plugin without an agent loads`() = runBlocking {
+        val jar = jarWithManifest(scope = "host", requiresAgent = false)
+
+        repository.loadPlugin(jar.absolutePath)
+
+        val loaded = repository.loadedPlugins.getValue(PLUGIN_ID)
+        assertEquals(JetWhaleHostPluginScope.HOST, loaded.manifest.scope)
+        assertTrue(repository.failedJarsFlow.first().isEmpty())
+    }
+
+    @Test
+    fun `a plugin that declares no scope is session-scoped`() = runBlocking {
+        val jar = jarWithManifest(scope = null, requiresAgent = true)
+
+        repository.loadPlugin(jar.absolutePath)
+
+        assertEquals(JetWhaleHostPluginScope.SESSION, repository.loadedPlugins.getValue(PLUGIN_ID).manifest.scope)
+    }
+
+    private fun jarWithManifest(scope: String?, requiresAgent: Boolean): File {
+        val manifest = buildString {
+            append("""{"plugins":[{"pluginId":"$PLUGIN_ID","pluginName":"Manifest Test",""")
+            append(""""version":"1.0.0","factoryClass":"${ManifestTestPluginFactory::class.java.name}",""")
+            append(""""requiresAgent":$requiresAgent""")
+            if (scope != null) append(""","scope":"$scope"""")
+            append("}]}")
+        }
+        val jar = File.createTempFile("jetwhale-manifest-test-", ".jar").apply { deleteOnExit() }
+        JarOutputStream(jar.outputStream()).use { out ->
+            out.putNextEntry(JarEntry("META-INF/jetwhale/plugin-manifest.json"))
+            out.write(manifest.toByteArray())
+            out.closeEntry()
+        }
+        return jar
+    }
+
+    private companion object {
+        const val PLUGIN_ID = "com.example.manifesttest"
+    }
+}

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstanceServiceHeadlessTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginInstanceServiceHeadlessTest.kt
@@ -6,19 +6,34 @@ import com.kitakkun.jetwhale.host.model.HostPluginFrameSender
 import com.kitakkun.jetwhale.host.model.LoadedHostPlugin
 import com.kitakkun.jetwhale.host.model.PluginDataStoreRepository
 import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdbResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifest
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginScope
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMessagingHostPlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhalePluginStorage
+import com.kitakkun.jetwhale.host.sdk.JetWhaleSessionInfo
+import com.kitakkun.jetwhale.host.sdk.JetWhaleSessions
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.io.ByteArrayInputStream
+import java.io.InputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration
 
 /**
  * Whether a plugin renders a UI is only knowable from the instantiated plugin, so the service that
@@ -62,7 +77,10 @@ class DefaultPluginInstanceServiceHeadlessTest {
         assertEquals(emptyMap(), service.headlessPluginsFlow.value.pluginIdsBySession)
     }
 
-    private fun serviceWith(createPlugin: () -> JetWhaleHostPlugin) = DefaultPluginInstanceService(
+    private fun serviceWith(
+        scope: JetWhaleHostPluginScope = JetWhaleHostPluginScope.SESSION,
+        createPlugin: () -> JetWhaleHostPlugin,
+    ) = DefaultPluginInstanceService(
         pluginFactoryRepository = FakePluginFactoryRepository(
             LoadedHostPlugin(
                 manifest = JetWhaleHostPluginManifest(
@@ -71,15 +89,80 @@ class DefaultPluginInstanceServiceHeadlessTest {
                     version = "1.0.0",
                     factoryClass = "com.example.TestFactory",
                     requiresAgent = false,
+                    scope = scope,
                 ),
                 factory = object : JetWhaleHostPluginFactory {
-                    override fun createPlugin(): JetWhaleHostPlugin = createPlugin()
+                    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = createPlugin()
                 },
             ),
         ),
         frameSender = frameSender,
         pluginDataStoreRepository = dataStoreRepository,
+        hostPluginContext = FakeHostPluginContext(),
     )
+
+    // -- host-scoped instances -------------------------------------------------------------
+
+    @Test
+    fun `a host-scoped instance is created with no session connected`() {
+        val service = serviceWith(scope = JetWhaleHostPluginScope.HOST) { object : JetWhaleHostPlugin() {} }
+
+        val created = service.initializeHostScopedInstanceIfNeeded(pluginId)
+
+        assertTrue(created)
+        assertNotNull(service.getHostScopedInstance(pluginId))
+        assertEquals(setOf(pluginId), service.headlessPluginsFlow.value.hostScopedPluginIds)
+    }
+
+    @Test
+    fun `a host-scoped instance is created only once`() {
+        val service = serviceWith(scope = JetWhaleHostPluginScope.HOST) { object : JetWhaleHostPlugin() {} }
+        service.initializeHostScopedInstanceIfNeeded(pluginId)
+
+        assertFalse(service.initializeHostScopedInstanceIfNeeded(pluginId))
+    }
+
+    @Test
+    fun `closing a session leaves the host-scoped instance alone`() {
+        val service = serviceWith(scope = JetWhaleHostPluginScope.HOST) { object : JetWhaleHostPlugin() {} }
+        service.initializeHostScopedInstanceIfNeeded(pluginId)
+
+        service.unloadPluginInstanceForSession(sessionId)
+
+        assertNotNull(service.getHostScopedInstance(pluginId))
+    }
+
+    @Test
+    fun `disabling the plugin disposes its host-scoped instance`() {
+        val service = serviceWith(scope = JetWhaleHostPluginScope.HOST) { object : JetWhaleHostPlugin() {} }
+        service.initializeHostScopedInstanceIfNeeded(pluginId)
+
+        service.unloadPluginInstancesForPlugin(pluginId)
+
+        assertNull(service.getHostScopedInstance(pluginId))
+        assertTrue(service.headlessPluginsFlow.value.hostScopedPluginIds.isEmpty())
+    }
+
+    @Test
+    fun `a messaging plugin declared host-scoped gets no instance`() {
+        val service = serviceWith(scope = JetWhaleHostPluginScope.HOST) { object : JetWhaleMessagingHostPlugin() {} }
+
+        val created = service.initializeHostScopedInstanceIfNeeded(pluginId)
+
+        assertFalse(created)
+        assertNull(service.getHostScopedInstance(pluginId))
+    }
+
+    private class FakeHostPluginContext : JetWhaleHostPluginContext {
+        override val adb: JetWhaleAdb = object : JetWhaleAdb {
+            override val executable: String = "adb"
+            override suspend fun run(vararg args: String, timeout: Duration): JetWhaleAdbResult = JetWhaleAdbResult(0, "")
+            override suspend fun <T> runStreaming(vararg args: String, timeout: Duration, consume: suspend (InputStream) -> T): T = consume(ByteArrayInputStream(ByteArray(0)))
+        }
+        override val sessions: JetWhaleSessions = object : JetWhaleSessions {
+            override val active: StateFlow<List<JetWhaleSessionInfo>> = MutableStateFlow(emptyList())
+        }
+    }
 
     private class UiPlugin :
         JetWhaleHostPlugin(),

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationServiceTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginSessionReconciliationServiceTest.kt
@@ -12,8 +12,10 @@ import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifest
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginScope
 import com.kitakkun.jetwhale.protocol.messaging.PluginFrame
 import com.kitakkun.jetwhale.protocol.negotiation.JetWhaleAppMetadata
 import com.kitakkun.jetwhale.protocol.negotiation.JetWhalePluginInfo
@@ -30,6 +32,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DefaultPluginSessionReconciliationServiceTest {
     private val pluginId = "com.example.plugin"
@@ -43,15 +46,19 @@ class DefaultPluginSessionReconciliationServiceTest {
         installedPlugins = persistentListOf(JetWhalePluginInfo(pluginId, "1.0.0")),
     )
 
-    private val loadedPlugin = LoadedHostPlugin(
+    private val loadedPlugin = loadedPlugin(JetWhaleHostPluginScope.SESSION)
+
+    private fun loadedPlugin(scope: JetWhaleHostPluginScope) = LoadedHostPlugin(
         manifest = JetWhaleHostPluginManifest(
             pluginId = pluginId,
             pluginName = "Test",
             version = "1.0.0",
             factoryClass = "com.example.TestFactory",
+            requiresAgent = scope == JetWhaleHostPluginScope.SESSION,
+            scope = scope,
         ),
         factory = object : JetWhaleHostPluginFactory {
-            override fun createPlugin(): JetWhaleHostPlugin = object : JetWhaleHostPlugin() {}
+            override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = object : JetWhaleHostPlugin() {}
         },
     )
 
@@ -79,6 +86,31 @@ class DefaultPluginSessionReconciliationServiceTest {
         factoryRepository.load(loadedPlugin)
 
         assertEquals(setOf(sessionId), withTimeout(TIMEOUT_MILLIS) { instanceService.calls.receive() })
+
+        collectJob.cancel()
+    }
+
+    /**
+     * A host-scoped plugin belongs to the host, not to a session, so nothing about its instance may
+     * wait for a session to connect.
+     */
+    @Test
+    fun `a host-scoped plugin is instantiated with no session connected`() = runBlocking {
+        val factoryRepository = FakePluginFactoryRepository()
+        factoryRepository.load(loadedPlugin(JetWhaleHostPluginScope.HOST))
+        val instanceService = FakePluginInstanceService(factoryRepository)
+        val service = DefaultPluginSessionReconciliationService(
+            sessionRepository = FakeDebugSessionRepository(MutableStateFlow(persistentListOf())),
+            enabledPluginsRepository = FakeEnabledPluginsRepository(setOf(pluginId)),
+            pluginFactoryRepository = factoryRepository,
+            pluginInstanceService = instanceService,
+        )
+
+        val collectJob = launch { service.reconciliationEvents().collect { } }
+
+        assertEquals(pluginId, withTimeout(TIMEOUT_MILLIS) { instanceService.hostScopedCalls.receive() })
+        assertTrue(service.isHostScoped(pluginId))
+        assertEquals(emptySet(), service.targetSessionIds(pluginId, listOf(activeSession)))
 
         collectJob.cancel()
     }
@@ -136,6 +168,9 @@ class DefaultPluginSessionReconciliationServiceTest {
         /** The session ids newly initialized by each reconciliation pass, in order. */
         val calls: Channel<Set<String>> = Channel(Channel.UNLIMITED)
 
+        /** The plugin ids whose host-scoped instance was asked for, in order. */
+        val hostScopedCalls: Channel<String> = Channel(Channel.UNLIMITED)
+
         private val initializedSessionIds = mutableSetOf<String>()
 
         override val pluginInstanceEventFlow: SharedFlow<PluginInstanceEvent> = MutableSharedFlow()
@@ -154,9 +189,15 @@ class DefaultPluginSessionReconciliationServiceTest {
             return newSessionIds
         }
 
+        override fun initializeHostScopedInstanceIfNeeded(pluginId: String): Boolean {
+            hostScopedCalls.trySend(pluginId)
+            return true
+        }
+
         override fun getLoadedPluginInstances(): List<LoadedPluginInstance> = emptyList()
         override fun unloadPluginInstanceForSession(sessionId: String) = Unit
         override fun getPluginInstanceForSession(pluginId: String, sessionId: String): JetWhaleHostPlugin? = null
+        override fun getHostScopedInstance(pluginId: String): JetWhaleHostPlugin? = null
         override fun unloadPluginInstancesForPlugin(pluginId: String) = Unit
         override fun clearAllPluginInstances() = Unit
         override suspend fun routeFrame(sessionId: String, frame: PluginFrame) = Unit

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -25,6 +25,7 @@ import io.ktor.server.sse.sse
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.SseServerTransport
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
@@ -177,14 +178,17 @@ class DefaultMcpServerService(
         statusHolder.update(McpServerStatus.Stopped)
     }
 
-    private fun onPluginInstanceReady(pluginId: String, sessionId: String) {
-        val plugin = pluginInstanceService.getPluginInstanceForSession(pluginId, sessionId)
+    private fun onPluginInstanceReady(pluginId: String, sessionId: String?) {
+        val plugin = when (sessionId) {
+            null -> pluginInstanceService.getHostScopedInstance(pluginId)
+            else -> pluginInstanceService.getPluginInstanceForSession(pluginId, sessionId)
+        }
         if (plugin is JetWhaleMcpCapablePlugin) {
             toolRegistry.register(pluginId, sessionId, plugin)
         }
     }
 
-    private fun onPluginInstanceDisposed(pluginId: String, sessionId: String) {
+    private fun onPluginInstanceDisposed(pluginId: String, sessionId: String?) {
         toolRegistry.unregister(pluginId, sessionId)
     }
 
@@ -213,10 +217,12 @@ class DefaultMcpServerService(
     /**
      * Registers plugin-defined tools from the [McpToolRegistry] at connection time.
      * Since tool lists are computed at connection-time, newly added tools appear on the
-     * next client reconnect.
+     * next client reconnect — a host-scoped plugin that becomes ready after a client connected
+     * included.
      *
-     * A `sessionId` parameter is automatically injected into every plugin tool's schema
-     * so the caller can identify which session to route the call to.
+     * A `sessionId` parameter is automatically injected into every session-scoped plugin tool's
+     * schema so the caller can identify which session to route the call to. A host-scoped plugin's
+     * tools belong to no session and are registered with exactly the parameters they declare.
      */
     private fun registerPluginTools(registrar: McpToolRegistrar) {
         for ((toolName, descriptor) in toolRegistry.allRegistrations()) {
@@ -231,12 +237,26 @@ class DefaultMcpServerService(
                 inputSchema = inputSchema,
                 resolvePluginIdForSession = { sessionId -> toolRegistry.pluginIdFor(toolName, sessionId) },
             ) { request ->
-                // Forward the arguments as raw JSON so structured (object/array) parameters keep
-                // their shape; the command's parameter DSL decodes each value by its declared type.
-                val arguments = request.arguments ?: emptyMap()
-                val result = toolRegistry.dispatch(toolName, arguments)
-                CallToolResult(content = listOf(TextContent(result ?: "null")))
+                dispatchPluginTool(toolName, request)
             }
         }
+        for (registration in toolRegistry.allHostScopedRegistrations()) {
+            registrar.addHostScopedPluginTool(
+                name = registration.name,
+                description = registration.descriptor.description,
+                inputSchema = registration.descriptor.toToolSchema(),
+                pluginId = registration.pluginId,
+            ) { request ->
+                dispatchPluginTool(registration.name, request)
+            }
+        }
+    }
+
+    private suspend fun dispatchPluginTool(toolName: String, request: CallToolRequest): CallToolResult {
+        // Forward the arguments as raw JSON so structured (object/array) parameters keep their
+        // shape; the command's parameter DSL decodes each value by its declared type.
+        val result = toolRegistry.dispatch(toolName, request.arguments ?: emptyMap())
+            ?: return CallToolResult(content = listOf(TextContent("null")))
+        return CallToolResult(content = result.toCallToolContent())
     }
 }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommand.kt
@@ -6,7 +6,6 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonObject
 
@@ -53,7 +52,7 @@ abstract class HostMcpCommand :
         ) { request ->
             try {
                 val result = execute(JetWhaleMcpArguments(JsonObject(request.arguments ?: emptyMap())))
-                CallToolResult(content = listOf(TextContent(result)))
+                CallToolResult(content = result.toCallToolContent())
             } catch (e: CancellationException) {
                 throw e
             } catch (e: JetWhaleMcpArgumentException) {

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolExtensions.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolExtensions.kt
@@ -1,13 +1,18 @@
 package com.kitakkun.jetwhale.host.mcp
 
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.ContentBlock
+import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import java.util.Base64
 
 /**
  * Assembles the MCP input schema of a tool declared with the parameter DSL.
@@ -27,6 +32,21 @@ fun JetWhaleMcpToolDescriptor.toToolSchema(
     ),
     required = leadingProperties.keys.toList() + parameters.filterValues { it.required }.keys,
 )
+
+/**
+ * Maps a command's result to the MCP protocol's content blocks. Image bytes are base64-encoded here,
+ * which is the one place the encoding happens — a command hands over raw bytes.
+ */
+fun JetWhaleMcpResult.toCallToolContent(): List<ContentBlock> = content.map { block ->
+    when (block) {
+        is JetWhaleMcpContent.Text -> TextContent(block.text)
+
+        is JetWhaleMcpContent.Image -> ImageContent(
+            data = Base64.getEncoder().encodeToString(block.data),
+            mimeType = block.mimeType,
+        )
+    }
+}
 
 fun errorResult(message: String): CallToolResult = CallToolResult(
     content = listOf(TextContent(buildJsonObject { put("error", message) }.toString())),

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistrar.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistrar.kt
@@ -70,6 +70,29 @@ class McpToolRegistrar(
         )
     }
 
+    /**
+     * Registers a tool contributed by a host-scoped plugin.
+     *
+     * Such a tool takes no `sessionId` — its plugin has a single instance that belongs to no session
+     * — so attribution is fixed to [pluginId] rather than resolved from the arguments.
+     */
+    fun addHostScopedPluginTool(
+        name: String,
+        description: String,
+        inputSchema: ToolSchema,
+        pluginId: String,
+        handler: suspend ClientConnection.(CallToolRequest) -> CallToolResult,
+    ) {
+        addTrackedTool(
+            name = name,
+            description = description,
+            inputSchema = inputSchema,
+            permission = McpToolPermission.PluginTool(name),
+            resolvePluginId = { pluginId },
+            handler = handler,
+        )
+    }
+
     private fun addTrackedTool(
         name: String,
         description: String,

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistry.kt
@@ -7,6 +7,7 @@ import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,9 +22,10 @@ import java.util.concurrent.ConcurrentHashMap
  * Registry that tracks MCP tools contributed by plugin instances that implement
  * [JetWhaleMcpCapablePlugin].
  *
- * A single tool entry covers all sessions that have the plugin installed. When a tool is
- * invoked, the caller must supply a `sessionId` argument so the registry can route the
- * call to the correct plugin instance.
+ * A session-scoped plugin's tool entry covers all sessions that have the plugin installed, so an
+ * invocation must supply a `sessionId` argument for the registry to route the call to the right
+ * instance. A host-scoped plugin has a single instance and no session, so its tools are held
+ * separately and dispatched on the tool name alone.
  */
 class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) {
 
@@ -32,6 +34,9 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
      * that currently have the tool active.
      */
     private val registrations: ConcurrentHashMap<String, PluginToolEntry> = ConcurrentHashMap()
+
+    /** Maps a host-scoped plugin's tool name to its descriptor and the single plugin that owns it. */
+    private val hostScopedRegistrations: ConcurrentHashMap<String, HostScopedToolEntry> = ConcurrentHashMap()
 
     /**
      * Which plugins currently offer MCP tools, so the UI can mark them before an agent acts.
@@ -42,13 +47,19 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
     /**
      * Registers all MCP tools declared by a plugin instance.
      * Only called if the plugin implements [JetWhaleMcpCapablePlugin].
+     *
+     * @param sessionId The session the instance belongs to, or null for a host-scoped plugin.
      */
-    fun register(pluginId: String, sessionId: String, plugin: JetWhaleMcpCapablePlugin) {
+    fun register(pluginId: String, sessionId: String?, plugin: JetWhaleMcpCapablePlugin) {
         plugin.mcpCommands.forEach { command ->
-            val entry = registrations.getOrPut(command.name) {
-                PluginToolEntry(descriptor = command.toDescriptor(), sessionToPlugin = ConcurrentHashMap())
+            if (sessionId == null) {
+                hostScopedRegistrations[command.name] = HostScopedToolEntry(descriptor = command.toDescriptor(), pluginId = pluginId)
+            } else {
+                val entry = registrations.getOrPut(command.name) {
+                    PluginToolEntry(descriptor = command.toDescriptor(), sessionToPlugin = ConcurrentHashMap())
+                }
+                entry.sessionToPlugin[sessionId] = pluginId
             }
-            entry.sessionToPlugin[sessionId] = pluginId
         }
         publishCapablePlugins()
     }
@@ -56,13 +67,20 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
     /**
      * Removes the given session from every tool entry.
      * Tool entries with no remaining sessions are cleaned up.
+     *
+     * @param sessionId The session the instance belonged to, or null for a host-scoped plugin, whose
+     *   tools are dropped outright.
      */
-    fun unregister(pluginId: String, sessionId: String) {
-        registrations.entries.removeIf { (_, entry) ->
-            if (entry.sessionToPlugin[sessionId] == pluginId) {
-                entry.sessionToPlugin.remove(sessionId)
+    fun unregister(pluginId: String, sessionId: String?) {
+        if (sessionId == null) {
+            hostScopedRegistrations.entries.removeIf { (_, entry) -> entry.pluginId == pluginId }
+        } else {
+            registrations.entries.removeIf { (_, entry) ->
+                if (entry.sessionToPlugin[sessionId] == pluginId) {
+                    entry.sessionToPlugin.remove(sessionId)
+                }
+                entry.sessionToPlugin.isEmpty()
             }
-            entry.sessionToPlugin.isEmpty()
         }
         publishCapablePlugins()
     }
@@ -70,12 +88,18 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
     /**
      * Dispatches a tool call to the owning plugin instance.
      *
-     * The [arguments] map must contain a `sessionId` key that identifies the target session.
-     * That key is stripped before forwarding to the plugin.
+     * For a session-scoped tool the [arguments] map must contain a `sessionId` key that identifies
+     * the target session; that key is stripped before forwarding to the plugin. A host-scoped tool
+     * takes no `sessionId` and goes straight to the plugin's single instance.
      *
-     * @return The result string, or null if not found or plugin returned null.
+     * @return The result, or null if not found.
      */
-    suspend fun dispatch(toolName: String, arguments: Map<String, JsonElement>): String? {
+    suspend fun dispatch(toolName: String, arguments: Map<String, JsonElement>): JetWhaleMcpResult? {
+        val hostScoped = hostScopedRegistrations[toolName]
+        if (hostScoped != null) {
+            val plugin = pluginInstanceService.getHostScopedInstance(hostScoped.pluginId) as? JetWhaleMcpCapablePlugin ?: return null
+            return execute(plugin, toolName, JsonObject(arguments))
+        }
         val sessionId = (arguments["sessionId"] as? JsonPrimitive)?.content ?: return null
         val entry = registrations[toolName] ?: return null
         val pluginId = entry.sessionToPlugin[sessionId] ?: return null
@@ -83,13 +107,17 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
             pluginId = pluginId,
             sessionId = sessionId,
         ) as? JetWhaleMcpCapablePlugin ?: return null
+        return execute(plugin, toolName, JsonObject(arguments - "sessionId"))
+    }
+
+    private suspend fun execute(plugin: JetWhaleMcpCapablePlugin, toolName: String, arguments: JsonObject): JetWhaleMcpResult? {
         val command = plugin.mcpCommands.firstOrNull { it.name == toolName } ?: return null
         return try {
-            command.execute(JetWhaleMcpArguments(JsonObject(arguments - "sessionId")))
+            command.execute(JetWhaleMcpArguments(arguments))
         } catch (e: JetWhaleMcpArgumentException) {
             // A caller mistake becomes a payload the AI agent can read and correct, instead of
             // an MCP-level failure.
-            buildJsonObject { put("error", e.message.orEmpty()) }.toString()
+            JetWhaleMcpResult.text(buildJsonObject { put("error", e.message.orEmpty()) }.toString())
         }
     }
 
@@ -102,24 +130,14 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
     /** Removes all registered plugin tools. Call on server stop to avoid stale entries on restart. */
     fun clear() {
         registrations.clear()
+        hostScopedRegistrations.clear()
         publishCapablePlugins()
     }
 
     private fun publishCapablePlugins() {
         val toolsBySessionAndPlugin = mutableMapOf<String, MutableMap<String, MutableList<McpToolSummary>>>()
         registrations.forEach { (toolName, entry) ->
-            val summary = McpToolSummary(
-                name = toolName,
-                description = entry.descriptor.description,
-                parameters = entry.descriptor.parameters.map { (paramName, param) ->
-                    McpToolParameterSummary(
-                        name = paramName,
-                        type = (param.schema["type"] as? JsonPrimitive)?.content.orEmpty(),
-                        required = param.required,
-                        description = param.description,
-                    )
-                },
-            )
+            val summary = entry.descriptor.toSummary(toolName)
             entry.sessionToPlugin.forEach { (sessionId, pluginId) ->
                 toolsBySessionAndPlugin
                     .getOrPut(sessionId) { mutableMapOf() }
@@ -127,20 +145,54 @@ class McpToolRegistry(private val pluginInstanceService: PluginInstanceService) 
                     .add(summary)
             }
         }
+        val hostScopedToolsByPlugin = mutableMapOf<String, MutableList<McpToolSummary>>()
+        hostScopedRegistrations.forEach { (toolName, entry) ->
+            hostScopedToolsByPlugin.getOrPut(entry.pluginId) { mutableListOf() }.add(entry.descriptor.toSummary(toolName))
+        }
         mcpCapablePluginsFlow.value = McpCapablePlugins(
-            toolsBySessionAndPlugin.mapValues { (_, byPlugin) ->
+            toolsBySessionAndPlugin = toolsBySessionAndPlugin.mapValues { (_, byPlugin) ->
                 byPlugin.mapValues { (_, tools) -> tools.sortedBy { it.name } }
             },
+            hostScopedToolsByPlugin = hostScopedToolsByPlugin.mapValues { (_, tools) -> tools.sortedBy { it.name } },
         )
     }
 
-    /** Returns all tools that have at least one active session, with their descriptors. */
+    /** Returns all session-scoped tools that have at least one active session, with their descriptors. */
     fun allRegistrations(): List<Pair<String, JetWhaleMcpToolDescriptor>> = registrations.entries
         .filter { it.value.sessionToPlugin.isNotEmpty() }
         .map { (name, entry) -> name to entry.descriptor }
+
+    /** Returns every tool published by a host-scoped plugin instance, with the plugin that owns it. */
+    fun allHostScopedRegistrations(): List<HostScopedRegistration> = hostScopedRegistrations.entries
+        .map { (name, entry) -> HostScopedRegistration(name = name, pluginId = entry.pluginId, descriptor = entry.descriptor) }
 }
+
+private fun JetWhaleMcpToolDescriptor.toSummary(toolName: String): McpToolSummary = McpToolSummary(
+    name = toolName,
+    description = description,
+    parameters = parameters.map { (paramName, param) ->
+        McpToolParameterSummary(
+            name = paramName,
+            type = (param.schema["type"] as? JsonPrimitive)?.content.orEmpty(),
+            required = param.required,
+            description = param.description,
+        )
+    },
+)
 
 data class PluginToolEntry(
     val descriptor: JetWhaleMcpToolDescriptor,
     val sessionToPlugin: ConcurrentHashMap<String, String>,
+)
+
+data class HostScopedToolEntry(
+    val descriptor: JetWhaleMcpToolDescriptor,
+    val pluginId: String,
+)
+
+/** One tool of a host-scoped plugin, as the MCP server registers it: no session, one owning plugin. */
+data class HostScopedRegistration(
+    val name: String,
+    val pluginId: String,
+    val descriptor: JetWhaleMcpToolDescriptor,
 )

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommands.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommands.kt
@@ -8,6 +8,7 @@ import com.kitakkun.jetwhale.host.model.LogLevel
 import com.kitakkun.jetwhale.host.model.McpHostToolGroup
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.Inject
@@ -34,7 +35,7 @@ class GetLogsCommand(
     private val level by enumOrNull("Only return entries logged at this level.", LogLevel.entries)
     private val contains by stringOrNull("Only return entries whose message contains this substring, case-insensitively.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val requestedLimit = arguments[limit] ?: DEFAULT_LIMIT
         if (requestedLimit !in 1..MAX_LIMIT) {
             throw JetWhaleMcpArgumentException("invalid limit: expected 1..$MAX_LIMIT but was $requestedLimit")
@@ -48,11 +49,13 @@ class GetLogsCommand(
         }
         val returned = matching.takeLast(requestedLimit)
 
-        return Json.encodeToString(
-            GetLogsResult(
-                logs = returned.map { it.toJson() },
-                returned = returned.size,
-                total = matching.size,
+        return JetWhaleMcpResult.text(
+            Json.encodeToString(
+                GetLogsResult(
+                    logs = returned.map { it.toJson() },
+                    returned = returned.size,
+                    total = matching.size,
+                ),
             ),
         )
     }
@@ -68,10 +71,10 @@ class ClearLogsCommand(
     override val description: String =
         "Host-wide: discards every captured host log entry. Clear before reproducing an issue so that jetwhale.getLogs afterwards shows only what the reproduction produced."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val cleared = logCaptureService.logs.value.size
         logCaptureService.clearLogs()
-        return Json.encodeToString(ClearLogsResult(cleared = cleared))
+        return JetWhaleMcpResult.text(Json.encodeToString(ClearLogsResult(cleared = cleared)))
     }
 }
 

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommand.kt
@@ -14,6 +14,7 @@ import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
 import com.kitakkun.jetwhale.host.model.PluginSessionReconciliationService
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.Inject
@@ -49,7 +50,7 @@ class HostNavigationCommand(
     private val sessionId by stringOrNull("Only for PLUGIN. Defaults to the session already selected in the drawer.")
     private val settingsSection by enumOrNull("Only for SETTINGS. Defaults to GENERAL.", HostSettingsSection.entries)
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val request = arguments.toRequest()
         hostNavigationService.navigate(request)
 
@@ -59,21 +60,25 @@ class HostNavigationCommand(
         val applied = withTimeoutOrNull(CONFIRMATION_TIMEOUT_MILLIS) {
             hostNavigationService.currentView.filterNotNull().first { request.matches(it.destination) }
         }?.destination
-            ?: return Json.encodeToString(
-                NavigateResult(
-                    applied = false,
-                    reason = "The host window did not report the requested destination within $CONFIRMATION_TIMEOUT_MILLIS ms. It may still be starting up.",
+            ?: return JetWhaleMcpResult.text(
+                Json.encodeToString(
+                    NavigateResult(
+                        applied = false,
+                        reason = "The host window did not report the requested destination within $CONFIRMATION_TIMEOUT_MILLIS ms. It may still be starting up.",
+                    ),
                 ),
             )
 
-        return Json.encodeToString(
-            NavigateResult(
-                applied = true,
-                destination = applied.kind.name,
-                pluginId = applied.pluginId,
-                sessionId = applied.sessionId,
-                settingsSection = applied.settingsSection?.name,
-                poppedOut = applied.poppedOutPlugins.any { it.pluginId == applied.pluginId && it.sessionId == applied.sessionId },
+        return JetWhaleMcpResult.text(
+            Json.encodeToString(
+                NavigateResult(
+                    applied = true,
+                    destination = applied.kind.name,
+                    pluginId = applied.pluginId,
+                    sessionId = applied.sessionId,
+                    settingsSection = applied.settingsSection?.name,
+                    poppedOut = applied.poppedOutPlugins.any { it.pluginId == applied.pluginId && it.sessionId == applied.sessionId },
+                ),
             ),
         )
     }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommands.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommands.kt
@@ -12,8 +12,10 @@ import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
 import com.kitakkun.jetwhale.host.model.PluginInstanceEvent
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.model.PluginTrustService
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginScope
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.Inject
@@ -42,7 +44,7 @@ class ListInstalledPluginsCommand(
     override val description: String =
         "Host-wide: lists every plugin installed into the debug tool and whether it is enabled, plus the official plugins that could still be installed and any jar that failed to load or is awaiting trust. Use jetwhale.listPlugins instead to see what a particular debug session advertises."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val loaded = pluginFactoryRepository.loadedPlugins
         val enabledPluginIds = enabledPluginsRepository.enabledPluginIdsFlow.first()
 
@@ -52,23 +54,26 @@ class ListInstalledPluginsCommand(
                 name = plugin.manifest.pluginName,
                 version = plugin.manifest.version,
                 requiresAgent = plugin.manifest.requiresAgent,
+                scope = if (plugin.manifest.scope == JetWhaleHostPluginScope.HOST) "host" else "session",
                 enabled = plugin.manifest.pluginId in enabledPluginIds,
             )
         }.sortedBy { it.pluginId }
 
-        return Json.encodeToString(
-            ListInstalledPluginsResult(
-                installed = installed,
-                availableOfficial = OfficialPluginCatalog.plugins.map { official ->
-                    OfficialPluginJson(
-                        pluginId = official.pluginId,
-                        displayName = official.displayName,
-                        description = official.description,
-                        installed = official.pluginId in loaded,
-                    )
-                },
-                failedJars = pluginFactoryRepository.failedJarsFlow.first().map { FailedJarJson(it.jarPath, it.reason) },
-                untrustedJars = pluginTrustService.untrustedJarPathsFlow.first(),
+        return JetWhaleMcpResult.text(
+            Json.encodeToString(
+                ListInstalledPluginsResult(
+                    installed = installed,
+                    availableOfficial = OfficialPluginCatalog.plugins.map { official ->
+                        OfficialPluginJson(
+                            pluginId = official.pluginId,
+                            displayName = official.displayName,
+                            description = official.description,
+                            installed = official.pluginId in loaded,
+                        )
+                    },
+                    failedJars = pluginFactoryRepository.failedJarsFlow.first().map { FailedJarJson(it.jarPath, it.reason) },
+                    untrustedJars = pluginTrustService.untrustedJarPathsFlow.first(),
+                ),
             ),
         )
     }
@@ -93,36 +98,44 @@ class SetPluginEnabledCommand(
     private val pluginId by string("The plugin to toggle; from jetwhale.listInstalledPlugins.")
     private val enabled by boolean("True to enable the plugin, false to disable it.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val targetPluginId = arguments[pluginId]
         if (targetPluginId !in pluginFactoryRepository.loadedPlugins) {
             throw JetWhaleMcpArgumentException("invalid pluginId: '$targetPluginId' is not installed. See jetwhale.listInstalledPlugins.")
         }
         val shouldEnable = arguments[enabled]
+        // A host-scoped plugin is instantiated whether or not anything is connected, so it is worth
+        // waiting for even with no session.
+        val isHostScoped = pluginFactoryRepository.loadedPlugins[targetPluginId]?.manifest?.scope == JetWhaleHostPluginScope.HOST
 
         // Reconciliation runs asynchronously, so collect the Ready events before flipping the flag —
         // otherwise "ok" would be reported before any instance actually exists. With nothing
-        // connected there is nothing to instantiate, so skip the wait entirely.
+        // connected and nothing host-scoped there is nothing to instantiate, so skip the wait entirely.
         val hasActiveSession = debugSessionRepository.debugSessionsFlow.firstOrNull().orEmpty().any { it.isActive }
         val instantiatedSessions = mutableSetOf<String>()
+        var instantiatedForHost = false
         coroutineScope {
             val collector = launch {
                 pluginInstanceService.pluginInstanceEventFlow
                     .filterIsInstance<PluginInstanceEvent.Ready>()
                     .filter { it.pluginId == targetPluginId }
-                    .collect { instantiatedSessions += it.sessionId }
+                    // A host-scoped instance reports a null sessionId: it belongs to the host itself.
+                    .collect { event -> event.sessionId?.let { instantiatedSessions += it } ?: run { instantiatedForHost = true } }
             }
             enabledPluginsRepository.setPluginEnabled(targetPluginId, shouldEnable)
-            if (shouldEnable && hasActiveSession) delay(INSTANTIATION_TIMEOUT_MILLIS)
+            if (shouldEnable && (hasActiveSession || isHostScoped)) delay(INSTANTIATION_TIMEOUT_MILLIS)
             collector.cancel()
         }
 
-        return Json.encodeToString(
-            SetPluginEnabledResult(
-                pluginId = targetPluginId,
-                enabled = shouldEnable,
-                instantiatedForSessions = instantiatedSessions.sorted(),
-                reconnectRequiredForNewTools = shouldEnable,
+        return JetWhaleMcpResult.text(
+            Json.encodeToString(
+                SetPluginEnabledResult(
+                    pluginId = targetPluginId,
+                    enabled = shouldEnable,
+                    instantiatedForSessions = instantiatedSessions.sorted(),
+                    instantiatedForHost = instantiatedForHost,
+                    reconnectRequiredForNewTools = shouldEnable,
+                ),
             ),
         )
     }
@@ -142,7 +155,7 @@ class InstallOfficialPluginCommand(
 
     private val pluginId by string("The official plugin to install; from the availableOfficial list of jetwhale.listInstalledPlugins.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         // Whether an agent may install at all is the Manage plugins permission, enforced for every
         // tool in the group by McpToolRegistrar before this runs.
         val targetPluginId = arguments[pluginId]
@@ -151,12 +164,14 @@ class InstallOfficialPluginCommand(
                 "invalid pluginId: '$targetPluginId' is not an official plugin. Only ${OfficialPluginCatalog.plugins.joinToString { it.pluginId }} can be installed over MCP.",
             )
         if (targetPluginId in pluginFactoryRepository.loadedPlugins) {
-            return Json.encodeToString(
-                InstallOfficialPluginResult(
-                    pluginId = targetPluginId,
-                    installed = true,
-                    alreadyInstalled = true,
-                    nextStep = "jetwhale.setPluginEnabled",
+            return JetWhaleMcpResult.text(
+                Json.encodeToString(
+                    InstallOfficialPluginResult(
+                        pluginId = targetPluginId,
+                        installed = true,
+                        alreadyInstalled = true,
+                        nextStep = "jetwhale.setPluginEnabled",
+                    ),
                 ),
             )
         }
@@ -167,12 +182,14 @@ class InstallOfficialPluginCommand(
 
         withContext(Dispatchers.IO) { officialPluginInstallService.install(plugin) }
 
-        return Json.encodeToString(
-            InstallOfficialPluginResult(
-                pluginId = targetPluginId,
-                installed = true,
-                alreadyInstalled = false,
-                nextStep = "jetwhale.setPluginEnabled",
+        return JetWhaleMcpResult.text(
+            Json.encodeToString(
+                InstallOfficialPluginResult(
+                    pluginId = targetPluginId,
+                    installed = true,
+                    alreadyInstalled = false,
+                    nextStep = "jetwhale.setPluginEnabled",
+                ),
             ),
         )
     }
@@ -183,6 +200,8 @@ data class SetPluginEnabledResult(
     val pluginId: String,
     val enabled: Boolean,
     val instantiatedForSessions: List<String>,
+    /** True when this call brought up the single instance of a host-scoped plugin. */
+    val instantiatedForHost: Boolean,
     val reconnectRequiredForNewTools: Boolean,
 )
 
@@ -210,6 +229,8 @@ data class InstalledPluginJson(
     val name: String,
     val version: String,
     val requiresAgent: Boolean,
+    /** "session" for one instance per debug session, "host" for a single host-wide instance. */
+    val scope: String,
     val enabled: Boolean,
 )
 

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommands.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommands.kt
@@ -7,6 +7,7 @@ import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
 import com.kitakkun.jetwhale.host.model.McpHostToolGroup
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.Inject
@@ -38,7 +39,7 @@ class UpdateSettingsCommand(
     private val persistData by booleanOrNull("Whether captured debug data survives a host restart.")
     private val restartDebugServer by booleanOrNull("Whether to restart the debug server so ws/wss changes take effect now. Defaults to true when a ws/wss setting changed.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         // Validate every port before writing any of them, so a bad argument late in the list cannot
         // leave the settings half-applied.
         val newServerPort = arguments[serverPort]?.requireValidPort("serverPort")
@@ -93,12 +94,14 @@ class UpdateSettingsCommand(
             notes += "The debug server is still running with its previous configuration; restart it with jetwhale.restartDebugServer to apply the change."
         }
 
-        return Json.encodeToString(
-            UpdateSettingsResult(
-                applied = applied,
-                debugServerRestarted = shouldRestart,
-                mcpServerRestarted = false,
-                notes = notes,
+        return JetWhaleMcpResult.text(
+            Json.encodeToString(
+                UpdateSettingsResult(
+                    applied = applied,
+                    debugServerRestarted = shouldRestart,
+                    mcpServerRestarted = false,
+                    notes = notes,
+                ),
             ),
         )
     }
@@ -124,16 +127,18 @@ class RestartDebugServerCommand(
     override val description: String =
         "Host-wide: stops and restarts the debug WebSocket server that agents connect to. This disconnects every session — every sessionId you hold becomes invalid and each app has to reconnect."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         restartDebugServer(settingsRepository, debugWebSocketServer)
         val status = debugWebSocketServer.statusFlow.value.toJson()
-        return Json.encodeToString(
-            RestartDebugServerResult(
-                state = status.state,
-                host = status.host,
-                port = status.port,
-                wssPort = status.wssPort,
-                note = SERVER_RESTART_NOTE,
+        return JetWhaleMcpResult.text(
+            Json.encodeToString(
+                RestartDebugServerResult(
+                    state = status.state,
+                    host = status.host,
+                    port = status.port,
+                    wssPort = status.wssPort,
+                    note = SERVER_RESTART_NOTE,
+                ),
             ),
         )
     }

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommand.kt
@@ -20,6 +20,7 @@ import com.kitakkun.jetwhale.host.model.PluginFactoryRepository
 import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
 import com.kitakkun.jetwhale.host.model.PluginTrustService
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.Inject
@@ -49,40 +50,42 @@ class HostStatusCommand(
     override val description: String =
         "Host-wide: one snapshot of the debug tool — its version, both servers, how many sessions and plugins are live, and the current settings. Call this first to orient yourself before any other jetwhale tool."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val sessions = debugSessionRepository.debugSessionsFlow.firstOrNull().orEmpty()
 
-        return Json.encodeToString(
-            HostStatusResult(
-                host = HostInfoJson(
-                    version = hostVersionInfo.version,
-                    isSnapshot = hostVersionInfo.isSnapshot,
-                    os = HostOs.current.name,
+        return JetWhaleMcpResult.text(
+            Json.encodeToString(
+                HostStatusResult(
+                    host = HostInfoJson(
+                        version = hostVersionInfo.version,
+                        isSnapshot = hostVersionInfo.isSnapshot,
+                        os = HostOs.current.name,
+                    ),
+                    debugServer = debugWebSocketServer.statusFlow.value.toJson(),
+                    mcpServer = mcpServerStatusHolder.statusFlow.value.toJson(),
+                    sessions = SessionCountsJson(
+                        total = sessions.size,
+                        active = sessions.count { it.isActive },
+                    ),
+                    plugins = PluginCountsJson(
+                        loaded = pluginFactoryRepository.loadedPlugins.size,
+                        enabled = enabledPluginsRepository.enabledPluginIdsFlow.first().size,
+                        failedJars = pluginFactoryRepository.failedJarsFlow.first().size,
+                        untrustedJars = pluginTrustService.untrustedJarPathsFlow.first().size,
+                        installInProgress = pluginInstallProgressRepository.progressFlow.first() != null,
+                    ),
+                    settings = SettingsJson(
+                        serverPort = settingsRepository.serverPortFlow.value,
+                        wssPort = settingsRepository.wssPortFlow.value,
+                        wssEnabled = settingsRepository.wssEnabledFlow.value,
+                        mcpServerPort = settingsRepository.mcpServerPortFlow.value,
+                        adbAutoPortMappingEnabled = settingsRepository.adbAutoPortMappingEnabledFlow.value,
+                        checkForUpdatesOnStartup = settingsRepository.checkForUpdatesOnStartupFlow.value,
+                        persistData = settingsRepository.persistDataFlow.value,
+                    ),
+                    permissions = mcpPermissionsRepository.permissionsFlow.value.toJson(),
+                    ui = hostNavigationService.currentView.value?.toJson(),
                 ),
-                debugServer = debugWebSocketServer.statusFlow.value.toJson(),
-                mcpServer = mcpServerStatusHolder.statusFlow.value.toJson(),
-                sessions = SessionCountsJson(
-                    total = sessions.size,
-                    active = sessions.count { it.isActive },
-                ),
-                plugins = PluginCountsJson(
-                    loaded = pluginFactoryRepository.loadedPlugins.size,
-                    enabled = enabledPluginsRepository.enabledPluginIdsFlow.first().size,
-                    failedJars = pluginFactoryRepository.failedJarsFlow.first().size,
-                    untrustedJars = pluginTrustService.untrustedJarPathsFlow.first().size,
-                    installInProgress = pluginInstallProgressRepository.progressFlow.first() != null,
-                ),
-                settings = SettingsJson(
-                    serverPort = settingsRepository.serverPortFlow.value,
-                    wssPort = settingsRepository.wssPortFlow.value,
-                    wssEnabled = settingsRepository.wssEnabledFlow.value,
-                    mcpServerPort = settingsRepository.mcpServerPortFlow.value,
-                    adbAutoPortMappingEnabled = settingsRepository.adbAutoPortMappingEnabledFlow.value,
-                    checkForUpdatesOnStartup = settingsRepository.checkForUpdatesOnStartupFlow.value,
-                    persistData = settingsRepository.persistDataFlow.value,
-                ),
-                permissions = mcpPermissionsRepository.permissionsFlow.value.toJson(),
-                ui = hostNavigationService.currentView.value?.toJson(),
             ),
         )
     }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -10,6 +10,7 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpParameterDescriptor
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpToolDescriptor
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -214,6 +215,64 @@ class DefaultMcpServerServiceTest {
                 assertNotNull(callResult)
                 val text = callResult.content.filterIsInstance<TextContent>().first().text
                 assertEquals("Hello, World!", text)
+            } finally {
+                client.close()
+            }
+        } finally {
+            service.stop()
+        }
+    }
+
+    @Test
+    fun `a host-scoped plugin's tool is listed without a sessionId and callable with no session`() = runBlocking {
+        val hostScopedPluginId = "com.example.hostscoped"
+        val fakePlugin = FakeMcpCapablePlugin("com.example.hostscoped.greet")
+
+        // No session exists at all: the instance belongs to the host itself.
+        every { pluginInstanceService.getLoadedPluginInstances() } returns listOf(
+            LoadedPluginInstance(hostScopedPluginId, sessionId = null, plugin = fakePlugin),
+        )
+        every { pluginInstanceService.getHostScopedInstance(hostScopedPluginId) } returns fakePlugin
+
+        service.start(host, port)
+        try {
+            val client = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$port/sse")
+            try {
+                val tool = client.listTools().tools.first { it.name == "com.example.hostscoped.greet" }
+                assertFalse("sessionId" in tool.inputSchema.properties?.keys.orEmpty())
+                assertFalse("sessionId" in tool.inputSchema.required.orEmpty())
+
+                val callResult = client.callTool("com.example.hostscoped.greet", mapOf("name" to "World"))
+                assertNotNull(callResult)
+                assertEquals("Hello, World!", callResult.content.filterIsInstance<TextContent>().first().text)
+            } finally {
+                client.close()
+            }
+        } finally {
+            service.stop()
+        }
+    }
+
+    @Test
+    fun `a plugin command answering with an image reaches the client as image content`() = runBlocking {
+        val pluginId = "com.example.camera"
+        val sessionId = "session-camera"
+        val fakePlugin = FakeImageCapablePlugin()
+
+        every { pluginInstanceService.getLoadedPluginInstances() } returns listOf(
+            LoadedPluginInstance(pluginId, sessionId, fakePlugin),
+        )
+        every { pluginInstanceService.getPluginInstanceForSession(pluginId, sessionId) } returns fakePlugin
+
+        service.start(host, port)
+        try {
+            val client = HttpClient(CIO) { install(SSE) }.mcpSse("http://$host:$port/sse")
+            try {
+                val callResult = client.callTool("com.example.camera.capture", mapOf("sessionId" to sessionId))
+                assertNotNull(callResult)
+                val image = callResult.content.filterIsInstance<ImageContent>().single()
+                assertEquals("image/png", image.mimeType)
+                assertEquals(java.util.Base64.getEncoder().encodeToString(CAPTURE_BYTES), image.data)
             } finally {
                 client.close()
             }
@@ -690,6 +749,23 @@ private class FailingMcpTool(private val name: String) : JetWhaleMcpTool {
     }
 }
 
+private val CAPTURE_BYTES = byteArrayOf(9, 8, 7)
+
+/** A plugin whose tool answers with an image, which the server has to base64-encode. */
+private class FakeImageCapablePlugin :
+    JetWhaleHostPlugin(),
+    JetWhaleMcpCapablePlugin {
+
+    override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
+        object : JetWhaleMcpCommand() {
+            override val name = "com.example.camera.capture"
+            override val description = "Captures a screenshot"
+
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.image(CAPTURE_BYTES, "image/png")
+        },
+    )
+}
+
 private class FakeMcpCapablePlugin(private val toolName: String = "com.example.test.greet") :
     JetWhaleHostPlugin(),
     JetWhaleMcpCapablePlugin {
@@ -701,7 +777,7 @@ private class FakeMcpCapablePlugin(private val toolName: String = "com.example.t
 
             private val greetName by string("Name to greet", name = "name")
 
-            override suspend fun execute(arguments: JetWhaleMcpArguments): String = "Hello, ${arguments[greetName]}!"
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text("Hello, ${arguments[greetName]}!")
         },
     )
 }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/HostMcpCommandTest.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.host.mcp
 import com.kitakkun.jetwhale.host.model.McpHostToolGroup
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
@@ -12,12 +13,14 @@ import io.ktor.client.plugins.sse.SSE
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.client.mcpSse
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.Tool
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import java.util.Base64
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -65,6 +68,16 @@ class HostMcpCommandTest {
         val result = client.callTool("jetwhale.test.explode", emptyMap())
         assertEquals(true, result.isError)
         assertContains(result.firstText(), "boom")
+    }
+
+    @Test
+    fun `an image result reaches the client as base64 image content`() = withHostCommand(ScreenshotHostCommand()) { client ->
+        val result = client.callTool("jetwhale.test.screenshot", emptyMap())
+
+        val image = result.content.filterIsInstance<ImageContent>().single()
+        assertEquals("image/png", image.mimeType)
+        // The command hands over raw bytes; base64 is the host's job.
+        assertEquals(Base64.getEncoder().encodeToString(SCREENSHOT_BYTES), image.data)
     }
 
     @Test
@@ -123,7 +136,7 @@ private class EchoHostCommand : HostMcpCommand() {
     private val text by string("Text to echo back.")
     private val times by intOrNull("How many times to repeat it.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[text].repeat(arguments[times] ?: 1)
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[text].repeat(arguments[times] ?: 1))
 }
 
 private class ExplodingHostCommand : HostMcpCommand() {
@@ -131,5 +144,15 @@ private class ExplodingHostCommand : HostMcpCommand() {
     override val group: McpHostToolGroup = McpHostToolGroup.OBSERVE
     override val description: String = "Always fails."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = throw IllegalStateException("boom")
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = throw IllegalStateException("boom")
+}
+
+private val SCREENSHOT_BYTES = byteArrayOf(1, 2, 3, 4, 5)
+
+private class ScreenshotHostCommand : HostMcpCommand() {
+    override val name: String = "jetwhale.test.screenshot"
+    override val group: McpHostToolGroup = McpHostToolGroup.OBSERVE
+    override val description: String = "Answers with an image."
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.image(SCREENSHOT_BYTES, "image/png")
 }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpPermissionEnforcementTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpPermissionEnforcementTest.kt
@@ -6,6 +6,7 @@ import com.kitakkun.jetwhale.host.model.McpPermissions
 import com.kitakkun.jetwhale.host.model.McpToolPermission
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
@@ -232,7 +233,7 @@ private class ObserveCommand : HostMcpCommand() {
     override val group: McpHostToolGroup = McpHostToolGroup.OBSERVE
     override val description: String = "Observes."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = "observed"
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text("observed")
 }
 
 private class RestartCommand : HostMcpCommand() {
@@ -240,7 +241,7 @@ private class RestartCommand : HostMcpCommand() {
     override val group: McpHostToolGroup = McpHostToolGroup.SETTINGS_AND_SERVERS
     override val description: String = "Restarts."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = "restarted"
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text("restarted")
 }
 
 /** Stands in for the built-in UI tools: takes a `pluginId`, so the check resolves per call. */

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpResultText.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpResultText.kt
@@ -1,0 +1,9 @@
+package com.kitakkun.jetwhale.host.mcp
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+
+/** The text of a single-block result, which is what every command under test answers with. */
+@OptIn(ExperimentalJetWhaleApi::class)
+val JetWhaleMcpResult.text: String get() = (content.single() as JetWhaleMcpContent.Text).text

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistryTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolRegistryTest.kt
@@ -6,14 +6,22 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.mock
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalJetWhaleApi::class)
 class McpToolRegistryTest {
 
-    private val registry = McpToolRegistry(mock<PluginInstanceService>())
+    private val pluginInstanceService = mock<PluginInstanceService>()
+    private val registry = McpToolRegistry(pluginInstanceService)
 
     @Test
     fun `no plugins are reported as MCP-capable before anything registers`() {
@@ -67,6 +75,58 @@ class McpToolRegistryTest {
         assertEquals(emptyMap(), registry.mcpCapablePluginsFlow.value.toolsBySessionAndPlugin)
     }
 
+    // -- host-scoped plugins ----------------------------------------------------------------
+
+    @Test
+    fun `a host-scoped plugin's tools are registered without a session`() {
+        registry.register("com.example.host", sessionId = null, plugin = FakeTooledPlugin("host.greet"))
+
+        val registration = registry.allHostScopedRegistrations().single()
+        assertEquals("host.greet", registration.name)
+        assertEquals("com.example.host", registration.pluginId)
+        // A host-scoped tool declares exactly its own parameters; no sessionId is injected anywhere.
+        assertTrue(registration.descriptor.parameters.isEmpty())
+        assertTrue(registry.allRegistrations().isEmpty())
+    }
+
+    @Test
+    fun `a host-scoped plugin is reported as MCP-capable whatever the session`() {
+        registry.register("com.example.host", sessionId = null, plugin = FakeTooledPlugin("host.greet"))
+
+        val capable = registry.mcpCapablePluginsFlow.value
+        assertEquals(setOf("com.example.host"), capable.pluginIdsFor(null))
+        assertEquals(listOf("host.greet"), capable.toolsFor(null, "com.example.host").map { it.name })
+    }
+
+    @Test
+    fun `a host-scoped tool is dispatched without a sessionId argument`() = runBlocking {
+        val plugin = FakeTooledPlugin("host.greet")
+        every { pluginInstanceService.getHostScopedInstance("com.example.host") } returns plugin
+        registry.register("com.example.host", sessionId = null, plugin = plugin)
+
+        val result = registry.dispatch("host.greet", emptyMap())
+
+        assertEquals("ok", requireNotNull(result).text)
+    }
+
+    @Test
+    fun `unregistering a host-scoped plugin drops its tools`() {
+        registry.register("com.example.host", sessionId = null, plugin = FakeTooledPlugin("host.greet"))
+
+        registry.unregister("com.example.host", sessionId = null)
+
+        assertTrue(registry.allHostScopedRegistrations().isEmpty())
+        assertEquals(emptySet(), registry.mcpCapablePluginsFlow.value.pluginIdsFor(null))
+    }
+
+    @Test
+    fun `a session-scoped tool call without a sessionId is not dispatched`() = runBlocking {
+        registry.register("com.example.a", "session-1", FakeTooledPlugin("a.greet"))
+
+        assertNull(registry.dispatch("a.greet", emptyMap()))
+        assertNull(registry.dispatch("a.greet", mapOf("sessionId" to JsonPrimitive("session-2"))))
+    }
+
     @Test
     fun `pluginIdFor resolves the owner of a tool for a session`() {
         registry.register("com.example.a", "session-1", FakeTooledPlugin("a.greet"))
@@ -86,7 +146,7 @@ private class FakeTooledPlugin(private vararg val toolNames: String) :
         object : JetWhaleMcpCommand() {
             override val name = toolName
             override val description = "Fake tool for testing"
-            override suspend fun execute(arguments: JetWhaleMcpArguments): String = "ok"
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text("ok")
         }
     }
 }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolSchemaTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/McpToolSchemaTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class McpToolSchemaTest {
 
@@ -39,6 +40,15 @@ class McpToolSchemaTest {
     @Test
     fun `toToolSchema requires only the parameters that are declared required`() {
         assertEquals(listOf("required1"), descriptor.toToolSchema().required)
+    }
+
+    /** A host-scoped plugin's tools route on the tool name alone, so no session may leak into them. */
+    @Test
+    fun `toToolSchema without leading properties advertises no sessionId`() {
+        val schema = descriptor.toToolSchema()
+
+        assertFalse("sessionId" in requireNotNull(schema.properties).keys)
+        assertFalse("sessionId" in schema.required.orEmpty())
     }
 
     @Test

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScrollToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScrollToolTest.kt
@@ -222,7 +222,7 @@ class ScrollToolTest {
         private val scene: PluginComposeScene,
     ) : PluginComposeSceneService {
         override fun updateHostDensity(density: Density) = Unit
-        override suspend fun getOrCreatePluginScene(pluginId: String, sessionId: String): PluginComposeScene = scene
+        override suspend fun getOrCreatePluginScene(pluginId: String, sessionId: String?): PluginComposeScene = scene
         override fun disposePluginSceneForSession(sessionId: String) = Unit
         override fun disposePluginScenesForPlugin(pluginId: String) = Unit
         override fun disposeAllPluginScenes() = Unit

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommandsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostLogCommandsTest.kt
@@ -1,10 +1,12 @@
 package com.kitakkun.jetwhale.host.mcp.tools.host
 
+import com.kitakkun.jetwhale.host.mcp.text
 import com.kitakkun.jetwhale.host.model.LogCaptureService
 import com.kitakkun.jetwhale.host.model.LogEntry
 import com.kitakkun.jetwhale.host.model.LogLevel
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
@@ -86,9 +88,9 @@ class HostLogCommandsTest {
 
     @Test
     fun `clearLogs reports how many entries were dropped`() = runBlocking {
-        val json = ClearLogsCommand(logCaptureService).execute(arguments())
+        val result = ClearLogsCommand(logCaptureService).execute(arguments())
 
-        assertEquals(3, Json.decodeFromString<ClearLogsResult>(json).cleared)
+        assertEquals(3, Json.decodeFromString<ClearLogsResult>(result.text).cleared)
         verify { logCaptureService.clearLogs() }
     }
 }
@@ -101,4 +103,4 @@ private fun logEntry(message: String, level: LogLevel) = LogEntry(
 
 private fun arguments(vararg entries: Pair<String, JsonPrimitive>) = JetWhaleMcpArguments(JsonObject(entries.toMap()))
 
-private fun String.decodeLogs() = Json.decodeFromString<GetLogsResult>(this)
+private fun JetWhaleMcpResult.decodeLogs() = Json.decodeFromString<GetLogsResult>(text)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommandTest.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.mcp.tools.host
 
+import com.kitakkun.jetwhale.host.mcp.text
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.DebugSessionRepository
 import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
@@ -14,10 +15,12 @@ import com.kitakkun.jetwhale.host.model.PluginSessionReconciliationService
 import com.kitakkun.jetwhale.host.model.PoppedOutPlugin
 import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifest
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.protocol.negotiation.JetWhalePluginInfo
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
@@ -207,10 +210,10 @@ private fun loadedPlugin(pluginId: String) = LoadedHostPlugin(
         factoryClass = "$pluginId.Factory",
     ),
     factory = object : JetWhaleHostPluginFactory {
-        override fun createPlugin(): JetWhaleHostPlugin = throw UnsupportedOperationException()
+        override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = throw UnsupportedOperationException()
     },
 )
 
 private fun arguments(vararg entries: Pair<String, JsonPrimitive>) = JetWhaleMcpArguments(JsonObject(entries.toMap()))
 
-private fun String.decode() = Json.decodeFromString<NavigateResult>(this)
+private fun JetWhaleMcpResult.decode() = Json.decodeFromString<NavigateResult>(text)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommandsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostPluginCommandsTest.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.mcp.tools.host
 
+import com.kitakkun.jetwhale.host.mcp.text
 import com.kitakkun.jetwhale.host.model.DebugSessionRepository
 import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
 import com.kitakkun.jetwhale.host.model.FailedPluginJar
@@ -12,10 +13,12 @@ import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
 import com.kitakkun.jetwhale.host.model.PluginInstanceService
 import com.kitakkun.jetwhale.host.model.PluginTrustService
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginManifest
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -126,7 +129,7 @@ class HostPluginCommandsTest {
     fun `setPluginEnabled disables a plugin without waiting for instantiation`() = runBlocking {
         val result = setPluginEnabled
             .execute(arguments("pluginId" to JsonPrimitive("com.example.local"), "enabled" to JsonPrimitive(false)))
-            .let { Json.decodeFromString<SetPluginEnabledResult>(it) }
+            .let { Json.decodeFromString<SetPluginEnabledResult>(it.text) }
 
         assertFalse(result.enabled)
         assertFalse(result.reconnectRequiredForNewTools)
@@ -156,7 +159,7 @@ class HostPluginCommandsTest {
     fun `installOfficialPlugin installs the catalog entry and points at the next step`() = runBlocking {
         val result = installOfficialPlugin
             .execute(arguments("pluginId" to JsonPrimitive(officialPluginId)))
-            .let { Json.decodeFromString<InstallOfficialPluginResult>(it) }
+            .let { Json.decodeFromString<InstallOfficialPluginResult>(it.text) }
 
         assertTrue(result.installed)
         assertFalse(result.alreadyInstalled)
@@ -172,7 +175,7 @@ class HostPluginCommandsTest {
 
         val result = installOfficialPlugin
             .execute(arguments("pluginId" to JsonPrimitive(officialPluginId)))
-            .let { Json.decodeFromString<InstallOfficialPluginResult>(it) }
+            .let { Json.decodeFromString<InstallOfficialPluginResult>(it.text) }
 
         assertTrue(result.alreadyInstalled)
     }
@@ -187,10 +190,10 @@ private fun loadedPlugin(pluginId: String, name: String, requiresAgent: Boolean)
         requiresAgent = requiresAgent,
     ),
     factory = object : JetWhaleHostPluginFactory {
-        override fun createPlugin(): JetWhaleHostPlugin = throw UnsupportedOperationException()
+        override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = throw UnsupportedOperationException()
     },
 )
 
 private fun arguments(vararg entries: Pair<String, JsonPrimitive>) = JetWhaleMcpArguments(JsonObject(entries.toMap()))
 
-private fun String.decodeList() = Json.decodeFromString<ListInstalledPluginsResult>(this)
+private fun JetWhaleMcpResult.decodeList() = Json.decodeFromString<ListInstalledPluginsResult>(text)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommandsTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostSettingsCommandsTest.kt
@@ -1,10 +1,12 @@
 package com.kitakkun.jetwhale.host.mcp.tools.host
 
+import com.kitakkun.jetwhale.host.mcp.text
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
 import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -133,7 +135,7 @@ class HostSettingsCommandsTest {
 
         val result = RestartDebugServerCommand(settingsRepository, debugWebSocketServer)
             .execute(arguments())
-            .let { Json.decodeFromString<RestartDebugServerResult>(it) }
+            .let { Json.decodeFromString<RestartDebugServerResult>(it.text) }
 
         verifySuspend { debugWebSocketServer.start("localhost", 5080, null) }
         assertTrue("dropped" in result.note)
@@ -143,7 +145,7 @@ class HostSettingsCommandsTest {
     fun `restartDebugServer reports the state the server ended up in`() = runBlocking {
         val result = RestartDebugServerCommand(settingsRepository, debugWebSocketServer)
             .execute(arguments())
-            .let { Json.decodeFromString<RestartDebugServerResult>(it) }
+            .let { Json.decodeFromString<RestartDebugServerResult>(it.text) }
 
         assertEquals("Started", result.state)
         assertEquals(5080, result.port)
@@ -153,4 +155,4 @@ class HostSettingsCommandsTest {
 
 private fun arguments(vararg entries: Pair<String, JsonPrimitive>) = JetWhaleMcpArguments(JsonObject(entries.toMap()))
 
-private fun String.decodeSettings() = Json.decodeFromString<UpdateSettingsResult>(this)
+private fun JetWhaleMcpResult.decodeSettings() = Json.decodeFromString<UpdateSettingsResult>(text)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommandTest.kt
@@ -2,6 +2,7 @@ package com.kitakkun.jetwhale.host.mcp.tools.host
 
 import com.kitakkun.jetwhale.host.mcp.FakeMcpPermissionsRepository
 import com.kitakkun.jetwhale.host.mcp.McpServerStatusHolder
+import com.kitakkun.jetwhale.host.mcp.text
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.DebugSessionRepository
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
@@ -20,6 +21,7 @@ import com.kitakkun.jetwhale.host.model.PluginInstallProgressRepository
 import com.kitakkun.jetwhale.host.model.PluginTrustService
 import com.kitakkun.jetwhale.host.model.SessionTransportSecurity
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
@@ -174,4 +176,4 @@ private fun session(id: String, isActive: Boolean) = DebugSession(
 
 private fun arguments() = JetWhaleMcpArguments(JsonObject(emptyMap()))
 
-private fun String.decode() = Json.decodeFromString<HostStatusResult>(this)
+private fun JetWhaleMcpResult.decode() = Json.decodeFromString<HostStatusResult>(text)

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/HeadlessPlugins.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/HeadlessPlugins.kt
@@ -5,14 +5,19 @@ package com.kitakkun.jetwhale.host.model
  * has no scene to show for them. They still run — they can talk to their agent and publish MCP
  * tools — so this marks "nothing to display", not "not working".
  *
- * Keyed by session id, because UI-ness is read off a live plugin instance and an instance exists per
- * session. A plugin with no instance yet is absent from the map and is therefore not reported as
- * headless.
+ * Session-scoped plugins are keyed by session id, because UI-ness is read off a live plugin instance
+ * and an instance exists per session. A host-scoped plugin has a single instance and no session, so
+ * it is headless for every session at once and is listed in [hostScopedPluginIds] instead. A plugin
+ * with no instance yet is absent from both and is therefore not reported as headless.
  */
-data class HeadlessPlugins(val pluginIdsBySession: Map<String, Set<String>>) {
-    fun isHeadless(sessionId: String?, pluginId: String): Boolean = sessionId != null && pluginIdsBySession[sessionId]?.contains(pluginId) == true
+data class HeadlessPlugins(
+    val pluginIdsBySession: Map<String, Set<String>>,
+    val hostScopedPluginIds: Set<String>,
+) {
+    fun isHeadless(sessionId: String?, pluginId: String): Boolean = pluginId in hostScopedPluginIds ||
+        (sessionId != null && pluginIdsBySession[sessionId]?.contains(pluginId) == true)
 
     companion object {
-        val Empty = HeadlessPlugins(emptyMap())
+        val Empty = HeadlessPlugins(emptyMap(), emptySet())
     }
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/McpCapablePlugins.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/McpCapablePlugins.kt
@@ -23,12 +23,17 @@ data class McpToolSummary(
  * ...) can drive any plugin's UI regardless, so absence here does not mean an agent cannot reach
  * the plugin at all — only that the plugin publishes nothing of its own.
  */
-data class McpCapablePlugins(val toolsBySessionAndPlugin: Map<String, Map<String, List<McpToolSummary>>>) {
-    fun pluginIdsFor(sessionId: String?): Set<String> = sessionId?.let { toolsBySessionAndPlugin[it]?.keys }.orEmpty()
+data class McpCapablePlugins(
+    val toolsBySessionAndPlugin: Map<String, Map<String, List<McpToolSummary>>>,
+    /** Tools published by host-scoped plugins, which belong to no session. */
+    val hostScopedToolsByPlugin: Map<String, List<McpToolSummary>>,
+) {
+    fun pluginIdsFor(sessionId: String?): Set<String> = hostScopedToolsByPlugin.keys + sessionId?.let { toolsBySessionAndPlugin[it]?.keys }.orEmpty()
 
-    fun toolsFor(sessionId: String?, pluginId: String): List<McpToolSummary> = sessionId?.let { toolsBySessionAndPlugin[it]?.get(pluginId) }.orEmpty()
+    fun toolsFor(sessionId: String?, pluginId: String): List<McpToolSummary> = hostScopedToolsByPlugin[pluginId]
+        ?: sessionId?.let { toolsBySessionAndPlugin[it]?.get(pluginId) }.orEmpty()
 
     companion object {
-        val Empty = McpCapablePlugins(emptyMap())
+        val Empty = McpCapablePlugins(emptyMap(), emptyMap())
     }
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeSceneQueryKeyFactory.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeSceneQueryKeyFactory.kt
@@ -6,5 +6,5 @@ package com.kitakkun.jetwhale.host.model
  * interface and create a key per plugin instance.
  */
 fun interface PluginComposeSceneQueryKeyFactory {
-    fun create(pluginId: String, sessionId: String): PluginComposeSceneQueryKey
+    fun create(pluginId: String, sessionId: String?): PluginComposeSceneQueryKey
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeSceneService.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginComposeSceneService.kt
@@ -15,10 +15,11 @@ interface PluginComposeSceneService {
      */
     fun updateHostDensity(density: Density)
 
+    /** @param sessionId The session the instance belongs to, or null for a host-scoped plugin. */
     @OptIn(InternalComposeUiApi::class)
     suspend fun getOrCreatePluginScene(
         pluginId: String,
-        sessionId: String,
+        sessionId: String?,
     ): PluginComposeScene
 
     fun disposePluginSceneForSession(sessionId: String)

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstanceEvent.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstanceEvent.kt
@@ -1,6 +1,9 @@
 package com.kitakkun.jetwhale.host.model
 
 sealed interface PluginInstanceEvent {
-    data class Ready(val pluginId: String, val sessionId: String) : PluginInstanceEvent
-    data class Disposed(val pluginId: String, val sessionId: String) : PluginInstanceEvent
+    /** [sessionId] is null for the single instance of a host-scoped plugin. */
+    data class Ready(val pluginId: String, val sessionId: String?) : PluginInstanceEvent
+
+    /** [sessionId] is null for the single instance of a host-scoped plugin. */
+    data class Disposed(val pluginId: String, val sessionId: String?) : PluginInstanceEvent
 }

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstanceService.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginInstanceService.kt
@@ -5,9 +5,10 @@ import com.kitakkun.jetwhale.protocol.messaging.PluginFrame
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
+/** A live plugin instance. [sessionId] is null for the single instance of a host-scoped plugin. */
 data class LoadedPluginInstance(
     val pluginId: String,
-    val sessionId: String,
+    val sessionId: String?,
     val plugin: JetWhaleHostPlugin,
 )
 
@@ -25,10 +26,17 @@ interface PluginInstanceService {
     /** Returns all currently loaded plugin instances. */
     fun getLoadedPluginInstances(): List<LoadedPluginInstance>
 
+    /** Disposes every session-scoped instance of [sessionId]; host-scoped instances are untouched. */
     fun unloadPluginInstanceForSession(sessionId: String)
     fun getPluginInstanceForSession(pluginId: String, sessionId: String): JetWhaleHostPlugin?
 
+    /** The single instance of a host-scoped plugin, or null while it has none. */
+    fun getHostScopedInstance(pluginId: String): JetWhaleHostPlugin?
+
+    /** Disposes every instance of [pluginId], the host-scoped one included. */
     fun unloadPluginInstancesForPlugin(pluginId: String)
+
+    /** Disposes every instance the host holds, host-scoped ones included. */
     fun clearAllPluginInstances()
 
     /**
@@ -37,6 +45,14 @@ interface PluginInstanceService {
      * @return The set of session IDs for which new plugin instances were initialized.
      */
     fun initializePluginInstancesForSessionsIfNeeded(pluginId: String, sessionIds: Set<String>): Set<String>
+
+    /**
+     * Initializes the single instance of a host-scoped plugin if it does not exist yet. It is tied to
+     * no session, so it is created as soon as the plugin is enabled and loaded.
+     *
+     * @return true when this call created the instance.
+     */
+    fun initializeHostScopedInstanceIfNeeded(pluginId: String): Boolean
 
     /** Routes an inbound plugin [frame] to the peer of the matching plugin instance in [sessionId]. */
     suspend fun routeFrame(sessionId: String, frame: PluginFrame)

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginMetaData.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginMetaData.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.host.model
 
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginScope
 import java.net.URL
 
 data class PluginMetaData(
@@ -8,6 +9,8 @@ data class PluginMetaData(
     val version: String,
     /** When false, this is a host-only plugin: available for any active session without negotiation. */
     val requiresAgent: Boolean = true,
+    /** Whether the host holds one instance per session or a single instance for the whole host. */
+    val scope: JetWhaleHostPluginScope,
     val activeIconResource: PluginIconResource? = null,
     val inactiveIconResource: PluginIconResource? = null,
 )

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginSessionReconciliationService.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/PluginSessionReconciliationService.kt
@@ -21,9 +21,16 @@ interface PluginSessionReconciliationService {
     /**
      * The ids of the sessions that should hold an instance of [pluginId] given [sessions]. An
      * agent-backed plugin targets only sessions whose agent advertised it; a host-only plugin
-     * targets every session.
+     * targets every session; a host-scoped plugin targets none, because its single instance belongs
+     * to the host rather than to a session.
      */
     fun targetSessionIds(pluginId: String, sessions: List<DebugSession>): Set<String>
+
+    /**
+     * Whether [pluginId] holds a single host-scoped instance instead of one per session. Unknown or
+     * unloaded plugins default to `false`.
+     */
+    fun isHostScoped(pluginId: String): Boolean
 
     /**
      * A cold flow that reconciles enabled plugins against active sessions for as long as it is

--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreenContext.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreenContext.kt
@@ -15,11 +15,13 @@ import kotlinx.coroutines.flow.filter
  * Screen context for a plugin instance. The plugin/session ids arrive as NavKey arguments, so
  * this is created via assisted injection; the compose-scene query is keyed by those ids and
  * built by the injected [PluginComposeSceneQueryKeyFactory].
+ *
+ * [sessionId] is null for a host-scoped plugin, whose single instance belongs to no session.
  */
 @AssistedInject
 class PluginScreenContext(
     @Assisted val pluginId: String,
-    @Assisted val sessionId: String,
+    @Assisted val sessionId: String?,
     pluginComposeSceneQueryKeyFactory: PluginComposeSceneQueryKeyFactory,
     pluginHotReloadService: PluginHotReloadService,
     val headlessPluginsSubscriptionKey: HeadlessPluginsSubscriptionKey,
@@ -36,6 +38,6 @@ class PluginScreenContext(
 
     @AssistedFactory
     fun interface Factory {
-        fun create(pluginId: String, sessionId: String): PluginScreenContext
+        fun create(pluginId: String, sessionId: String?): PluginScreenContext
     }
 }

--- a/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHeadlessPluginFactory.kt
+++ b/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHeadlessPluginFactory.kt
@@ -2,15 +2,17 @@ package com.kitakkun.jetwhale.plugins.example.host
 
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 
 // Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
 @Suppress("UNUSED")
 class ExampleHeadlessPluginFactory : JetWhaleHostPluginFactory {
-    override fun createPlugin(): JetWhaleHostPlugin = ExampleHeadlessPlugin()
+    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = ExampleHeadlessPlugin()
 }
 
 /**
@@ -34,5 +36,5 @@ private class EchoCommand : JetWhaleMcpCommand() {
 
     private val text by string("Text to echo back.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[text]
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[text])
 }

--- a/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostOnlyPluginFactory.kt
+++ b/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostOnlyPluginFactory.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
 import com.kitakkun.jetwhale.host.ui.JwButton
@@ -22,7 +23,7 @@ import com.kitakkun.jetwhale.host.ui.JwToolbar
 // Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
 @Suppress("UNUSED")
 class ExampleHostOnlyPluginFactory : JetWhaleHostPluginFactory {
-    override fun createPlugin(): JetWhaleHostPlugin = ExampleHostOnlyPlugin()
+    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = ExampleHostOnlyPlugin()
 }
 
 /**

--- a/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostPluginFactory.kt
+++ b/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostPluginFactory.kt
@@ -5,11 +5,13 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMessagingHostPlugin
 import com.kitakkun.jetwhale.plugins.example.protocol.ButtonClicked
 import com.kitakkun.jetwhale.plugins.example.protocol.Ping
@@ -25,7 +27,7 @@ import kotlinx.serialization.json.put
 // Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
 @Suppress("UNUSED")
 class ExampleHostPluginFactory : JetWhaleHostPluginFactory {
-    override fun createPlugin(): JetWhaleHostPlugin = ExampleHostPlugin()
+    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = ExampleHostPlugin()
 }
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -70,16 +72,18 @@ private class ExampleHostPlugin :
             override val name = "com.kitakkun.jetwhale.example.sendPing"
             override val description = "Sends a Ping request to the debuggee and returns whether a Pong reply was received."
 
-            override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
                 val pongReceived = try {
                     messenger.request(Ping)
                     true
                 } catch (e: JetWhaleMessagingException) {
                     false
                 }
-                return buildJsonObject {
-                    put("pongReceived", pongReceived)
-                }.toString()
+                return JetWhaleMcpResult.text(
+                    buildJsonObject {
+                        put("pongReceived", pongReceived)
+                    }.toString(),
+                )
             }
         },
         object : JetWhaleMcpCommand() {
@@ -88,10 +92,10 @@ private class ExampleHostPlugin :
 
             private val limit by intOrNull("Maximum number of log entries to return. Returns all entries if omitted.")
 
-            override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
                 val limit = arguments[this.limit]
                 val logs = if (limit != null) eventLogs.takeLast(limit) else eventLogs.toList()
-                return Json.encodeToJsonElement(logs).toString()
+                return JetWhaleMcpResult.text(Json.encodeToJsonElement(logs).toString())
             }
         },
     )

--- a/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostScopedPluginFactory.kt
+++ b/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostScopedPluginFactory.kt
@@ -1,0 +1,53 @@
+package com.kitakkun.jetwhale.plugins.example.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdbUnavailableException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import kotlin.time.Duration.Companion.seconds
+
+// Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
+@Suppress("UNUSED")
+class ExampleHostScopedPluginFactory : JetWhaleHostPluginFactory {
+    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = ExampleHostScopedPlugin(context.adb)
+}
+
+/**
+ * A **host-scoped** example plugin: its manifest entry declares `"scope": "host"`, so the host holds
+ * a single instance of it that is created as soon as the plugin is enabled — with no app connected
+ * and no session in existence. Its MCP tool therefore takes no `sessionId`.
+ *
+ * It is headless (no [com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi]) and does its work
+ * through the host services it is handed at creation, here the shared adb runner.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+private class ExampleHostScopedPlugin(adb: JetWhaleAdb) :
+    JetWhaleHostPlugin(),
+    JetWhaleMcpCapablePlugin {
+
+    override val mcpCommands: List<JetWhaleMcpCommand> = listOf(AdbVersionCommand(adb))
+}
+
+/** How long to let `adb version` run; it either answers at once or adb is not working. */
+private val ADB_VERSION_TIMEOUT = 10.seconds
+
+@OptIn(ExperimentalJetWhaleApi::class)
+private class AdbVersionCommand(private val adb: JetWhaleAdb) : JetWhaleMcpCommand() {
+    override val name = "com.kitakkun.jetwhale.example.hostscoped.adbVersion"
+    override val description = "Reports the version of the adb the debug tool resolved, to show a host-scoped plugin working with no app connected."
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
+        val result = try {
+            adb.run("version", timeout = ADB_VERSION_TIMEOUT)
+        } catch (e: JetWhaleAdbUnavailableException) {
+            return JetWhaleMcpResult.text("adb is not available on this machine: ${e.message}")
+        }
+        return JetWhaleMcpResult.text("adb executable: ${adb.executable}\nexit code: ${result.exitCode}\n${result.output}")
+    }
+}

--- a/jetwhale-plugins/example/host/src/main/resources/META-INF/jetwhale/plugin-manifest.json
+++ b/jetwhale-plugins/example/host/src/main/resources/META-INF/jetwhale/plugin-manifest.json
@@ -36,6 +36,18 @@
         "activePath": "icons/window_filled.svg",
         "inactivePath": "icons/window_outlined.svg"
       }
+    },
+    {
+      "pluginId": "com.kitakkun.jetwhale.example.hostscoped",
+      "pluginName": "Example Host-scoped Plugin",
+      "version": "1.0.0",
+      "factoryClass": "com.kitakkun.jetwhale.plugins.example.host.ExampleHostScopedPluginFactory",
+      "requiresAgent": false,
+      "scope": "host",
+      "icon": {
+        "activePath": "icons/window_filled.svg",
+        "inactivePath": "icons/window_outlined.svg"
+      }
     }
   ]
 }

--- a/jetwhale-plugins/nav3/host/api/host.api
+++ b/jetwhale-plugins/nav3/host/api/host.api
@@ -1,6 +1,6 @@
 public final class com/kitakkun/jetwhale/plugins/nav3/host/Nav3HostPluginFactory : com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginFactory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun createPlugin ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
+	public fun createPlugin (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginContext;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
 }
 

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/GetBackStackCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/GetBackStackCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
@@ -17,21 +18,23 @@ internal class GetBackStackCommand(
 
     private val stackId by stringOrNull("Which back stack to read. Returns every registered stack if omitted.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val requested = arguments[stackId]
         val stacks = controller.stacks().filter { requested == null || it.stackId == requested }
-        return buildJsonObject {
-            putJsonArray("stacks") { stacks.forEach { add(it.toMcpJson()) } }
-            if (stacks.isEmpty()) {
-                put(
-                    "note",
-                    if (requested == null) {
-                        "The app has no Navigation 3 back stack registered; it must call TrackNavBackStack (or registerBackStack) first."
-                    } else {
-                        "No back stack is registered as '$requested'."
-                    },
-                )
-            }
-        }.toString()
+        return JetWhaleMcpResult.text(
+            buildJsonObject {
+                putJsonArray("stacks") { stacks.forEach { add(it.toMcpJson()) } }
+                if (stacks.isEmpty()) {
+                    put(
+                        "note",
+                        if (requested == null) {
+                            "The app has no Navigation 3 back stack registered; it must call TrackNavBackStack (or registerBackStack) first."
+                        } else {
+                            "No back stack is registered as '$requested'."
+                        },
+                    )
+                }
+            }.toString(),
+        )
     }
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/ListNavKeyTypesCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/ListNavKeyTypesCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 
 @OptIn(ExperimentalJetWhaleApi::class)
 internal class ListNavKeyTypesCommand(
@@ -12,5 +13,5 @@ internal class ListNavKeyTypesCommand(
     override val description =
         "Lists the NavKey types this app can be navigated to, each with its fields and a ready-to-fill JSON template. Fill a template in and pass it to pushNavKey."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = controller.keyTypes().toMcpJson().toString()
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(controller.keyTypes().toMcpJson().toString())
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/MoveNavKeyToTopCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/MoveNavKeyToTopCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -16,11 +17,13 @@ internal class MoveNavKeyToTopCommand(
     private val index by int("Index of the entry to bring to the top (0 is the root).")
     private val stackId by stringOrNull("Which back stack to edit. Defaults to the app's only one.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val target = resolveStackId(arguments[stackId], controller.stacks().map { it.stackId })
-        return controller.mutate(
-            stackId = target,
-            operations = listOf(NavBackStackOperation.MoveToTop(index = arguments[index])),
-        ).toMcpJson()
+        return JetWhaleMcpResult.text(
+            controller.mutate(
+                stackId = target,
+                operations = listOf(NavBackStackOperation.MoveToTop(index = arguments[index])),
+            ).toMcpJson(),
+        )
     }
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/Nav3HostPluginFactory.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/Nav3HostPluginFactory.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
@@ -29,7 +30,7 @@ import kotlinx.coroutines.launch
 // Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
 @Suppress("UNUSED")
 class Nav3HostPluginFactory : JetWhaleHostPluginFactory {
-    override fun createPlugin(): JetWhaleHostPlugin = Nav3HostPlugin()
+    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = Nav3HostPlugin()
 }
 
 @OptIn(ExperimentalJetWhaleApi::class)

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/PopBackStackCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/PopBackStackCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -18,13 +19,13 @@ internal class PopBackStackCommand(
     private val inclusive by booleanOrNull("With toIndex: also pop the entry at that index. Defaults to false.")
     private val stackId by stringOrNull("Which back stack to pop. Defaults to the app's only one.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val target = resolveStackId(arguments[stackId], controller.stacks().map { it.stackId })
         val requestedIndex = arguments[toIndex]
         val operation = when (requestedIndex) {
             null -> NavBackStackOperation.Pop(count = arguments[count] ?: 1)
             else -> NavBackStackOperation.PopTo(index = requestedIndex, inclusive = arguments[inclusive] ?: false)
         }
-        return controller.mutate(stackId = target, operations = listOf(operation)).toMcpJson()
+        return JetWhaleMcpResult.text(controller.mutate(stackId = target, operations = listOf(operation)).toMcpJson())
     }
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/PushNavKeyCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/PushNavKeyCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -17,12 +18,12 @@ internal class PushNavKeyCommand(
     private val index by intOrNull("Insert the key at this index instead of on top of the stack (0 is the root).")
     private val stackId by stringOrNull("Which back stack to push onto. Defaults to the app's only one.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val target = resolveStackId(arguments[stackId], controller.stacks().map { it.stackId })
         val result = controller.mutate(
             stackId = target,
             operations = listOf(NavBackStackOperation.Push(key = arguments[key], index = arguments[index])),
         )
-        return result.toMcpJson()
+        return JetWhaleMcpResult.text(result.toMcpJson())
     }
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/RemoveNavKeyCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/RemoveNavKeyCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.nav3.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 
 @OptIn(ExperimentalJetWhaleApi::class)
@@ -16,11 +17,13 @@ internal class RemoveNavKeyCommand(
     private val index by int("Index of the entry to remove (0 is the root).")
     private val stackId by stringOrNull("Which back stack to edit. Defaults to the app's only one.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val target = resolveStackId(arguments[stackId], controller.stacks().map { it.stackId })
-        return controller.mutate(
-            stackId = target,
-            operations = listOf(NavBackStackOperation.RemoveAt(index = arguments[index])),
-        ).toMcpJson()
+        return JetWhaleMcpResult.text(
+            controller.mutate(
+                stackId = target,
+                operations = listOf(NavBackStackOperation.RemoveAt(index = arguments[index])),
+            ).toMcpJson(),
+        )
     }
 }

--- a/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/ReplaceBackStackCommand.kt
+++ b/jetwhale-plugins/nav3/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/ReplaceBackStackCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 import kotlinx.serialization.json.JsonObject
 
@@ -18,7 +19,7 @@ internal class ReplaceBackStackCommand(
     private val keys by jsonArray("The new back stack as a JSON array of NavKey objects, root first, e.g. [{\"type\":\"Home\"},{\"type\":\"Detail\",\"id\":\"42\"}]. Must not be empty.")
     private val stackId by stringOrNull("Which back stack to replace. Defaults to the app's only one.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val target = resolveStackId(arguments[stackId], controller.stacks().map { it.stackId })
         val newKeys = arguments[keys]
         if (newKeys.isEmpty()) {
@@ -27,9 +28,11 @@ internal class ReplaceBackStackCommand(
         newKeys.forEachIndexed { index, element ->
             if (element !is JsonObject) throw JetWhaleMcpArgumentException("keys[$index] is not a JSON object")
         }
-        return controller.mutate(
-            stackId = target,
-            operations = listOf(NavBackStackOperation.ReplaceAll(keys = newKeys.toList())),
-        ).toMcpJson()
+        return JetWhaleMcpResult.text(
+            controller.mutate(
+                stackId = target,
+                operations = listOf(NavBackStackOperation.ReplaceAll(keys = newKeys.toList())),
+            ).toMcpJson(),
+        )
     }
 }

--- a/jetwhale-plugins/nav3/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/Nav3McpCommandsTest.kt
+++ b/jetwhale-plugins/nav3/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/nav3/host/Nav3McpCommandsTest.kt
@@ -4,6 +4,8 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.MutationResult
 import com.kitakkun.jetwhale.plugins.nav3.protocol.NavBackStackOperation
 import kotlinx.coroutines.runBlocking
@@ -20,9 +22,13 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
+/** The text of a single-block result, which is what every command under test answers with. */
+@OptIn(ExperimentalJetWhaleApi::class)
+private val JetWhaleMcpResult.text: String get() = (content.single() as JetWhaleMcpContent.Text).text
+
 @OptIn(ExperimentalJetWhaleApi::class)
 private fun JetWhaleMcpCommand.run(arguments: JsonObject = buildJsonObject { }): JsonObject = runBlocking {
-    Json.parseToJsonElement(execute(JetWhaleMcpArguments(arguments))).jsonObject
+    Json.parseToJsonElement(execute(JetWhaleMcpArguments(arguments)).text).jsonObject
 }
 
 @OptIn(ExperimentalJetWhaleApi::class)

--- a/jetwhale-plugins/network/host/api/host.api
+++ b/jetwhale-plugins/network/host/api/host.api
@@ -28,7 +28,7 @@ public final class com/kitakkun/jetwhale/plugins/network/host/HttpTransaction {
 public final class com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory : com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginFactory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun createPlugin ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
+	public fun createPlugin (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginContext;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
 }
 
 public final class com/kitakkun/jetwhale/plugins/network/host/NetworkInspectorScreenKt {

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/AddMockRuleCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/AddMockRuleCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.network.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
 import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
@@ -40,7 +41,7 @@ internal class AddMockRuleCommand(
     )
     private val delayMs by longOrNull("Artificial delay before the mocked response is delivered, in milliseconds. Defaults to 0.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val rule = MockRule(
             id = UUID.randomUUID().toString(),
             name = arguments[ruleName] ?: "",
@@ -57,10 +58,12 @@ internal class AddMockRuleCommand(
                 delayMs = arguments[delayMs] ?: 0L,
             ),
         )
-        return when (val failure = syncMockRules(mockRules() + rule)) {
-            null -> Json.encodeToJsonElement(rule).toString()
-            else -> syncErrorJson(failure)
-        }
+        return JetWhaleMcpResult.text(
+            when (val failure = syncMockRules(mockRules() + rule)) {
+                null -> Json.encodeToJsonElement(rule).toString()
+                else -> syncErrorJson(failure)
+            },
+        )
     }
 
     // The explicit headers map wins; contentType only fills in a Content-Type when absent.

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ClearTransactionsCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ClearTransactionsCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.network.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -13,5 +14,5 @@ internal class ClearTransactionsCommand(
     override val name = "$TOOL_PREFIX.clearTransactions"
     override val description = "Clears the captured HTTP transaction list."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = buildJsonObject { put("clearedCount", clearTransactions()) }.toString()
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(buildJsonObject { put("clearedCount", clearTransactions()) }.toString())
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/GetMockConfigCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/GetMockConfigCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.network.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
@@ -17,8 +18,10 @@ internal class GetMockConfigCommand(
     override val name = "$TOOL_PREFIX.getMockConfig"
     override val description = "Returns the current mock configuration: the global enabled flag and all mock rules."
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String = buildJsonObject {
-        put("enabled", mockingEnabled())
-        put("rules", Json.encodeToJsonElement(mockRules()))
-    }.toString()
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(
+        buildJsonObject {
+            put("enabled", mockingEnabled())
+            put("rules", Json.encodeToJsonElement(mockRules()))
+        }.toString(),
+    )
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/GetTransactionCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/GetTransactionCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 
 @OptIn(ExperimentalJetWhaleApi::class)
 internal class GetTransactionCommand(
@@ -15,10 +16,10 @@ internal class GetTransactionCommand(
 
     private val txId by string("The transaction id from listTransactions.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val txId = arguments[this.txId]
         val transaction = transactions().firstOrNull { it.txId == txId }
             ?: throw JetWhaleMcpArgumentException("no transaction with txId: $txId")
-        return redactForMcp(transaction).toDetailJson().toString()
+        return JetWhaleMcpResult.text(redactForMcp(transaction).toDetailJson().toString())
     }
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ListTransactionsCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/ListTransactionsCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -36,7 +37,7 @@ internal class ListTransactionsCommand(
         "Only include transactions with this HTTP method (case-insensitive).",
     )
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val urlContains = arguments[this.urlContains]
         val method = arguments[this.method]
         val limit = arguments[this.limit]
@@ -72,9 +73,11 @@ internal class ListTransactionsCommand(
             else -> filtered.take(limit)
         }
         val nextCursor = page.lastOrNull()?.txId?.takeIf { afterTxId != null && page.size < filtered.size }
-        return buildJsonObject {
-            put("transactions", JsonArray(page.map { redactForMcp(it).toSummaryJson() }))
-            nextCursor?.let { put("nextCursor", it) }
-        }.toString()
+        return JetWhaleMcpResult.text(
+            buildJsonObject {
+                put("transactions", JsonArray(page.map { redactForMcp(it).toSummaryJson() }))
+                nextCursor?.let { put("nextCursor", it) }
+            }.toString(),
+        )
     }
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
@@ -32,7 +33,7 @@ import kotlinx.coroutines.launch
 // Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
 @Suppress("UNUSED")
 class NetworkHostPluginFactory : JetWhaleHostPluginFactory {
-    override fun createPlugin(): JetWhaleHostPlugin = NetworkHostPlugin()
+    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = NetworkHostPlugin()
 }
 
 private const val MAX_TRANSACTIONS = 500

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/RemoveMockRuleCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/RemoveMockRuleCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import kotlinx.serialization.json.buildJsonObject
@@ -19,14 +20,16 @@ internal class RemoveMockRuleCommand(
 
     private val id by string("The rule id from getMockConfig or addMockRule.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val id = arguments[this.id]
         val current = mockRules()
         val remaining = current.filterNot { it.id == id }
         if (remaining.size == current.size) throw JetWhaleMcpArgumentException("no mock rule with id: $id")
-        return when (val failure = syncMockRules(remaining)) {
-            null -> buildJsonObject { put("removedId", id) }.toString()
-            else -> syncErrorJson(failure)
-        }
+        return JetWhaleMcpResult.text(
+            when (val failure = syncMockRules(remaining)) {
+                null -> buildJsonObject { put("removedId", id) }.toString()
+                else -> syncErrorJson(failure)
+            },
+        )
     }
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockRulesCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockRulesCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.network.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockRule
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import kotlinx.serialization.json.Json
@@ -21,11 +22,13 @@ internal class SetMockRulesCommand(
 
     private val rules by serializable<List<MockRule>>("The full list of mock rules to apply, replacing the current set.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val newRules = arguments[rules]
-        return when (val failure = syncMockRules(newRules)) {
-            null -> buildJsonObject { put("rules", Json.encodeToJsonElement(newRules)) }.toString()
-            else -> syncErrorJson(failure)
-        }
+        return JetWhaleMcpResult.text(
+            when (val failure = syncMockRules(newRules)) {
+                null -> buildJsonObject { put("rules", Json.encodeToJsonElement(newRules)) }.toString()
+                else -> syncErrorJson(failure)
+            },
+        )
     }
 }

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockingEnabledCommand.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/SetMockingEnabledCommand.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.network.host
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -16,11 +17,13 @@ internal class SetMockingEnabledCommand(
 
     private val enabled by boolean("true to enable mocking, false to disable.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val enabled = arguments[this.enabled]
-        return when (val failure = syncMockingEnabled(enabled)) {
-            null -> buildJsonObject { put("enabled", enabled) }.toString()
-            else -> syncErrorJson(failure)
-        }
+        return JetWhaleMcpResult.text(
+            when (val failure = syncMockingEnabled(enabled)) {
+                null -> buildJsonObject { put("enabled", enabled) }.toString()
+                else -> syncErrorJson(failure)
+            },
+        )
     }
 }

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/McpParameterDslTest.kt
@@ -5,6 +5,8 @@ import com.kitakkun.jetwhale.host.sdk.DefaultArgumentJson
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
 import com.kitakkun.jetwhale.plugins.network.protocol.MockResponseSpec
@@ -28,9 +30,13 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+/** The text of a single-block result, which is what every command under test answers with. */
+@OptIn(ExperimentalJetWhaleApi::class)
+private val JetWhaleMcpResult.text: String get() = (content.single() as JetWhaleMcpContent.Text).text
+
 @OptIn(ExperimentalJetWhaleApi::class, ExperimentalSerializationApi::class)
 class McpParameterDslTest {
-    private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))) }
+    private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))).text }
 
     private fun JetWhaleMcpCommand.schemaOf(parameter: String): JsonObject = toDescriptor().parameters.getValue(parameter).schema
 
@@ -44,49 +50,49 @@ class McpParameterDslTest {
         override val name = "test.stringMap"
         override val description = "echoes a string map"
         val headers by stringMap("A string-to-string map.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[headers].entries.joinToString(",") { "${it.key}=${it.value}" }
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[headers].entries.joinToString(",") { "${it.key}=${it.value}" })
     }
 
     private class OptionalStringMapCommand : JetWhaleMcpCommand() {
         override val name = "test.optionalStringMap"
         override val description = "echoes an optional string map"
         val headers by stringMapOrNull("An optional string-to-string map.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[headers]?.size?.toString() ?: "absent"
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[headers]?.size?.toString() ?: "absent")
     }
 
     private class StringListCommand : JetWhaleMcpCommand() {
         override val name = "test.stringList"
         override val description = "echoes a string list"
         val items by stringList("A list of strings.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[items].joinToString(",")
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[items].joinToString(","))
     }
 
     private class JsonObjectCommand : JetWhaleMcpCommand() {
         override val name = "test.jsonObject"
         override val description = "echoes a raw json object"
         val payload by jsonObject("A raw JSON object.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[payload].toString()
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[payload].toString())
     }
 
     private class JsonArrayCommand : JetWhaleMcpCommand() {
         override val name = "test.jsonArray"
         override val description = "echoes a raw json array"
         val payload by jsonArray("A raw JSON array.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[payload].size.toString()
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[payload].size.toString())
     }
 
     private class EnumCommand : JetWhaleMcpCommand() {
         override val name = "test.enum"
         override val description = "echoes an enum"
         val matchType by enum("How the pattern is compared.", MockMatchType.entries)
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[matchType].name
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[matchType].name)
     }
 
     private class SerializableCommand : JetWhaleMcpCommand() {
         override val name = "test.serializable"
         override val description = "echoes serializable mock rules"
         val rules by serializable<List<MockRule>>("The mock rules to apply.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[rules].joinToString(",") { "${it.id}:${it.matcher.matchType}" }
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[rules].joinToString(",") { "${it.id}:${it.matcher.matchType}" })
     }
 
     // Both the advertised schema and the decoder come from this format, so they cannot disagree.
@@ -97,7 +103,7 @@ class McpParameterDslTest {
         override val name = "test.snakeCase"
         override val description = "echoes mock rules named in snake_case"
         val rules by serializable<List<MockRule>>("The mock rules to apply.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[rules].single().matcher.urlPattern
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[rules].single().matcher.urlPattern)
     }
 
     // PluginFrame is a sealed interface whose subclasses (including those of the nested sealed
@@ -106,7 +112,7 @@ class McpParameterDslTest {
         override val name = "test.sealed"
         override val description = "echoes a plugin frame"
         val frame by serializable<PluginFrame>("A plugin frame.")
-        override suspend fun execute(arguments: JetWhaleMcpArguments): String = arguments[frame].let { "${it::class.simpleName}:${it.pluginId}" }
+        override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text(arguments[frame].let { "${it::class.simpleName}:${it.pluginId}" })
     }
 
     @Test

--- a/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommandsTest.kt
+++ b/jetwhale-plugins/network/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkMcpCommandsTest.kt
@@ -4,6 +4,8 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.network.protocol.CapturedHttpRequest
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatchType
 import com.kitakkun.jetwhale.plugins.network.protocol.MockMatcher
@@ -26,6 +28,10 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+/** The text of a single-block result, which is what every command under test answers with. */
+@OptIn(ExperimentalJetWhaleApi::class)
+private val JetWhaleMcpResult.text: String get() = (content.single() as JetWhaleMcpContent.Text).text
+
 @OptIn(ExperimentalJetWhaleApi::class)
 class NetworkMcpCommandsTest {
     private fun tx(txId: String, timestampMs: Long, url: String = "https://api.example.com/$txId", method: String = "GET") = HttpTransaction(
@@ -38,7 +44,7 @@ class NetworkMcpCommandsTest {
 
     private fun execute(command: JetWhaleMcpCommand, vararg args: Pair<String, String>): String = executeJson(command, *args.map { (key, value) -> key to JsonPrimitive(value) }.toTypedArray())
 
-    private fun executeJson(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))) }
+    private fun executeJson(command: JetWhaleMcpCommand, vararg args: Pair<String, JsonElement>): String = runBlocking { command.execute(JetWhaleMcpArguments(JsonObject(args.toMap()))).text }
 
     private fun txIdsOf(result: String): List<String> = Json.parseToJsonElement(result).jsonObject
         .getValue("transactions").jsonArray
@@ -205,9 +211,9 @@ class NetworkMcpCommandsTest {
             override val name = "test.late"
             override val description = "declares a parameter inside execute"
 
-            override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+            override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
                 val late by stringOrNull("declared too late")
-                return late.name
+                return JetWhaleMcpResult.text(late.name)
             }
         }
         command.toDescriptor()
@@ -225,7 +231,7 @@ class NetworkMcpCommandsTest {
                 private val first by stringOrNull("first declaration", name = "x")
                 private val second by stringOrNull("second declaration", name = "x")
 
-                override suspend fun execute(arguments: JetWhaleMcpArguments): String = "unused"
+                override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult = JetWhaleMcpResult.text("unused")
             }
         }
         assertTrue("declared twice" in exception.message!!, exception.message!!)

--- a/jetwhale-plugins/semantics/host/api/host.api
+++ b/jetwhale-plugins/semantics/host/api/host.api
@@ -1,6 +1,6 @@
 public final class com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory : com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginFactory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun createPlugin ()Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
+	public fun createPlugin (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginContext;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
 }
 

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
 import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginUi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
@@ -26,7 +27,7 @@ import kotlin.time.TimeSource
 // Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
 @Suppress("UNUSED")
 class ComposeSemanticsInspectorPluginFactory : JetWhaleHostPluginFactory {
-    override fun createPlugin(): JetWhaleHostPlugin = ComposeNodeInspectorHostPlugin()
+    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = ComposeNodeInspectorHostPlugin()
 }
 
 @OptIn(ExperimentalJetWhaleApi::class)

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
@@ -36,7 +37,7 @@ internal class FindNodesCommand(
     private val includeInvisible by booleanOrNull("Include nodes that are not laid out or fully clipped away. Defaults to false.")
     private val limit by intOrNull("Maximum number of nodes to return, in tree order. Returns all matches if omitted.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val limit = arguments[limit]
         if (limit != null && limit <= 0) throw JetWhaleMcpArgumentException("invalid limit: $limit (expected a positive integer)")
 
@@ -60,7 +61,7 @@ internal class FindNodesCommand(
                 ),
             )
         } catch (e: JetWhaleMessagingException) {
-            return agentErrorJson(e)
+            return JetWhaleMcpResult.text(agentErrorJson(e))
         }
 
         val matches = snapshot.roots.flatMap { root ->
@@ -69,13 +70,15 @@ internal class FindNodesCommand(
         }
         val page = if (limit == null) matches else matches.take(limit)
 
-        return buildJsonObject {
-            put("nodes", JsonArray(page.map { (rootId, node) -> node.toMcpJson(rootId = rootId, includeChildren = false) }))
-            put("totalMatches", matches.size)
-            put("truncated", page.size < matches.size)
-            if (snapshot.warnings.isNotEmpty()) {
-                put("warnings", JsonArray(snapshot.warnings.map { JsonPrimitive(it) }))
-            }
-        }.toString()
+        return JetWhaleMcpResult.text(
+            buildJsonObject {
+                put("nodes", JsonArray(page.map { (rootId, node) -> node.toMcpJson(rootId = rootId, includeChildren = false) }))
+                put("totalMatches", matches.size)
+                put("truncated", page.size < matches.size)
+                if (snapshot.warnings.isNotEmpty()) {
+                    put("warnings", JsonArray(snapshot.warnings.map { JsonPrimitive(it) }))
+                }
+            }.toString(),
+        )
     }
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/GetNodeTreeCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/GetNodeTreeCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
@@ -37,7 +38,7 @@ internal class GetNodeTreeCommand(
         "Return only this root. Use it to look at just the dialog on top, for example. Returns every root if omitted.",
     )
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val snapshot = try {
             capture(
                 NodeTreeCaptureOptions(
@@ -47,7 +48,7 @@ internal class GetNodeTreeCommand(
                 ),
             )
         } catch (e: JetWhaleMessagingException) {
-            return agentErrorJson(e)
+            return JetWhaleMcpResult.text(agentErrorJson(e))
         }
 
         val requestedRootId = arguments[rootId]
@@ -64,6 +65,6 @@ internal class GetNodeTreeCommand(
             roots
         }
 
-        return snapshot.copy(roots = pruned).toMcpJson().toString()
+        return JetWhaleMcpResult.text(snapshot.copy(roots = pruned).toMcpJson().toString())
     }
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/PerformNodeActionCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/PerformNodeActionCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
@@ -40,7 +41,7 @@ internal class PerformNodeActionCommand(
     private val scrollX by intOrNull("Horizontal scroll distance in pixels for ScrollBy. Defaults to 0.")
     private val scrollY by intOrNull("Vertical scroll distance in pixels for ScrollBy. Defaults to 0.")
 
-    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
         val nodeId = arguments[nodeId]
         val action = arguments[action]
         val result: NodeActionResult
@@ -58,16 +59,18 @@ internal class PerformNodeActionCommand(
                 ),
             )
         } catch (e: JetWhaleMessagingException) {
-            return agentErrorJson(e)
+            return JetWhaleMcpResult.text(agentErrorJson(e))
         }
 
-        return buildJsonObject {
-            put("performed", result.performed)
-            put("rootId", rootId)
-            put("nodeId", nodeId)
-            put("action", action.name)
-            result.message?.let { put("message", it) }
-        }.toString()
+        return JetWhaleMcpResult.text(
+            buildJsonObject {
+                put("performed", result.performed)
+                put("rootId", rootId)
+                put("nodeId", nodeId)
+                put("action", action.name)
+                result.message?.let { put("message", it) }
+            }.toString(),
+        )
     }
 
     /**

--- a/plugins/jetwhale/skills/plugin-qa/SKILL.md
+++ b/plugins/jetwhale/skills/plugin-qa/SKILL.md
@@ -276,7 +276,9 @@ Running against a real app costs a device, and `adb` is where the time goes:
   through, and delete the output file before each run.
 
 Everything else in this document applies unchanged — the plugin's own tools take the same
-`sessionId` the built-ins do.
+`sessionId` the built-ins do, unless the plugin declares `"scope": "host"` in its manifest. A
+host-scoped plugin has one instance for the whole host, so its tools take **no `sessionId`** and can
+be called with no app connected.
 
 ## 4. Reaching the tools
 

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -36,6 +36,11 @@
             "type": "boolean",
             "description": "Whether this plugin needs an agent counterpart. true (default): available only for sessions whose agent advertised this pluginId. false: host-only (no agent, no messaging), instantiated for every active session."
           },
+          "scope": {
+            "type": "string",
+            "enum": ["session", "host"],
+            "description": "How many instances of this plugin the host creates. \"session\" (default): one instance per active debug session; its MCP tools take a sessionId. \"host\": a single instance for the whole host, created as soon as the plugin is enabled — before any app connects — whose MCP tools take no sessionId. A host-scoped plugin must also declare \"requiresAgent\": false."
+          },
           "agentVersionRange": {
             "type": "object",
             "description": "Specifies the range of agent plugin versions this host plugin is compatible with. Omit to allow all agent versions.",


### PR DESCRIPTION
## Summary

Groundwork for plugins that drive a **device or the machine** rather than an app — the first consumer will be an Android device plugin wrapping adb, which must run before the app under test is installed and must return screenshots as images. Three additions, no compatibility shims (alpha):

### 1. Host-scoped plugins
- Manifest gains `"scope": "session" | "host"` (default `session`); `scope: host` + `requiresAgent: true` is rejected at load.
- A host-scoped plugin has **one instance per host**, created when it is enabled and loaded — with zero sessions — and disposed on disable/unload; hot reload re-creates it. Session close never touches it.
- Its MCP tools are registered **without** the injected `sessionId` and dispatched straight to that instance (`McpToolRegistrar.addHostScopedPluginTool`, permission `PluginTool(name)`, attribution fixed to the plugin).
- Sidebar shows it as Enabled/Disabled regardless of the selected session; opening it uses `sessionId = null`. Popout stays session-only for now.
- `jetwhale.listInstalledPlugins` reports `scope`; `jetwhale.setPluginEnabled` reports `instantiatedForHost`.

### 2. `JetWhaleHostPluginContext`
- `createPlugin(context)` — `context.adb` (`executable`, `run(args, timeout)`, `runStreaming(args, timeout, consume)`) and `context.sessions.active`.
- One adb process runner in the host (`DefaultJetWhaleAdb`, `Dispatchers.IO`, timeout + forced destroy); `DefaultADBAutoWiringService` now uses it too.

### 3. `JetWhaleMcpResult`
- `JetWhaleMcpCommand.execute` returns text and/or image content; mapped to the MCP SDK's `TextContent` / `ImageContent`. All in-repo commands updated.

### Docs / schema / example
- `developing-plugins.md`: "Host-scoped plugins", "Host services: JetWhaleHostPluginContext", manifest table, `JetWhaleMcpResult`. `mcp-server.md` and the plugin-qa skill note that host-scoped tools take no `sessionId`. JSON schema updated.
- Example plugin: `com.kitakkun.jetwhale.example.hostscoped` (headless, one `adbVersion` tool).

## Breaking
`JetWhaleHostPluginFactory.createPlugin()` → `createPlugin(context)`; `JetWhaleMcpCommand.execute(): String` → `: JetWhaleMcpResult`. ABI dumps regenerated for host-sdk and the plugin host modules.

## Testing
- `:jetwhale-host-sdk:check`, `:jetwhale-host:core:{data,mcp}:test`, `:jetwhale-host:app:test`, all four `:jetwhale-plugins:*:host:check`, `checkKotlinAbi`, `spotlessCheck` — pass.
- New tests: host-scoped instance lifecycle (zero sessions, single instance, survives session close, disposed on disable, messaging plugin refused), reconciliation with no sessions, manifest validation (real jar), registry host-scoped dispatch, tool schema without `sessionId`, image → base64 mapping, server-level listing/calling with no session.
- Headless smoke run: enabled the example host-scoped plugin with **no session connected**; `tools/list` shows `…hostscoped.adbVersion` with schema `{"properties":{},"required":[]}`; calling it returned adb's version text. ADB auto port mapping stayed attached to `track-devices` throughout.
- Not exercised: the GUI path for a host-scoped plugin (headless run only), a host-scoped plugin *with* a UI, hot reload of one with a real jar rebuild.
