### PR TITLE
feat(android-device): Android Device plugin (adb over MCP)

### DIFF
--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -56,6 +56,7 @@ jobs:
             :jetwhale-plugins:network:agent-ktor:checkKotlinAbi \
             :jetwhale-plugins:network:agent-okhttp:checkKotlinAbi \
             :jetwhale-plugins:network:host:checkKotlinAbi \
+            :jetwhale-plugins:android-device:host:checkKotlinAbi \
             :jetwhale-plugins:nav3:protocol:checkKotlinAbi \
             :jetwhale-plugins:nav3:agent:checkKotlinAbi \
             :jetwhale-plugins:nav3:host:checkKotlinAbi \

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ from its plugin catalog, add the matching artifact to your app, and register it 
   — the Compose node tree of a running screen
 - **[Nav3 Navigator](https://kitakkun.github.io/JetWhale/guide/nav3-navigator)** — the Navigation 3
   back stack, and pushing or popping entries from the host
+- **[Android Device](https://kitakkun.github.io/JetWhale/guide/android-device)** — a connected
+  device or emulator over adb: install, launch, tap, type, screenshot, logcat, all as MCP tools
 
 ## Developing plugins
 

--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -81,6 +81,7 @@ export default defineConfig({
           { text: 'Network Inspector', link: '/guide/network-inspector' },
           { text: 'Nav3 Navigator', link: '/guide/nav3-navigator' },
           { text: 'Compose Semantics Inspector', link: '/guide/compose-semantics-inspector' },
+          { text: 'Android Device', link: '/guide/android-device' },
           { text: 'MCP Server', link: '/guide/mcp-server' },
           { text: 'Host Settings', link: '/guide/host-settings' },
           { text: 'ADB Auto Port Mapping', link: '/guide/adb-auto-port-mapping' },

--- a/docs/guide/android-device.md
+++ b/docs/guide/android-device.md
@@ -1,0 +1,197 @@
+# Android Device
+
+Android Device is an official JetWhale plugin that turns a connected device or emulator into
+[MCP](/guide/mcp-server) tools: find it, install and launch an app, tap and type at it, look at the
+screen, read the log, reset its state. An AI agent can run a whole QA pass through it without ever
+typing `adb`.
+
+- 🔌 **29 tools** covering discovery, screen, input, apps, logs, files and ports
+- 🎯 Every tool targets its device explicitly — `-s <serial>` is never left off, and with several
+  devices connected an omitted `serial` is an error rather than a guess
+- 🧾 Every result carries the exact adb argument vectors that ran, so a caller can audit what happened
+- 🚫 No arbitrary `shell` tool: each tool validates its own input, which is the point
+
+## Why not raw adb?
+
+An agent driving `adb` by hand gets four things wrong over and over: it targets the wrong device
+when two are connected, it taps coordinates that are not on the screen (which `input tap` accepts
+silently and ignores), it sends text whose spaces and quotes the shell eats, and it reads a
+`Failure [...]` line as success because the exit code was zero. Every tool here closes one of those:
+the target is resolved before the tool body runs, coordinates are checked against `wm size`, text is
+escaped for both the shell and `input text`, and install output is parsed rather than trusted.
+
+## Setup
+
+The plugin is **host-scoped**: one instance for the whole debug tool, created as soon as it is
+enabled. It needs **no agent in your app** and no session — installing the app under test is itself
+one of its tools. It is headless, so it has no screen in the host window.
+
+Install it from the host's **official catalog**: **Settings → Plugins → Add Plugins → Official
+Plugins**. See [Host Settings → Plugins](/guide/host-settings#plugins) for the other install routes.
+
+It uses the same adb executable the host resolved for its own
+[port mapping](/guide/adb-auto-port-mapping), so there is nothing to configure. If the host cannot
+find an Android SDK, every tool answers with `{"ok": false, "error": "adb is not available …"}`
+rather than failing the MCP server.
+
+## Choosing the device
+
+Every tool except `listDevices` takes an optional `serial`:
+
+| `serial` | What happens |
+|---|---|
+| Given | It must appear in `adb devices -l` in state `device`. An unknown serial, or one that is `offline` / `unauthorized`, is an argument error naming the serials that *are* known and their states. |
+| Omitted, one device connected | That device is used. |
+| Omitted, no device connected | Argument error: "no device is connected". |
+| Omitted, several devices connected | Argument error listing the serials. Nothing is picked for you. |
+
+## Reading a result
+
+Every tool answers with JSON shaped like this:
+
+```json
+{
+  "serial": "emulator-5554",
+  "ok": true,
+  "x": 540,
+  "y": 1200,
+  "adb": [
+    ["devices", "-l"],
+    ["-s", "emulator-5554", "shell", "wm", "size"],
+    ["-s", "emulator-5554", "shell", "wm", "density"],
+    ["-s", "emulator-5554", "shell", "input", "tap", "540", "1200"]
+  ]
+}
+```
+
+`adb` is the exact argument vectors that ran, in order — the audit trail. `ok` is `false` when the
+device refused the command, and the result then carries `error`, `exitCode` and the command's
+`output`. A mistake in the **call itself** (unknown serial, off-screen coordinate, text that cannot
+be typed, a path that does not exist) comes back as `{"error": "…"}` instead, without anything
+having been sent to the device.
+
+## Tools
+
+All tool names are prefixed `com.kitakkun.jetwhale.androiddevice.`. Coordinates are **screen
+pixels** unless `unit` is `DP`, in which case they are converted with the device's density.
+
+### Discovery and state
+
+| Tool | Arguments | What it does |
+|---|---|---|
+| `listDevices` | — | Lists every device adb can see: `serial`, `state`, `model`, `product`, `transportId`, `isEmulator`. Start here. |
+| `deviceInfo` | `serial?` | Model, manufacturer, Android release and SDK level, screen size and density, current rotation. |
+| `waitForDevice` | `serial?`, `timeoutSeconds?` | Waits for the device to connect and finish booting (`sys.boot_completed=1`). Defaults to 60 seconds, because adb's own wait has no timeout at all. |
+| `wake` | `serial?` | Wakes the screen and dismisses the keyguard, so a screenshot shows the app. |
+| `setRotation` | `serial?`, `rotation` | Pins the screen to `PORTRAIT`, `LANDSCAPE`, `REVERSE_PORTRAIT` or `REVERSE_LANDSCAPE`, or hands it back to the sensor with `AUTO`. |
+| `setAnimations` | `serial?`, `enabled` | Turns the three system animation scales on or off. Off makes a QA run stable — a screenshot taken mid-transition otherwise catches a half-drawn screen. |
+
+### Screen
+
+| Tool | Arguments | What it does |
+|---|---|---|
+| `screenshot` | `serial?`, `scale?`, `saveTo?` | Captures the screen and returns it as an **image block** plus a text block `{serial, width, height, scale, savedTo?}`. `scale` is a factor in `(0, 1]`, defaulting to 1 because a full-size capture is what a caller expects. `saveTo` also writes the PNG to an absolute path on the machine running the host. |
+
+::: warning Coordinates in a scaled screenshot
+`tap` takes the device's own screen pixels. A screenshot captured at `scale: 0.5` is half that size,
+so a coordinate read off it has to be doubled — or capture at full size and skip the arithmetic.
+:::
+
+### Input
+
+| Tool | Arguments | What it does |
+|---|---|---|
+| `tap` | `serial?`, `x`, `y`, `unit?` | Taps a point. Rejected if it is not on the screen, with the size in the message. |
+| `longPress` | `serial?`, `x`, `y`, `unit?`, `durationMs?` | Presses and holds. Defaults to 800 ms, which clears every platform long-press timeout (400–500 ms) with margin. |
+| `swipe` | `serial?`, `fromX`, `fromY`, `toX`, `toY`, `unit?`, `durationMs?` | Drags between two points; both ends are checked. Defaults to 300 ms, which the platform reads as a drag rather than a fling. |
+| `type` | `serial?`, `text` | Types into whatever has focus — tap the field first. Spaces and shell metacharacters are escaped for you. |
+| `key` | `serial?`, `key` | Sends a named key: `BACK`, `HOME`, `ENTER`, `TAB`, `DELETE`, `ESCAPE`, `APP_SWITCH`, `POWER`, `VOLUME_UP`, `VOLUME_DOWN`, `DPAD_UP`, `DPAD_DOWN`, `DPAD_LEFT`, `DPAD_RIGHT`, `DPAD_CENTER`, `MENU`, `SEARCH`, `CAMERA`, `WAKEUP`, `SLEEP`. |
+| `keyCode` | `serial?`, `code` | Sends a raw Android key code, for keys `key` does not name. |
+
+### Apps
+
+| Tool | Arguments | What it does |
+|---|---|---|
+| `installApk` | `serial?`, `apkPath`, `reinstall?`, `grantPermissions?` | Installs an APK from an absolute path on this machine. Both flags default to `true`, because a QA loop reinstalls the same app and should not stop on a permission dialog. Reports the `INSTALL_FAILED_*` reason, not just an exit code. |
+| `uninstallApp` | `serial?`, `packageName`, `keepData?` | Uninstalls an app. |
+| `appInfo` | `serial?`, `packageName` | `{installed, versionName, versionCode, firstInstallTime}`. |
+| `launchApp` | `serial?`, `packageName`, `activity?` | Launches the app. With no `activity`, the launcher activity is resolved first. The app is **not** force-stopped, so a warm start stays a warm start — call `stopApp` first when you want a cold one. |
+| `stopApp` | `serial?`, `packageName` | Force-stops the app. |
+| `clearAppData` | `serial?`, `packageName` | Takes the app back to a first-run state. |
+| `grantPermission` / `revokePermission` | `serial?`, `packageName`, `permission` | Grants or revokes a runtime permission. |
+| `currentActivity` | `serial?` | The foreground activity as `{packageName, activity}` — use it to confirm a launch landed. |
+| `openUrl` | `serial?`, `url`, `packageName?` | Opens a URL or deep link with `ACTION_VIEW`. Naming the package skips the chooser dialog. |
+| `startActivity` | `serial?`, `action?`, `component?`, `dataUri?`, `extras?` | A generic `am start` builder for what the tools above do not cover. Every value is quoted for the device's shell. |
+
+### Logs
+
+| Tool | Arguments | What it does |
+|---|---|---|
+| `logcat` | `serial?`, `packageName?`, `tag?`, `priority?`, `lines?`, `since?` | Reads the log and returns it as text. `packageName` selects the app's running process by pid. `lines` defaults to 200, which keeps the payload something an agent can read. `since` takes logcat's own `"MM-DD hh:mm:ss.mmm"`. Never streams — the call always terminates. |
+| `clearLogcat` | `serial?` | Empties the buffers, so the next read shows only what happened after this point. |
+
+### Files and ports
+
+| Tool | Arguments | What it does |
+|---|---|---|
+| `pushFile` | `serial?`, `hostPath`, `devicePath` | Copies a file onto the device — a fixture, a database, a config. |
+| `pullFile` | `serial?`, `devicePath`, `hostPath` | Copies a file off the device. |
+| `reversePort` | `serial?`, `devicePort`, `hostPort`, `remove?` | Maps a device port to one on this machine, for when the debug tool listens on a non-default port. |
+
+## A QA pass, end to end
+
+```text
+listDevices                        → serial: emulator-5554
+setAnimations   enabled=false      → a screenshot cannot catch a transition
+installApk      apkPath=…/app-debug.apk
+launchApp       packageName=com.example.qa.sample
+currentActivity                    → com.example.qa.sample/.MainActivity
+screenshot                         → the screen, as an image
+```
+
+From there, the [Compose Semantics Inspector](/guide/compose-semantics-inspector) turns pixels into
+structure: its `findNodes` returns each node's `bounds` **and a ready-made `tap` point in screen
+pixels**, which is exactly what this plugin's `tap` takes.
+
+```text
+semantics.findNodes  text="Sign in" → tap: {x: 540, y: 1180}
+tap                  x=540 y=1180
+type                 text="a b 'c'"
+key                  key=BACK
+logcat               packageName=com.example.qa.sample
+clearAppData         packageName=com.example.qa.sample  → back to first run
+```
+
+Pairing the two is the point: the semantics tree says *where* to tap, and this plugin does the
+tapping — no screenshot arithmetic in between.
+
+## Permissions
+
+Every tool here is a plugin tool, so the host's per-plugin
+[MCP permissions](/guide/mcp-server) apply: a host started without the plugin's tools granted does
+not offer them at all.
+
+These tools change or destroy state on the device — grant them deliberately:
+
+| Tool | What it costs |
+|---|---|
+| `uninstallApp` | The app and, unless `keepData`, everything it stored |
+| `clearAppData` | Databases, preferences, caches and granted runtime permissions |
+| `installApk` | Replaces the installed build of the same application id |
+| `stopApp` | The app's in-memory state |
+| `revokePermission` | Can restart the app's process |
+| `pushFile` | Overwrites whatever is at `devicePath` |
+
+## Limits
+
+- **`type` is printable ASCII only.** `input text` writes through the key character map, so
+  anything else is rejected with a message naming the characters rather than sent as garbage. For
+  non-ASCII input, set the text through the app — the Compose Semantics Inspector's
+  `performNodeAction` has a `SetText` action.
+- **There is no `shell` tool.** An arbitrary shell reintroduces exactly the class of mistake this
+  plugin exists to remove. `startActivity` covers the intent case; anything else is a missing tool,
+  not a missing escape hatch.
+- **No screen recording**, because an agent cannot read a video, and **no UI automator dump** — the
+  [Compose Semantics Inspector](/guide/compose-semantics-inspector) covers the tree, faster and with
+  more in it.
+- **Android only.** iOS devices are not driven by adb and are out of scope here.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -570,6 +570,7 @@ version as the host release they belong to.
 | `jetwhale-network-inspector`, `-agent`, `-agent-ktor`, `-agent-okhttp`, `-protocol` | [Network Inspector](/guide/network-inspector). |
 | `jetwhale-nav3-navigator`, `jetwhale-nav3-agent`, `jetwhale-nav3-protocol` | [Nav3 Navigator](/guide/nav3-navigator). |
 | `jetwhale-compose-semantics-inspector`, `-agent`, `-protocol` | [Compose Semantics Inspector](/guide/compose-semantics-inspector). |
+| `jetwhale-android-device` | [Android Device](/guide/android-device). Host plugin only — it drives a device over adb and needs nothing in your app. |
 
 The `-navigator` / `-inspector` artifacts (no suffix) are the **host** plugin jars — you install
 those into the host rather than into your app; see [Host Settings → Plugins](/guide/host-settings#plugins).
@@ -587,5 +588,6 @@ no watchOS/tvOS targets.
 - [Network Inspector](/guide/network-inspector) — inspect and mock HTTP traffic
 - [Compose Semantics Inspector](/guide/compose-semantics-inspector) — browse your app's Compose node tree and
   drive it by node
+- [Android Device](/guide/android-device) — install, launch and drive an Android device over adb
 - [MCP Server](/guide/mcp-server) — let AI agents drive your app
 - [Developing Plugins](/guide/developing-plugins) — build your own debugging tools

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/OfficialPluginCatalog.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/OfficialPluginCatalog.kt
@@ -60,6 +60,12 @@ object OfficialPluginCatalog {
             artifactId = "jetwhale-nav3-navigator",
         ),
         OfficialPlugin(
+            pluginId = "com.kitakkun.jetwhale.androiddevice",
+            displayName = "Android Device",
+            description = "Drive a connected Android device or emulator over adb: install, launch, tap, type, screenshot, logcat.",
+            artifactId = "jetwhale-android-device",
+        ),
+        OfficialPlugin(
             pluginId = "com.kitakkun.jetwhale.semantics",
             displayName = "Compose Semantics Inspector",
             description = "Browse and drive the Compose node tree of connected debug sessions.",

--- a/jetwhale-plugins/android-device/host/api/host.api
+++ b/jetwhale-plugins/android-device/host/api/host.api
@@ -1,0 +1,5 @@
+public final class com/kitakkun/jetwhale/plugins/androiddevice/host/AndroidDevicePluginFactory : com/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginFactory {
+	public fun <init> ()V
+	public fun createPlugin (Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPluginContext;)Lcom/kitakkun/jetwhale/host/sdk/JetWhaleHostPlugin;
+}
+

--- a/jetwhale-plugins/android-device/host/build.gradle.kts
+++ b/jetwhale-plugins/android-device/host/build.gradle.kts
@@ -1,0 +1,48 @@
+@file:OptIn(ExperimentalAbiValidation::class)
+
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
+plugins {
+    alias(libs.plugins.jvm)
+    // Provides packagePlugin / installPlugin / stageDevPlugin / runJetWhale / runJetWhaleHot (published).
+    alias(libs.plugins.jetwhalePlugin)
+    // In-repo only: adds runJetWhaleLocal, which launches the local :jetwhale-host:app project.
+    alias(libs.plugins.jetwhaleHostLaunch)
+    alias(libs.plugins.publish)
+}
+
+kotlin {
+    abiValidation {
+    }
+}
+
+// Distinct group so this module's coordinates don't collide with the other plugins' `host`.
+group = "com.kitakkun.jetwhale.plugins.androiddevice"
+
+jetwhalePlugin {
+    // Unique name so the packaged plugin jar doesn't collide with the other plugin modules (also
+    // project name "host") in ~/.jetwhale/plugins/ or the dev staging directory.
+    pluginArchiveName.set("jetwhale-android-device")
+}
+
+dependencies {
+    // Provided by the host at runtime, so compileOnly: these must be neither bundled into the
+    // plugin jar nor listed in its dependency manifest. This plugin is headless, so it needs no
+    // Compose artifacts at all.
+    compileOnly(projects.jetwhaleHostSdk)
+    compileOnly(libs.kotlinxSerializationJson)
+
+    testImplementation(projects.jetwhaleHostSdk)
+    testImplementation(libs.kotlinTest)
+    testImplementation(libs.kotlinxSerializationJson)
+    testImplementation(libs.kotlinxCoroutinesCore)
+}
+
+// The jetwhalePlugin convention publishes the `packageMavenPlugin` jar (the module's classes plus a
+// manifest of its runtime dependencies) as the main artifact; the host's "Install from Maven"
+// feature downloads it and fetches the listed dependencies itself.
+jetwhalePublish {
+    artifactId = "jetwhale-android-device"
+    name = "JetWhale Android Device"
+    description = "JetWhale host plugin that drives a connected Android device over adb and exposes it over MCP."
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/Adb.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/Adb.kt
@@ -1,0 +1,47 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdbResult
+import java.io.InputStream
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * How long each class of adb command is allowed to take. Every call this plugin makes names one of
+ * these, so a device that stops answering fails the tool instead of hanging the MCP server.
+ */
+internal object AdbTimeouts {
+    /** `devices -l`, `getprop`, `wm size` — answered from the daemon or a single property read. */
+    val QUICK = 10.seconds
+
+    /** `input`, `am start`, `settings put`, `dumpsys` — one round trip into a running system server. */
+    val SHELL = 30.seconds
+
+    /** `screencap`, `logcat -d`, `push`, `pull` — bounded but proportional to a payload. */
+    val TRANSFER = 2.minutes
+
+    /** `install`, `pm clear`, `uninstall` — the package manager rewrites storage. */
+    val PACKAGE = 5.minutes
+}
+
+/**
+ * Runs adb commands and records the exact argument vectors it ran, in order, so every tool result
+ * can report what actually happened rather than only its own summary of it.
+ */
+internal class AdbRun(private val adb: JetWhaleAdb) {
+    private val recorded = mutableListOf<List<String>>()
+
+    /** The argument vectors passed to adb so far, oldest first. */
+    val invocations: List<List<String>> get() = recorded.toList()
+
+    suspend fun exec(vararg args: String, timeout: Duration): JetWhaleAdbResult {
+        recorded += args.toList()
+        return adb.run(*args, timeout = timeout)
+    }
+
+    suspend fun <T> stream(vararg args: String, timeout: Duration, consume: suspend (InputStream) -> T): T {
+        recorded += args.toList()
+        return adb.runStreaming(*args, timeout = timeout, consume = consume)
+    }
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/AdbDevice.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/AdbDevice.kt
@@ -1,0 +1,49 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+/** One line of `adb devices -l`. */
+internal data class AdbDevice(
+    val serial: String,
+    /** adb's own connection state: `device`, `offline`, `unauthorized`, ... Only `device` is usable. */
+    val state: String,
+    val model: String?,
+    val product: String?,
+    val transportId: String?,
+) {
+    val isEmulator: Boolean get() = serial.startsWith("emulator-")
+
+    val isUsable: Boolean get() = state == USABLE_STATE
+
+    companion object {
+        /** The one state in which adb will accept commands for a device. */
+        const val USABLE_STATE = "device"
+    }
+}
+
+/**
+ * Parses `adb devices -l`. The header line and adb's own daemon chatter are skipped; a line whose
+ * second column is missing is not a device entry and is ignored.
+ */
+internal fun parseAdbDevices(output: String): List<AdbDevice> = output.lineSequence()
+    .map { it.trim() }
+    .filter { it.isNotEmpty() }
+    .filterNot { it.startsWith("List of devices") }
+    .filterNot { it.startsWith("*") }
+    .filterNot { it.startsWith("adb server") }
+    .mapNotNull { line ->
+        val columns = line.split(Regex("\\s+"))
+        if (columns.size < 2) return@mapNotNull null
+        val properties = columns.drop(2)
+            .mapNotNull { column ->
+                val separator = column.indexOf(':')
+                if (separator <= 0) null else column.substring(0, separator) to column.substring(separator + 1)
+            }
+            .toMap()
+        AdbDevice(
+            serial = columns[0],
+            state = columns[1],
+            model = properties["model"],
+            product = properties["product"],
+            transportId = properties["transport_id"],
+        )
+    }
+    .toList()

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/AndroidDeviceCommand.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/AndroidDeviceCommand.kt
@@ -1,0 +1,161 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdbResult
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdbUnavailableException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.io.InputStream
+import kotlin.time.Duration
+
+/** The tool-name prefix every command shares; it is this plugin's pluginId. */
+internal const val TOOL_PREFIX = "com.kitakkun.jetwhale.androiddevice"
+
+internal const val SERIAL_DESCRIPTION =
+    "adb serial of the device to act on, as listed by listDevices. Omit it when exactly one device " +
+        "is connected; with several connected, omitting it is an error rather than a guess."
+
+/**
+ * A tool that acts on one device. It resolves the target before the tool body runs, so no command
+ * can reach a device it did not name, and it records every adb argument vector it issues so the
+ * result can say exactly what ran.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal abstract class AndroidDeviceCommand(private val adb: JetWhaleAdb) : JetWhaleMcpCommand() {
+    // Declared here so it is the first parameter of every tool; base-class property initializers
+    // run before the subclass declares its own.
+    private val serial by stringOrNull(SERIAL_DESCRIPTION)
+
+    final override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
+        val run = AdbRun(adb)
+        return try {
+            val device = resolveDevice(run, arguments[serial])
+            executeOnDevice(arguments, DeviceTarget(device, run))
+        } catch (e: JetWhaleAdbUnavailableException) {
+            adbUnavailableResult(e)
+        }
+    }
+
+    protected abstract suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult
+}
+
+/**
+ * The resolved device plus the recorder of what has been run against it. Every adb call a tool
+ * makes goes through here, so the `-s <serial>` targeting cannot be forgotten.
+ */
+internal class DeviceTarget(
+    val device: AdbDevice,
+    private val run: AdbRun,
+) {
+    val serial: String get() = device.serial
+
+    /** Runs `adb -s <serial> <args>`. */
+    suspend fun adb(vararg args: String, timeout: Duration): JetWhaleAdbResult = run.exec("-s", serial, *args, timeout = timeout)
+
+    /** Runs `adb -s <serial> shell <args>`; the arguments reach the device joined by spaces. */
+    suspend fun shell(vararg args: String, timeout: Duration): JetWhaleAdbResult = adb("shell", *args, timeout = timeout)
+
+    /** Runs `adb -s <serial> <args>` and hands the caller raw stdout, for binary or unbounded output. */
+    suspend fun <T> stream(vararg args: String, timeout: Duration, consume: suspend (InputStream) -> T): T = run.stream("-s", serial, *args, timeout = timeout, consume = consume)
+
+    /** The adb argument vectors run so far, oldest first. */
+    val invocations: List<List<String>> get() = run.invocations
+}
+
+/**
+ * Builds a tool result: the device it acted on, whatever the tool has to say, and the adb argument
+ * vectors that produced it. `adb` comes last so the interesting part of the payload is read first.
+ */
+internal fun DeviceTarget.resultJson(build: JsonObjectBuilder.() -> Unit): String = buildJsonObject {
+    put("serial", serial)
+    build()
+    put("adb", invocations.toJson())
+}.toString()
+
+/** A tool result for an adb command the device refused: the tool ran, the device said no. */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal fun DeviceTarget.failureResult(result: JetWhaleAdbResult, error: String): JetWhaleMcpResult = JetWhaleMcpResult.text(
+    resultJson {
+        put("ok", false)
+        put("error", error)
+        put("exitCode", result.exitCode)
+        put("output", result.output.trim())
+    },
+)
+
+/** A tool result for an adb command that did what was asked. */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal fun DeviceTarget.successResult(build: JsonObjectBuilder.() -> Unit = {}): JetWhaleMcpResult = JetWhaleMcpResult.text(
+    resultJson {
+        put("ok", true)
+        build()
+    },
+)
+
+/** Fails the call unless the adb command succeeded, so a tool body never reads output of a failed command. */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal fun DeviceTarget.requireSuccess(result: JetWhaleAdbResult, error: String): JetWhaleMcpResult? = if (result.exitCode == 0) null else failureResult(result, error)
+
+internal fun List<List<String>>.toJson(): JsonArray = JsonArray(map { invocation -> JsonArray(invocation.map(::JsonPrimitive)) })
+
+/**
+ * No amount of retrying brings a missing SDK back, so this is reported as plainly as possible
+ * rather than as a device-level failure.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal fun adbUnavailableResult(e: JetWhaleAdbUnavailableException): JetWhaleMcpResult = JetWhaleMcpResult.text(
+    buildJsonObject {
+        put("ok", false)
+        put("error", "adb is not available on this machine: ${e.message}")
+    }.toString(),
+)
+
+/**
+ * Picks the device a tool acts on.
+ *
+ * A named serial must be connected and usable; an omitted one resolves only when there is exactly
+ * one candidate, because silently picking one of several is the mistake this plugin exists to
+ * prevent.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal suspend fun resolveDevice(run: AdbRun, serial: String?): AdbDevice {
+    val result = run.exec("devices", "-l", timeout = AdbTimeouts.QUICK)
+    if (result.exitCode != 0) {
+        throw JetWhaleMcpArgumentException("`adb devices -l` failed with exit code ${result.exitCode}: ${result.output.trim()}")
+    }
+    val devices = parseAdbDevices(result.output)
+
+    if (serial != null) {
+        val match = devices.firstOrNull { it.serial == serial }
+            ?: throw JetWhaleMcpArgumentException("unknown serial: $serial (${describe(devices)})")
+        if (!match.isUsable) {
+            throw JetWhaleMcpArgumentException("device $serial is in state '${match.state}', not '${AdbDevice.USABLE_STATE}'")
+        }
+        return match
+    }
+
+    val usable = devices.filter { it.isUsable }
+    return when (usable.size) {
+        1 -> usable.single()
+
+        0 -> throw JetWhaleMcpArgumentException("no device is connected (${describe(devices)})")
+
+        else -> throw JetWhaleMcpArgumentException(
+            "several devices are connected, so serial is required: ${usable.joinToString(", ") { it.serial }}",
+        )
+    }
+}
+
+private fun describe(devices: List<AdbDevice>): String = if (devices.isEmpty()) {
+    "`adb devices -l` lists no devices at all"
+} else {
+    "known devices: " + devices.joinToString(", ") { "${it.serial} (${it.state})" }
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/AndroidDevicePluginFactory.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/AndroidDevicePluginFactory.kt
@@ -1,0 +1,71 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginContext
+import com.kitakkun.jetwhale.host.sdk.JetWhaleHostPluginFactory
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+
+// Instantiated by the host via the fully-qualified name declared in plugin-manifest.json.
+@Suppress("UNUSED")
+class AndroidDevicePluginFactory : JetWhaleHostPluginFactory {
+    override fun createPlugin(context: JetWhaleHostPluginContext): JetWhaleHostPlugin = AndroidDevicePlugin(context.adb)
+}
+
+/**
+ * Drives a connected Android device or emulator over adb, as MCP tools: find it, install and launch
+ * an app, tap and type at it, look at the screen, read the log, reset its state.
+ *
+ * It is **host-scoped**, because a device exists whether or not an app is attached to the debug
+ * tool — installing the app under test is itself one of these tools — and headless, because
+ * everything it does is done by an agent rather than looked at in a window.
+ *
+ * Every tool runs through the host's own [JetWhaleAdb]. That is what makes the results auditable:
+ * there is one adb, each tool names its device explicitly, and each result carries the argument
+ * vectors it ran.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+private class AndroidDevicePlugin(adb: JetWhaleAdb) :
+    JetWhaleHostPlugin(),
+    JetWhaleMcpCapablePlugin {
+
+    override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
+        // Discovery and state
+        ListDevicesCommand(adb),
+        DeviceInfoCommand(adb),
+        WaitForDeviceCommand(adb),
+        WakeCommand(adb),
+        SetRotationCommand(adb),
+        SetAnimationsCommand(adb),
+        // Screen
+        ScreenshotCommand(adb),
+        // Input
+        TapCommand(adb),
+        LongPressCommand(adb),
+        SwipeCommand(adb),
+        TypeCommand(adb),
+        KeyCommand(adb),
+        KeyCodeCommand(adb),
+        // Apps
+        InstallApkCommand(adb),
+        UninstallAppCommand(adb),
+        AppInfoCommand(adb),
+        LaunchAppCommand(adb),
+        StopAppCommand(adb),
+        ClearAppDataCommand(adb),
+        PermissionCommand(adb, grant = true),
+        PermissionCommand(adb, grant = false),
+        CurrentActivityCommand(adb),
+        OpenUrlCommand(adb),
+        StartActivityCommand(adb),
+        // Logs
+        LogcatCommand(adb),
+        ClearLogcatCommand(adb),
+        // Files and ports
+        PushFileCommand(adb),
+        PullFileCommand(adb),
+        ReversePortCommand(adb),
+    )
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/AppCommands.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/AppCommands.kt
@@ -1,0 +1,316 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import kotlinx.serialization.json.put
+import java.io.File
+
+internal const val PACKAGE_NAME_DESCRIPTION = "Application id of the app, e.g. com.example.qa.sample."
+
+private val PACKAGE_NAME_PATTERN = Regex("[A-Za-z][A-Za-z0-9_]*(\\.[A-Za-z0-9_]+)*")
+
+/**
+ * Everything reaching the device's shell is single-quoted, so this is not about escaping — it is
+ * about failing on a value that cannot be a package name at all, rather than passing it to `pm` and
+ * reporting whatever it says.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal fun requirePackageName(value: String): String {
+    if (!PACKAGE_NAME_PATTERN.matches(value)) throw JetWhaleMcpArgumentException("invalid packageName: $value (expected an application id such as com.example.qa.sample)")
+    return value
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class InstallApkCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.installApk"
+    override val description =
+        "Installs an APK from this machine onto the device. Destructive: with reinstall it replaces " +
+            "the installed build of the same application id. Reports the install failure reason " +
+            "(INSTALL_FAILED_*) rather than only an exit code."
+
+    private val apkPath by string("Absolute path to the APK on the machine running the debug tool.")
+    private val reinstall by booleanOrNull("Pass -r to replace an already installed build. Defaults to true, because a QA loop installs the same app over and over.")
+    private val grantPermissions by booleanOrNull("Pass -g to grant every runtime permission the manifest declares. Defaults to true, so a QA run is not stopped by a permission dialog.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val apk = File(arguments[apkPath])
+        if (!apk.isAbsolute) throw JetWhaleMcpArgumentException("invalid apkPath: ${apk.path} (expected an absolute path)")
+        if (!apk.isFile) throw JetWhaleMcpArgumentException("invalid apkPath: ${apk.path} (no such file)")
+
+        val flags = buildList {
+            if (arguments[reinstall] ?: true) add("-r")
+            if (arguments[grantPermissions] ?: true) add("-g")
+        }
+        val result = target.adb("install", *flags.toTypedArray(), apk.absolutePath, timeout = AdbTimeouts.PACKAGE)
+        val failure = parseInstallFailure(result.output)
+        if (result.exitCode != 0 || failure != null) {
+            return target.failureResult(result, failure ?: "install failed")
+        }
+        return target.successResult {
+            put("apkPath", apk.absolutePath)
+            put("output", result.output.trim())
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class UninstallAppCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.uninstallApp"
+    override val description = "Uninstalls an app. Destructive: it removes the app and, unless keepData is set, everything it stored."
+
+    private val packageName by string(PACKAGE_NAME_DESCRIPTION)
+    private val keepData by booleanOrNull("Pass -k to keep the app's data and cache directories. Defaults to false, which is what \"uninstall\" normally means.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val packageName = requirePackageName(arguments[packageName])
+        val flags = if (arguments[keepData] ?: false) arrayOf("-k") else emptyArray()
+        val result = target.adb("uninstall", *flags, packageName, timeout = AdbTimeouts.PACKAGE)
+        if (result.exitCode != 0 || !result.output.contains("Success")) {
+            return target.failureResult(result, "uninstall failed")
+        }
+        return target.successResult { put("packageName", packageName) }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class AppInfoCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.appInfo"
+    override val description =
+        "Reports whether an app is installed and, when it is, its version: {installed, versionName, " +
+            "versionCode, firstInstallTime}. Use it to confirm an install took, or which build is on the device."
+
+    private val packageName by string(PACKAGE_NAME_DESCRIPTION)
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val packageName = requirePackageName(arguments[packageName])
+        val result = target.shell("dumpsys", "package", singleQuoteForShell(packageName), timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "dumpsys package was refused")?.let { return it }
+
+        val app = parseInstalledApp(result.output, packageName)
+        return target.successResult {
+            put("packageName", packageName)
+            put("installed", app != null)
+            put("versionName", app?.versionName)
+            put("versionCode", app?.versionCode)
+            put("firstInstallTime", app?.firstInstallTime)
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class LaunchAppCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.launchApp"
+    override val description =
+        "Launches an app. With no activity given, the launcher activity is resolved first and " +
+            "started by name. The app is not force-stopped beforehand, so an already running app is " +
+            "brought forward as it would be by a real launch — call stopApp first when a cold start is wanted."
+
+    private val packageName by string(PACKAGE_NAME_DESCRIPTION)
+    private val activity by stringOrNull("Activity to start, e.g. .MainActivity or com.example.qa.sample.MainActivity. Omit to use the launcher activity.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val packageName = requirePackageName(arguments[packageName])
+        val component = arguments[activity]?.let { "$packageName/$it" } ?: run {
+            val resolved = target.shell(
+                "cmd",
+                "package",
+                "resolve-activity",
+                "--brief",
+                "-c",
+                "android.intent.category.LAUNCHER",
+                singleQuoteForShell(packageName),
+                timeout = AdbTimeouts.SHELL,
+            )
+            target.requireSuccess(resolved, "resolve-activity was refused")?.let { return it }
+            val activity = parseResolvedActivity(resolved.output)
+                ?: return target.failureResult(resolved, "$packageName has no launcher activity (is it installed?)")
+            "${activity.packageName}/${activity.activity}"
+        }
+
+        val started = target.shell("am", "start", "-n", singleQuoteForShell(component), timeout = AdbTimeouts.SHELL)
+        if (started.exitCode != 0 || started.output.contains("Error:")) {
+            return target.failureResult(started, "am start failed")
+        }
+        return target.successResult {
+            put("packageName", packageName)
+            put("component", component)
+            put("output", started.output.trim())
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class StopAppCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.stopApp"
+    override val description = "Force-stops an app. Destructive to its in-memory state: the next launch is a cold start."
+
+    private val packageName by string(PACKAGE_NAME_DESCRIPTION)
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val packageName = requirePackageName(arguments[packageName])
+        val result = target.shell("am", "force-stop", singleQuoteForShell(packageName), timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "am force-stop was refused")?.let { return it }
+        return target.successResult { put("packageName", packageName) }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class ClearAppDataCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.clearAppData"
+    override val description =
+        "Clears an app's data, taking it back to a first-run state. Destructive: databases, " +
+            "preferences, caches and granted runtime permissions are all gone. The app is also stopped."
+
+    private val packageName by string(PACKAGE_NAME_DESCRIPTION)
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val packageName = requirePackageName(arguments[packageName])
+        val result = target.shell("pm", "clear", singleQuoteForShell(packageName), timeout = AdbTimeouts.PACKAGE)
+        if (result.exitCode != 0 || !result.output.contains("Success")) {
+            return target.failureResult(result, "pm clear failed")
+        }
+        return target.successResult { put("packageName", packageName) }
+    }
+}
+
+/** `pm grant` and `pm revoke` differ only in the verb, so one class covers both. */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class PermissionCommand(adb: JetWhaleAdb, private val grant: Boolean) : AndroidDeviceCommand(adb) {
+    override val name = if (grant) "$TOOL_PREFIX.grantPermission" else "$TOOL_PREFIX.revokePermission"
+    override val description = if (grant) {
+        "Grants a runtime permission to an app, so a QA run reaches the screen behind the permission dialog."
+    } else {
+        "Revokes a runtime permission from an app, to exercise the denied path. Destructive: revoking a permission can restart the app's process."
+    }
+
+    private val packageName by string(PACKAGE_NAME_DESCRIPTION)
+    private val permission by string("Full permission name, e.g. android.permission.CAMERA.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val packageName = requirePackageName(arguments[packageName])
+        val permission = arguments[permission]
+        val verb = if (grant) "grant" else "revoke"
+        val result = target.shell("pm", verb, singleQuoteForShell(packageName), singleQuoteForShell(permission), timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "pm $verb failed")?.let { return it }
+        return target.successResult {
+            put("packageName", packageName)
+            put("permission", permission)
+            put("granted", grant)
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class CurrentActivityCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.currentActivity"
+    override val description =
+        "Reports the activity in the foreground as {packageName, activity}. Use it to confirm that a " +
+            "launch or a navigation landed where it was supposed to."
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val result = target.shell("dumpsys", "activity", "activities", timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "dumpsys activity activities was refused")?.let { return it }
+
+        val top = parseTopActivity(result.output)
+        return target.successResult {
+            put("packageName", top?.packageName)
+            put("activity", top?.activity)
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class OpenUrlCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.openUrl"
+    override val description =
+        "Opens a URL or deep link with an ACTION_VIEW intent. Name the package to send it straight to " +
+            "one app instead of leaving the device to pick, which a chooser dialog would otherwise stall on."
+
+    private val url by string("The URL or deep link to open, e.g. https://example.com/orders/42 or myapp://orders/42.")
+    private val packageName by stringOrNull("Restrict the intent to this app. Omit to let the device resolve it.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val url = arguments[url]
+        if (url.isBlank()) throw JetWhaleMcpArgumentException("invalid url: it is empty")
+        val packageName = arguments[packageName]?.let(::requirePackageName)
+
+        val args = buildList {
+            add("am")
+            add("start")
+            add("-a")
+            add("android.intent.action.VIEW")
+            add("-d")
+            add(singleQuoteForShell(url))
+            if (packageName != null) {
+                add("-p")
+                add(singleQuoteForShell(packageName))
+            }
+        }
+        val result = target.shell(*args.toTypedArray(), timeout = AdbTimeouts.SHELL)
+        if (result.exitCode != 0 || result.output.contains("Error:")) {
+            return target.failureResult(result, "am start failed")
+        }
+        return target.successResult {
+            put("url", url)
+            put("packageName", packageName)
+            put("output", result.output.trim())
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class StartActivityCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.startActivity"
+    override val description =
+        "Builds and sends an arbitrary `am start` intent, for what launchApp and openUrl do not cover. " +
+            "Give at least an action or a component; every value is quoted for the device's shell. " +
+            "Extras are sent as strings (--es)."
+
+    private val action by stringOrNull("Intent action, e.g. android.intent.action.SEND.")
+    private val component by stringOrNull("Target component as package/activity, e.g. com.example.qa.sample/.MainActivity.")
+    private val dataUri by stringOrNull("Intent data URI (the -d argument).")
+    private val extras by stringMapOrNull("String extras to attach, as {\"key\": \"value\"}. Each becomes --es key value.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val action = arguments[action]
+        val component = arguments[component]
+        val dataUri = arguments[dataUri]
+        val extras = arguments[extras].orEmpty()
+        if (action == null && component == null) throw JetWhaleMcpArgumentException("give at least one of action or component; an intent with neither matches nothing")
+
+        val args = buildList {
+            add("am")
+            add("start")
+            if (action != null) {
+                add("-a")
+                add(singleQuoteForShell(action))
+            }
+            if (component != null) {
+                add("-n")
+                add(singleQuoteForShell(component))
+            }
+            if (dataUri != null) {
+                add("-d")
+                add(singleQuoteForShell(dataUri))
+            }
+            extras.forEach { (key, value) ->
+                add("--es")
+                add(singleQuoteForShell(key))
+                add(singleQuoteForShell(value))
+            }
+        }
+        val result = target.shell(*args.toTypedArray(), timeout = AdbTimeouts.SHELL)
+        if (result.exitCode != 0 || result.output.contains("Error:")) {
+            return target.failureResult(result, "am start failed")
+        }
+        return target.successResult {
+            put("action", action)
+            put("component", component)
+            put("dataUri", dataUri)
+            put("output", result.output.trim())
+        }
+    }
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/Coordinates.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/Coordinates.kt
@@ -1,0 +1,52 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+
+/** The space a pointer tool's coordinates are given in. */
+internal enum class CoordinateUnit { PX, DP }
+
+internal const val UNIT_DESCRIPTION =
+    "Unit the coordinates are given in: PX (screen pixels, the default, and what every tool here " +
+        "reports) or DP, converted with the device's density."
+
+/**
+ * What the device says its screen is, as far as it could be read. Either half can be missing on a
+ * device whose window manager does not answer, which costs validation rather than the whole call.
+ */
+internal class CoordinateSpace(
+    val size: ScreenSize?,
+    val density: Int?,
+)
+
+/** Reads `wm size` and `wm density` from the device. */
+internal suspend fun DeviceTarget.readCoordinateSpace(): CoordinateSpace {
+    val size = shell("wm", "size", timeout = AdbTimeouts.QUICK).let { if (it.exitCode == 0) parseWmSize(it.output) else null }
+    val density = shell("wm", "density", timeout = AdbTimeouts.QUICK).let { if (it.exitCode == 0) parseWmDensity(it.output) else null }
+    return CoordinateSpace(size = size, density = density)
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal fun CoordinateSpace.toPixels(value: Int, unit: CoordinateUnit): Int = when (unit) {
+    CoordinateUnit.PX -> value
+
+    CoordinateUnit.DP -> dpToPixels(
+        value,
+        density ?: throw JetWhaleMcpArgumentException("unit DP needs the device density, which `wm density` did not report; give the coordinates in pixels instead"),
+    )
+}
+
+/**
+ * Rejects a point that is not on the screen. An off-screen tap is accepted silently by
+ * `input tap` and simply does nothing, which is the failure mode this check exists to turn into an
+ * answer.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal fun CoordinateSpace.requireOnScreen(xName: String, x: Int, yName: String, y: Int) {
+    val size = size ?: return
+    if (x < 0 || x >= size.width || y < 0 || y >= size.height) {
+        throw JetWhaleMcpArgumentException(
+            "$xName=$x, $yName=$y is outside the screen, which is ${size.width}x${size.height} pixels",
+        )
+    }
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/DeviceMetrics.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/DeviceMetrics.kt
@@ -1,0 +1,58 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import kotlin.math.roundToInt
+
+/** The screen size a tap has to fall inside, in screen pixels. */
+internal data class ScreenSize(val width: Int, val height: Int)
+
+/**
+ * `wm size`. An override size is what the window manager is actually driving the screen at, so it
+ * wins over the physical size whenever one is set:
+ * ```
+ * Physical size: 1080x2400
+ * Override size: 720x1600
+ * ```
+ */
+internal fun parseWmSize(output: String): ScreenSize? {
+    val sizes = SIZE_PATTERN.findAll(output).associate { match ->
+        match.groupValues[1].lowercase() to ScreenSize(match.groupValues[2].toInt(), match.groupValues[3].toInt())
+    }
+    return sizes["override"] ?: sizes["physical"]
+}
+
+/** `wm density`, with the same override-wins rule as [parseWmSize]. */
+internal fun parseWmDensity(output: String): Int? {
+    val densities = DENSITY_PATTERN.findAll(output).associate { match ->
+        match.groupValues[1].lowercase() to match.groupValues[2].toInt()
+    }
+    return densities["override"] ?: densities["physical"]
+}
+
+/**
+ * The rotation of the default display from `dumpsys window displays`, as the `Surface.ROTATION_*`
+ * index (0, 1, 2, 3) the platform's own APIs use. The window manager spells its current rotation in
+ * **degrees** (`mCurrentRotation=ROTATION_90`), so that form is converted; `mRotation` is already an
+ * index and is read as one.
+ */
+internal fun parseRotation(output: String): Int? {
+    val degrees = ROTATION_DEGREES_PATTERN.find(output)?.groupValues?.get(1)?.toIntOrNull()
+    if (degrees != null) return DEGREES_TO_ROTATION[degrees]
+    return ROTATION_INDEX_PATTERN.find(output)?.groupValues?.get(1)?.toIntOrNull()?.takeIf { it in 0..3 }
+}
+
+/** `getprop` in its `[key]: [value]` listing form. */
+internal fun parseGetProps(output: String): Map<String, String> = GETPROP_PATTERN.findAll(output)
+    .associate { match -> match.groupValues[1] to match.groupValues[2] }
+
+/** Converts a density-independent coordinate to screen pixels the way the platform does. */
+internal fun dpToPixels(value: Int, density: Int): Int = (value * density / DEFAULT_DENSITY.toDouble()).roundToInt()
+
+/** The density at which one dp is one pixel. */
+private const val DEFAULT_DENSITY = 160
+
+private val SIZE_PATTERN = Regex("(Physical|Override) size:\\s*(\\d+)x(\\d+)", RegexOption.IGNORE_CASE)
+private val DENSITY_PATTERN = Regex("(Physical|Override) density:\\s*(\\d+)", RegexOption.IGNORE_CASE)
+private val ROTATION_DEGREES_PATTERN = Regex("mCurrentRotation=ROTATION_(\\d+)")
+private val ROTATION_INDEX_PATTERN = Regex("\\bmRotation=(\\d)\\b")
+private val DEGREES_TO_ROTATION = mapOf(0 to 0, 90 to 1, 180 to 2, 270 to 3)
+private val GETPROP_PATTERN = Regex("^\\[([^\\]]+)]: \\[(.*)]$", RegexOption.MULTILINE)

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/DiscoveryCommands.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/DiscoveryCommands.kt
@@ -1,0 +1,255 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdbUnavailableException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class ListDevicesCommand(private val adb: JetWhaleAdb) : JetWhaleMcpCommand() {
+    override val name = "$TOOL_PREFIX.listDevices"
+    override val description =
+        "Lists the Android devices and emulators adb can see: [{serial, state, model, product, " +
+            "transportId, isEmulator}]. Only a device in state \"device\" accepts commands; its " +
+            "\"serial\" is what every other tool here takes. Start a QA run with this."
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
+        val run = AdbRun(adb)
+        val result = try {
+            run.exec("devices", "-l", timeout = AdbTimeouts.QUICK)
+        } catch (e: JetWhaleAdbUnavailableException) {
+            return adbUnavailableResult(e)
+        }
+        if (result.exitCode != 0) {
+            return JetWhaleMcpResult.text(
+                buildJsonObject {
+                    put("ok", false)
+                    put("error", "`adb devices -l` failed")
+                    put("exitCode", result.exitCode)
+                    put("output", result.output.trim())
+                    put("adb", run.invocations.toJson())
+                }.toString(),
+            )
+        }
+        val devices = parseAdbDevices(result.output)
+        return JetWhaleMcpResult.text(
+            buildJsonObject {
+                putJsonArray("devices") {
+                    devices.forEach { device ->
+                        addJsonObject {
+                            put("serial", device.serial)
+                            put("state", device.state)
+                            put("model", device.model)
+                            put("product", device.product)
+                            put("transportId", device.transportId)
+                            put("isEmulator", device.isEmulator)
+                        }
+                    }
+                }
+                put("adb", run.invocations.toJson())
+            }.toString(),
+        )
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class DeviceInfoCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.deviceInfo"
+    override val description =
+        "Reports what a device is and what its screen is: model, manufacturer, Android release and " +
+            "SDK level, screen size in pixels, density, and current rotation (0=portrait, 1=90° " +
+            "counter-clockwise, 2=180°, 3=270°). The size is what tap/swipe coordinates are validated against."
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val properties = target.shell("getprop", timeout = AdbTimeouts.QUICK).let { if (it.exitCode == 0) parseGetProps(it.output) else emptyMap() }
+        val space = target.readCoordinateSpace()
+        val rotation = target.shell("dumpsys", "window", "displays", timeout = AdbTimeouts.SHELL)
+            .let { if (it.exitCode == 0) parseRotation(it.output) else null }
+
+        return JetWhaleMcpResult.text(
+            target.resultJson {
+                put("state", target.device.state)
+                put("isEmulator", target.device.isEmulator)
+                put("model", properties["ro.product.model"])
+                put("manufacturer", properties["ro.product.manufacturer"])
+                put("androidRelease", properties["ro.build.version.release"])
+                put("sdkInt", properties["ro.build.version.sdk"]?.toIntOrNull())
+                putJsonObject("screen") {
+                    put("width", space.size?.width)
+                    put("height", space.size?.height)
+                    put("density", space.density)
+                }
+                put("rotation", rotation)
+            },
+        )
+    }
+}
+
+/** adb's own `wait-for-device` waits forever, so the tool carries the deadline instead. */
+private const val DEFAULT_WAIT_SECONDS = 60
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class WaitForDeviceCommand(private val adb: JetWhaleAdb) : JetWhaleMcpCommand() {
+    override val name = "$TOOL_PREFIX.waitForDevice"
+    override val description =
+        "Waits for a device to be connected and finished booting (sys.boot_completed=1), then " +
+            "returns its serial. Use it after starting an emulator or rebooting a device, before " +
+            "installing or launching anything."
+
+    // Not the shared serial parameter: this tool is the one that runs before a device is usable,
+    // so it cannot resolve its target up front the way the others do.
+    private val serial by stringOrNull(SERIAL_DESCRIPTION)
+    private val timeoutSeconds by intOrNull(
+        "How long to wait, in seconds. Defaults to $DEFAULT_WAIT_SECONDS, because adb's own wait has no timeout at all and a stuck boot would hang the call forever.",
+    )
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): JetWhaleMcpResult {
+        val serial = arguments[this.serial]
+        val timeoutSeconds = arguments[timeoutSeconds] ?: DEFAULT_WAIT_SECONDS
+        if (timeoutSeconds <= 0) throw JetWhaleMcpArgumentException("invalid timeoutSeconds: $timeoutSeconds (expected a positive integer)")
+        val budget = timeoutSeconds.seconds
+        val startedAt = TimeSource.Monotonic.markNow()
+
+        val run = AdbRun(adb)
+        val target = if (serial == null) emptyArray() else arrayOf("-s", serial)
+        try {
+            val connected = run.exec(*target, "wait-for-device", timeout = budget)
+            if (connected.exitCode != 0) {
+                return JetWhaleMcpResult.text(
+                    buildJsonObject {
+                        put("ok", false)
+                        put("error", "wait-for-device failed")
+                        put("exitCode", connected.exitCode)
+                        put("output", connected.output.trim())
+                        put("adb", run.invocations.toJson())
+                    }.toString(),
+                )
+            }
+
+            while (true) {
+                val booted = run.exec(*target, "shell", "getprop", "sys.boot_completed", timeout = AdbTimeouts.QUICK)
+                if (booted.exitCode == 0 && booted.output.trim() == "1") break
+                if (startedAt.elapsedNow() >= budget) {
+                    return JetWhaleMcpResult.text(
+                        buildJsonObject {
+                            put("ok", false)
+                            put("error", "the device connected but sys.boot_completed did not become 1 within $timeoutSeconds seconds")
+                            put("adb", run.invocations.toJson())
+                        }.toString(),
+                    )
+                }
+                delay(BOOT_POLL_INTERVAL)
+            }
+
+            val devices = run.exec("devices", "-l", timeout = AdbTimeouts.QUICK).let { parseAdbDevices(it.output) }
+            val resolved = if (serial != null) serial else devices.singleOrNull { it.isUsable }?.serial
+            return JetWhaleMcpResult.text(
+                buildJsonObject {
+                    put("ok", true)
+                    put("serial", resolved)
+                    put("waitedMs", startedAt.elapsedNow().inWholeMilliseconds)
+                    put("adb", run.invocations.toJson())
+                }.toString(),
+            )
+        } catch (e: JetWhaleAdbUnavailableException) {
+            return adbUnavailableResult(e)
+        }
+    }
+
+    private companion object {
+        val BOOT_POLL_INTERVAL = 1.seconds
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class WakeCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.wake"
+    override val description =
+        "Wakes the screen and dismisses the keyguard, so a screenshot shows the app rather than a " +
+            "black screen or the lock screen. Safe to call when the device is already awake."
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val wake = target.shell("input", "keyevent", "KEYCODE_WAKEUP", timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(wake, "KEYCODE_WAKEUP was refused")?.let { return it }
+        val dismiss = target.shell("wm", "dismiss-keyguard", timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(dismiss, "wm dismiss-keyguard was refused")?.let { return it }
+        return target.successResult()
+    }
+}
+
+/** The rotations `settings put system user_rotation` accepts, plus letting the sensor decide. */
+internal enum class DeviceRotation(val userRotation: Int?) {
+    PORTRAIT(0),
+    LANDSCAPE(1),
+    REVERSE_PORTRAIT(2),
+    REVERSE_LANDSCAPE(3),
+
+    /** Hands rotation back to the accelerometer. */
+    AUTO(null),
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class SetRotationCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.setRotation"
+    override val description =
+        "Pins the screen to a rotation, or hands it back to the accelerometer with AUTO. Pinning " +
+            "keeps a QA run reproducible: an unpinned device rotates under the test and invalidates " +
+            "every coordinate taken from an earlier screenshot."
+
+    private val rotation by enum("The rotation to pin the screen to, or AUTO to follow the sensor again.", DeviceRotation.entries)
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val rotation = arguments[rotation]
+        val accelerometer = if (rotation == DeviceRotation.AUTO) "1" else "0"
+        val toggled = target.shell("settings", "put", "system", "accelerometer_rotation", accelerometer, timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(toggled, "could not write accelerometer_rotation")?.let { return it }
+
+        rotation.userRotation?.let { userRotation ->
+            val applied = target.shell("settings", "put", "system", "user_rotation", userRotation.toString(), timeout = AdbTimeouts.SHELL)
+            target.requireSuccess(applied, "could not write user_rotation")?.let { return it }
+        }
+        return target.successResult {
+            put("rotation", rotation.name)
+            put("userRotation", rotation.userRotation)
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class SetAnimationsCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.setAnimations"
+    override val description =
+        "Turns the system's window, transition and animator scales on or off. Turning them off makes " +
+            "a QA run stable: a screenshot taken mid-transition otherwise catches a half-drawn screen."
+
+    private val enabled by boolean("true restores the scales to 1, false sets all three to 0.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val scale = if (arguments[enabled]) "1" else "0"
+        for (setting in ANIMATION_SETTINGS) {
+            val result = target.shell("settings", "put", "global", setting, scale, timeout = AdbTimeouts.SHELL)
+            target.requireSuccess(result, "could not write $setting")?.let { return it }
+        }
+        return target.successResult {
+            put("scale", scale.toInt())
+            put("settings", JsonArray(ANIMATION_SETTINGS.map { kotlinx.serialization.json.JsonPrimitive(it) }))
+        }
+    }
+
+    private companion object {
+        val ANIMATION_SETTINGS = listOf("window_animation_scale", "transition_animation_scale", "animator_duration_scale")
+    }
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/FileCommands.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/FileCommands.kt
@@ -1,0 +1,103 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import kotlinx.serialization.json.put
+import java.io.File
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class PushFileCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.pushFile"
+    override val description =
+        "Copies a file from this machine onto the device — a fixture, a database, a config. " +
+            "Destructive: an existing file at devicePath is overwritten."
+
+    private val hostPath by string("Absolute path of the source file on the machine running the debug tool.")
+    private val devicePath by string("Destination path on the device, e.g. /sdcard/Download/fixture.json.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val source = File(arguments[hostPath])
+        if (!source.isAbsolute) throw JetWhaleMcpArgumentException("invalid hostPath: ${source.path} (expected an absolute path)")
+        if (!source.exists()) throw JetWhaleMcpArgumentException("invalid hostPath: ${source.path} (no such file)")
+        val devicePath = requireDevicePath(arguments[devicePath])
+
+        val result = target.adb("push", source.absolutePath, devicePath, timeout = AdbTimeouts.TRANSFER)
+        target.requireSuccess(result, "adb push failed")?.let { return it }
+        return target.successResult {
+            put("hostPath", source.absolutePath)
+            put("devicePath", devicePath)
+            put("output", result.output.trim())
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class PullFileCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.pullFile"
+    override val description = "Copies a file off the device onto this machine — a log, a database, a crash dump. An existing file at hostPath is overwritten."
+
+    private val devicePath by string("Path of the source file on the device, e.g. /sdcard/Download/report.txt.")
+    private val hostPath by string("Absolute destination path on the machine running the debug tool. Its parent directory must exist.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val devicePath = requireDevicePath(arguments[devicePath])
+        val destination = File(arguments[hostPath])
+        if (!destination.isAbsolute) throw JetWhaleMcpArgumentException("invalid hostPath: ${destination.path} (expected an absolute path)")
+        if (destination.parentFile?.isDirectory != true) throw JetWhaleMcpArgumentException("invalid hostPath: ${destination.path} (its parent directory does not exist)")
+
+        val result = target.adb("pull", devicePath, destination.absolutePath, timeout = AdbTimeouts.TRANSFER)
+        target.requireSuccess(result, "adb pull failed")?.let { return it }
+        return target.successResult {
+            put("devicePath", devicePath)
+            put("hostPath", destination.absolutePath)
+            put("bytes", destination.length())
+            put("output", result.output.trim())
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class ReversePortCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.reversePort"
+    override val description =
+        "Maps a port on the device to a port on this machine, so an app can reach a server running " +
+            "here. Needed when the debug tool listens on a non-default port, or for any other local service."
+
+    private val devicePort by int("Port the app connects to on the device.")
+    private val hostPort by int("Port the traffic is forwarded to on the machine running the debug tool.")
+    private val remove by booleanOrNull("Remove the mapping for devicePort instead of creating one. Defaults to false; hostPort is ignored when it is true.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val devicePort = requirePort("devicePort", arguments[devicePort])
+        val hostPort = requirePort("hostPort", arguments[hostPort])
+        val remove = arguments[remove] ?: false
+
+        val result = if (remove) {
+            target.adb("reverse", "--remove", "tcp:$devicePort", timeout = AdbTimeouts.QUICK)
+        } else {
+            target.adb("reverse", "tcp:$devicePort", "tcp:$hostPort", timeout = AdbTimeouts.QUICK)
+        }
+        target.requireSuccess(result, if (remove) "adb reverse --remove failed" else "adb reverse failed")?.let { return it }
+        return target.successResult {
+            put("devicePort", devicePort)
+            put("hostPort", if (remove) null else hostPort)
+            put("removed", remove)
+        }
+    }
+}
+
+/** adb resolves a relative device path against whatever `adb shell`'s working directory happens to be, which is not something a QA run should depend on. */
+@OptIn(ExperimentalJetWhaleApi::class)
+private fun requireDevicePath(value: String): String {
+    if (!value.startsWith("/")) throw JetWhaleMcpArgumentException("invalid device path: $value (expected an absolute path such as /sdcard/Download/file.json)")
+    return value
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+private fun requirePort(name: String, value: Int): Int {
+    if (value !in 1..65535) throw JetWhaleMcpArgumentException("invalid $name: $value (expected a port between 1 and 65535)")
+    return value
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/InputCommands.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/InputCommands.kt
@@ -1,0 +1,201 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import kotlinx.serialization.json.put
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class TapCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.tap"
+    override val description =
+        "Taps a point on the screen. Coordinates are screen pixels unless unit is DP, and are " +
+            "checked against the device's screen size — an off-screen tap is rejected instead of " +
+            "being swallowed silently by the device."
+
+    private val x by int("Horizontal coordinate, measured from the left edge.")
+    private val y by int("Vertical coordinate, measured from the top edge.")
+    private val unit by enumOrNull(UNIT_DESCRIPTION, CoordinateUnit.entries)
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val space = target.readCoordinateSpace()
+        val unit = arguments[unit] ?: CoordinateUnit.PX
+        val x = space.toPixels(arguments[x], unit)
+        val y = space.toPixels(arguments[y], unit)
+        space.requireOnScreen("x", x, "y", y)
+
+        val result = target.shell("input", "tap", x.toString(), y.toString(), timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "input tap was refused")?.let { return it }
+        return target.successResult {
+            put("x", x)
+            put("y", y)
+        }
+    }
+}
+
+/**
+ * The platform's long-press timeout is 400–500ms depending on the build; 800ms is safely past every
+ * one of them without making a QA run noticeably slower.
+ */
+private const val DEFAULT_LONG_PRESS_MS = 800
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class LongPressCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.longPress"
+    override val description =
+        "Presses and holds a point, as a zero-length swipe of a given duration. Use it for context " +
+            "menus, drag handles and anything else a plain tap does not trigger."
+
+    private val x by int("Horizontal coordinate, measured from the left edge.")
+    private val y by int("Vertical coordinate, measured from the top edge.")
+    private val unit by enumOrNull(UNIT_DESCRIPTION, CoordinateUnit.entries)
+    private val durationMs by intOrNull(
+        "How long to hold, in milliseconds. Defaults to $DEFAULT_LONG_PRESS_MS, which clears every " +
+            "platform long-press timeout (400–500ms) with margin.",
+    )
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val space = target.readCoordinateSpace()
+        val unit = arguments[unit] ?: CoordinateUnit.PX
+        val x = space.toPixels(arguments[x], unit)
+        val y = space.toPixels(arguments[y], unit)
+        space.requireOnScreen("x", x, "y", y)
+        val durationMs = arguments[durationMs] ?: DEFAULT_LONG_PRESS_MS
+        if (durationMs <= 0) throw JetWhaleMcpArgumentException("invalid durationMs: $durationMs (expected a positive integer)")
+
+        val result = target.shell("input", "swipe", x.toString(), y.toString(), x.toString(), y.toString(), durationMs.toString(), timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "input swipe was refused")?.let { return it }
+        return target.successResult {
+            put("x", x)
+            put("y", y)
+            put("durationMs", durationMs)
+        }
+    }
+}
+
+/** Long enough for the platform to read it as a drag rather than a fling, short enough not to stall a run. */
+private const val DEFAULT_SWIPE_MS = 300
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class SwipeCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.swipe"
+    override val description =
+        "Drags from one point to another. Both ends are checked against the device's screen size. " +
+            "A shorter duration reads as a fling, a longer one as a deliberate drag."
+
+    private val fromX by int("Horizontal coordinate to start from.")
+    private val fromY by int("Vertical coordinate to start from.")
+    private val toX by int("Horizontal coordinate to end at.")
+    private val toY by int("Vertical coordinate to end at.")
+    private val unit by enumOrNull(UNIT_DESCRIPTION, CoordinateUnit.entries)
+    private val durationMs by intOrNull("How long the gesture takes, in milliseconds. Defaults to $DEFAULT_SWIPE_MS, which the platform reads as a drag rather than a fling.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val space = target.readCoordinateSpace()
+        val unit = arguments[unit] ?: CoordinateUnit.PX
+        val fromX = space.toPixels(arguments[fromX], unit)
+        val fromY = space.toPixels(arguments[fromY], unit)
+        val toX = space.toPixels(arguments[toX], unit)
+        val toY = space.toPixels(arguments[toY], unit)
+        space.requireOnScreen("fromX", fromX, "fromY", fromY)
+        space.requireOnScreen("toX", toX, "toY", toY)
+        val durationMs = arguments[durationMs] ?: DEFAULT_SWIPE_MS
+        if (durationMs <= 0) throw JetWhaleMcpArgumentException("invalid durationMs: $durationMs (expected a positive integer)")
+
+        val result = target.shell("input", "swipe", fromX.toString(), fromY.toString(), toX.toString(), toY.toString(), durationMs.toString(), timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "input swipe was refused")?.let { return it }
+        return target.successResult {
+            put("fromX", fromX)
+            put("fromY", fromY)
+            put("toX", toX)
+            put("toY", toY)
+            put("durationMs", durationMs)
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class TypeCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.type"
+    override val description =
+        "Types text into whatever currently has focus — tap the field first. Spaces and shell " +
+            "metacharacters are escaped for you. Only printable ASCII can be typed: `input text` " +
+            "writes through the key character map, so anything else is rejected rather than sent as garbage."
+
+    private val text by string("The text to type. Printable ASCII only.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val text = arguments[text]
+        val unsupported = unsupportedInputTextCharacters(text)
+        if (unsupported.isNotEmpty()) {
+            throw JetWhaleMcpArgumentException(
+                "invalid text: `input text` can only type printable ASCII, and this contains " +
+                    unsupported.joinToString(", ") { "'$it' (U+%04X)".format(it.code) },
+            )
+        }
+
+        val result = target.shell("input", "text", escapeForInputText(text), timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "input text was refused")?.let { return it }
+        return target.successResult {
+            put("text", text)
+            put("characters", text.length)
+        }
+    }
+}
+
+/** The key events a QA run reaches for; anything else goes through keyCode. */
+internal enum class DeviceKey {
+    BACK,
+    HOME,
+    ENTER,
+    TAB,
+    DELETE,
+    ESCAPE,
+    APP_SWITCH,
+    POWER,
+    VOLUME_UP,
+    VOLUME_DOWN,
+    DPAD_UP,
+    DPAD_DOWN,
+    DPAD_LEFT,
+    DPAD_RIGHT,
+    DPAD_CENTER,
+    MENU,
+    SEARCH,
+    CAMERA,
+    WAKEUP,
+    SLEEP,
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class KeyCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.key"
+    override val description = "Sends one of the key events a QA run needs by name. For anything outside this list, use keyCode."
+
+    private val key by enum("The key to send; it is sent as KEYCODE_<name>.", DeviceKey.entries)
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val keyCode = "KEYCODE_${arguments[key].name}"
+        val result = target.shell("input", "keyevent", keyCode, timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "input keyevent was refused")?.let { return it }
+        return target.successResult { put("key", keyCode) }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class KeyCodeCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.keyCode"
+    override val description = "Sends a raw Android key code, for the keys the `key` tool does not name."
+
+    private val code by int("Android KeyEvent key code, e.g. 82 for KEYCODE_MENU.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val code = arguments[code]
+        if (code < 0) throw JetWhaleMcpArgumentException("invalid code: $code (expected a non-negative integer)")
+        val result = target.shell("input", "keyevent", code.toString(), timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "input keyevent was refused")?.let { return it }
+        return target.successResult { put("code", code) }
+    }
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/LogCommands.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/LogCommands.kt
@@ -1,0 +1,86 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import kotlinx.serialization.json.put
+
+/** Log priorities, lowest first, as `logcat` spells them in a `TAG:PRIORITY` filter. */
+internal enum class LogPriority { V, D, I, W, E, F }
+
+/** Bounded by default so a tool result stays something an AI agent can actually read. */
+private const val DEFAULT_LOG_LINES = 200
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class LogcatCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.logcat"
+    override val description =
+        "Reads the device log and returns it as text, newest last. Narrow it with packageName (the " +
+            "app's current process), tag, and priority; the buffer is never streamed, so the call " +
+            "always terminates."
+
+    private val packageName by stringOrNull("Only show lines from this app's running process. The app has to be running for its pid to exist.")
+    private val tag by stringOrNull("Only show lines with this log tag.")
+    private val priority by enumOrNull("Lowest priority to show: V, D, I, W, E or F.", LogPriority.entries)
+    private val lines by intOrNull("How many of the most recent lines to return. Defaults to $DEFAULT_LOG_LINES, which keeps the payload something an agent can read. Ignored when since is given.")
+    private val since by stringOrNull("Only show lines after this time, as logcat writes it: \"MM-DD hh:mm:ss.mmm\".")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val packageName = arguments[packageName]?.let(::requirePackageName)
+        val tag = arguments[tag]
+        val priority = arguments[priority]
+        val lines = arguments[lines] ?: DEFAULT_LOG_LINES
+        if (lines <= 0) throw JetWhaleMcpArgumentException("invalid lines: $lines (expected a positive integer)")
+        val since = arguments[since]
+
+        val pid = if (packageName == null) {
+            null
+        } else {
+            val pidof = target.shell("pidof", singleQuoteForShell(packageName), timeout = AdbTimeouts.QUICK)
+            parsePid(pidof.output)
+                ?: return target.failureResult(pidof, "$packageName has no running process, so its log lines cannot be selected by pid; drop packageName to read the whole buffer")
+        }
+
+        val args = buildList {
+            add("logcat")
+            add("-d")
+            add("-t")
+            add(if (since != null) singleQuoteForShell(since) else lines.toString())
+            if (pid != null) {
+                add("--pid")
+                add(pid.toString())
+            }
+            // A tag filter only takes effect together with a `*:S` default that silences everything else.
+            if (tag != null) {
+                add(singleQuoteForShell("$tag:${(priority ?: LogPriority.V).name}"))
+                add(singleQuoteForShell("*:S"))
+            } else if (priority != null) {
+                add(singleQuoteForShell("*:${priority.name}"))
+            }
+        }
+
+        val result = target.shell(*args.toTypedArray(), timeout = AdbTimeouts.TRANSFER)
+        target.requireSuccess(result, "logcat was refused")?.let { return it }
+
+        val log = result.output.trim()
+        return target.successResult {
+            put("pid", pid)
+            put("lineCount", if (log.isEmpty()) 0 else log.lines().size)
+            put("log", log)
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class ClearLogcatCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.clearLogcat"
+    override val description = "Empties the device log buffers, so the next logcat call shows only what happened after this point."
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val result = target.shell("logcat", "-c", timeout = AdbTimeouts.SHELL)
+        target.requireSuccess(result, "logcat -c was refused")?.let { return it }
+        return target.successResult()
+    }
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/Parsers.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/Parsers.kt
@@ -1,0 +1,71 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+/** What `dumpsys package <pkg>` says about an installed package. */
+internal data class InstalledApp(
+    val versionName: String?,
+    val versionCode: Long?,
+    val firstInstallTime: String?,
+)
+
+/**
+ * `dumpsys package <pkg>`. The package is installed when the dump contains its own
+ * `Package [<name>]` block; a package that is not installed produces a dump with no such block
+ * (and, on most builds, an "Unable to find package" line).
+ */
+internal fun parseInstalledApp(output: String, packageName: String): InstalledApp? {
+    if (!output.contains("Package [$packageName]")) return null
+    return InstalledApp(
+        // `dumpsys` prints the string "null" for a version name the manifest does not set.
+        versionName = VERSION_NAME_PATTERN.find(output)?.groupValues?.get(1)?.trim()?.takeUnless { it == "null" },
+        versionCode = VERSION_CODE_PATTERN.find(output)?.groupValues?.get(1)?.toLongOrNull(),
+        firstInstallTime = FIRST_INSTALL_TIME_PATTERN.find(output)?.groupValues?.get(1)?.trim(),
+    )
+}
+
+/** The activity the device reports as being in the foreground. */
+internal data class TopActivity(
+    val packageName: String,
+    val activity: String,
+)
+
+/**
+ * `dumpsys activity activities`. Recent builds report `topResumedActivity`; older ones only
+ * `mResumedActivity`, so both are read and the first one found wins.
+ */
+internal fun parseTopActivity(output: String): TopActivity? {
+    val record = TOP_RESUMED_PATTERN.find(output) ?: RESUMED_PATTERN.find(output) ?: return null
+    return TopActivity(packageName = record.groupValues[1], activity = record.groupValues[2])
+}
+
+/**
+ * `cmd package resolve-activity --brief`. The brief form prints the resolved `package/activity` on
+ * its own line after a line of matching metadata; nothing resolved means no such line.
+ */
+internal fun parseResolvedActivity(output: String): TopActivity? {
+    val line = output.lineSequence()
+        .map { it.trim() }
+        .lastOrNull { it.matches(COMPONENT_LINE_PATTERN) }
+        ?: return null
+    val (packageName, activity) = line.split('/', limit = 2)
+    return TopActivity(packageName = packageName, activity = activity)
+}
+
+/**
+ * `adb install`. adb exits non-zero on most failures, but some builds report `Failure [REASON]` on
+ * a zero exit, so the output is read as well as the exit code.
+ */
+internal fun parseInstallFailure(output: String): String? {
+    INSTALL_FAILURE_PATTERN.find(output)?.let { return it.groupValues[1] }
+    return output.lineSequence().map { it.trim() }.firstOrNull { it.startsWith("adb: failed to install") }
+}
+
+/** `pidof <pkg>` prints the matching pids on one line, or nothing when the app is not running. */
+internal fun parsePid(output: String): Int? = output.trim().split(Regex("\\s+")).firstOrNull()?.toIntOrNull()
+
+private val VERSION_NAME_PATTERN = Regex("versionName=(.*)")
+private val VERSION_CODE_PATTERN = Regex("versionCode=(\\d+)")
+private val FIRST_INSTALL_TIME_PATTERN = Regex("firstInstallTime=(.*)")
+private val TOP_RESUMED_PATTERN = Regex("topResumedActivity=ActivityRecord\\{[^ ]+ [^ ]+ ([^/ ]+)/([^ }]+)")
+private val RESUMED_PATTERN = Regex("mResumedActivity:? ?ActivityRecord\\{[^ ]+ [^ ]+ ([^/ ]+)/([^ }]+)")
+private val COMPONENT_LINE_PATTERN = Regex("[A-Za-z0-9_.]+/[A-Za-z0-9_.$]+")
+private val INSTALL_FAILURE_PATTERN = Regex("Failure \\[([^]]*)]")

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/ScreenshotCommand.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/ScreenshotCommand.kt
@@ -1,0 +1,92 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import kotlinx.serialization.json.put
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class ScreenshotCommand(adb: JetWhaleAdb) : AndroidDeviceCommand(adb) {
+    override val name = "$TOOL_PREFIX.screenshot"
+    override val description =
+        "Captures the device screen as a PNG and returns it as an image block, plus a text block " +
+            "{serial, width, height, savedTo?, adb}. The reported width and height are of the " +
+            "returned image; tap coordinates are in the device's own screen pixels, so read a scaled " +
+            "screenshot's coordinates back through the scale, or capture at full size."
+
+    private val scale by serializableOrNull<Double>(
+        "Downscale factor in (0, 1]; defaults to 1, because a full-size capture is what a caller " +
+            "expects unless it asks for less. Only shrinks — the device is never captured larger than it is.",
+    )
+    private val saveTo by stringOrNull("Absolute path on the machine running the debug tool to also write the PNG to. The parent directory must exist.")
+
+    override suspend fun executeOnDevice(arguments: JetWhaleMcpArguments, target: DeviceTarget): JetWhaleMcpResult {
+        val scale = arguments[scale] ?: 1.0
+        if (scale <= 0.0 || scale > 1.0) throw JetWhaleMcpArgumentException("invalid scale: $scale (expected a value greater than 0 and at most 1)")
+        val saveTo = arguments[saveTo]?.let { path ->
+            val file = File(path)
+            if (!file.isAbsolute) throw JetWhaleMcpArgumentException("invalid saveTo: $path (expected an absolute path)")
+            if (file.parentFile?.isDirectory != true) throw JetWhaleMcpArgumentException("invalid saveTo: $path (its parent directory does not exist)")
+            file
+        }
+
+        val captured = target.stream("exec-out", "screencap", "-p", timeout = AdbTimeouts.TRANSFER) { it.readBytes() }
+        val decoded = ImageIO.read(ByteArrayInputStream(captured))
+            ?: return JetWhaleMcpResult.text(
+                target.resultJson {
+                    put("ok", false)
+                    put("error", "screencap returned ${captured.size} bytes that are not a readable PNG")
+                },
+            )
+
+        val png = if (scale == 1.0) captured else encodePng(decoded.scaledBy(scale))
+        val image = if (scale == 1.0) decoded else ImageIO.read(ByteArrayInputStream(png))
+        saveTo?.writeBytes(png)
+
+        return JetWhaleMcpResult(
+            listOf(
+                JetWhaleMcpContent.Image(png, "image/png"),
+                JetWhaleMcpContent.Text(
+                    target.resultJson {
+                        put("ok", true)
+                        put("width", image.width)
+                        put("height", image.height)
+                        put("scale", scale)
+                        put("savedTo", saveTo?.absolutePath)
+                    },
+                ),
+            ),
+        )
+    }
+}
+
+/** At least one pixel each way, so a very small scale still produces an image rather than a failure. */
+private fun BufferedImage.scaledBy(scale: Double): BufferedImage {
+    val targetWidth = max(1, (width * scale).roundToInt())
+    val targetHeight = max(1, (height * scale).roundToInt())
+    val scaled = BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_ARGB)
+    val graphics = scaled.createGraphics()
+    try {
+        graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+        graphics.drawImage(this, 0, 0, targetWidth, targetHeight, null)
+    } finally {
+        graphics.dispose()
+    }
+    return scaled
+}
+
+private fun encodePng(image: BufferedImage): ByteArray = ByteArrayOutputStream().use { bytes ->
+    ImageIO.write(image, "png", bytes)
+    bytes.toByteArray()
+}

--- a/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/Shell.kt
+++ b/jetwhale-plugins/android-device/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/Shell.kt
@@ -1,0 +1,33 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+/**
+ * Wraps a value in single quotes for the device's shell, so nothing in it is expanded, split or
+ * redirected. A single quote inside the value ends the quoting, emits an escaped quote, and starts
+ * it again — the only way to carry one through `sh`.
+ */
+internal fun singleQuoteForShell(value: String): String = "'" + value.replace("'", "'\\''") + "'"
+
+/**
+ * `input text` receives its argument through the device's shell and then splits it on spaces
+ * itself, so a typed string has to survive both: spaces become `%s`, and the characters the shell
+ * would otherwise act on are backslash-escaped.
+ */
+internal fun escapeForInputText(text: String): String = buildString {
+    for (character in text) {
+        when {
+            character == ' ' -> append("%s")
+            character in SHELL_SPECIAL_CHARACTERS -> append('\\').append(character)
+            else -> append(character)
+        }
+    }
+}
+
+/**
+ * `input text` writes its argument through the key character map, which only covers printable
+ * ASCII: anything outside it is dropped or turned into a different character rather than typed.
+ */
+internal fun unsupportedInputTextCharacters(text: String): List<Char> = text.filterNot { it in PRINTABLE_ASCII }.toSet().toList()
+
+private val SHELL_SPECIAL_CHARACTERS = setOf('\\', '\'', '"', '&', '<', '>', '(', ')', '|', ';', '$', '`')
+
+private val PRINTABLE_ASCII = ' '..'~'

--- a/jetwhale-plugins/android-device/host/src/main/resources/META-INF/jetwhale/plugin-manifest.json
+++ b/jetwhale-plugins/android-device/host/src/main/resources/META-INF/jetwhale/plugin-manifest.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../../../../../../../../schemas/plugin-manifest.schema.json",
+  "plugins": [
+    {
+      "pluginId": "com.kitakkun.jetwhale.androiddevice",
+      "pluginName": "Android Device",
+      "version": "1.0.0",
+      "factoryClass": "com.kitakkun.jetwhale.plugins.androiddevice.host.AndroidDevicePluginFactory",
+      "requiresAgent": false,
+      "scope": "host",
+      "icon": {
+        "activePath": "icons/android_device_filled.svg",
+        "inactivePath": "icons/android_device_outlined.svg"
+      }
+    }
+  ]
+}

--- a/jetwhale-plugins/android-device/host/src/main/resources/icons/android_device_filled.svg
+++ b/jetwhale-plugins/android-device/host/src/main/resources/icons/android_device_filled.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path d="M7 1H17C18.1046 1 19 1.89543 19 3V21C19 22.1046 18.1046 23 17 23H7C5.89543 23 5 22.1046 5 21V3C5 1.89543 5.89543 1 7 1ZM10 19V21H14V19H10Z"></path></svg>

--- a/jetwhale-plugins/android-device/host/src/main/resources/icons/android_device_outlined.svg
+++ b/jetwhale-plugins/android-device/host/src/main/resources/icons/android_device_outlined.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path d="M7 1H17C18.1046 1 19 1.89543 19 3V21C19 22.1046 18.1046 23 17 23H7C5.89543 23 5 22.1046 5 21V3C5 1.89543 5.89543 1 7 1ZM7 3V21H17V3H7ZM10 18H14V20H10V18Z"></path></svg>

--- a/jetwhale-plugins/android-device/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/CommandTest.kt
+++ b/jetwhale-plugins/android-device/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/CommandTest.kt
@@ -1,0 +1,415 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpContent
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpResult
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalJetWhaleApi::class)
+private fun JetWhaleMcpCommand.call(build: JsonObjectBuilder.() -> Unit = {}): JetWhaleMcpResult = runBlocking {
+    execute(JetWhaleMcpArguments(buildJsonObject(build)))
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+private fun JetWhaleMcpResult.textJson(): JsonObject = kotlinx.serialization.json.Json
+    .parseToJsonElement(content.filterIsInstance<JetWhaleMcpContent.Text>().single().text)
+    .jsonObject
+
+/** The screen every device fixture reports, so a coordinate assertion has something to be out of. */
+private val SCREEN_RULES = listOf(
+    reply("wm size", "Physical size: 1080x2400\n"),
+    reply("wm density", "Physical density: 440\n"),
+)
+
+private fun devicesRule(output: String = ONE_DEVICE_ATTACHED) = reply("devices -l", output)
+
+@OptIn(ExperimentalJetWhaleApi::class)
+class DeviceTargetingTest {
+    @Test
+    fun `resolves the single connected device when no serial is given`() {
+        val adb = FakeAdb(listOf(devicesRule()) + SCREEN_RULES)
+
+        val json = TapCommand(adb).call {
+            put("x", 10)
+            put("y", 20)
+        }.textJson()
+
+        assertEquals(TEST_SERIAL, json["serial"]?.jsonPrimitive?.content)
+        assertTrue(adb.commands.any { it == "-s $TEST_SERIAL shell input tap 10 20" })
+    }
+
+    @Test
+    fun `refuses a serial no device is listed under, and names the ones that are`() {
+        val adb = FakeAdb(listOf(devicesRule()) + SCREEN_RULES)
+
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            TapCommand(adb).call {
+                put("serial", "emulator-9999")
+                put("x", 10)
+                put("y", 20)
+            }
+        }
+
+        assertTrue(error.message!!.contains("unknown serial: emulator-9999"))
+        assertTrue(error.message!!.contains("$TEST_SERIAL (device)"))
+    }
+
+    @Test
+    fun `refuses a device that is listed but not in state device`() {
+        val adb = FakeAdb(listOf(devicesRule("List of devices attached\n$TEST_SERIAL          offline\n")))
+
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            TapCommand(adb).call {
+                put("serial", TEST_SERIAL)
+                put("x", 10)
+                put("y", 20)
+            }
+        }
+
+        assertTrue(error.message!!.contains("state 'offline'"))
+    }
+
+    @Test
+    fun `refuses to guess when several devices are connected`() {
+        val adb = FakeAdb(
+            listOf(
+                devicesRule(
+                    "List of devices attached\n" +
+                        "emulator-5554          device transport_id:1\n" +
+                        "emulator-5556          device transport_id:2\n",
+                ),
+            ),
+        )
+
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            TapCommand(adb).call {
+                put("x", 10)
+                put("y", 20)
+            }
+        }
+
+        assertTrue(error.message!!.contains("several devices"))
+        assertTrue(error.message!!.contains("emulator-5556"))
+    }
+
+    @Test
+    fun `says so when no device is connected at all`() {
+        val adb = FakeAdb(listOf(devicesRule("List of devices attached\n")))
+
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            TapCommand(adb).call {
+                put("x", 10)
+                put("y", 20)
+            }
+        }
+
+        assertTrue(error.message!!.contains("no device is connected"))
+    }
+
+    @Test
+    fun `reports the adb argument vectors it ran, in order`() {
+        val adb = FakeAdb(listOf(devicesRule()) + SCREEN_RULES)
+
+        val json = TapCommand(adb).call {
+            put("x", 10)
+            put("y", 20)
+        }.textJson()
+
+        val ran = json["adb"]!!.jsonArray.map { vector -> vector.jsonArray.map { it.jsonPrimitive.content } }
+        assertEquals(listOf("devices", "-l"), ran.first())
+        assertEquals(listOf("-s", TEST_SERIAL, "shell", "input", "tap", "10", "20"), ran.last())
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+class PointerInputTest {
+    @Test
+    fun `rejects a tap that would land off the screen, naming the size`() {
+        val adb = FakeAdb(listOf(devicesRule()) + SCREEN_RULES)
+
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            TapCommand(adb).call {
+                put("x", 1080)
+                put("y", 100)
+            }
+        }
+
+        assertTrue(error.message!!.contains("1080x2400"))
+        assertFalse(adb.commands.any { it.contains("input tap") })
+    }
+
+    @Test
+    fun `converts dp coordinates with the device density`() {
+        val adb = FakeAdb(listOf(devicesRule()) + SCREEN_RULES)
+
+        TapCommand(adb).call {
+            put("x", 100)
+            put("y", 200)
+            put("unit", "DP")
+        }
+
+        assertTrue(adb.commands.any { it.endsWith("input tap 275 550") })
+    }
+
+    @Test
+    fun `holds a long press past the platform's long-press timeout`() {
+        val adb = FakeAdb(listOf(devicesRule()) + SCREEN_RULES)
+
+        LongPressCommand(adb).call {
+            put("x", 10)
+            put("y", 20)
+        }
+
+        assertTrue(adb.commands.any { it.endsWith("input swipe 10 20 10 20 800") })
+    }
+
+    @Test
+    fun `checks both ends of a swipe`() {
+        val adb = FakeAdb(listOf(devicesRule()) + SCREEN_RULES)
+
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            SwipeCommand(adb).call {
+                put("fromX", 100)
+                put("fromY", 100)
+                put("toX", 100)
+                put("toY", 4000)
+            }
+        }
+
+        assertTrue(error.message!!.contains("toY=4000"))
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+class TypeCommandTest {
+    @Test
+    fun `escapes spaces and quotes on the way to input text`() {
+        val adb = FakeAdb(listOf(devicesRule()) + SCREEN_RULES)
+
+        TypeCommand(adb).call { put("text", "it's a test") }
+
+        assertTrue(adb.commands.any { it.endsWith("shell input text it\\'s%sa%stest") })
+    }
+
+    @Test
+    fun `refuses text input text cannot type, instead of sending garbage`() {
+        val adb = FakeAdb(listOf(devicesRule()) + SCREEN_RULES)
+
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            TypeCommand(adb).call { put("text", "héllo") }
+        }
+
+        assertTrue(error.message!!.contains("printable ASCII"))
+        assertFalse(adb.commands.any { it.contains("input text") })
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+class AppCommandTest {
+    @Test
+    fun `resolves the launcher activity when none is named`() {
+        val adb = FakeAdb(
+            listOf(
+                devicesRule(),
+                reply("resolve-activity", "priority=0 preferredOrder=0\n$TEST_PACKAGE/.MainActivity\n"),
+                reply("am start", "Starting: Intent { cmp=$TEST_PACKAGE/.MainActivity }\n"),
+            ),
+        )
+
+        val json = LaunchAppCommand(adb).call { put("packageName", TEST_PACKAGE) }.textJson()
+
+        assertEquals("$TEST_PACKAGE/.MainActivity", json["component"]?.jsonPrimitive?.content)
+        assertTrue(adb.commands.any { it.endsWith("shell am start -n '$TEST_PACKAGE/.MainActivity'") })
+    }
+
+    @Test
+    fun `reports an am start error as a failed result rather than a success`() {
+        val adb = FakeAdb(
+            listOf(
+                devicesRule(),
+                reply("resolve-activity", "$TEST_PACKAGE/.MainActivity\n"),
+                reply("am start", "Error: Activity class does not exist.\n"),
+            ),
+        )
+
+        val json = LaunchAppCommand(adb).call { put("packageName", TEST_PACKAGE) }.textJson()
+
+        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertTrue(json["output"]!!.jsonPrimitive.content.contains("Activity class does not exist"))
+    }
+
+    @Test
+    fun `names the install failure reason`() {
+        val apk = File.createTempFile("android-device-test", ".apk").apply { deleteOnExit() }
+        val adb = FakeAdb(listOf(devicesRule(), reply("install", "Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]\n")))
+
+        val json = InstallApkCommand(adb).call { put("apkPath", apk.absolutePath) }.textJson()
+
+        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("INSTALL_FAILED_UPDATE_INCOMPATIBLE", json["error"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `reinstalls and grants permissions by default, because that is what a QA loop needs`() {
+        val apk = File.createTempFile("android-device-test", ".apk").apply { deleteOnExit() }
+        val adb = FakeAdb(listOf(devicesRule(), reply("install", "Success\n")))
+
+        InstallApkCommand(adb).call { put("apkPath", apk.absolutePath) }
+
+        assertTrue(adb.commands.any { it.contains("install -r -g ") })
+    }
+
+    @Test
+    fun `refuses an apk path that is not a file on this machine`() {
+        val adb = FakeAdb(listOf(devicesRule()))
+
+        val error = assertFailsWith<JetWhaleMcpArgumentException> {
+            InstallApkCommand(adb).call { put("apkPath", "/nonexistent/example.apk") }
+        }
+
+        assertTrue(error.message!!.contains("no such file"))
+    }
+
+    @Test
+    fun `refuses a package name that cannot be one`() {
+        val adb = FakeAdb(listOf(devicesRule()))
+
+        assertFailsWith<JetWhaleMcpArgumentException> {
+            StopAppCommand(adb).call { put("packageName", "not a package; rm -rf /") }
+        }
+    }
+
+    @Test
+    fun `reports the foreground activity`() {
+        val adb = FakeAdb(
+            listOf(
+                devicesRule(),
+                reply("dumpsys activity activities", "  topResumedActivity=ActivityRecord{bbb u0 $TEST_PACKAGE/.MainActivity t42}\n"),
+            ),
+        )
+
+        val json = CurrentActivityCommand(adb).call().textJson()
+
+        assertEquals(TEST_PACKAGE, json["packageName"]?.jsonPrimitive?.content)
+        assertEquals(".MainActivity", json["activity"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `builds a generic intent from the parts it is given`() {
+        val adb = FakeAdb(listOf(devicesRule(), reply("am start", "Starting: Intent { ... }\n")))
+
+        StartActivityCommand(adb).call {
+            put("action", "android.intent.action.VIEW")
+            put("dataUri", "https://example.com/orders/42")
+            put(
+                "extras",
+                buildJsonObject { put("source", "qa run") },
+            )
+        }
+
+        assertTrue(
+            adb.commands.any {
+                it.endsWith("shell am start -a 'android.intent.action.VIEW' -d 'https://example.com/orders/42' --es 'source' 'qa run'")
+            },
+        )
+    }
+
+    @Test
+    fun `refuses an intent with neither an action nor a component`() {
+        val adb = FakeAdb(listOf(devicesRule()))
+
+        assertFailsWith<JetWhaleMcpArgumentException> { StartActivityCommand(adb).call() }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+class LogcatCommandTest {
+    @Test
+    fun `bounds the output and selects the app's own process`() {
+        val adb = FakeAdb(
+            listOf(
+                devicesRule(),
+                reply("pidof", "4321\n"),
+                reply("logcat -d", "08-25 19:00:00.000  4321  4321 I Example: hello\n"),
+            ),
+        )
+
+        val json = LogcatCommand(adb).call { put("packageName", TEST_PACKAGE) }.textJson()
+
+        assertEquals(4321, json["pid"]?.jsonPrimitive?.content?.toInt())
+        assertTrue(adb.commands.any { it.endsWith("shell logcat -d -t 200 --pid 4321") })
+    }
+
+    @Test
+    fun `silences everything but the requested tag`() {
+        val adb = FakeAdb(listOf(devicesRule(), reply("logcat -d", "")))
+
+        LogcatCommand(adb).call {
+            put("tag", "Example")
+            put("priority", "W")
+            put("lines", 50)
+        }
+
+        assertTrue(adb.commands.any { it.endsWith("shell logcat -d -t 50 'Example:W' '*:S'") })
+    }
+
+    @Test
+    fun `says why an app with no running process cannot be filtered by pid`() {
+        val adb = FakeAdb(listOf(devicesRule(), reply("pidof", "")))
+
+        val json = LogcatCommand(adb).call { put("packageName", TEST_PACKAGE) }.textJson()
+
+        assertFalse(json["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertTrue(json["error"]!!.jsonPrimitive.content.contains("no running process"))
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+class ScreenshotCommandTest {
+    @Test
+    fun `returns the capture as an image block next to its description`() {
+        val png = onePixelPng()
+        val adb = FakeAdb(listOf(devicesRule()), streamBytes = png)
+
+        val result = ScreenshotCommand(adb).call()
+
+        val image = result.content.filterIsInstance<JetWhaleMcpContent.Image>().single()
+        assertEquals("image/png", image.mimeType)
+        assertEquals(png.size, image.data.size)
+        val json = result.textJson()
+        assertEquals(1, json["width"]?.jsonPrimitive?.content?.toInt())
+        assertTrue(adb.commands.any { it == "-s $TEST_SERIAL exec-out screencap -p" })
+    }
+
+    @Test
+    fun `refuses a scale outside the range it can honour`() {
+        val adb = FakeAdb(listOf(devicesRule()), streamBytes = onePixelPng())
+
+        assertFailsWith<JetWhaleMcpArgumentException> {
+            ScreenshotCommand(adb).call { put("scale", 1.5) }
+        }
+    }
+
+    private fun onePixelPng(): ByteArray {
+        val image = java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+        val bytes = java.io.ByteArrayOutputStream()
+        javax.imageio.ImageIO.write(image, "png", bytes)
+        return bytes.toByteArray()
+    }
+}

--- a/jetwhale-plugins/android-device/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/FakeAdb.kt
+++ b/jetwhale-plugins/android-device/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/FakeAdb.kt
@@ -1,0 +1,53 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdb
+import com.kitakkun.jetwhale.host.sdk.JetWhaleAdbResult
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import kotlin.time.Duration
+
+/** A canned adb reply, matched against the argument vector joined by spaces. */
+internal class AdbRule(
+    val contains: String,
+    val exitCode: Int,
+    val output: String,
+)
+
+internal fun reply(contains: String, output: String = "", exitCode: Int = 0): AdbRule = AdbRule(contains, exitCode, output)
+
+/**
+ * Records every argument vector a command runs and answers from a fixed list of rules, so a test
+ * asserts on what reached adb rather than on what a device happened to do.
+ */
+internal class FakeAdb(
+    private val rules: List<AdbRule> = emptyList(),
+    private val streamBytes: ByteArray = ByteArray(0),
+) : JetWhaleAdb {
+    override val executable: String = "adb"
+
+    val invocations = mutableListOf<List<String>>()
+
+    /** The argument vectors run so far, each joined by spaces, for readable assertions. */
+    val commands: List<String> get() = invocations.map { it.joinToString(" ") }
+
+    override suspend fun run(vararg args: String, timeout: Duration): JetWhaleAdbResult {
+        invocations += args.toList()
+        val joined = args.joinToString(" ")
+        val rule = rules.firstOrNull { joined.contains(it.contains) }
+        return JetWhaleAdbResult(exitCode = rule?.exitCode ?: 0, output = rule?.output.orEmpty())
+    }
+
+    override suspend fun <T> runStreaming(vararg args: String, timeout: Duration, consume: suspend (InputStream) -> T): T {
+        invocations += args.toList()
+        return consume(ByteArrayInputStream(streamBytes))
+    }
+}
+
+/** One connected, usable emulator — the setup every tool is expected to resolve without a serial. */
+internal const val ONE_DEVICE_ATTACHED =
+    "List of devices attached\n" +
+        "emulator-5554          device product:sdk_gphone64_arm64 model:sdk_gphone64_arm64 device:emu64a transport_id:1\n"
+
+internal const val TEST_SERIAL = "emulator-5554"
+
+internal const val TEST_PACKAGE = "com.example.qa.sample"

--- a/jetwhale-plugins/android-device/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/ParsersTest.kt
+++ b/jetwhale-plugins/android-device/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/ParsersTest.kt
@@ -1,0 +1,172 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AdbDeviceParsingTest {
+    @Test
+    fun `reads the serial, state and long-form properties of every listed device`() {
+        val devices = parseAdbDevices(
+            "List of devices attached\n" +
+                "emulator-5554          device product:sdk_gphone64_arm64 model:sdk_gphone64_arm64 device:emu64a transport_id:1\n" +
+                "1A2B3C4D5E             device product:example_product model:Example_Model device:example transport_id:4\n",
+        )
+
+        assertEquals(2, devices.size)
+        assertEquals("emulator-5554", devices[0].serial)
+        assertEquals("device", devices[0].state)
+        assertEquals("sdk_gphone64_arm64", devices[0].model)
+        assertEquals("1", devices[0].transportId)
+        assertTrue(devices[0].isEmulator)
+        assertEquals("Example_Model", devices[1].model)
+        assertTrue(!devices[1].isEmulator)
+    }
+
+    @Test
+    fun `keeps unusable devices so a caller can be told why its serial does not work`() {
+        val devices = parseAdbDevices(
+            "List of devices attached\n" +
+                "emulator-5554          offline\n" +
+                "1A2B3C4D5E             unauthorized\n",
+        )
+
+        assertEquals(listOf("offline", "unauthorized"), devices.map { it.state })
+        assertTrue(devices.none { it.isUsable })
+    }
+
+    @Test
+    fun `ignores the header and adb's own daemon chatter`() {
+        val devices = parseAdbDevices(
+            "* daemon not running; starting now at tcp:5037\n" +
+                "* daemon started successfully\n" +
+                "List of devices attached\n",
+        )
+
+        assertTrue(devices.isEmpty())
+    }
+}
+
+class ScreenMetricsParsingTest {
+    @Test
+    fun `prefers the override size, because that is what the window manager is driving`() {
+        val size = parseWmSize("Physical size: 1080x2400\nOverride size: 720x1600\n")
+
+        assertEquals(ScreenSize(720, 1600), size)
+    }
+
+    @Test
+    fun `falls back to the physical size when nothing is overridden`() {
+        assertEquals(ScreenSize(1080, 2400), parseWmSize("Physical size: 1080x2400\n"))
+    }
+
+    @Test
+    fun `reads the density the same way round`() {
+        assertEquals(320, parseWmDensity("Physical density: 440\nOverride density: 320\n"))
+        assertEquals(440, parseWmDensity("Physical density: 440\n"))
+    }
+
+    @Test
+    fun `converts dp with the device density`() {
+        assertEquals(200, dpToPixels(100, density = 320))
+        assertEquals(100, dpToPixels(100, density = 160))
+    }
+
+    @Test
+    fun `converts the degrees the window manager names into a Surface rotation index`() {
+        assertEquals(0, parseRotation("      mCurrentRotation=ROTATION_0\n"))
+        assertEquals(1, parseRotation("      mCurrentRotation=ROTATION_90\n"))
+        assertEquals(2, parseRotation("      mCurrentRotation=ROTATION_180\n"))
+        assertEquals(3, parseRotation("      mCurrentRotation=ROTATION_270\n"))
+    }
+
+    @Test
+    fun `falls back to the index mRotation already carries`() {
+        assertEquals(3, parseRotation("  DisplayRotation\n    mRotation=3 mDeferredRotationPauseCount=0\n"))
+    }
+
+    @Test
+    fun `reads the bracketed getprop listing`() {
+        val properties = parseGetProps(
+            "[ro.product.model]: [Example Model]\n" +
+                "[ro.build.version.sdk]: [36]\n" +
+                "[ro.product.manufacturer]: [Example]\n",
+        )
+
+        assertEquals("Example Model", properties["ro.product.model"])
+        assertEquals("36", properties["ro.build.version.sdk"])
+    }
+}
+
+class PackageParsingTest {
+    @Test
+    fun `reads the version of an installed package`() {
+        val app = parseInstalledApp(
+            "Packages:\n" +
+                "  Package [$TEST_PACKAGE] (1a2b3c):\n" +
+                "    userId=10123\n" +
+                "    versionCode=12 minSdk=24 targetSdk=36\n" +
+                "    versionName=1.2.3\n" +
+                "    firstInstallTime=2026-01-02 03:04:05\n",
+            TEST_PACKAGE,
+        )
+
+        assertEquals("1.2.3", app?.versionName)
+        assertNull(parseInstalledApp("  Package [$TEST_PACKAGE] (1a2b3c):\n    versionName=null\n", TEST_PACKAGE)?.versionName)
+        assertEquals(12L, app?.versionCode)
+        assertEquals("2026-01-02 03:04:05", app?.firstInstallTime)
+    }
+
+    @Test
+    fun `reports a package with no block of its own as not installed`() {
+        assertNull(parseInstalledApp("Unable to find package: $TEST_PACKAGE\n", TEST_PACKAGE))
+    }
+
+    @Test
+    fun `reads the top resumed activity`() {
+        val top = parseTopActivity(
+            "  ResumedActivity: ActivityRecord{aaa u0 com.example.qa.other/.OtherActivity t1}\n" +
+                "  topResumedActivity=ActivityRecord{bbb u0 $TEST_PACKAGE/.MainActivity t42}\n",
+        )
+
+        assertEquals(TEST_PACKAGE, top?.packageName)
+        assertEquals(".MainActivity", top?.activity)
+    }
+
+    @Test
+    fun `falls back to mResumedActivity on builds that do not report a top one`() {
+        val top = parseTopActivity("    mResumedActivity: ActivityRecord{ccc u0 $TEST_PACKAGE/.MainActivity t7}\n")
+
+        assertEquals(TEST_PACKAGE, top?.packageName)
+        assertEquals(".MainActivity", top?.activity)
+    }
+
+    @Test
+    fun `reads the component resolve-activity prints in its brief form`() {
+        val resolved = parseResolvedActivity(
+            "priority=0 preferredOrder=0 match=0x0 specificIndex=-1 isDefault=false\n" +
+                "$TEST_PACKAGE/.MainActivity\n",
+        )
+
+        assertEquals(TEST_PACKAGE, resolved?.packageName)
+        assertEquals(".MainActivity", resolved?.activity)
+    }
+
+    @Test
+    fun `reports no component when nothing resolves`() {
+        assertNull(parseResolvedActivity("No activity found\n"))
+    }
+
+    @Test
+    fun `names the install failure reason rather than only the exit code`() {
+        assertEquals("INSTALL_FAILED_UPDATE_INCOMPATIBLE", parseInstallFailure("Performing Streamed Install\nFailure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]\n"))
+        assertNull(parseInstallFailure("Performing Streamed Install\nSuccess\n"))
+    }
+
+    @Test
+    fun `reads the first pid pidof prints`() {
+        assertEquals(4321, parsePid("4321 4399\n"))
+        assertNull(parsePid("\n"))
+    }
+}

--- a/jetwhale-plugins/android-device/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/ShellTest.kt
+++ b/jetwhale-plugins/android-device/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/androiddevice/host/ShellTest.kt
@@ -1,0 +1,52 @@
+package com.kitakkun.jetwhale.plugins.androiddevice.host
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ShellQuotingTest {
+    @Test
+    fun `wraps a value so the device shell cannot act on it`() {
+        assertEquals("'com.example.qa.sample'", singleQuoteForShell(TEST_PACKAGE))
+        assertEquals("'a b; rm -rf /'", singleQuoteForShell("a b; rm -rf /"))
+    }
+
+    @Test
+    fun `carries a single quote through by closing and reopening the quoting`() {
+        assertEquals("'it'\\''s'", singleQuoteForShell("it's"))
+    }
+}
+
+class InputTextEscapingTest {
+    @Test
+    fun `turns spaces into the escape input text splits on`() {
+        assertEquals("hello%sworld", escapeForInputText("hello world"))
+    }
+
+    @Test
+    fun `escapes the characters the device shell would otherwise act on`() {
+        assertEquals("a\\&b", escapeForInputText("a&b"))
+        assertEquals("a\\|b\\;c", escapeForInputText("a|b;c"))
+        assertEquals("\\\$HOME", escapeForInputText("\$HOME"))
+        assertEquals("it\\'s%s\\\"quoted\\\"", escapeForInputText("it's \"quoted\""))
+    }
+
+    @Test
+    fun `escapes a backslash so it arrives as one`() {
+        assertEquals("a\\\\b", escapeForInputText("a\\b"))
+    }
+
+    @Test
+    fun `accepts every printable ASCII character`() {
+        val printable = (' '..'~').joinToString("")
+
+        assertTrue(unsupportedInputTextCharacters(printable).isEmpty())
+    }
+
+    @Test
+    fun `names the characters input text cannot type`() {
+        val unsupported = unsupportedInputTextCharacters("café\n")
+
+        assertEquals(setOf('é', '\n'), unsupported.toSet())
+    }
+}

--- a/plugins/jetwhale/skills/plugin-qa/SKILL.md
+++ b/plugins/jetwhale/skills/plugin-qa/SKILL.md
@@ -280,6 +280,23 @@ Everything else in this document applies unchanged — the plugin's own tools ta
 host-scoped plugin has one instance for the whole host, so its tools take **no `sessionId`** and can
 be called with no app connected.
 
+### Driving the device itself, without shelling out to adb
+
+Everything above about a wedged server, a dropped transport and a stale output file is the cost of
+running `adb` by hand. The **Android Device** plugin
+(`com.kitakkun.jetwhale.androiddevice`, in `jetwhale-plugins/android-device`) removes most of it: it
+is host-scoped, so enabling it gives you tools that need no session, and they cover the whole loop —
+`listDevices`, `waitForDevice`, `installApk`, `launchApp`, `currentActivity`, `tap` / `swipe` /
+`type` / `key`, `screenshot`, `logcat`, `clearAppData`. Every tool targets its device explicitly,
+validates coordinates against `wm size`, and reports the adb argument vectors it ran, so a failed
+step says which command failed rather than leaving you to guess.
+
+Use it for the debuggee side of a QA run — getting the app onto the device and into the right
+screen — and the host's own tools for the plugin UI you are actually verifying. When the app under
+test is Compose, pair it with the Compose Semantics Inspector: `findNodes` returns a `tap` point in
+screen pixels, which is what `androiddevice.tap` takes, so §5's density arithmetic never enters into
+it. See [Android Device](../../../../docs/guide/android-device.md) for the full tool list.
+
 ## 4. Reaching the tools
 
 The host's MCP server is SSE on `http://localhost:<mcp-server-port>/sse`, with **no

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -54,6 +54,8 @@ include(":jetwhale-plugins:example:host")
 include(":jetwhale-plugins:example:protocol")
 include(":jetwhale-plugins:example:agent")
 
+include(":jetwhale-plugins:android-device:host")
+
 include(":jetwhale-plugins:network:protocol")
 include(":jetwhale-plugins:network:agent")
 include(":jetwhale-plugins:network:agent-ktor")


### PR DESCRIPTION
> Stacked on #244 (host-scoped plugins / plugin context / rich MCP results). Review the last commit only; retarget to `main` after #244 merges.

## Summary

A **host-scoped, headless** plugin (`com.kitakkun.jetwhale.androiddevice`, module `jetwhale-plugins/android-device/host`, artifact `jetwhale-android-device`) that wraps adb behind **29 MCP tools**, so an Android app's QA can be driven end to end from JetWhale — before the app is even installed, with no session required.

### Tools
- **Discovery / state**: `listDevices`, `deviceInfo`, `waitForDevice`, `wake`, `setRotation`, `setAnimations`
- **Screen**: `screenshot` (image content; optional `scale`, `saveTo`)
- **Input**: `tap`, `longPress`, `swipe`, `type`, `key` (enum), `keyCode`
- **Apps**: `installApk`, `uninstallApp`, `appInfo`, `launchApp`, `stopApp`, `clearAppData`, `grantPermission`, `revokePermission`, `currentActivity`, `openUrl`, `startActivity`
- **Logs / files / ports**: `logcat`, `clearLogcat`, `pushFile`, `pullFile`, `reversePort`

### Guard rails (the reason this exists instead of raw adb)
- `serial` may be omitted only when exactly one device is in state `device`; otherwise the error lists the known serials — never a silent pick.
- Coordinates validated against `wm size`; `unit: "dp"` converts with the device density.
- `type` escapes for the shell **and** `input text` (`%s` for space, specials backslashed) and rejects non-ASCII with the offending code point named.
- Package names, paths and extras are validated/quoted; every result carries `"adb": [[...], ...]` — the exact argument vectors that ran.
- All adb calls go through `context.adb` with explicit timeouts. No arbitrary `shell` tool.

### Docs
`docs/guide/android-device.md` (tool table, targeting rule, a worked QA flow combining it with the Compose Semantics Inspector's `tap` points, destructive-tool list), README / getting-started / sidebar entries, official catalog entry, plugin-qa skill note.

## Testing
- `:jetwhale-plugins:android-device:host:check`, `checkKotlinAbi`, `spotlessCheck`, `packagePlugin` — pass; 51 unit tests (parsers, shell escaping, command behaviour against a recording fake adb, neutral fixtures).
- Emulator smoke run (headless host, **no session connected**): every tool above exercised, including `installApk` of the demo APK → `launchApp` → `currentActivity` → `tap` (px and dp; counter advanced, confirmed by screenshot) → `type` of `it's a "test" & more` (rendered exactly) → `logcat --pid` → `clearAppData`; error cases for unknown serial, off-screen tap, non-ASCII text, bad package name, missing APK path.
- Two bugs found by the smoke run and fixed: `parseRotation` (WM prints degrees, not the `Surface.ROTATION_*` index) and `appInfo.versionName` literal `"null"`.
- Not exercised: multi-device resolution and `offline`/`unauthorized` states on real hardware (unit-tested only), the Maven install route, vitepress build of the new page.
