### PR TITLE
feat(semantics): read and edit an Android View's attributes live

### DIFF
--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -79,10 +79,17 @@ rebuild. Select a `View` node in the host and the attributes appear under its se
 | Group | Attributes |
 |---|---|
 | **State** | `visibility` (`VISIBLE`/`INVISIBLE`/`GONE`), `enabled`, `selected`, `activated`, `clickable`, `focusable`, and `focused` read-only |
-| **Layout** | `layout.width` / `layout.height` (either constant or a pixel length), `padding.*`, `margin.*` (when the parent hands out margins), `minWidth` / `minHeight`, and `bounds` read-only |
+| **Layout** | `layout.width` / `layout.height` (`MATCH_PARENT`, `WRAP_CONTENT` or a pixel length), `padding.*`, `margin.*` (when the parent hands out margins), `minWidth` / `minHeight`, and `bounds` read-only |
 | **Appearance** | `alpha`, `backgroundColor` (when the background is a flat color; otherwise `background` names the drawable, read-only), `elevation`, `translationX` / `translationY`, `rotation`, `scaleX` / `scaleY` |
 | **Text** | on a `TextView`: `text`, `hint`, `textSize`, `textColor`, `maxLines` |
 | **Info** | `id` (`@id/name`) and `class`, both read-only |
+
+Each attribute has one type, and the type is what decides the editor — a `visibility` is always a
+dropdown of its options, a `padding.left` always a pixel field. `layout.width` and `layout.height`
+take *either* a constant or a length, so they have a type of their own that says both: a dropdown of
+`MATCH_PARENT`, `WRAP_CONTENT` and **Fixed**, with a pixel field that Fixed enables. The editor looks
+the same whichever the size currently is, so a `WRAP_CONTENT` can be given a width and a width can be
+put back to `WRAP_CONTENT`.
 
 Three things to know:
 
@@ -283,11 +290,25 @@ carries its `id` (what `setViewAttribute` names), `label`, `group`, `type`, `val
 — a Compose node — comes back as a `message` rather than an error. See
 [Editing View attributes](#editing-view-attributes).
 
+`type` is one of `bool`, `int`, `float`, `text`, `color`, `dimension`, `enum` and `layoutSize`, and
+it is the whole of what the attribute takes: a `dimension` is a pixel figure and nothing else, an
+`enum` is one of its `options` and nothing else. A `layoutSize` — `layout.width`, `layout.height` —
+is the one that takes either, and it lists its `constants` whichever it currently reads as, so both
+possibilities are visible from a single read:
+
+```
+{ "id": "layout.width", "type": "layoutSize", "value": "WRAP_CONTENT",
+  "constants": ["MATCH_PARENT", "WRAP_CONTENT"] }
+{ "id": "layout.width", "type": "layoutSize", "value": "500.0", "dp": 250.0,
+  "constants": ["MATCH_PARENT", "WRAP_CONTENT"] }
+```
+
 ### `com.kitakkun.jetwhale.semantics.setViewAttribute`
 
 Changes one attribute: `rootId`, `nodeId`, `attributeId`, and `value` as a **string**, read according
 to the attribute's own type — `"GONE"`, `"true"`, `"0.5"`, `"#80FF0000"`, `"24"` — so there is no
-sealed JSON to construct. The answer carries the attribute as it reads back afterwards, which is not
+sealed JSON to construct. A `layoutSize` takes one of its constants, case-insensitively, or a pixel
+figure: `"wrap_content"`, `"match_parent"`, `"500"`. The answer carries the attribute as it reads back afterwards, which is not
 always what was asked for: an app may clamp a value or ignore it. The edit is temporary, and only
 `View` nodes have attributes at all.
 

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -12,9 +12,9 @@ browse it in the host and hand it to an AI agent over [MCP](/guide/mcp-server).
 - 👆 Run a node's own semantics action — click, long click, set text, scroll, focus, dismiss —
   from the host or from an AI agent
 - 🪟 Dialogs and popups appear as their own roots, because that is what they are in Compose
-- 🤝 On Android, the Android `View`s around and inside the composition are in the same tree — see
-  [Android View support](#android-view-support)
-- 🤖 Three MCP tools so an agent can see the screen structurally instead of guessing at pixels
+- 🤝 On Android, the Android `View`s around and inside the composition are in the same tree, and a
+  `View`'s attributes can be read and edited live — see [Android View support](#android-view-support)
+- 🤖 Five MCP tools so an agent can see the screen structurally instead of guessing at pixels
 
 ## What the tree contains
 
@@ -70,13 +70,45 @@ tap: `Click` → `performClick()`, `LongClick` → `performLongClick()`, `SetTex
 `requestFocus()`. `Dismiss`, `Expand` and `Collapse` have no `View` counterpart and come back
 `performed: false` saying so. As always, only what a node lists in `actions` can be invoked.
 
-Three limits are worth knowing:
+### Editing View attributes
+
+A `View` node also exposes its **platform attributes** — the properties a Layout Inspector shows —
+and most of them can be changed live, so you can try a padding, a color or a `GONE` without a
+rebuild. Select a `View` node in the host and the attributes appear under its semantics, grouped:
+
+| Group | Attributes |
+|---|---|
+| **State** | `visibility` (`VISIBLE`/`INVISIBLE`/`GONE`), `enabled`, `selected`, `activated`, `clickable`, `focusable`, and `focused` read-only |
+| **Layout** | `layout.width` / `layout.height` (either constant or a pixel length), `padding.*`, `margin.*` (when the parent hands out margins), `minWidth` / `minHeight`, and `bounds` read-only |
+| **Appearance** | `alpha`, `backgroundColor` (when the background is a flat color; otherwise `background` names the drawable, read-only), `elevation`, `translationX` / `translationY`, `rotation`, `scaleX` / `scaleY` |
+| **Text** | on a `TextView`: `text`, `hint`, `textSize`, `textColor`, `maxLines` |
+| **Info** | `id` (`@id/name`) and `class`, both read-only |
+
+Three things to know:
+
+- **It is a curated list, not reflection.** Every attribute is named explicitly. Reflection over a
+  view's getters is what makes the equivalent elsewhere fragile, and Android's non-SDK interface
+  restrictions block most of what it would reach anyway. The list says exactly what the agent will
+  touch.
+- **An edit is temporary.** The app owns the property: a relayout, a rebind, or the app writing it
+  itself takes the value back. This is a way to *see* a change, not to make one.
+- **Compose nodes have none.** A semantics node is a projection of composition state, so writing to
+  it would be undone by the next recomposition — which is why Android Studio's Layout Inspector
+  edits views and not Compose either. Asking for the attributes of a Compose node answers a message
+  saying so rather than failing.
+
+Attributes are fetched per node when you select one, never as part of a capture: a tree of two
+hundred nodes must not carry thirty attributes each.
+
+Two MCP tools do the same from an agent —
+[`getViewAttributes`](#com-kitakkun-jetwhale-semantics-getviewattributes) and
+[`setViewAttribute`](#com-kitakkun-jetwhale-semantics-setviewattribute).
+
+Two limits are worth knowing:
 
 - **A window with no Compose in it is not captured.** The composition is what announces a window to
   the probe, so a plain `AlertDialog` built from views does not appear. This plugin inspects Compose
   apps; it is not a general View inspector.
-- **No layout attributes.** `layoutParams`, padding, background and the rest are Layout Inspector's
-  job and are deliberately not reported.
 - **A merged capture can fold an `AndroidView` away.** The embedded views hang off the semantics
   node the `AndroidView { }` creates; when an ancestor merges its descendants (a `Button`, a
   `mergeDescendants = true` modifier), that node is folded into the ancestor in the merged tree and
@@ -193,11 +225,12 @@ Open the **Compose Semantics Inspector** in the host, select your app's session,
 
 Select a node to see its full semantics on the right, along with a button for every action it
 actually exposes. There is also a **Copy `adb shell input tap`** button for the times you do want to
-drive the app through the input system.
+drive the app through the input system. Select an Android `View` node and its editable attributes
+appear below that — see [Editing View attributes](#editing-view-attributes).
 
 ## MCP tools
 
-The plugin contributes three tools to the host's [MCP server](/guide/mcp-server). As with every
+The plugin contributes five tools to the host's [MCP server](/guide/mcp-server). As with every
 plugin tool, JetWhale injects the `sessionId` parameter and routes the call to the right session.
 
 ### `com.kitakkun.jetwhale.semantics.findNodes`
@@ -240,6 +273,28 @@ A typical agent loop:
 findNodes(testTag: "login-button")     → { "nodes": [{ "rootId": "compose-root-1f2e", "id": 42, … }] }
 performNodeAction(nodeId: 42, action: "Click")
 findNodes()                            → the new screen's interactive nodes
+```
+
+### `com.kitakkun.jetwhale.semantics.getViewAttributes`
+
+Reads one Android `View` node's platform attributes, addressed by `rootId` and `nodeId`. Each entry
+carries its `id` (what `setViewAttribute` names), `label`, `group`, `type`, `value` as a string, the
+`options` of an enum, and `editable: false` when it cannot be written. A node that has no attributes
+— a Compose node — comes back as a `message` rather than an error. See
+[Editing View attributes](#editing-view-attributes).
+
+### `com.kitakkun.jetwhale.semantics.setViewAttribute`
+
+Changes one attribute: `rootId`, `nodeId`, `attributeId`, and `value` as a **string**, read according
+to the attribute's own type — `"GONE"`, `"true"`, `"0.5"`, `"#80FF0000"`, `"24"` — so there is no
+sealed JSON to construct. The answer carries the attribute as it reads back afterwards, which is not
+always what was asked for: an app may clamp a value or ignore it. The edit is temporary, and only
+`View` nodes have attributes at all.
+
+```
+findNodes(resourceId: "status")   → { "nodes": [{ "rootId": "android-window-1f2e", "id": -4, "kind": "View" }] }
+getViewAttributes(rootId: "android-window-1f2e", nodeId: -4)
+setViewAttribute(rootId: "android-window-1f2e", nodeId: -4, attributeId: "textColor", value: "#FF0000FF")
 ```
 
 ## Why not the CLI?

--- a/jetwhale-plugins/semantics/agent/api/agent.klib.api
+++ b/jetwhale-plugins/semantics/agent/api/agent.klib.api
@@ -18,6 +18,11 @@ abstract interface com.kitakkun.jetwhale.plugins.semantics.agent/ComposeUiThread
     abstract suspend fun <#A1: kotlin/Any?> await(kotlin/Function0<#A1>): #A1 // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeUiThread.await|await(kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
 }
 
+abstract interface com.kitakkun.jetwhale.plugins.semantics.agent/ViewAttributeSource { // com.kitakkun.jetwhale.plugins.semantics.agent/ViewAttributeSource|null[0]
+    abstract suspend fun attributes(kotlin/Int): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot? // com.kitakkun.jetwhale.plugins.semantics.agent/ViewAttributeSource.attributes|attributes(kotlin.Int){}[0]
+    abstract suspend fun setAttribute(kotlin/Int, kotlin/String, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult // com.kitakkun.jetwhale.plugins.semantics.agent/ViewAttributeSource.setAttribute|setAttribute(kotlin.Int;kotlin.String;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue){}[0]
+}
+
 final class com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin : com.kitakkun.jetwhale.agent.sdk/JetWhaleAgentPlugin { // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin|null[0]
     constructor <init>() // com.kitakkun.jetwhale.plugins.semantics.agent/JetWhaleSemanticsAgentPlugin.<init>|<init>(){}[0]
 

--- a/jetwhale-plugins/semantics/agent/api/jvm/agent.api
+++ b/jetwhale-plugins/semantics/agent/api/jvm/agent.api
@@ -57,3 +57,8 @@ public final class com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsOwnerN
 	public static synthetic fun registerSemanticsOwner$default (Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry;Landroidx/compose/ui/semantics/SemanticsOwner;Ljava/lang/String;Ljava/lang/String;FLkotlin/jvm/functions/Function0;Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeUiThread;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSourceRegistry$Registration;
 }
 
+public abstract interface class com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSource {
+	public abstract fun attributes (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun setAttribute (ILjava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/AndroidWindowNodeSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/AndroidWindowNodeSource.kt
@@ -13,6 +13,9 @@ import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
 import java.lang.ref.WeakReference
 
 /**
@@ -29,7 +32,9 @@ import java.lang.ref.WeakReference
  * screen, and a strong reference here would keep a destroyed activity's whole view tree alive for as
  * long as the process runs.
  */
-internal class AndroidWindowNodeSource(rootView: View) : ComposeNodeSource {
+internal class AndroidWindowNodeSource(rootView: View) :
+    ComposeNodeSource,
+    ViewAttributeSource {
     override val sourceId: String = "android-window-${System.identityHashCode(rootView).toString(16)}"
 
     private val rootViewRef = WeakReference(rootView)
@@ -60,11 +65,8 @@ internal class AndroidWindowNodeSource(rootView: View) : ComposeNodeSource {
         val rootView = attachedRootView()
             ?: return@await NodeActionResult(performed = false, message = "the window is no longer readable")
 
-        // The sign of the id says which half of the tree the node came from: Compose's semantics ids
-        // are non-negative, the ones this agent assigns to views are negative.
         if (request.nodeId < 0) {
-            val view = ViewNodeIds.viewOf(request.nodeId)?.takeIf { it.rootView === rootView }
-                ?: return@await unknownNode(request.nodeId)
+            val view = viewInWindow(request.nodeId, rootView) ?: return@await unknownNode(request.nodeId)
             view.performViewAction(request)
         } else {
             val node = rootView.findSemanticsNode(request.nodeId) ?: return@await unknownNode(request.nodeId)
@@ -72,11 +74,39 @@ internal class AndroidWindowNodeSource(rootView: View) : ComposeNodeSource {
         }
     }
 
+    // -- ViewAttributeSource ---------------------------------------------------
+    //
+    // A window is the only root that has platform attributes at all: its nodes include real `View`s.
+    // The work itself lives in ViewAttributes.kt; this only resolves the node and hops to the UI
+    // thread, the same way performAction does.
+
+    override suspend fun attributes(nodeId: Int): ViewAttributeSnapshot? = AndroidComposeUiThread.await {
+        val rootView = attachedRootView() ?: return@await null
+        viewInWindow(nodeId, rootView)?.readAttributes(rootId = sourceId, nodeId = nodeId)
+    }
+
+    override suspend fun setAttribute(nodeId: Int, attributeId: String, value: ViewAttributeValue): ViewAttributeResult = AndroidComposeUiThread.await {
+        val rootView = attachedRootView()
+            ?: return@await ViewAttributeResult(applied = false, message = "the window is no longer readable")
+        val view = viewInWindow(nodeId, rootView)
+            ?: return@await ViewAttributeResult(applied = false, message = noViewAttributesMessage(nodeId))
+        view.writeAttribute(attributeId = attributeId, value = value)
+    }
+
     private fun unknownNode(nodeId: Int): NodeActionResult = NodeActionResult(
         performed = false,
         message = "unknown nodeId: $nodeId (the node may have left this window; capture the tree again)",
     )
 }
+
+/**
+ * The `View` [nodeId] names, when it is a `View` node that is still part of [rootView]'s window.
+ *
+ * The sign of the id says which half of the tree the node came from: Compose's semantics ids are
+ * non-negative, the ones this agent assigns to views are negative — so a Compose id resolves to no
+ * view here, which is the right answer for both callers.
+ */
+private fun viewInWindow(nodeId: Int, rootView: View): View? = ViewNodeIds.viewOf(nodeId)?.takeIf { it.rootView === rootView }
 
 /**
  * Searches every composition in the window for a semantics node.

--- a/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributes.kt
+++ b/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributes.kt
@@ -1,0 +1,480 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import android.content.res.Resources
+import android.graphics.drawable.ColorDrawable
+import android.util.TypedValue
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import kotlin.math.roundToInt
+
+// The attributes of an Android `View` that this plugin reads, and the subset it writes.
+//
+// The list is an explicit allowlist rather than reflection over the view's getters. Reflection is
+// what makes the equivalent in other layout inspectors fragile, and Android's non-SDK interface
+// restrictions block most of what it would reach anyway; a typed list is smaller, says exactly what
+// it will touch, and cannot surprise the app being debugged.
+//
+// Everything here must run on the main thread.
+
+/**
+ * One attribute: how to read it off a view, and how to write it back when it can be written.
+ *
+ * @param read `null` when the attribute does not apply to this view — a `text` on a non-`TextView`,
+ *   a margin on a view whose parent hands out no margins — in which case it is simply absent.
+ * @param write `null` for a read-only attribute. The caller invalidates afterwards.
+ * @param relayouts whether a successful write needs a new layout pass rather than only a redraw.
+ *   Defaults to `false` because most attributes only change how the view is painted; the ones that
+ *   change how big it is, or where, say so.
+ */
+private class ViewAttributeDescriptor(
+    val id: String,
+    val label: String,
+    val group: String,
+    val read: (View) -> ViewAttributeValue?,
+    val write: ((View, ViewAttributeValue) -> Unit)?,
+    val relayouts: Boolean = false,
+)
+
+/** Reads every attribute this view exposes, in the order the descriptors are declared. */
+internal fun View.readAttributes(rootId: String, nodeId: Int): ViewAttributeSnapshot = ViewAttributeSnapshot(
+    rootId = rootId,
+    nodeId = nodeId,
+    viewClass = javaClass.name,
+    attributes = VIEW_ATTRIBUTES.mapNotNull { it.toAttribute(this) },
+)
+
+/**
+ * Writes one attribute and reads it back, so the caller reports the value that actually took effect
+ * rather than the one it asked for — an app can clamp a value, or ignore it.
+ */
+internal fun View.writeAttribute(attributeId: String, value: ViewAttributeValue): ViewAttributeResult {
+    val descriptor = VIEW_ATTRIBUTES.firstOrNull { it.id == attributeId }
+        ?: return ViewAttributeResult(applied = false, message = "unknown attributeId: $attributeId")
+    if (descriptor.read(this) == null) {
+        return ViewAttributeResult(applied = false, message = "${descriptor.id} does not apply to a ${javaClass.name}")
+    }
+    val write = descriptor.write
+        ?: return ViewAttributeResult(applied = false, message = "${descriptor.id} is read-only")
+
+    return try {
+        write(this, value)
+        // An app may reject a layoutParams change from its own onLayout, so the value is read back
+        // after the pass that would apply it is requested rather than before.
+        if (descriptor.relayouts) requestLayout() else invalidate()
+        ViewAttributeResult(applied = true, attribute = descriptor.toAttribute(this))
+    } catch (e: Throwable) {
+        ViewAttributeResult(applied = false, message = e.message?.takeIf { it.isNotBlank() } ?: (e::class.simpleName ?: "the write failed"))
+    }
+}
+
+private fun ViewAttributeDescriptor.toAttribute(view: View): ViewAttribute? = read(view)?.let { value ->
+    ViewAttribute(id = id, label = label, group = group, value = value, editable = write != null)
+}
+
+// -- The allowlist ------------------------------------------------------------
+
+private const val GROUP_STATE = "State"
+private const val GROUP_LAYOUT = "Layout"
+private const val GROUP_APPEARANCE = "Appearance"
+private const val GROUP_TEXT = "Text"
+private const val GROUP_INFO = "Info"
+
+private val VISIBILITY_OPTIONS = listOf("VISIBLE", "INVISIBLE", "GONE")
+
+private val VIEW_ATTRIBUTES: List<ViewAttributeDescriptor> = buildList {
+    // State ------------------------------------------------------------------
+    add(
+        ViewAttributeDescriptor(
+            id = "visibility",
+            label = "visibility",
+            group = GROUP_STATE,
+            read = { view -> ViewAttributeValue.EnumValue(view.visibilityName(), VISIBILITY_OPTIONS) },
+            write = { view, value -> view.visibility = value.asVisibility("visibility") },
+            relayouts = true,
+        ),
+    )
+    addFlag(id = "enabled", group = GROUP_STATE, read = { it.isEnabled }, write = { view, on -> view.isEnabled = on })
+    addFlag(id = "selected", group = GROUP_STATE, read = { it.isSelected }, write = { view, on -> view.isSelected = on })
+    addFlag(id = "activated", group = GROUP_STATE, read = { it.isActivated }, write = { view, on -> view.isActivated = on })
+    addFlag(id = "clickable", group = GROUP_STATE, read = { it.isClickable }, write = { view, on -> view.isClickable = on })
+    addFlag(id = "focusable", group = GROUP_STATE, read = { it.isFocusable }, write = { view, on -> view.isFocusable = on })
+    // Read-only: taking focus is an action with side effects of its own — a keyboard, a scroll —
+    // so it belongs to performNodeAction's RequestFocus rather than to a property editor.
+    addFlag(id = "focused", group = GROUP_STATE, read = { it.isFocused }, write = null)
+
+    // Layout -----------------------------------------------------------------
+    addLayoutSize(id = "layout.width", read = { it.width }, write = { params, size -> params.width = size })
+    addLayoutSize(id = "layout.height", read = { it.height }, write = { params, size -> params.height = size })
+    addDimension(
+        id = "padding.left",
+        group = GROUP_LAYOUT,
+        read = { it.paddingLeft.toFloat() },
+        write = { view, px -> view.setPadding(px.roundToInt(), view.paddingTop, view.paddingRight, view.paddingBottom) },
+        relayouts = true,
+    )
+    addDimension(
+        id = "padding.top",
+        group = GROUP_LAYOUT,
+        read = { it.paddingTop.toFloat() },
+        write = { view, px -> view.setPadding(view.paddingLeft, px.roundToInt(), view.paddingRight, view.paddingBottom) },
+        relayouts = true,
+    )
+    addDimension(
+        id = "padding.right",
+        group = GROUP_LAYOUT,
+        read = { it.paddingRight.toFloat() },
+        write = { view, px -> view.setPadding(view.paddingLeft, view.paddingTop, px.roundToInt(), view.paddingBottom) },
+        relayouts = true,
+    )
+    addDimension(
+        id = "padding.bottom",
+        group = GROUP_LAYOUT,
+        read = { it.paddingBottom.toFloat() },
+        write = { view, px -> view.setPadding(view.paddingLeft, view.paddingTop, view.paddingRight, px.roundToInt()) },
+        relayouts = true,
+    )
+    addMargin(id = "margin.left", read = { it.leftMargin }, write = { params, px -> params.leftMargin = px })
+    addMargin(id = "margin.top", read = { it.topMargin }, write = { params, px -> params.topMargin = px })
+    addMargin(id = "margin.right", read = { it.rightMargin }, write = { params, px -> params.rightMargin = px })
+    addMargin(id = "margin.bottom", read = { it.bottomMargin }, write = { params, px -> params.bottomMargin = px })
+    addDimension(
+        id = "minWidth",
+        group = GROUP_LAYOUT,
+        read = { it.minimumWidth.toFloat() },
+        write = { view, px -> view.minimumWidth = px.roundToInt() },
+        relayouts = true,
+    )
+    addDimension(
+        id = "minHeight",
+        group = GROUP_LAYOUT,
+        read = { it.minimumHeight.toFloat() },
+        write = { view, px -> view.minimumHeight = px.roundToInt() },
+        relayouts = true,
+    )
+    add(
+        ViewAttributeDescriptor(
+            id = "bounds",
+            label = "bounds (window)",
+            group = GROUP_LAYOUT,
+            read = { view ->
+                val location = IntArray(2).also(view::getLocationInWindow)
+                ViewAttributeValue.TextValue("${location[0]},${location[1]},${location[0] + view.width},${location[1] + view.height}")
+            },
+            write = null,
+        ),
+    )
+
+    // Appearance -------------------------------------------------------------
+    addFloat(
+        id = "alpha",
+        group = GROUP_APPEARANCE,
+        read = { it.alpha },
+        // Anything outside 0..1 is silently treated as opaque by the platform, which would read back
+        // as "applied" while nothing changed; clamping makes the reported value the honest one.
+        write = { view, value -> view.alpha = value.coerceIn(0f, 1f) },
+    )
+    add(
+        ViewAttributeDescriptor(
+            id = "backgroundColor",
+            label = "backgroundColor",
+            group = GROUP_APPEARANCE,
+            // Only a flat color background has a color to report; anything else is described by the
+            // read-only `background` attribute below.
+            read = { view -> (view.background as? ColorDrawable)?.let { ViewAttributeValue.ColorValue(it.color) } },
+            write = { view, value -> view.setBackgroundColor(value.asColor("backgroundColor")) },
+        ),
+    )
+    add(
+        ViewAttributeDescriptor(
+            id = "background",
+            label = "background",
+            group = GROUP_APPEARANCE,
+            read = { view ->
+                view.background
+                    ?.takeIf { it !is ColorDrawable }
+                    ?.let { ViewAttributeValue.TextValue(it.javaClass.name) }
+            },
+            write = null,
+        ),
+    )
+    addDimension(id = "elevation", group = GROUP_APPEARANCE, read = { it.elevation }, write = { view, px -> view.elevation = px }, relayouts = false)
+    addDimension(id = "translationX", group = GROUP_APPEARANCE, read = { it.translationX }, write = { view, px -> view.translationX = px }, relayouts = false)
+    addDimension(id = "translationY", group = GROUP_APPEARANCE, read = { it.translationY }, write = { view, px -> view.translationY = px }, relayouts = false)
+    addFloat(id = "rotation", group = GROUP_APPEARANCE, read = { it.rotation }, write = { view, value -> view.rotation = value })
+    addFloat(id = "scaleX", group = GROUP_APPEARANCE, read = { it.scaleX }, write = { view, value -> view.scaleX = value })
+    addFloat(id = "scaleY", group = GROUP_APPEARANCE, read = { it.scaleY }, write = { view, value -> view.scaleY = value })
+
+    // Text -------------------------------------------------------------------
+    add(
+        ViewAttributeDescriptor(
+            id = "text",
+            label = "text",
+            group = GROUP_TEXT,
+            read = { view -> (view as? TextView)?.let { ViewAttributeValue.TextValue(it.text?.toString().orEmpty()) } },
+            write = { view, value -> (view as TextView).text = value.asText("text") },
+            relayouts = true,
+        ),
+    )
+    add(
+        ViewAttributeDescriptor(
+            id = "hint",
+            label = "hint",
+            group = GROUP_TEXT,
+            read = { view -> (view as? TextView)?.let { ViewAttributeValue.TextValue(it.hint?.toString().orEmpty()) } },
+            write = { view, value -> (view as TextView).hint = value.asText("hint") },
+            relayouts = true,
+        ),
+    )
+    add(
+        ViewAttributeDescriptor(
+            id = "textSize",
+            label = "textSize",
+            group = GROUP_TEXT,
+            // The px figure is what the platform stores; the second figure is the sp the app would
+            // have written, which is the number a reader recognises.
+            read = { view -> (view as? TextView)?.let { ViewAttributeValue.DimensionValue(px = it.textSize, dp = it.textSize / view.scaledTextDensity()) } },
+            write = { view, value -> (view as TextView).setTextSize(TypedValue.COMPLEX_UNIT_PX, value.asDimensionPx("textSize")) },
+            relayouts = true,
+        ),
+    )
+    add(
+        ViewAttributeDescriptor(
+            id = "textColor",
+            label = "textColor",
+            group = GROUP_TEXT,
+            read = { view -> (view as? TextView)?.let { ViewAttributeValue.ColorValue(it.currentTextColor) } },
+            write = { view, value -> (view as TextView).setTextColor(value.asColor("textColor")) },
+        ),
+    )
+    add(
+        ViewAttributeDescriptor(
+            id = "maxLines",
+            label = "maxLines",
+            group = GROUP_TEXT,
+            read = { view -> (view as? TextView)?.let { ViewAttributeValue.IntValue(it.maxLines) } },
+            write = { view, value -> (view as TextView).maxLines = value.asInt("maxLines") },
+            relayouts = true,
+        ),
+    )
+
+    // Info -------------------------------------------------------------------
+    add(
+        ViewAttributeDescriptor(
+            id = "id",
+            label = "android:id",
+            group = GROUP_INFO,
+            read = { view -> view.resourceEntryNameOrNull()?.let { ViewAttributeValue.TextValue("@id/$it") } },
+            write = null,
+        ),
+    )
+    add(
+        ViewAttributeDescriptor(
+            id = "class",
+            label = "class",
+            group = GROUP_INFO,
+            read = { view -> ViewAttributeValue.TextValue(view.javaClass.name) },
+            write = null,
+        ),
+    )
+}
+
+// -- Descriptor builders ------------------------------------------------------
+
+private fun MutableList<ViewAttributeDescriptor>.addFlag(
+    id: String,
+    group: String,
+    read: (View) -> Boolean,
+    write: ((View, Boolean) -> Unit)?,
+) {
+    val setValue: ((View, ViewAttributeValue) -> Unit)? = if (write == null) {
+        null
+    } else {
+        { view, value -> write(view, value.asBoolean(id)) }
+    }
+    add(
+        ViewAttributeDescriptor(
+            id = id,
+            label = id,
+            group = group,
+            read = { view -> ViewAttributeValue.BooleanValue(read(view)) },
+            write = setValue,
+        ),
+    )
+}
+
+private fun MutableList<ViewAttributeDescriptor>.addFloat(
+    id: String,
+    group: String,
+    read: (View) -> Float,
+    write: (View, Float) -> Unit,
+) {
+    add(
+        ViewAttributeDescriptor(
+            id = id,
+            label = id,
+            group = group,
+            read = { view -> ViewAttributeValue.FloatValue(read(view)) },
+            write = { view, value -> write(view, value.asFloat(id)) },
+        ),
+    )
+}
+
+private fun MutableList<ViewAttributeDescriptor>.addDimension(
+    id: String,
+    group: String,
+    read: (View) -> Float,
+    write: (View, Float) -> Unit,
+    relayouts: Boolean,
+) {
+    add(
+        ViewAttributeDescriptor(
+            id = id,
+            label = id,
+            group = group,
+            read = { view -> view.dimension(read(view)) },
+            write = { view, value -> write(view, value.asDimensionPx(id)) },
+            relayouts = relayouts,
+        ),
+    )
+}
+
+/** A margin exists only when the view's parent hands out [ViewGroup.MarginLayoutParams]; otherwise it is absent. */
+private fun MutableList<ViewAttributeDescriptor>.addMargin(
+    id: String,
+    read: (ViewGroup.MarginLayoutParams) -> Int,
+    write: (ViewGroup.MarginLayoutParams, Int) -> Unit,
+) {
+    add(
+        ViewAttributeDescriptor(
+            id = id,
+            label = id,
+            group = GROUP_LAYOUT,
+            read = { view -> view.marginParams()?.let { view.dimension(read(it).toFloat()) } },
+            write = { view, value ->
+                val params = view.marginParams() ?: throw IllegalStateException("$id needs a parent that hands out margins")
+                write(params, value.asDimensionPx(id).roundToInt())
+                // MarginLayoutParams is the live object, but the parent only re-reads it when the
+                // params are set back on the view.
+                view.layoutParams = params
+            },
+            relayouts = true,
+        ),
+    )
+}
+
+/**
+ * `layout.width` / `layout.height`: either of the two constants that name a rule, or a pixel length.
+ *
+ * Read and written through `layoutParams`, so a view that has none yet — one not attached to a
+ * parent — reports neither.
+ */
+private fun MutableList<ViewAttributeDescriptor>.addLayoutSize(
+    id: String,
+    read: (ViewGroup.LayoutParams) -> Int,
+    write: (ViewGroup.LayoutParams, Int) -> Unit,
+) {
+    add(
+        ViewAttributeDescriptor(
+            id = id,
+            label = id,
+            group = GROUP_LAYOUT,
+            read = { view ->
+                view.layoutParams?.let { params ->
+                    val raw = read(params)
+                    layoutSizeValue(constantName = layoutSizeConstantName(raw), px = raw.toFloat(), density = view.density())
+                }
+            },
+            write = { view, value ->
+                val params = view.layoutParams ?: throw IllegalStateException("$id needs a view that has layout params")
+                write(params, value.asLayoutSize(id))
+                view.layoutParams = params
+            },
+            relayouts = true,
+        ),
+    )
+}
+
+// -- Value conversion ---------------------------------------------------------
+
+private fun View.density(): Float = resources.displayMetrics.density
+
+// A TextView's size is written in sp, which scales with the user's font-size setting on top of the
+// display density — so the sp figure needs that scale, not the plain one.
+@Suppress("DEPRECATION")
+private fun View.scaledTextDensity(): Float = resources.displayMetrics.scaledDensity
+
+private fun View.dimension(px: Float): ViewAttributeValue.DimensionValue = ViewAttributeValue.DimensionValue(px = px, dp = px / density())
+
+private fun View.marginParams(): ViewGroup.MarginLayoutParams? = layoutParams as? ViewGroup.MarginLayoutParams
+
+private fun View.visibilityName(): String = when (visibility) {
+    View.VISIBLE -> "VISIBLE"
+    View.INVISIBLE -> "INVISIBLE"
+    else -> "GONE"
+}
+
+private fun layoutSizeConstantName(raw: Int): String? = when (raw) {
+    ViewGroup.LayoutParams.MATCH_PARENT -> "MATCH_PARENT"
+    ViewGroup.LayoutParams.WRAP_CONTENT -> "WRAP_CONTENT"
+    else -> null
+}
+
+/**
+ * The entry name of the view's `android:id`, or `null` when it has none. A generated id has no entry
+ * to look up, so the lookup is allowed to fail rather than being guarded by a check on the packing.
+ */
+private fun View.resourceEntryNameOrNull(): String? {
+    if (id == View.NO_ID) return null
+    return try {
+        resources?.getResourceEntryName(id)
+    } catch (_: Resources.NotFoundException) {
+        null
+    }
+}
+
+private fun ViewAttributeValue.asBoolean(attributeId: String): Boolean = (this as? ViewAttributeValue.BooleanValue)?.value
+    ?: throw IllegalArgumentException(wrongVariantMessage(attributeId, "bool", this))
+
+private fun ViewAttributeValue.asInt(attributeId: String): Int = (this as? ViewAttributeValue.IntValue)?.value
+    ?: throw IllegalArgumentException(wrongVariantMessage(attributeId, "int", this))
+
+private fun ViewAttributeValue.asFloat(attributeId: String): Float = (this as? ViewAttributeValue.FloatValue)?.value
+    ?: throw IllegalArgumentException(wrongVariantMessage(attributeId, "float", this))
+
+private fun ViewAttributeValue.asText(attributeId: String): String = (this as? ViewAttributeValue.TextValue)?.value
+    ?: throw IllegalArgumentException(wrongVariantMessage(attributeId, "text", this))
+
+private fun ViewAttributeValue.asColor(attributeId: String): Int = (this as? ViewAttributeValue.ColorValue)?.argb
+    ?: throw IllegalArgumentException(wrongVariantMessage(attributeId, "color", this))
+
+private fun ViewAttributeValue.asDimensionPx(attributeId: String): Float = (this as? ViewAttributeValue.DimensionValue)?.px
+    ?: throw IllegalArgumentException(wrongVariantMessage(attributeId, "dimension", this))
+
+private fun ViewAttributeValue.asVisibility(attributeId: String): Int {
+    val name = (this as? ViewAttributeValue.EnumValue)?.value
+        ?: throw IllegalArgumentException(wrongVariantMessage(attributeId, "enum", this))
+    return when (name) {
+        "VISIBLE" -> View.VISIBLE
+        "INVISIBLE" -> View.INVISIBLE
+        "GONE" -> View.GONE
+        else -> throw IllegalArgumentException("unknown $attributeId: $name (expected one of ${VISIBILITY_OPTIONS.joinToString(", ")})")
+    }
+}
+
+/** Accepts either of the two constants or a pixel length, which is how the attribute reads back too. */
+private fun ViewAttributeValue.asLayoutSize(attributeId: String): Int = when (this) {
+    is ViewAttributeValue.EnumValue -> when (value) {
+        "MATCH_PARENT" -> ViewGroup.LayoutParams.MATCH_PARENT
+        "WRAP_CONTENT" -> ViewGroup.LayoutParams.WRAP_CONTENT
+        else -> throw IllegalArgumentException("unknown $attributeId: $value (expected one of ${LAYOUT_SIZE_CONSTANTS.joinToString(", ")}, or a dimension)")
+    }
+
+    is ViewAttributeValue.DimensionValue -> px.roundToInt()
+
+    else -> throw IllegalArgumentException(wrongVariantMessage(attributeId, "enum or dimension", this))
+}

--- a/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributes.kt
+++ b/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributes.kt
@@ -466,15 +466,14 @@ private fun ViewAttributeValue.asVisibility(attributeId: String): Int {
     }
 }
 
-/** Accepts either of the two constants or a pixel length, which is how the attribute reads back too. */
-private fun ViewAttributeValue.asLayoutSize(attributeId: String): Int = when (this) {
-    is ViewAttributeValue.EnumValue -> when (value) {
+/** Either of the two constants or a pixel length, exactly as the attribute reads back. */
+private fun ViewAttributeValue.asLayoutSize(attributeId: String): Int {
+    val size = this as? ViewAttributeValue.LayoutSizeValue
+        ?: throw IllegalArgumentException(wrongVariantMessage(attributeId, "layoutSize", this))
+    return when (size.constant) {
+        null -> (size.px ?: throw IllegalArgumentException("$attributeId needs either a constant or a pixel length, but neither was sent")).roundToInt()
         "MATCH_PARENT" -> ViewGroup.LayoutParams.MATCH_PARENT
         "WRAP_CONTENT" -> ViewGroup.LayoutParams.WRAP_CONTENT
-        else -> throw IllegalArgumentException("unknown $attributeId: $value (expected one of ${LAYOUT_SIZE_CONSTANTS.joinToString(", ")}, or a dimension)")
+        else -> throw IllegalArgumentException("unknown $attributeId: ${size.constant} (expected one of ${LAYOUT_SIZE_CONSTANTS.joinToString(", ")}, or a pixel length)")
     }
-
-    is ViewAttributeValue.DimensionValue -> px.roundToInt()
-
-    else -> throw IllegalArgumentException(wrongVariantMessage(attributeId, "enum or dimension", this))
 }

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/JetWhaleSemanticsAgentPlugin.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/JetWhaleSemanticsAgentPlugin.kt
@@ -3,10 +3,12 @@ package com.kitakkun.jetwhale.plugins.semantics.agent
 import com.kitakkun.jetwhale.agent.sdk.JetWhaleAgentPlugin
 import com.kitakkun.jetwhale.plugins.semantics.protocol.CaptureNodeTree
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessageHandlers
 import com.kitakkun.jetwhale.protocol.messaging.reply
 import kotlinx.coroutines.CancellationException
@@ -16,9 +18,11 @@ import kotlin.time.TimeSource
 /**
  * Platform-agnostic core of the Compose Semantics Inspector agent plugin.
  *
- * It answers two host requests — capture the semantics tree, and invoke one node's action — by
- * delegating to the [ComposeNodeSource]s registered in [ComposeNodeSourceRegistry]. Register the
- * plugin with the agent runtime, and install a platform probe so the registry has roots to read:
+ * It answers host requests — capture the semantics tree, invoke one node's action, and read or write
+ * a `View` node's platform attributes — by delegating to the [ComposeNodeSource]s registered in
+ * [ComposeNodeSourceRegistry]. The attribute requests need the optional [ViewAttributeSource]
+ * capability, which only the Android window source has. Register the plugin with the agent runtime,
+ * and install a platform probe so the registry has roots to read:
  *
  * ```kotlin
  * // Android, Application.onCreate()
@@ -41,6 +45,12 @@ class JetWhaleSemanticsAgentPlugin : JetWhaleAgentPlugin() {
         }
         onRequest { request: PerformNodeAction ->
             reply(performAction(request))
+        }
+        onRequest { request: GetViewAttributes ->
+            reply(readViewAttributes(request))
+        }
+        onRequest { request: SetViewAttribute ->
+            reply(writeViewAttribute(request))
         }
     }
 

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeRequests.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeRequests.kt
@@ -1,0 +1,50 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
+import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import kotlinx.coroutines.CancellationException
+
+// Answers the two attribute requests, kept apart from the capture and action handlers because the
+// capability is optional: a root has attributes only when its source implements ViewAttributeSource.
+
+/** Reads every attribute of one node, or says why it has none. */
+internal suspend fun readViewAttributes(request: GetViewAttributes): ViewAttributeResponse {
+    val source = sourceOf(request.rootId)
+        ?: return ViewAttributeResponse(snapshot = null, message = unknownRoot(request.rootId))
+    val attributeSource = source as? ViewAttributeSource
+        ?: return ViewAttributeResponse(snapshot = null, message = ROOT_WITHOUT_ATTRIBUTES)
+    return try {
+        attributeSource.attributes(request.nodeId)
+            ?.let { ViewAttributeResponse(snapshot = it) }
+            ?: ViewAttributeResponse(snapshot = null, message = noViewAttributesMessage(request.nodeId))
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        ViewAttributeResponse(snapshot = null, message = "reading the attributes failed: ${e.describeFailure()}")
+    }
+}
+
+/** Writes one attribute of one node, reporting a refusal rather than failing the request. */
+internal suspend fun writeViewAttribute(request: SetViewAttribute): ViewAttributeResult {
+    val source = sourceOf(request.rootId)
+        ?: return ViewAttributeResult(applied = false, message = unknownRoot(request.rootId))
+    val attributeSource = source as? ViewAttributeSource
+        ?: return ViewAttributeResult(applied = false, message = ROOT_WITHOUT_ATTRIBUTES)
+    return try {
+        attributeSource.setAttribute(nodeId = request.nodeId, attributeId = request.attributeId, value = request.value)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        ViewAttributeResult(applied = false, message = "writing the attribute failed: ${e.describeFailure()}")
+    }
+}
+
+private fun sourceOf(rootId: String): ComposeNodeSource? = ComposeNodeSourceRegistry.sources.firstOrNull { it.sourceId == rootId }
+
+private const val ROOT_WITHOUT_ATTRIBUTES: String = "this root has no View attributes (it is a composition read through its SemanticsOwner)"
+
+private fun unknownRoot(rootId: String): String = "unknown rootId: $rootId (the root may have been detached; capture the tree again)"
+
+private fun Throwable.describeFailure(): String = message?.takeIf { it.isNotBlank() } ?: (this::class.simpleName ?: "unknown error")

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSource.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.semantics.agent
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import com.kitakkun.jetwhale.plugins.semantics.protocol.type
 
 /**
  * A node source whose nodes carry platform attributes that can be read, and some of which can be
@@ -41,16 +42,7 @@ internal fun noViewAttributesMessage(nodeId: Int): String = if (nodeId >= 0) {
 }
 
 /** The `@SerialName` of [value]'s variant — how a message names the shape a caller sent or owes. */
-internal fun variantNameOf(value: ViewAttributeValue): String = when (value) {
-    is ViewAttributeValue.BooleanValue -> "bool"
-    is ViewAttributeValue.IntValue -> "int"
-    is ViewAttributeValue.FloatValue -> "float"
-    is ViewAttributeValue.TextValue -> "text"
-    is ViewAttributeValue.ColorValue -> "color"
-    is ViewAttributeValue.DimensionValue -> "dimension"
-    is ViewAttributeValue.EnumValue -> "enum"
-    is ViewAttributeValue.LayoutSizeValue -> "layoutSize"
-}
+internal fun variantNameOf(value: ViewAttributeValue): String = value.type.wireName
 
 /** Names what the attribute takes and what arrived, so a caller can fix the call from the message alone. */
 internal fun wrongVariantMessage(attributeId: String, expected: String, actual: ViewAttributeValue): String = "$attributeId expects a value of type '$expected', but a '${variantNameOf(actual)}' value was sent"

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSource.kt
@@ -1,0 +1,71 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+
+/**
+ * A node source whose nodes carry platform attributes that can be read, and some of which can be
+ * written.
+ *
+ * This is a capability a source may or may not have, not part of [ComposeNodeSource]: a source that
+ * has none — a composition read through its `SemanticsOwner` — simply does not implement it, and the
+ * plugin answers "not supported" for its roots rather than every such source having to carry a pair
+ * of no-op methods.
+ */
+interface ViewAttributeSource {
+    /**
+     * Every attribute the node addressed by [nodeId] exposes, or `null` when this source has no such
+     * node — it left the window, or it is a Compose semantics node, which has no platform attributes.
+     */
+    suspend fun attributes(nodeId: Int): ViewAttributeSnapshot?
+
+    /**
+     * Writes one attribute, reporting the outcome rather than throwing: a rejected value, an unknown
+     * [attributeId] and an app that refuses the change are all normal answers.
+     */
+    suspend fun setAttribute(nodeId: Int, attributeId: String, value: ViewAttributeValue): ViewAttributeResult
+}
+
+/**
+ * Why [ViewAttributeSource] reports nothing for [nodeId].
+ *
+ * The sign of the id is what separates the two cases, and it is part of the transport contract: a
+ * Compose semantics node's id is non-negative, a `View` node's is negative.
+ */
+internal fun noViewAttributesMessage(nodeId: Int): String = if (nodeId >= 0) {
+    "node $nodeId is a Compose semantics node, which has no View attributes: a semantics node is a projection of composition state, " +
+        "so a write to it would be undone by the next recomposition. Only View nodes (negative ids) have attributes."
+} else {
+    "unknown nodeId: $nodeId (the node may have left this window; capture the tree again)"
+}
+
+/** The `@SerialName` of [value]'s variant — how a message names the shape a caller sent or owes. */
+internal fun variantNameOf(value: ViewAttributeValue): String = when (value) {
+    is ViewAttributeValue.BooleanValue -> "bool"
+    is ViewAttributeValue.IntValue -> "int"
+    is ViewAttributeValue.FloatValue -> "float"
+    is ViewAttributeValue.TextValue -> "text"
+    is ViewAttributeValue.ColorValue -> "color"
+    is ViewAttributeValue.DimensionValue -> "dimension"
+    is ViewAttributeValue.EnumValue -> "enum"
+}
+
+/** Names what the attribute takes and what arrived, so a caller can fix the call from the message alone. */
+internal fun wrongVariantMessage(attributeId: String, expected: String, actual: ViewAttributeValue): String = "$attributeId expects a value of type '$expected', but a '${variantNameOf(actual)}' value was sent"
+
+/**
+ * A layout size as either of the two constants that are not lengths at all, or as the length it
+ * otherwise is.
+ *
+ * @param constantName `MATCH_PARENT` or `WRAP_CONTENT` when the raw size is one of them, `null`
+ *   when it is a pixel figure.
+ */
+internal fun layoutSizeValue(constantName: String?, px: Float, density: Float): ViewAttributeValue = if (constantName != null) {
+    ViewAttributeValue.EnumValue(value = constantName, options = LAYOUT_SIZE_CONSTANTS)
+} else {
+    ViewAttributeValue.DimensionValue(px = px, dp = px / density)
+}
+
+/** The two `layout.width` / `layout.height` values that name a rule instead of a length. */
+internal val LAYOUT_SIZE_CONSTANTS: List<String> = listOf("MATCH_PARENT", "WRAP_CONTENT")

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSource.kt
@@ -49,6 +49,7 @@ internal fun variantNameOf(value: ViewAttributeValue): String = when (value) {
     is ViewAttributeValue.ColorValue -> "color"
     is ViewAttributeValue.DimensionValue -> "dimension"
     is ViewAttributeValue.EnumValue -> "enum"
+    is ViewAttributeValue.LayoutSizeValue -> "layoutSize"
 }
 
 /** Names what the attribute takes and what arrived, so a caller can fix the call from the message alone. */
@@ -56,16 +57,17 @@ internal fun wrongVariantMessage(attributeId: String, expected: String, actual: 
 
 /**
  * A layout size as either of the two constants that are not lengths at all, or as the length it
- * otherwise is.
+ * otherwise is — one value either way, so an editor for it never changes shape.
  *
  * @param constantName `MATCH_PARENT` or `WRAP_CONTENT` when the raw size is one of them, `null`
  *   when it is a pixel figure.
  */
-internal fun layoutSizeValue(constantName: String?, px: Float, density: Float): ViewAttributeValue = if (constantName != null) {
-    ViewAttributeValue.EnumValue(value = constantName, options = LAYOUT_SIZE_CONSTANTS)
-} else {
-    ViewAttributeValue.DimensionValue(px = px, dp = px / density)
-}
+internal fun layoutSizeValue(constantName: String?, px: Float, density: Float): ViewAttributeValue.LayoutSizeValue = ViewAttributeValue.LayoutSizeValue(
+    constant = constantName,
+    px = px.takeIf { constantName == null },
+    dp = (px / density).takeIf { constantName == null },
+    constants = LAYOUT_SIZE_CONSTANTS,
+)
 
 /** The two `layout.width` / `layout.height` values that name a rule instead of a length. */
 internal val LAYOUT_SIZE_CONSTANTS: List<String> = listOf("MATCH_PARENT", "WRAP_CONTENT")

--- a/jetwhale-plugins/semantics/agent/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSourceTest.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSourceTest.kt
@@ -11,17 +11,31 @@ import kotlin.test.assertTrue
  */
 class ViewAttributeSourceTest {
     @Test
-    fun `reports a layout size that names a rule as that rule and offers both`() {
+    fun `reports a layout size that names a rule as that rule and no length`() {
         val value = layoutSizeValue(constantName = "MATCH_PARENT", px = -1f, density = 2f)
 
-        assertEquals(ViewAttributeValue.EnumValue("MATCH_PARENT", listOf("MATCH_PARENT", "WRAP_CONTENT")), value)
+        assertEquals(
+            ViewAttributeValue.LayoutSizeValue(constant = "MATCH_PARENT", px = null, dp = null, constants = listOf("MATCH_PARENT", "WRAP_CONTENT")),
+            value,
+        )
     }
 
     @Test
-    fun `reports a layout size that is a length as a dimension in both pixels and dp`() {
+    fun `reports a layout size that is a length in both pixels and dp and no constant`() {
         val value = layoutSizeValue(constantName = null, px = 48f, density = 2f)
 
-        assertEquals(ViewAttributeValue.DimensionValue(px = 48f, dp = 24f), value)
+        assertEquals(
+            ViewAttributeValue.LayoutSizeValue(constant = null, px = 48f, dp = 24f, constants = listOf("MATCH_PARENT", "WRAP_CONTENT")),
+            value,
+        )
+    }
+
+    @Test
+    fun `a layout size offers the constants whichever of the two cases it is in`() {
+        val constants = listOf("MATCH_PARENT", "WRAP_CONTENT")
+
+        assertEquals(constants, layoutSizeValue(constantName = "WRAP_CONTENT", px = -2f, density = 2f).constants)
+        assertEquals(constants, layoutSizeValue(constantName = null, px = 48f, density = 2f).constants)
     }
 
     @Test
@@ -41,6 +55,7 @@ class ViewAttributeSourceTest {
             ViewAttributeValue.ColorValue(0) to "color",
             ViewAttributeValue.DimensionValue(px = 1f, dp = 1f) to "dimension",
             ViewAttributeValue.EnumValue("A", listOf("A")) to "enum",
+            ViewAttributeValue.LayoutSizeValue(constant = "WRAP_CONTENT", px = null, dp = null, constants = listOf("WRAP_CONTENT")) to "layoutSize",
         )
 
         for ((value, name) in variants) {

--- a/jetwhale-plugins/semantics/agent/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSourceTest.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeSourceTest.kt
@@ -1,0 +1,64 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The decisions the attribute layer makes that are not tied to a live `View`. The rest of it reads
+ * and writes real views, which needs an instrumented device rather than this source set.
+ */
+class ViewAttributeSourceTest {
+    @Test
+    fun `reports a layout size that names a rule as that rule and offers both`() {
+        val value = layoutSizeValue(constantName = "MATCH_PARENT", px = -1f, density = 2f)
+
+        assertEquals(ViewAttributeValue.EnumValue("MATCH_PARENT", listOf("MATCH_PARENT", "WRAP_CONTENT")), value)
+    }
+
+    @Test
+    fun `reports a layout size that is a length as a dimension in both pixels and dp`() {
+        val value = layoutSizeValue(constantName = null, px = 48f, density = 2f)
+
+        assertEquals(ViewAttributeValue.DimensionValue(px = 48f, dp = 24f), value)
+    }
+
+    @Test
+    fun `a mismatched value names both what the attribute takes and what arrived`() {
+        val message = wrongVariantMessage("visibility", "enum", ViewAttributeValue.BooleanValue(true))
+
+        assertEquals("visibility expects a value of type 'enum', but a 'bool' value was sent", message)
+    }
+
+    @Test
+    fun `every value variant has a name a message can use`() {
+        val variants = listOf(
+            ViewAttributeValue.BooleanValue(true) to "bool",
+            ViewAttributeValue.IntValue(1) to "int",
+            ViewAttributeValue.FloatValue(1f) to "float",
+            ViewAttributeValue.TextValue("a") to "text",
+            ViewAttributeValue.ColorValue(0) to "color",
+            ViewAttributeValue.DimensionValue(px = 1f, dp = 1f) to "dimension",
+            ViewAttributeValue.EnumValue("A", listOf("A")) to "enum",
+        )
+
+        for ((value, name) in variants) {
+            assertEquals(name, variantNameOf(value))
+        }
+    }
+
+    @Test
+    fun `a Compose node id is explained rather than reported as missing`() {
+        val message = noViewAttributesMessage(nodeId = 42)
+
+        assertTrue(message.contains("Compose semantics node"), message)
+    }
+
+    @Test
+    fun `a View node id that resolves to nothing says the tree has moved on`() {
+        val message = noViewAttributesMessage(nodeId = -3)
+
+        assertTrue(message.contains("capture the tree again"), message)
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
@@ -12,10 +12,14 @@ import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCapablePlugin
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMessagingHostPlugin
 import com.kitakkun.jetwhale.plugins.semantics.protocol.CaptureNodeTree
+import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import com.kitakkun.jetwhale.protocol.messaging.request
 import kotlinx.coroutines.launch
@@ -66,6 +70,12 @@ private class ComposeNodeInspectorHostPlugin :
 
     private suspend fun performAction(request: PerformNodeAction): NodeActionResult = messenger.request(request)
 
+    // Attributes are read per node, on demand, so they stay out of the capture and out of the
+    // capture lock: a selection change must not queue behind an auto-refresh.
+    private suspend fun loadViewAttributes(request: GetViewAttributes): ViewAttributeResponse = messenger.request(request)
+
+    private suspend fun setViewAttribute(request: SetViewAttribute): ViewAttributeResult = messenger.request(request)
+
     // -------------------------------------------------------------------------
     // JetWhaleHostPluginUi
     // -------------------------------------------------------------------------
@@ -101,6 +111,8 @@ private class ComposeNodeInspectorHostPlugin :
                     }
                 }
             },
+            onLoadViewAttributes = ::loadViewAttributes,
+            onSetViewAttribute = ::setViewAttribute,
         )
     }
 
@@ -115,6 +127,11 @@ private class ComposeNodeInspectorHostPlugin :
             lastSnapshot = { snapshot },
             capture = ::capture,
             perform = ::performAction,
+        ),
+        GetViewAttributesCommand(getAttributes = ::loadViewAttributes),
+        SetViewAttributeCommand(
+            getAttributes = ::loadViewAttributes,
+            setAttribute = ::setViewAttribute,
         ),
     )
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
@@ -100,6 +100,7 @@ private class ComposeNodeInspectorHostPlugin :
             roundTripMs = roundTripMs,
             errorMessage = errorMessage,
             actionStatus = actionStatus,
+            viewAttributes = viewAttributes.state,
             onCapture = { options ->
                 try {
                     capture(options)
@@ -123,7 +124,15 @@ private class ComposeNodeInspectorHostPlugin :
                     }
                 }
             },
-            viewAttributes = viewAttributes,
+            onSelectedNodeChange = { key ->
+                // Only an Android View has attributes to read; anything else the tree lands on —
+                // a Compose node, nothing at all — leaves the store holding nothing.
+                when (val attributeKey = snapshot.viewAttributeNode(key)) {
+                    null -> viewAttributes.clear()
+                    else -> viewAttributes.select(rootId = attributeKey.rootId, nodeId = attributeKey.nodeId)
+                }
+            },
+            onCommitViewAttribute = viewAttributes::commit,
         )
     }
 

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
@@ -76,6 +76,18 @@ private class ComposeNodeInspectorHostPlugin :
 
     private suspend fun setViewAttribute(request: SetViewAttribute): ViewAttributeResult = messenger.request(request)
 
+    // Owned by the plugin rather than by the panel: the attributes outlive the panel being closed,
+    // a write outlives the editor that started it, and an agent's write goes through here too, so
+    // an open panel is never left showing a value the app no longer has. Built lazily because
+    // pluginScope is bound by the runtime after the instance is constructed.
+    private val viewAttributes by lazy {
+        ViewAttributeStore(
+            scope = pluginScope,
+            read = ::loadViewAttributes,
+            write = ::setViewAttribute,
+        )
+    }
+
     // -------------------------------------------------------------------------
     // JetWhaleHostPluginUi
     // -------------------------------------------------------------------------
@@ -111,8 +123,7 @@ private class ComposeNodeInspectorHostPlugin :
                     }
                 }
             },
-            onLoadViewAttributes = ::loadViewAttributes,
-            onSetViewAttribute = ::setViewAttribute,
+            viewAttributes = viewAttributes,
         )
     }
 
@@ -120,18 +131,22 @@ private class ComposeNodeInspectorHostPlugin :
     // JetWhaleMcpCapablePlugin
     // -------------------------------------------------------------------------
 
-    override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
-        GetNodeTreeCommand(capture = ::capture),
-        FindNodesCommand(capture = ::capture),
-        PerformNodeActionCommand(
-            lastSnapshot = { snapshot },
-            capture = ::capture,
-            perform = ::performAction,
-        ),
-        GetViewAttributesCommand(getAttributes = ::loadViewAttributes),
-        SetViewAttributeCommand(
-            getAttributes = ::loadViewAttributes,
-            setAttribute = ::setViewAttribute,
-        ),
-    )
+    // Lazy for the same reason the store is: reading this list builds the store, and the store needs
+    // pluginScope. The runtime asks for the commands well after it has bound one.
+    override val mcpCommands: List<JetWhaleMcpCommand> by lazy {
+        listOf(
+            GetNodeTreeCommand(capture = ::capture),
+            FindNodesCommand(capture = ::capture),
+            PerformNodeActionCommand(
+                lastSnapshot = { snapshot },
+                capture = ::capture,
+                perform = ::performAction,
+            ),
+            GetViewAttributesCommand(getAttributes = viewAttributes::readAttributes),
+            SetViewAttributeCommand(
+                getAttributes = viewAttributes::readAttributes,
+                setAttribute = viewAttributes::writeAttribute,
+            ),
+        )
+    }
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -56,6 +56,7 @@ import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
 import com.kitakkun.jetwhale.plugins.semantics.protocol.UiNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewNode
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -68,6 +69,11 @@ import kotlin.math.roundToInt
  * Captures are pull-based — a capture reads the debuggee's semantics on its main thread, so the app
  * pays only when someone is looking. Auto-refresh exists for watching a screen change, but is off by
  * default for the same reason.
+ *
+ * Data in, events out: everything the screen draws arrives as a value, and everything it wants done
+ * leaves as a callback. Which node is selected is the screen's own business — it is where the tree
+ * is clicked — so it is reported upward rather than asked for, and the plugin decides what reading
+ * to do about it.
  */
 @Composable
 internal fun ComposeSemanticsInspectorScreen(
@@ -76,9 +82,11 @@ internal fun ComposeSemanticsInspectorScreen(
     roundTripMs: Long?,
     errorMessage: String?,
     actionStatus: String?,
+    viewAttributes: ViewAttributesUiState,
     onCapture: suspend (NodeTreeCaptureOptions) -> Unit,
     onPerformAction: (PerformNodeAction) -> Unit,
-    viewAttributes: ViewAttributeStore,
+    onSelectedNodeChange: (NodeKey?) -> Unit,
+    onCommitViewAttribute: (ViewAttribute, String) -> Unit,
 ) {
     var merged by rememberPersistent("merged-tree", default = true)
     var interactiveOnly by rememberPersistent("interactive-only", default = false)
@@ -120,15 +128,10 @@ internal fun ComposeSemanticsInspectorScreen(
         snapshot?.roots?.firstOrNull { it.rootId == key.rootId }?.findNode(key.nodeId)
     }
 
-    // Only an Android View has attributes; anything else selected — a Compose node, nothing at all —
-    // is the store holding nothing. The store does the reading, on the plugin's own scope, so this
-    // only tells it which node the tree is on.
-    val attributeKey = selectedKey?.takeIf { selectedNode is ViewNode }
-    LaunchedEffect(attributeKey) {
-        when (attributeKey) {
-            null -> viewAttributes.clear()
-            else -> viewAttributes.select(rootId = attributeKey.rootId, nodeId = attributeKey.nodeId)
-        }
+    // Reported rather than acted on: what a selection is worth reading from the app is the plugin's
+    // decision, and this screen has no way to read anything anyway.
+    LaunchedEffect(selectedKey) {
+        onSelectedNodeChange(selectedKey)
     }
 
     // The host hands the plugin an unpainted scene, so the screen paints its own background;
@@ -177,8 +180,9 @@ internal fun ComposeSemanticsInspectorScreen(
                 NodeDetail(
                     rootId = selectedKey?.rootId,
                     node = selectedNode,
-                    onPerformAction = onPerformAction,
                     viewAttributes = viewAttributes,
+                    onPerformAction = onPerformAction,
+                    onCommitViewAttribute = onCommitViewAttribute,
                 )
             },
         )
@@ -365,8 +369,9 @@ private fun UiNode.actionSummary(): String = when {
 private fun NodeDetail(
     rootId: String?,
     node: UiNode?,
+    viewAttributes: ViewAttributesUiState,
     onPerformAction: (PerformNodeAction) -> Unit,
-    viewAttributes: ViewAttributeStore,
+    onCommitViewAttribute: (ViewAttribute, String) -> Unit,
 ) {
     if (node == null || rootId == null) {
         JwEmptyState(title = "Select a node to see its semantics and the actions it exposes.")
@@ -485,13 +490,7 @@ private fun NodeDetail(
         // projection of composition state, so there is nothing here that could be edited to last.
         if (node is ViewNode) {
             JwHorizontalDivider()
-            ViewAttributesPanel(
-                attributes = viewAttributes.attributes,
-                message = viewAttributes.message,
-                writeStatus = viewAttributes.writeStatus,
-                writeFailed = viewAttributes.writeFailed,
-                onCommit = viewAttributes::commit,
-            )
+            ViewAttributesPanel(state = viewAttributes, onCommit = onCommitViewAttribute)
         }
     }
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -51,15 +51,11 @@ import com.kitakkun.jetwhale.host.ui.JwTreeRow
 import com.kitakkun.jetwhale.host.ui.LocalJwContentColor
 import com.kitakkun.jetwhale.host.ui.rememberJwSplitPaneState
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode
-import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
-import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
 import com.kitakkun.jetwhale.plugins.semantics.protocol.UiNode
-import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
-import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewNode
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -82,8 +78,7 @@ internal fun ComposeSemanticsInspectorScreen(
     actionStatus: String?,
     onCapture: suspend (NodeTreeCaptureOptions) -> Unit,
     onPerformAction: (PerformNodeAction) -> Unit,
-    onLoadViewAttributes: suspend (GetViewAttributes) -> ViewAttributeResponse,
-    onSetViewAttribute: suspend (SetViewAttribute) -> ViewAttributeResult,
+    viewAttributes: ViewAttributeStore,
 ) {
     var merged by rememberPersistent("merged-tree", default = true)
     var interactiveOnly by rememberPersistent("interactive-only", default = false)
@@ -123,6 +118,17 @@ internal fun ComposeSemanticsInspectorScreen(
     }
     val selectedNode = selectedKey?.let { key ->
         snapshot?.roots?.firstOrNull { it.rootId == key.rootId }?.findNode(key.nodeId)
+    }
+
+    // Only an Android View has attributes; anything else selected — a Compose node, nothing at all —
+    // is the store holding nothing. The store does the reading, on the plugin's own scope, so this
+    // only tells it which node the tree is on.
+    val attributeKey = selectedKey?.takeIf { selectedNode is ViewNode }
+    LaunchedEffect(attributeKey) {
+        when (attributeKey) {
+            null -> viewAttributes.clear()
+            else -> viewAttributes.select(rootId = attributeKey.rootId, nodeId = attributeKey.nodeId)
+        }
     }
 
     // The host hands the plugin an unpainted scene, so the screen paints its own background;
@@ -172,8 +178,7 @@ internal fun ComposeSemanticsInspectorScreen(
                     rootId = selectedKey?.rootId,
                     node = selectedNode,
                     onPerformAction = onPerformAction,
-                    onLoadViewAttributes = onLoadViewAttributes,
-                    onSetViewAttribute = onSetViewAttribute,
+                    viewAttributes = viewAttributes,
                 )
             },
         )
@@ -361,8 +366,7 @@ private fun NodeDetail(
     rootId: String?,
     node: UiNode?,
     onPerformAction: (PerformNodeAction) -> Unit,
-    onLoadViewAttributes: suspend (GetViewAttributes) -> ViewAttributeResponse,
-    onSetViewAttribute: suspend (SetViewAttribute) -> ViewAttributeResult,
+    viewAttributes: ViewAttributeStore,
 ) {
     if (node == null || rootId == null) {
         JwEmptyState(title = "Select a node to see its semantics and the actions it exposes.")
@@ -482,10 +486,11 @@ private fun NodeDetail(
         if (node is ViewNode) {
             JwHorizontalDivider()
             ViewAttributesPanel(
-                rootId = rootId,
-                nodeId = node.id,
-                loadAttributes = onLoadViewAttributes,
-                writeAttribute = onSetViewAttribute,
+                attributes = viewAttributes.attributes,
+                message = viewAttributes.message,
+                writeStatus = viewAttributes.writeStatus,
+                writeFailed = viewAttributes.writeFailed,
+                onCommit = viewAttributes::commit,
             )
         }
     }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -51,11 +51,15 @@ import com.kitakkun.jetwhale.host.ui.JwTreeRow
 import com.kitakkun.jetwhale.host.ui.LocalJwContentColor
 import com.kitakkun.jetwhale.host.ui.rememberJwSplitPaneState
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
 import com.kitakkun.jetwhale.plugins.semantics.protocol.UiNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewNode
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -78,6 +82,8 @@ internal fun ComposeSemanticsInspectorScreen(
     actionStatus: String?,
     onCapture: suspend (NodeTreeCaptureOptions) -> Unit,
     onPerformAction: (PerformNodeAction) -> Unit,
+    onLoadViewAttributes: suspend (GetViewAttributes) -> ViewAttributeResponse,
+    onSetViewAttribute: suspend (SetViewAttribute) -> ViewAttributeResult,
 ) {
     var merged by rememberPersistent("merged-tree", default = true)
     var interactiveOnly by rememberPersistent("interactive-only", default = false)
@@ -166,6 +172,8 @@ internal fun ComposeSemanticsInspectorScreen(
                     rootId = selectedKey?.rootId,
                     node = selectedNode,
                     onPerformAction = onPerformAction,
+                    onLoadViewAttributes = onLoadViewAttributes,
+                    onSetViewAttribute = onSetViewAttribute,
                 )
             },
         )
@@ -353,6 +361,8 @@ private fun NodeDetail(
     rootId: String?,
     node: UiNode?,
     onPerformAction: (PerformNodeAction) -> Unit,
+    onLoadViewAttributes: suspend (GetViewAttributes) -> ViewAttributeResponse,
+    onSetViewAttribute: suspend (SetViewAttribute) -> ViewAttributeResult,
 ) {
     if (node == null || rootId == null) {
         JwEmptyState(title = "Select a node to see its semantics and the actions it exposes.")
@@ -466,6 +476,18 @@ private fun NodeDetail(
             enabled = !node.boundsInScreen.isEmpty,
             style = JwButtonStyle.Text,
         )
+
+        // Only an Android View has platform attributes to show. A Compose node's semantics are a
+        // projection of composition state, so there is nothing here that could be edited to last.
+        if (node is ViewNode) {
+            JwHorizontalDivider()
+            ViewAttributesPanel(
+                rootId = rootId,
+                nodeId = node.id,
+                loadAttributes = onLoadViewAttributes,
+                writeAttribute = onSetViewAttribute,
+            )
+        }
     }
 }
 

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTree.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTree.kt
@@ -48,6 +48,19 @@ internal fun NodeTreeSnapshot.findRootOf(nodeId: Int): ComposeRoot? = roots.last
 internal fun NodeTreeSnapshot.nodeCount(): Int = roots.sumOf { it.node?.asSequence()?.count() ?: 0 }
 
 /**
+ * The node whose platform attributes are worth reading, given what the tree has selected: only an
+ * Android `View` has any.
+ *
+ * `null` for a Compose node, for no selection, and for a key this snapshot does not hold — all of
+ * which mean the attribute section has nothing to show.
+ */
+internal fun NodeTreeSnapshot?.viewAttributeNode(selected: NodeKey?): NodeKey? {
+    if (selected == null) return null
+    val node = this?.roots?.firstOrNull { it.rootId == selected.rootId }?.findNode(selected.nodeId)
+    return selected.takeIf { node is ViewNode }
+}
+
+/**
  * `true` when the node offers something to do: an action, editable content, or scrolling.
  *
  * This is the filter that answers "what can be operated here" — the question both the tree view's

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
@@ -9,7 +9,9 @@ import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeType
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import com.kitakkun.jetwhale.plugins.semantics.protocol.type
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -19,6 +21,15 @@ import kotlinx.serialization.json.put
 
 // The two attribute tools. They sit apart from the tree tools because they address one View node
 // rather than the tree, and because only View nodes have anything to answer.
+
+// Both tools describe the value types from ViewAttributeType rather than spelling them out, so a
+// type added there cannot leave the descriptions behind — which is how they came to advertise a
+// shape a read no longer had.
+private val WRITTEN_AS_BY_TYPE = ViewAttributeType.entries.joinToString(", ") { "${it.wireName} takes ${it.writtenAs}" }
+
+private val EXTRA_FIELDS_BY_TYPE = ViewAttributeType.entries
+    .filter { it.extraFields.isNotEmpty() }
+    .joinToString("; ", prefix = "An entry also carries ") { "${it.extraFields.joinToString(" and ") { field -> "\"$field\"" }} for a ${it.wireName}" }
 
 private const val TEMPORARY_NOTICE =
     "Only Android View nodes (the ones findNodes marks \"kind\": \"View\", with a negative id) have attributes: a Compose " +
@@ -34,13 +45,9 @@ internal class GetViewAttributesCommand(
         "Reads the platform attributes of one Android View node — visibility, layout size, padding, margins, alpha, " +
             "background color, text, text size and color — as {\"rootId\", \"nodeId\", \"viewClass\", \"attributes\": " +
             "[{\"id\", \"label\", \"group\", \"type\", \"value\", \"editable\"}]}. \"id\" is what setViewAttribute " +
-            "names, and \"type\" says how to write it: bool (\"true\"), int (\"24\"), float (\"0.5\"), text, " +
-            "color (\"#AARRGGBB\"), dimension (pixels, \"48\"), enum (one of the entry's \"options\") or layoutSize — " +
-            "layout.width / layout.height, which always accept either one of the entry's \"constants\" " +
-            "(\"WRAP_CONTENT\", \"MATCH_PARENT\") or a pixel figure, whatever they currently read as. An entry also " +
-            "carries \"options\" for an enum, \"constants\" for a layoutSize, and \"dp\" for a dimension or for a " +
-            "layoutSize that names a length. \"editable\": false " +
-            "marks a read-only attribute. Answers {\"message\"} instead when the node has no attributes. " +
+            "names, and \"type\" says how to write it — $WRITTEN_AS_BY_TYPE. $EXTRA_FIELDS_BY_TYPE. " +
+            "\"editable\": false marks a read-only attribute. layoutSize is layout.width / layout.height. " +
+            "Answers {\"message\"} instead when the node has no attributes. " +
             TEMPORARY_NOTICE
 
     private val rootId by string("The root the node belongs to, as reported by findNodes or getNodeTree.")
@@ -165,17 +172,7 @@ internal fun ViewAttribute.toMcpJson(): JsonObject = buildJsonObject {
 }
 
 /** The `type` an agent sees, and the name [parseViewAttributeValue] reads a string under. */
-internal val ViewAttributeValue.typeName: String
-    get() = when (this) {
-        is ViewAttributeValue.BooleanValue -> "bool"
-        is ViewAttributeValue.IntValue -> "int"
-        is ViewAttributeValue.FloatValue -> "float"
-        is ViewAttributeValue.TextValue -> "text"
-        is ViewAttributeValue.ColorValue -> "color"
-        is ViewAttributeValue.DimensionValue -> "dimension"
-        is ViewAttributeValue.EnumValue -> "enum"
-        is ViewAttributeValue.LayoutSizeValue -> "layoutSize"
-    }
+internal val ViewAttributeValue.typeName: String get() = type.wireName
 
 /** The value as the string an agent both reads and writes it as. */
 internal fun ViewAttributeValue.asText(): String = when (this) {

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
@@ -35,7 +35,9 @@ internal class GetViewAttributesCommand(
             "background color, text, text size and color — as {\"rootId\", \"nodeId\", \"viewClass\", \"attributes\": " +
             "[{\"id\", \"label\", \"group\", \"type\", \"value\", \"options\", \"editable\"}]}. \"id\" is what " +
             "setViewAttribute names, and \"type\" says how to write it: bool (\"true\"), int (\"24\"), float (\"0.5\"), " +
-            "text, color (\"#AARRGGBB\"), dimension (pixels, \"48\") or enum (one of \"options\"). \"editable\": false " +
+            "text, color (\"#AARRGGBB\"), dimension (pixels, \"48\"), enum (one of \"options\") or layoutSize — " +
+            "layout.width / layout.height, which take either one of \"constants\" (\"WRAP_CONTENT\", \"MATCH_PARENT\") " +
+            "or a pixel figure, whichever the value currently reads as. \"editable\": false " +
             "marks a read-only attribute. Answers {\"message\"} instead when the node has no attributes. " +
             TEMPORARY_NOTICE
 
@@ -85,7 +87,8 @@ internal class SetViewAttributeCommand(
     private val value by string(
         "The new value as a string, read according to the attribute's type: bool \"true\"/\"false\", int \"24\", float \"0.5\", " +
             "text as-is, color \"#AARRGGBB\" or \"#RRGGBB\", dimension as a pixel figure \"48\", enum as one of the options " +
-            "getViewAttributes listed, e.g. \"GONE\".",
+            "getViewAttributes listed, e.g. \"GONE\", layoutSize as one of the constants it listed — \"wrap_content\", " +
+            "\"match_parent\" — or a pixel figure \"500\".",
     )
 
     override suspend fun execute(arguments: JetWhaleMcpArguments): String {
@@ -146,6 +149,13 @@ internal fun ViewAttribute.toMcpJson(): JsonObject = buildJsonObject {
         // The pixel figure is authoritative; the dp figure is what makes it recognisable.
         is ViewAttributeValue.DimensionValue -> put("dp", current.dp)
 
+        // Both of what this takes are spelled out whichever one it currently reads as: the
+        // constants it accepts, and — when it is a length — that length in dp as well.
+        is ViewAttributeValue.LayoutSizeValue -> {
+            put("constants", JsonArray(current.constants.map { JsonPrimitive(it) }))
+            current.dp?.let { put("dp", it) }
+        }
+
         else -> Unit
     }
     // Most attributes can be written; the read-only ones are the ones worth pointing out.
@@ -162,6 +172,7 @@ internal val ViewAttributeValue.typeName: String
         is ViewAttributeValue.ColorValue -> "color"
         is ViewAttributeValue.DimensionValue -> "dimension"
         is ViewAttributeValue.EnumValue -> "enum"
+        is ViewAttributeValue.LayoutSizeValue -> "layoutSize"
     }
 
 /** The value as the string an agent both reads and writes it as. */
@@ -173,15 +184,16 @@ internal fun ViewAttributeValue.asText(): String = when (this) {
     is ViewAttributeValue.ColorValue -> formatArgb(argb)
     is ViewAttributeValue.DimensionValue -> px.toString()
     is ViewAttributeValue.EnumValue -> value
+    is ViewAttributeValue.LayoutSizeValue -> constant ?: px?.toString() ?: ""
 }
 
 /**
  * Reads [text] as a new value for an attribute whose value currently reads as [current] — the
  * current variant is what an agent would otherwise have to reconstruct as sealed JSON by hand.
  *
- * A layout size is the one attribute that takes either shape, so a numeric string is accepted where
- * an enum reads today and a name where a dimension does; the agent decides whether the name is one
- * it knows.
+ * The variant is fixed per attribute, so what each branch accepts is the whole of what the attribute
+ * takes: a dimension is a number and nothing else, an enum is one of its options, and the one
+ * attribute that takes either a name or a number — a layout size — says so in its own variant.
  */
 @OptIn(ExperimentalJetWhaleApi::class)
 internal fun parseViewAttributeValue(attributeId: String, current: ViewAttributeValue, text: String): ViewAttributeValue = when (current) {
@@ -204,21 +216,23 @@ internal fun parseViewAttributeValue(attributeId: String, current: ViewAttribute
     )
 
     is ViewAttributeValue.DimensionValue -> {
-        val px = text.trim().toFloatOrNull()
-        if (px != null) {
-            ViewAttributeValue.DimensionValue(px = px, dp = px)
-        } else {
-            ViewAttributeValue.EnumValue(value = text.trim().uppercase(), options = emptyList())
-        }
+        val px = text.trim().toFloatOrNull() ?: invalidValue(attributeId, text, "a length in pixels")
+        ViewAttributeValue.DimensionValue(px = px, dp = px)
     }
 
-    is ViewAttributeValue.EnumValue -> {
-        val match = current.options.firstOrNull { it.equals(text.trim(), ignoreCase = true) }
+    is ViewAttributeValue.EnumValue -> ViewAttributeValue.EnumValue(
+        value = current.options.firstOrNull { it.equals(text.trim(), ignoreCase = true) }
+            ?: invalidValue(attributeId, text, "one of ${current.options.joinToString(", ")}"),
+        options = current.options,
+    )
+
+    is ViewAttributeValue.LayoutSizeValue -> {
+        val constant = current.constants.firstOrNull { it.equals(text.trim(), ignoreCase = true) }
         val px = text.trim().toFloatOrNull()
         when {
-            match != null -> ViewAttributeValue.EnumValue(value = match, options = current.options)
-            px != null -> ViewAttributeValue.DimensionValue(px = px, dp = px)
-            else -> invalidValue(attributeId, text, "one of ${current.options.joinToString(", ")}")
+            constant != null -> current.copy(constant = constant, px = null, dp = null)
+            px != null -> current.copy(constant = null, px = px, dp = px)
+            else -> invalidValue(attributeId, text, "one of ${current.constants.joinToString(", ")}, or a length in pixels")
         }
     }
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
@@ -33,11 +33,13 @@ internal class GetViewAttributesCommand(
     override val description =
         "Reads the platform attributes of one Android View node — visibility, layout size, padding, margins, alpha, " +
             "background color, text, text size and color — as {\"rootId\", \"nodeId\", \"viewClass\", \"attributes\": " +
-            "[{\"id\", \"label\", \"group\", \"type\", \"value\", \"options\", \"editable\"}]}. \"id\" is what " +
-            "setViewAttribute names, and \"type\" says how to write it: bool (\"true\"), int (\"24\"), float (\"0.5\"), " +
-            "text, color (\"#AARRGGBB\"), dimension (pixels, \"48\"), enum (one of \"options\") or layoutSize — " +
-            "layout.width / layout.height, which take either one of \"constants\" (\"WRAP_CONTENT\", \"MATCH_PARENT\") " +
-            "or a pixel figure, whichever the value currently reads as. \"editable\": false " +
+            "[{\"id\", \"label\", \"group\", \"type\", \"value\", \"editable\"}]}. \"id\" is what setViewAttribute " +
+            "names, and \"type\" says how to write it: bool (\"true\"), int (\"24\"), float (\"0.5\"), text, " +
+            "color (\"#AARRGGBB\"), dimension (pixels, \"48\"), enum (one of the entry's \"options\") or layoutSize — " +
+            "layout.width / layout.height, which always accept either one of the entry's \"constants\" " +
+            "(\"WRAP_CONTENT\", \"MATCH_PARENT\") or a pixel figure, whatever they currently read as. An entry also " +
+            "carries \"options\" for an enum, \"constants\" for a layoutSize, and \"dp\" for a dimension or for a " +
+            "layoutSize that names a length. \"editable\": false " +
             "marks a read-only attribute. Answers {\"message\"} instead when the node has no attributes. " +
             TEMPORARY_NOTICE
 

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
@@ -1,0 +1,244 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
+import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+// The two attribute tools. They sit apart from the tree tools because they address one View node
+// rather than the tree, and because only View nodes have anything to answer.
+
+private const val TEMPORARY_NOTICE =
+    "Only Android View nodes (the ones findNodes marks \"kind\": \"View\", with a negative id) have attributes: a Compose " +
+        "node's semantics are a projection of composition state, so writing to one would be undone by the next recomposition. " +
+        "An edit is temporary — a relayout, a rebind, or the app writing the property itself takes the value back."
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class GetViewAttributesCommand(
+    private val getAttributes: suspend (GetViewAttributes) -> ViewAttributeResponse,
+) : JetWhaleMcpCommand() {
+    override val name = "$TOOL_PREFIX.getViewAttributes"
+    override val description =
+        "Reads the platform attributes of one Android View node — visibility, layout size, padding, margins, alpha, " +
+            "background color, text, text size and color — as {\"rootId\", \"nodeId\", \"viewClass\", \"attributes\": " +
+            "[{\"id\", \"label\", \"group\", \"type\", \"value\", \"options\", \"editable\"}]}. \"id\" is what " +
+            "setViewAttribute names, and \"type\" says how to write it: bool (\"true\"), int (\"24\"), float (\"0.5\"), " +
+            "text, color (\"#AARRGGBB\"), dimension (pixels, \"48\") or enum (one of \"options\"). \"editable\": false " +
+            "marks a read-only attribute. Answers {\"message\"} instead when the node has no attributes. " +
+            TEMPORARY_NOTICE
+
+    private val rootId by string("The root the node belongs to, as reported by findNodes or getNodeTree.")
+    private val nodeId by int("The View node's id, as reported by findNodes or getNodeTree. It is negative.")
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val rootId = arguments[rootId]
+        val nodeId = arguments[nodeId]
+        val response = try {
+            getAttributes(GetViewAttributes(rootId = rootId, nodeId = nodeId))
+        } catch (e: JetWhaleMessagingException) {
+            return agentErrorJson(e)
+        }
+        val snapshot = response.snapshot
+            ?: return buildJsonObject {
+                put("rootId", rootId)
+                put("nodeId", nodeId)
+                put("message", response.message ?: "this node has no View attributes")
+            }.toString()
+
+        return buildJsonObject {
+            put("rootId", snapshot.rootId)
+            put("nodeId", snapshot.nodeId)
+            put("viewClass", snapshot.viewClass)
+            put("attributes", JsonArray(snapshot.attributes.map { it.toMcpJson() }))
+        }.toString()
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+internal class SetViewAttributeCommand(
+    private val getAttributes: suspend (GetViewAttributes) -> ViewAttributeResponse,
+    private val setAttribute: suspend (SetViewAttribute) -> ViewAttributeResult,
+) : JetWhaleMcpCommand() {
+    override val name = "$TOOL_PREFIX.setViewAttribute"
+    override val description =
+        "Changes one attribute of one Android View node in the running app and returns " +
+            "{\"applied\", \"rootId\", \"nodeId\", \"attributeId\", \"message\", \"attribute\"}, where \"attribute\" is the " +
+            "value as it reads back afterwards — an app may clamp or ignore what was asked for. The value is given as a " +
+            "string and parsed for the attribute's own type: \"GONE\", \"true\", \"0.5\", \"#80FF0000\", \"24\". " +
+            "Call getViewAttributes first to see the ids, types and enum options. " + TEMPORARY_NOTICE
+
+    private val rootId by string("The root the node belongs to, as reported by findNodes or getNodeTree.")
+    private val nodeId by int("The View node's id, as reported by findNodes or getNodeTree. It is negative.")
+    private val attributeId by string("The attribute's \"id\" from getViewAttributes, e.g. visibility, text, padding.left, layout.width.")
+    private val value by string(
+        "The new value as a string, read according to the attribute's type: bool \"true\"/\"false\", int \"24\", float \"0.5\", " +
+            "text as-is, color \"#AARRGGBB\" or \"#RRGGBB\", dimension as a pixel figure \"48\", enum as one of the options " +
+            "getViewAttributes listed, e.g. \"GONE\".",
+    )
+
+    override suspend fun execute(arguments: JetWhaleMcpArguments): String {
+        val rootId = arguments[rootId]
+        val nodeId = arguments[nodeId]
+        val attributeId = arguments[attributeId]
+        val text = arguments[value]
+
+        val result = try {
+            // The current value is what says how to read the string, so the write always starts from
+            // a fresh read; it also means an unknown id is caught here, where the known ids can be listed.
+            val response = getAttributes(GetViewAttributes(rootId = rootId, nodeId = nodeId))
+            val snapshot = response.snapshot
+                ?: return errorJson(response.message ?: "this node has no View attributes")
+            val current = snapshot.attributes.firstOrNull { it.id == attributeId }
+                ?: throw JetWhaleMcpArgumentException(
+                    "unknown attributeId: $attributeId (this ${snapshot.viewClass} exposes ${snapshot.attributes.joinToString { it.id }})",
+                )
+            if (!current.editable) throw JetWhaleMcpArgumentException("$attributeId is read-only on a ${snapshot.viewClass}")
+
+            setAttribute(
+                SetViewAttribute(
+                    rootId = rootId,
+                    nodeId = nodeId,
+                    attributeId = attributeId,
+                    value = parseViewAttributeValue(attributeId, current.value, text),
+                ),
+            )
+        } catch (e: JetWhaleMessagingException) {
+            return agentErrorJson(e)
+        }
+
+        return buildJsonObject {
+            put("applied", result.applied)
+            put("rootId", rootId)
+            put("nodeId", nodeId)
+            put("attributeId", attributeId)
+            result.message?.let { put("message", it) }
+            result.attribute?.let { put("attribute", it.toMcpJson()) }
+        }.toString()
+    }
+}
+
+/**
+ * Renders one attribute for an AI agent: the value flattened to a string of the same shape the
+ * setter takes, so a value read here can be written back without being reshaped.
+ */
+internal fun ViewAttribute.toMcpJson(): JsonObject = buildJsonObject {
+    val current = value
+    put("id", id)
+    put("label", label)
+    put("group", group)
+    put("type", current.typeName)
+    put("value", current.asText())
+    when (current) {
+        is ViewAttributeValue.EnumValue -> put("options", JsonArray(current.options.map { JsonPrimitive(it) }))
+
+        // The pixel figure is authoritative; the dp figure is what makes it recognisable.
+        is ViewAttributeValue.DimensionValue -> put("dp", current.dp)
+
+        else -> Unit
+    }
+    // Most attributes can be written; the read-only ones are the ones worth pointing out.
+    if (!editable) put("editable", false)
+}
+
+/** The `type` an agent sees, and the name [parseViewAttributeValue] reads a string under. */
+internal val ViewAttributeValue.typeName: String
+    get() = when (this) {
+        is ViewAttributeValue.BooleanValue -> "bool"
+        is ViewAttributeValue.IntValue -> "int"
+        is ViewAttributeValue.FloatValue -> "float"
+        is ViewAttributeValue.TextValue -> "text"
+        is ViewAttributeValue.ColorValue -> "color"
+        is ViewAttributeValue.DimensionValue -> "dimension"
+        is ViewAttributeValue.EnumValue -> "enum"
+    }
+
+/** The value as the string an agent both reads and writes it as. */
+internal fun ViewAttributeValue.asText(): String = when (this) {
+    is ViewAttributeValue.BooleanValue -> value.toString()
+    is ViewAttributeValue.IntValue -> value.toString()
+    is ViewAttributeValue.FloatValue -> value.toString()
+    is ViewAttributeValue.TextValue -> value
+    is ViewAttributeValue.ColorValue -> formatArgb(argb)
+    is ViewAttributeValue.DimensionValue -> px.toString()
+    is ViewAttributeValue.EnumValue -> value
+}
+
+/**
+ * Reads [text] as a new value for an attribute whose value currently reads as [current] — the
+ * current variant is what an agent would otherwise have to reconstruct as sealed JSON by hand.
+ *
+ * A layout size is the one attribute that takes either shape, so a numeric string is accepted where
+ * an enum reads today and a name where a dimension does; the agent decides whether the name is one
+ * it knows.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+internal fun parseViewAttributeValue(attributeId: String, current: ViewAttributeValue, text: String): ViewAttributeValue = when (current) {
+    is ViewAttributeValue.BooleanValue -> ViewAttributeValue.BooleanValue(
+        text.trim().toBooleanStrictOrNull() ?: invalidValue(attributeId, text, "true or false"),
+    )
+
+    is ViewAttributeValue.IntValue -> ViewAttributeValue.IntValue(
+        text.trim().toIntOrNull() ?: invalidValue(attributeId, text, "a whole number"),
+    )
+
+    is ViewAttributeValue.FloatValue -> ViewAttributeValue.FloatValue(
+        text.trim().toFloatOrNull() ?: invalidValue(attributeId, text, "a number"),
+    )
+
+    is ViewAttributeValue.TextValue -> ViewAttributeValue.TextValue(text)
+
+    is ViewAttributeValue.ColorValue -> ViewAttributeValue.ColorValue(
+        parseArgb(text) ?: invalidValue(attributeId, text, "a color as #AARRGGBB or #RRGGBB"),
+    )
+
+    is ViewAttributeValue.DimensionValue -> {
+        val px = text.trim().toFloatOrNull()
+        if (px != null) {
+            ViewAttributeValue.DimensionValue(px = px, dp = px)
+        } else {
+            ViewAttributeValue.EnumValue(value = text.trim().uppercase(), options = emptyList())
+        }
+    }
+
+    is ViewAttributeValue.EnumValue -> {
+        val match = current.options.firstOrNull { it.equals(text.trim(), ignoreCase = true) }
+        val px = text.trim().toFloatOrNull()
+        when {
+            match != null -> ViewAttributeValue.EnumValue(value = match, options = current.options)
+            px != null -> ViewAttributeValue.DimensionValue(px = px, dp = px)
+            else -> invalidValue(attributeId, text, "one of ${current.options.joinToString(", ")}")
+        }
+    }
+}
+
+/** `#AARRGGBB` or `#RRGGBB`, the notation a `View`'s colors are written in; the short form is opaque. */
+internal fun parseArgb(text: String): Int? {
+    val digits = text.trim().removePrefix("#")
+    if (digits.any { it !in HEX_DIGITS }) return null
+    return when (digits.length) {
+        8 -> digits.toLongOrNull(radix = 16)?.toInt()
+        6 -> digits.toLongOrNull(radix = 16)?.toInt()?.or(OPAQUE_ALPHA)
+        else -> null
+    }
+}
+
+internal fun formatArgb(argb: Int): String = "#" + (argb.toLong() and 0xFFFFFFFFL).toString(radix = 16).padStart(8, '0').uppercase()
+
+private const val OPAQUE_ALPHA = 0xFF shl 24
+
+private const val HEX_DIGITS = "0123456789abcdefABCDEF"
+
+@OptIn(ExperimentalJetWhaleApi::class)
+private fun invalidValue(attributeId: String, text: String, expected: String): Nothing = throw JetWhaleMcpArgumentException("invalid value for $attributeId: \"$text\" (expected $expected)")

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeStore.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeStore.kt
@@ -1,0 +1,164 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
+import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * The attributes of the one `View` node the panel is showing, and every write that reaches them.
+ *
+ * Owned by the plugin instance rather than by the composition for three reasons: the attributes
+ * survive the panel being closed and reopened, a write outlives the panel that started it — the
+ * device applies it either way, so the outcome is worth keeping — and an agent's write goes through
+ * here too, so the panel cannot be left showing a value the app no longer has.
+ *
+ * Attributes are fetched per node rather than carried by the capture — a tree of two hundred nodes
+ * would otherwise haul thirty attributes each — so a selection change is a read.
+ */
+internal class ViewAttributeStore(
+    /** Outlives the panel, so a write started there is still recorded after it closes. */
+    private val scope: CoroutineScope,
+    private val read: suspend (GetViewAttributes) -> ViewAttributeResponse,
+    private val write: suspend (SetViewAttribute) -> ViewAttributeResult,
+) {
+    /** The node whose attributes are held, or `null` when the selection has none. */
+    var node: NodeKey? by mutableStateOf(null)
+        private set
+
+    /** The attributes of [node], or `null` while they are being read or could not be. */
+    var attributes: List<ViewAttribute>? by mutableStateOf(null)
+        private set
+
+    /** Why there are no attributes to show, when there are none. */
+    var message: String? by mutableStateOf(null)
+        private set
+
+    /** What the last write to [node] came back with. */
+    var writeStatus: String? by mutableStateOf(null)
+        private set
+
+    var writeFailed: Boolean by mutableStateOf(false)
+        private set
+
+    // Writes run one at a time. Each is its own coroutine, so two edits made in quick succession —
+    // a switch toggled twice, a field committed and then a dropdown picked, a user and an agent
+    // writing at once — would otherwise race, and the row and the status line would settle on
+    // whichever answer happened to arrive last rather than on the last edit made.
+    private val writeLock = Mutex()
+
+    /**
+     * Holds the attributes of [rootId]/[nodeId], reading them if they are not already held.
+     *
+     * Selecting the node that is already held is nothing: the panel leaving and re-entering the
+     * composition must not spend a round trip to the app re-reading what is already on screen.
+     */
+    fun select(rootId: String, nodeId: Int) {
+        val key = NodeKey(rootId = rootId, nodeId = nodeId)
+        if (key == node) return
+        node = key
+        attributes = null
+        message = null
+        writeStatus = null
+        writeFailed = false
+        scope.launch {
+            val response = try {
+                read(GetViewAttributes(rootId = rootId, nodeId = nodeId))
+            } catch (e: JetWhaleMessagingException) {
+                // A read that comes back after the selection moved on describes a node nobody is
+                // looking at any more, so it is dropped rather than shown against the new one.
+                if (node == key) {
+                    attributes = null
+                    message = "The app did not answer: ${e.message}"
+                }
+                return@launch
+            }
+            if (node != key) return@launch
+            attributes = response.snapshot?.attributes
+            message = response.message
+        }
+    }
+
+    /** Holds nothing — the selection is a Compose node, or there is no selection. */
+    fun clear() {
+        node = null
+        attributes = null
+        message = null
+        writeStatus = null
+        writeFailed = false
+    }
+
+    /**
+     * Writes [text] to [attribute] on the held node, and records what came back.
+     *
+     * Fire-and-forget for the panel's editors, which have no scope of their own to wait in; the
+     * write itself runs on the plugin's scope, so navigating away mid-write still records the
+     * outcome.
+     */
+    @OptIn(ExperimentalJetWhaleApi::class)
+    fun commit(attribute: ViewAttribute, text: String) {
+        val key = node ?: return
+        scope.launch {
+            writeLock.withLock {
+                val value = try {
+                    parseViewAttributeValue(attribute.id, attribute.value, text)
+                } catch (e: JetWhaleMcpArgumentException) {
+                    writeStatus = e.message
+                    writeFailed = true
+                    return@withLock
+                }
+                try {
+                    apply(SetViewAttribute(rootId = key.rootId, nodeId = key.nodeId, attributeId = attribute.id, value = value))
+                } catch (e: JetWhaleMessagingException) {
+                    writeStatus = "${attribute.id} failed: ${e.message}"
+                    writeFailed = true
+                }
+            }
+        }
+    }
+
+    /** Reads any node's attributes, for the MCP tool that asks about one the panel is not showing. */
+    suspend fun readAttributes(request: GetViewAttributes): ViewAttributeResponse = read(request)
+
+    /**
+     * Writes one attribute of any node and returns what came back, for the MCP tool — which has a
+     * caller waiting on the answer, and so cannot go through [commit].
+     */
+    suspend fun writeAttribute(request: SetViewAttribute): ViewAttributeResult = writeLock.withLock { apply(request) }
+
+    /** The write itself, already serialised by [writeLock]. */
+    private suspend fun apply(request: SetViewAttribute): ViewAttributeResult {
+        val result = write(request)
+        // Only the node the panel is holding: an agent may write to one the user is not looking at,
+        // and the panel must go on showing the node it is showing.
+        if (node == NodeKey(rootId = request.rootId, nodeId = request.nodeId)) {
+            record(attributeId = request.attributeId, result = result)
+        }
+        return result
+    }
+
+    private fun record(attributeId: String, result: ViewAttributeResult) {
+        // The row shows what came back, not what was asked for: an app may clamp a value or ignore
+        // it, and the difference is exactly what the panel is for.
+        result.attribute?.let { written ->
+            attributes = attributes?.map { if (it.id == written.id) written else it }
+        }
+        writeFailed = !result.applied
+        writeStatus = when {
+            result.applied -> "$attributeId: ${result.attribute?.value?.asText() ?: "written"}"
+            else -> "$attributeId: ${result.message ?: "not applied"}"
+        }
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeStore.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeStore.kt
@@ -38,19 +38,8 @@ internal class ViewAttributeStore(
     var node: NodeKey? by mutableStateOf(null)
         private set
 
-    /** The attributes of [node], or `null` while they are being read or could not be. */
-    var attributes: List<ViewAttribute>? by mutableStateOf(null)
-        private set
-
-    /** Why there are no attributes to show, when there are none. */
-    var message: String? by mutableStateOf(null)
-        private set
-
-    /** What the last write to [node] came back with. */
-    var writeStatus: String? by mutableStateOf(null)
-        private set
-
-    var writeFailed: Boolean by mutableStateOf(false)
+    /** What the panel draws for [node]: one value, so the composition takes data rather than this store. */
+    var state: ViewAttributesUiState by mutableStateOf(ViewAttributesUiState.Empty)
         private set
 
     // Writes run one at a time. Each is its own coroutine, so two edits made in quick succession —
@@ -69,10 +58,7 @@ internal class ViewAttributeStore(
         val key = NodeKey(rootId = rootId, nodeId = nodeId)
         if (key == node) return
         node = key
-        attributes = null
-        message = null
-        writeStatus = null
-        writeFailed = false
+        state = ViewAttributesUiState.Empty
         scope.launch {
             val response = try {
                 read(GetViewAttributes(rootId = rootId, nodeId = nodeId))
@@ -80,24 +66,19 @@ internal class ViewAttributeStore(
                 // A read that comes back after the selection moved on describes a node nobody is
                 // looking at any more, so it is dropped rather than shown against the new one.
                 if (node == key) {
-                    attributes = null
-                    message = "The app did not answer: ${e.message}"
+                    state = state.copy(attributes = null, message = "The app did not answer: ${e.message}")
                 }
                 return@launch
             }
             if (node != key) return@launch
-            attributes = response.snapshot?.attributes
-            message = response.message
+            state = state.copy(attributes = response.snapshot?.attributes, message = response.message)
         }
     }
 
     /** Holds nothing — the selection is a Compose node, or there is no selection. */
     fun clear() {
         node = null
-        attributes = null
-        message = null
-        writeStatus = null
-        writeFailed = false
+        state = ViewAttributesUiState.Empty
     }
 
     /**
@@ -115,15 +96,13 @@ internal class ViewAttributeStore(
                 val value = try {
                     parseViewAttributeValue(attribute.id, attribute.value, text)
                 } catch (e: JetWhaleMcpArgumentException) {
-                    writeStatus = e.message
-                    writeFailed = true
+                    state = state.copy(writeStatus = e.message, writeFailed = true)
                     return@withLock
                 }
                 try {
                     apply(SetViewAttribute(rootId = key.rootId, nodeId = key.nodeId, attributeId = attribute.id, value = value))
                 } catch (e: JetWhaleMessagingException) {
-                    writeStatus = "${attribute.id} failed: ${e.message}"
-                    writeFailed = true
+                    state = state.copy(writeStatus = "${attribute.id} failed: ${e.message}", writeFailed = true)
                 }
             }
         }
@@ -152,13 +131,17 @@ internal class ViewAttributeStore(
     private fun record(attributeId: String, result: ViewAttributeResult) {
         // The row shows what came back, not what was asked for: an app may clamp a value or ignore
         // it, and the difference is exactly what the panel is for.
-        result.attribute?.let { written ->
-            attributes = attributes?.map { if (it.id == written.id) written else it }
+        val attributes = when (val written = result.attribute) {
+            null -> state.attributes
+            else -> state.attributes?.map { if (it.id == written.id) written else it }
         }
-        writeFailed = !result.applied
-        writeStatus = when {
-            result.applied -> "$attributeId: ${result.attribute?.value?.asText() ?: "written"}"
-            else -> "$attributeId: ${result.message ?: "not applied"}"
-        }
+        state = state.copy(
+            attributes = attributes,
+            writeFailed = !result.applied,
+            writeStatus = when {
+                result.applied -> "$attributeId: ${result.attribute?.value?.asText() ?: "written"}"
+                else -> "$attributeId: ${result.message ?: "not applied"}"
+            },
+        )
     }
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -21,11 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
 import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
@@ -332,17 +330,14 @@ private fun TextEditor(
         enabled = enabled,
         placeholder = placeholder,
         textStyle = JwTheme.textStyles.code,
-        modifier = modifier
-            .onFocusChanged { state ->
-                if (!state.isFocused) commit()
-            }
-            .onPreviewKeyEvent { event ->
-                if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
-                    commit()
-                    true
-                } else {
-                    false
-                }
-            },
+        // Enter arrives as the field's own IME action rather than being taken off the key stream
+        // before it: an input method composing a word — a Japanese one converting kana — spends
+        // Enter on accepting its candidate, and a preview handler would swallow that keystroke and
+        // write the half-composed text instead.
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { commit() }),
+        modifier = modifier.onFocusChanged { state ->
+            if (!state.isFocused) commit()
+        },
     )
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
@@ -13,11 +13,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,8 +23,6 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
-import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
 import com.kitakkun.jetwhale.host.ui.JwDropdownButton
 import com.kitakkun.jetwhale.host.ui.JwMenuItem
 import com.kitakkun.jetwhale.host.ui.JwSectionHeader
@@ -38,85 +34,25 @@ import com.kitakkun.jetwhale.host.ui.JwText
 import com.kitakkun.jetwhale.host.ui.JwTextField
 import com.kitakkun.jetwhale.host.ui.JwTheme
 import com.kitakkun.jetwhale.host.ui.JwTone
-import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
-import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
-import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
-import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
-import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 /**
  * The platform attributes of the selected Android `View` node, and an editor for the ones that can
  * be written.
  *
- * Attributes are fetched per node rather than carried by the capture — a tree of two hundred nodes
- * would otherwise haul thirty attributes each — so this loads whenever the selection changes.
+ * A view of [ViewAttributeStore] and nothing more: the read, the write and their outcome live on
+ * the plugin instance, so this panel can be closed and reopened without any of them being redone or
+ * lost, and an agent writing through the same store is seen here.
  */
-@OptIn(ExperimentalJetWhaleApi::class)
 @Composable
 internal fun ViewAttributesPanel(
-    rootId: String,
-    nodeId: Int,
-    loadAttributes: suspend (GetViewAttributes) -> ViewAttributeResponse,
-    writeAttribute: suspend (SetViewAttribute) -> ViewAttributeResult,
+    attributes: List<ViewAttribute>?,
+    message: String?,
+    writeStatus: String?,
+    writeFailed: Boolean,
+    onCommit: (ViewAttribute, String) -> Unit,
 ) {
-    var attributes by remember(rootId, nodeId) { mutableStateOf<List<ViewAttribute>?>(null) }
-    var message by remember(rootId, nodeId) { mutableStateOf<String?>(null) }
-    var writeStatus by remember(rootId, nodeId) { mutableStateOf<String?>(null) }
-    var writeFailed by remember(rootId, nodeId) { mutableStateOf(false) }
-    val scope = rememberCoroutineScope()
-
-    // Writes run one at a time. Each is its own coroutine, so two edits made in quick succession —
-    // a switch toggled twice, a field committed and then a dropdown picked — would otherwise race,
-    // and the row and the status line would settle on whichever answer happened to arrive last
-    // rather than on the last edit made.
-    val writeLock = remember(rootId, nodeId) { Mutex() }
-
-    LaunchedEffect(rootId, nodeId) {
-        try {
-            val response = loadAttributes(GetViewAttributes(rootId = rootId, nodeId = nodeId))
-            attributes = response.snapshot?.attributes
-            message = response.message
-        } catch (e: JetWhaleMessagingException) {
-            attributes = null
-            message = "The app did not answer: ${e.message}"
-        }
-    }
-
-    fun commit(attribute: ViewAttribute, text: String) {
-        scope.launch {
-            writeLock.withLock {
-                val value = try {
-                    parseViewAttributeValue(attribute.id, attribute.value, text)
-                } catch (e: JetWhaleMcpArgumentException) {
-                    writeStatus = e.message
-                    writeFailed = true
-                    return@withLock
-                }
-                try {
-                    val result = writeAttribute(SetViewAttribute(rootId = rootId, nodeId = nodeId, attributeId = attribute.id, value = value))
-                    // The row shows what came back, not what was asked for: an app may clamp a value
-                    // or ignore it, and the difference is exactly what the panel is for.
-                    result.attribute?.let { written ->
-                        attributes = attributes?.map { if (it.id == written.id) written else it }
-                    }
-                    writeFailed = !result.applied
-                    writeStatus = when {
-                        result.applied -> "${attribute.id}: ${result.attribute?.value?.asText() ?: "written"}"
-                        else -> "${attribute.id}: ${result.message ?: "not applied"}"
-                    }
-                } catch (e: JetWhaleMessagingException) {
-                    writeStatus = "${attribute.id} failed: ${e.message}"
-                    writeFailed = true
-                }
-            }
-        }
-    }
-
     Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(JwSpacing.small)) {
         JwSectionHeader(title = "View attributes", contentPadding = PaddingValues(0.dp))
         JwText(
@@ -125,21 +61,20 @@ internal fun ViewAttributesPanel(
             color = JwTheme.colors.textSecondary,
         )
 
-        val loaded = attributes
         when {
-            loaded == null && message == null -> JwText(
+            attributes == null && message == null -> JwText(
                 text = "Reading the view's attributes…",
                 style = JwTheme.textStyles.bodySmall,
                 color = JwTheme.colors.textSecondary,
             )
 
-            loaded == null -> JwStatusLine(text = message.orEmpty(), tone = JwTone.Warning)
+            attributes == null -> JwStatusLine(text = message.orEmpty(), tone = JwTone.Warning)
 
             else -> {
-                for ((group, rows) in loaded.groupBy { it.group }) {
+                for ((group, rows) in attributes.groupBy { it.group }) {
                     JwSectionHeader(title = group, contentPadding = PaddingValues(0.dp))
                     for (attribute in rows) {
-                        AttributeRow(attribute = attribute, onCommit = { text -> commit(attribute, text) })
+                        AttributeRow(attribute = attribute, onCommit = { text -> onCommit(attribute, text) })
                     }
                 }
             }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
@@ -48,6 +48,8 @@ import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * The platform attributes of the selected Android `View` node, and an editor for the ones that can
@@ -70,6 +72,12 @@ internal fun ViewAttributesPanel(
     var writeFailed by remember(rootId, nodeId) { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
+    // Writes run one at a time. Each is its own coroutine, so two edits made in quick succession —
+    // a switch toggled twice, a field committed and then a dropdown picked — would otherwise race,
+    // and the row and the status line would settle on whichever answer happened to arrive last
+    // rather than on the last edit made.
+    val writeLock = remember(rootId, nodeId) { Mutex() }
+
     LaunchedEffect(rootId, nodeId) {
         try {
             val response = loadAttributes(GetViewAttributes(rootId = rootId, nodeId = nodeId))
@@ -83,28 +91,30 @@ internal fun ViewAttributesPanel(
 
     fun commit(attribute: ViewAttribute, text: String) {
         scope.launch {
-            val value = try {
-                parseViewAttributeValue(attribute.id, attribute.value, text)
-            } catch (e: JetWhaleMcpArgumentException) {
-                writeStatus = e.message
-                writeFailed = true
-                return@launch
-            }
-            try {
-                val result = writeAttribute(SetViewAttribute(rootId = rootId, nodeId = nodeId, attributeId = attribute.id, value = value))
-                // The row shows what came back, not what was asked for: an app may clamp a value or
-                // ignore it, and the difference is exactly what the panel is for.
-                result.attribute?.let { written ->
-                    attributes = attributes?.map { if (it.id == written.id) written else it }
+            writeLock.withLock {
+                val value = try {
+                    parseViewAttributeValue(attribute.id, attribute.value, text)
+                } catch (e: JetWhaleMcpArgumentException) {
+                    writeStatus = e.message
+                    writeFailed = true
+                    return@withLock
                 }
-                writeFailed = !result.applied
-                writeStatus = when {
-                    result.applied -> "${attribute.id}: ${result.attribute?.value?.asText() ?: "written"}"
-                    else -> "${attribute.id}: ${result.message ?: "not applied"}"
+                try {
+                    val result = writeAttribute(SetViewAttribute(rootId = rootId, nodeId = nodeId, attributeId = attribute.id, value = value))
+                    // The row shows what came back, not what was asked for: an app may clamp a value
+                    // or ignore it, and the difference is exactly what the panel is for.
+                    result.attribute?.let { written ->
+                        attributes = attributes?.map { if (it.id == written.id) written else it }
+                    }
+                    writeFailed = !result.applied
+                    writeStatus = when {
+                        result.applied -> "${attribute.id}: ${result.attribute?.value?.asText() ?: "written"}"
+                        else -> "${attribute.id}: ${result.message ?: "not applied"}"
+                    }
+                } catch (e: JetWhaleMessagingException) {
+                    writeStatus = "${attribute.id} failed: ${e.message}"
+                    writeFailed = true
                 }
-            } catch (e: JetWhaleMessagingException) {
-                writeStatus = "${attribute.id} failed: ${e.message}"
-                writeFailed = true
             }
         }
     }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
@@ -1,0 +1,243 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.unit.dp
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.ui.JwDropdownButton
+import com.kitakkun.jetwhale.host.ui.JwMenuItem
+import com.kitakkun.jetwhale.host.ui.JwSectionHeader
+import com.kitakkun.jetwhale.host.ui.JwShapes
+import com.kitakkun.jetwhale.host.ui.JwSpacing
+import com.kitakkun.jetwhale.host.ui.JwStatusLine
+import com.kitakkun.jetwhale.host.ui.JwSwitch
+import com.kitakkun.jetwhale.host.ui.JwText
+import com.kitakkun.jetwhale.host.ui.JwTextField
+import com.kitakkun.jetwhale.host.ui.JwTheme
+import com.kitakkun.jetwhale.host.ui.JwTone
+import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
+import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import kotlinx.coroutines.launch
+
+/**
+ * The platform attributes of the selected Android `View` node, and an editor for the ones that can
+ * be written.
+ *
+ * Attributes are fetched per node rather than carried by the capture — a tree of two hundred nodes
+ * would otherwise haul thirty attributes each — so this loads whenever the selection changes.
+ */
+@OptIn(ExperimentalJetWhaleApi::class)
+@Composable
+internal fun ViewAttributesPanel(
+    rootId: String,
+    nodeId: Int,
+    loadAttributes: suspend (GetViewAttributes) -> ViewAttributeResponse,
+    writeAttribute: suspend (SetViewAttribute) -> ViewAttributeResult,
+) {
+    var attributes by remember(rootId, nodeId) { mutableStateOf<List<ViewAttribute>?>(null) }
+    var message by remember(rootId, nodeId) { mutableStateOf<String?>(null) }
+    var writeStatus by remember(rootId, nodeId) { mutableStateOf<String?>(null) }
+    var writeFailed by remember(rootId, nodeId) { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(rootId, nodeId) {
+        try {
+            val response = loadAttributes(GetViewAttributes(rootId = rootId, nodeId = nodeId))
+            attributes = response.snapshot?.attributes
+            message = response.message
+        } catch (e: JetWhaleMessagingException) {
+            attributes = null
+            message = "The app did not answer: ${e.message}"
+        }
+    }
+
+    fun commit(attribute: ViewAttribute, text: String) {
+        scope.launch {
+            val value = try {
+                parseViewAttributeValue(attribute.id, attribute.value, text)
+            } catch (e: JetWhaleMcpArgumentException) {
+                writeStatus = e.message
+                writeFailed = true
+                return@launch
+            }
+            try {
+                val result = writeAttribute(SetViewAttribute(rootId = rootId, nodeId = nodeId, attributeId = attribute.id, value = value))
+                // The row shows what came back, not what was asked for: an app may clamp a value or
+                // ignore it, and the difference is exactly what the panel is for.
+                result.attribute?.let { written ->
+                    attributes = attributes?.map { if (it.id == written.id) written else it }
+                }
+                writeFailed = !result.applied
+                writeStatus = when {
+                    result.applied -> "${attribute.id}: ${result.attribute?.value?.asText() ?: "written"}"
+                    else -> "${attribute.id}: ${result.message ?: "not applied"}"
+                }
+            } catch (e: JetWhaleMessagingException) {
+                writeStatus = "${attribute.id} failed: ${e.message}"
+                writeFailed = true
+            }
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(JwSpacing.small)) {
+        JwSectionHeader(title = "View attributes", contentPadding = PaddingValues(0.dp))
+        JwText(
+            text = "Edits are temporary: a relayout, a rebind, or the app writing the property itself takes the value back.",
+            style = JwTheme.textStyles.labelSmall,
+            color = JwTheme.colors.textSecondary,
+        )
+
+        val loaded = attributes
+        when {
+            loaded == null && message == null -> JwText(
+                text = "Reading the view's attributes…",
+                style = JwTheme.textStyles.bodySmall,
+                color = JwTheme.colors.textSecondary,
+            )
+
+            loaded == null -> JwStatusLine(text = message.orEmpty(), tone = JwTone.Warning)
+
+            else -> {
+                for ((group, rows) in loaded.groupBy { it.group }) {
+                    JwSectionHeader(title = group, contentPadding = PaddingValues(0.dp))
+                    for (attribute in rows) {
+                        AttributeRow(attribute = attribute, onCommit = { text -> commit(attribute, text) })
+                    }
+                }
+            }
+        }
+
+        writeStatus?.let { JwStatusLine(text = it, tone = if (writeFailed) JwTone.Error else JwTone.Accent) }
+    }
+}
+
+/** Fits "backgroundColor", the longest attribute label. */
+private val AttributeLabelWidth = 120.dp
+
+/** Wide enough for `#AARRGGBB` and for the enum names, without crowding the pane. */
+private val AttributeEditorWidth = 180.dp
+
+private val ColorSwatchSize = 16.dp
+
+@Composable
+private fun AttributeRow(attribute: ViewAttribute, onCommit: (String) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(JwSpacing.medium),
+    ) {
+        JwText(
+            text = attribute.label,
+            style = JwTheme.textStyles.bodySmall,
+            color = JwTheme.colors.textSecondary,
+            modifier = Modifier.width(AttributeLabelWidth),
+        )
+        val value = attribute.value
+        when {
+            !attribute.editable -> JwText(text = value.asText(), style = JwTheme.textStyles.code)
+
+            value is ViewAttributeValue.BooleanValue -> JwSwitch(
+                checked = value.value,
+                onCheckedChange = { onCommit(it.toString()) },
+                contentDescription = attribute.label,
+            )
+
+            value is ViewAttributeValue.EnumValue -> EnumEditor(value = value, onCommit = onCommit)
+
+            value is ViewAttributeValue.ColorValue -> Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(JwSpacing.small),
+            ) {
+                Box(
+                    Modifier
+                        .size(ColorSwatchSize)
+                        .background(Color(value.argb), JwShapes.extraSmall)
+                        .border(1.dp, JwTheme.colors.border, JwShapes.extraSmall),
+                )
+                TextEditor(current = value.asText(), onCommit = onCommit)
+            }
+
+            else -> TextEditor(current = value.asText(), onCommit = onCommit)
+        }
+    }
+}
+
+@Composable
+private fun EnumEditor(value: ViewAttributeValue.EnumValue, onCommit: (String) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    Box(Modifier.width(AttributeEditorWidth)) {
+        JwDropdownButton(
+            text = value.value,
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+        ) {
+            for (option in value.options) {
+                JwMenuItem(
+                    text = option,
+                    selected = option == value.value,
+                    onClick = {
+                        expanded = false
+                        onCommit(option)
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * A field that commits on Enter or when it loses focus — never on every keystroke, which would send
+ * a write to the app for each character typed.
+ */
+@Composable
+private fun TextEditor(current: String, onCommit: (String) -> Unit) {
+    var draft by remember(current) { mutableStateOf(current) }
+    JwTextField(
+        value = draft,
+        onValueChange = { draft = it },
+        textStyle = JwTheme.textStyles.code,
+        modifier = Modifier
+            .width(AttributeEditorWidth)
+            .onFocusChanged { state ->
+                if (!state.isFocused && draft != current) onCommit(draft)
+            }
+            .onPreviewKeyEvent { event ->
+                if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
+                    onCommit(draft)
+                    true
+                } else {
+                    false
+                }
+            },
+    )
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
@@ -147,7 +147,14 @@ private val AttributeLabelWidth = 120.dp
 /** Wide enough for `#AARRGGBB` and for the enum names, without crowding the pane. */
 private val AttributeEditorWidth = 180.dp
 
+/** The two halves of the layout-size editor: the wider one fits `MATCH_PARENT` without eliding it. */
+private val LayoutSizeChoiceWidth = 170.dp
+private val LayoutSizePixelWidth = 62.dp
+
 private val ColorSwatchSize = 16.dp
+
+/** The layout-size choice that is a length rather than one of the constants. */
+private const val FIXED_CHOICE = "Fixed"
 
 @Composable
 private fun AttributeRow(attribute: ViewAttribute, onCommit: (String) -> Unit) {
@@ -174,6 +181,8 @@ private fun AttributeRow(attribute: ViewAttribute, onCommit: (String) -> Unit) {
 
             value is ViewAttributeValue.EnumValue -> EnumEditor(value = value, onCommit = onCommit)
 
+            value is ViewAttributeValue.LayoutSizeValue -> LayoutSizeEditor(value = value, onCommit = onCommit)
+
             value is ViewAttributeValue.ColorValue -> Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(JwSpacing.small),
@@ -184,10 +193,22 @@ private fun AttributeRow(attribute: ViewAttribute, onCommit: (String) -> Unit) {
                         .background(Color(value.argb), JwShapes.extraSmall)
                         .border(1.dp, JwTheme.colors.border, JwShapes.extraSmall),
                 )
-                TextEditor(current = value.asText(), onCommit = onCommit)
+                TextEditor(
+                    current = value.asText(),
+                    enabled = true,
+                    placeholder = null,
+                    modifier = Modifier.width(AttributeEditorWidth),
+                    onCommit = onCommit,
+                )
             }
 
-            else -> TextEditor(current = value.asText(), onCommit = onCommit)
+            else -> TextEditor(
+                current = value.asText(),
+                enabled = true,
+                placeholder = null,
+                modifier = Modifier.width(AttributeEditorWidth),
+                onCommit = onCommit,
+            )
         }
     }
 }
@@ -216,24 +237,98 @@ private fun EnumEditor(value: ViewAttributeValue.EnumValue, onCommit: (String) -
 }
 
 /**
- * A field that commits on Enter or when it loses focus — never on every keystroke, which would send
- * a write to the app for each character typed.
+ * A layout size, whose editor is one shape whichever of the two cases the value is in: the
+ * constants and "Fixed" in a dropdown, and a pixel field that only "Fixed" enables.
+ *
+ * Picking "Fixed" writes nothing on its own — there is no length to write yet — it only opens the
+ * field, so the choice is remembered here until the number that follows it lands.
  */
 @Composable
-private fun TextEditor(current: String, onCommit: (String) -> Unit) {
+private fun LayoutSizeEditor(value: ViewAttributeValue.LayoutSizeValue, onCommit: (String) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    var fixed by remember(value) { mutableStateOf(value.constant == null) }
+    val choice = if (fixed) FIXED_CHOICE else value.constant.orEmpty()
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(JwSpacing.small),
+    ) {
+        Box(Modifier.width(LayoutSizeChoiceWidth)) {
+            JwDropdownButton(
+                text = choice,
+                expanded = expanded,
+                onExpandedChange = { expanded = it },
+            ) {
+                for (constant in value.constants) {
+                    JwMenuItem(
+                        text = constant,
+                        selected = constant == choice,
+                        onClick = {
+                            expanded = false
+                            fixed = false
+                            onCommit(constant)
+                        },
+                    )
+                }
+                JwMenuItem(
+                    text = FIXED_CHOICE,
+                    selected = fixed,
+                    onClick = {
+                        expanded = false
+                        fixed = true
+                    },
+                )
+            }
+        }
+        TextEditor(
+            current = value.px?.toString().orEmpty(),
+            enabled = fixed,
+            placeholder = "px",
+            modifier = Modifier.width(LayoutSizePixelWidth),
+            onCommit = onCommit,
+        )
+    }
+}
+
+/**
+ * A field that commits on Enter or when it loses focus — never on every keystroke, which would send
+ * a write to the app for each character typed.
+ *
+ * A commit repeats nothing: the draft only reaches the app when it differs from what was last sent.
+ * Enter followed by a blur, or Enter twice, would otherwise write the same value again — the draft
+ * does not converge on [current] until the write comes back, and never converges at all when the
+ * write is refused.
+ */
+@Composable
+private fun TextEditor(
+    current: String,
+    enabled: Boolean,
+    placeholder: String?,
+    modifier: Modifier,
+    onCommit: (String) -> Unit,
+) {
     var draft by remember(current) { mutableStateOf(current) }
+    var committed by remember(current) { mutableStateOf(current) }
+
+    fun commit() {
+        if (draft == committed) return
+        committed = draft
+        onCommit(draft)
+    }
+
     JwTextField(
         value = draft,
         onValueChange = { draft = it },
+        enabled = enabled,
+        placeholder = placeholder,
         textStyle = JwTheme.textStyles.code,
-        modifier = Modifier
-            .width(AttributeEditorWidth)
+        modifier = modifier
             .onFocusChanged { state ->
-                if (!state.isFocused && draft != current) onCommit(draft)
+                if (!state.isFocused) commit()
             }
             .onPreviewKeyEvent { event ->
                 if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
-                    onCommit(draft)
+                    commit()
                     true
                 } else {
                     false

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributesPanel.kt
@@ -38,21 +38,41 @@ import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
 
 /**
+ * Everything the attribute section draws, and nothing more.
+ *
+ * The read, the write and their outcome all live on the plugin instance; what reaches the
+ * composition is this value, so the panel is a function of data and the plugin is free to keep the
+ * attributes across the panel being closed and reopened, and to let an agent's write land in them.
+ */
+internal data class ViewAttributesUiState(
+    /** The attributes of the node the section is showing, or `null` while they are being read or could not be. */
+    val attributes: List<ViewAttribute>?,
+    /** Why there are no attributes to show, when there are none. */
+    val message: String?,
+    /** What the last write to the shown node came back with. */
+    val writeStatus: String?,
+    val writeFailed: Boolean,
+) {
+    companion object {
+        /** Nothing read and nothing written: the section before a `View` is selected. */
+        val Empty = ViewAttributesUiState(attributes = null, message = null, writeStatus = null, writeFailed = false)
+    }
+}
+
+/**
  * The platform attributes of the selected Android `View` node, and an editor for the ones that can
  * be written.
  *
- * A view of [ViewAttributeStore] and nothing more: the read, the write and their outcome live on
- * the plugin instance, so this panel can be closed and reopened without any of them being redone or
- * lost, and an agent writing through the same store is seen here.
+ * Data in, events out: [state] is what to draw and [onCommit] is the edit leaving. Nothing here
+ * reads or writes the app.
  */
 @Composable
 internal fun ViewAttributesPanel(
-    attributes: List<ViewAttribute>?,
-    message: String?,
-    writeStatus: String?,
-    writeFailed: Boolean,
+    state: ViewAttributesUiState,
     onCommit: (ViewAttribute, String) -> Unit,
 ) {
+    val attributes = state.attributes
+    val message = state.message
     Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(JwSpacing.small)) {
         JwSectionHeader(title = "View attributes", contentPadding = PaddingValues(0.dp))
         JwText(
@@ -80,7 +100,7 @@ internal fun ViewAttributesPanel(
             }
         }
 
-        writeStatus?.let { JwStatusLine(text = it, tone = if (writeFailed) JwTone.Error else JwTone.Accent) }
+        state.writeStatus?.let { JwStatusLine(text = it, tone = if (state.writeFailed) JwTone.Error else JwTone.Accent) }
     }
 }
 

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTreeTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTreeTest.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.plugins.semantics.host
 
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewNode
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -169,5 +170,32 @@ class NodeTreeTest {
         assertEquals("Send", node(id = 1, text = "Send").displayLabel())
         assertEquals("Button", node(id = 1, role = "Button").displayLabel())
         assertEquals("#1", node(id = 1).displayLabel())
+    }
+
+    @Test
+    fun `viewAttributeNode takes a selected View node`() {
+        val tree = snapshot(root("window-1", node = node(id = 1, children = listOf(viewNode(id = -4, viewClass = "android.widget.TextView")))))
+
+        assertEquals(NodeKey(rootId = "window-1", nodeId = -4), tree.viewAttributeNode(NodeKey(rootId = "window-1", nodeId = -4)))
+    }
+
+    @Test
+    fun `viewAttributeNode takes no Compose node, and no selection at all`() {
+        val tree = snapshot(root("window-1", node = node(id = 1)))
+
+        assertNull(tree.viewAttributeNode(NodeKey(rootId = "window-1", nodeId = 1)))
+        assertNull(tree.viewAttributeNode(null))
+    }
+
+    @Test
+    fun `viewAttributeNode takes no node this snapshot does not hold`() {
+        val tree = snapshot(root("window-1", node = viewNode(id = -4, viewClass = "android.widget.TextView")))
+
+        // The right id under the wrong root is as absent as an id nothing carries: node ids are
+        // only unique within their root.
+        assertNull(tree.viewAttributeNode(NodeKey(rootId = "window-2", nodeId = -4)))
+        assertNull(tree.viewAttributeNode(NodeKey(rootId = "window-1", nodeId = -9)))
+        val notCaptured: NodeTreeSnapshot? = null
+        assertNull(notCaptured.viewAttributeNode(NodeKey(rootId = "window-1", nodeId = -4)))
     }
 }

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommandsTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommandsTest.kt
@@ -1,0 +1,274 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.annotations.ExperimentalJetWhaleApi
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArgumentException
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpArguments
+import com.kitakkun.jetwhale.host.sdk.JetWhaleMcpCommand
+import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
+import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalJetWhaleApi::class)
+private fun JetWhaleMcpCommand.run(arguments: JsonObject): JsonObject = runBlocking {
+    Json.parseToJsonElement(execute(JetWhaleMcpArguments(arguments))).jsonObject
+}
+
+private fun attribute(
+    id: String,
+    value: ViewAttributeValue,
+    group: String = "State",
+    editable: Boolean = true,
+): ViewAttribute = ViewAttribute(id = id, label = id, group = group, value = value, editable = editable)
+
+private fun response(vararg attributes: ViewAttribute): ViewAttributeResponse = ViewAttributeResponse(
+    snapshot = ViewAttributeSnapshot(
+        rootId = "window-1",
+        nodeId = -4,
+        viewClass = "android.widget.TextView",
+        attributes = attributes.toList(),
+    ),
+)
+
+private fun arguments(vararg pairs: Pair<String, Any>): JsonObject = buildJsonObject {
+    for ((key, value) in pairs) {
+        when (value) {
+            is Int -> put(key, value)
+            else -> put(key, value.toString())
+        }
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+class ViewAttributeCommandsTest {
+    @Test
+    fun `getViewAttributes reports each attribute with the type that says how to write it`() {
+        val command = GetViewAttributesCommand(
+            getAttributes = {
+                response(
+                    attribute("visibility", ViewAttributeValue.EnumValue("VISIBLE", listOf("VISIBLE", "INVISIBLE", "GONE"))),
+                    attribute("padding.left", ViewAttributeValue.DimensionValue(px = 48f, dp = 24f), group = "Layout"),
+                )
+            },
+        )
+
+        val result = command.run(arguments("rootId" to "window-1", "nodeId" to -4))
+
+        assertEquals("android.widget.TextView", result["viewClass"]?.jsonPrimitive?.content)
+        val rows = result["attributes"]!!.jsonArray.map { it.jsonObject }
+        assertEquals("enum", rows[0]["type"]?.jsonPrimitive?.content)
+        assertEquals("VISIBLE", rows[0]["value"]?.jsonPrimitive?.content)
+        assertEquals(listOf("VISIBLE", "INVISIBLE", "GONE"), rows[0]["options"]!!.jsonArray.map { it.jsonPrimitive.content })
+        assertEquals("dimension", rows[1]["type"]?.jsonPrimitive?.content)
+        assertEquals("48.0", rows[1]["value"]?.jsonPrimitive?.content)
+        assertEquals(24f, rows[1]["dp"]?.jsonPrimitive?.content?.toFloat())
+    }
+
+    @Test
+    fun `getViewAttributes marks only the read-only attributes, which are the exception`() {
+        val command = GetViewAttributesCommand(
+            getAttributes = {
+                response(
+                    attribute("enabled", ViewAttributeValue.BooleanValue(true)),
+                    attribute("class", ViewAttributeValue.TextValue("android.widget.TextView"), group = "Info", editable = false),
+                )
+            },
+        )
+
+        val rows = command.run(arguments("rootId" to "window-1", "nodeId" to -4))["attributes"]!!.jsonArray.map { it.jsonObject }
+
+        assertNull(rows[0]["editable"])
+        assertEquals(false, rows[1]["editable"]?.jsonPrimitive?.content?.toBoolean())
+    }
+
+    @Test
+    fun `getViewAttributes passes on the reason a node has none instead of failing`() {
+        val command = GetViewAttributesCommand(
+            getAttributes = { ViewAttributeResponse(snapshot = null, message = "node 42 is a Compose semantics node, which has no View attributes") },
+        )
+
+        val result = command.run(arguments("rootId" to "window-1", "nodeId" to 42))
+
+        assertTrue(result["message"]!!.jsonPrimitive.content.contains("Compose semantics node"))
+        assertNull(result["attributes"])
+    }
+
+    @Test
+    fun `setViewAttribute reads the string as the type the attribute currently has`() {
+        var sent: SetViewAttribute? = null
+        val command = SetViewAttributeCommand(
+            getAttributes = { response(attribute("visibility", ViewAttributeValue.EnumValue("VISIBLE", listOf("VISIBLE", "INVISIBLE", "GONE")))) },
+            setAttribute = { request ->
+                sent = request
+                ViewAttributeResult(
+                    applied = true,
+                    attribute = attribute("visibility", ViewAttributeValue.EnumValue("GONE", listOf("VISIBLE", "INVISIBLE", "GONE"))),
+                )
+            },
+        )
+
+        val result = command.run(arguments("rootId" to "window-1", "nodeId" to -4, "attributeId" to "visibility", "value" to "gone"))
+
+        assertEquals(ViewAttributeValue.EnumValue("GONE", listOf("VISIBLE", "INVISIBLE", "GONE")), sent?.value)
+        assertTrue(result["applied"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("GONE", result["attribute"]!!.jsonObject["value"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `setViewAttribute names the ids the view does have when the one asked for is unknown`() {
+        val command = SetViewAttributeCommand(
+            getAttributes = { response(attribute("enabled", ViewAttributeValue.BooleanValue(true))) },
+            setAttribute = { ViewAttributeResult(applied = true) },
+        )
+
+        val failure = assertFailsWith<JetWhaleMcpArgumentException> {
+            command.run(arguments("rootId" to "window-1", "nodeId" to -4, "attributeId" to "colour", "value" to "red"))
+        }
+
+        assertTrue(failure.message!!.contains("unknown attributeId: colour"), failure.message!!)
+        assertTrue(failure.message!!.contains("enabled"), failure.message!!)
+    }
+
+    @Test
+    fun `setViewAttribute refuses a read-only attribute before reaching the app`() {
+        var reached = false
+        val command = SetViewAttributeCommand(
+            getAttributes = { response(attribute("bounds", ViewAttributeValue.TextValue("0,0,10,10"), group = "Layout", editable = false)) },
+            setAttribute = {
+                reached = true
+                ViewAttributeResult(applied = true)
+            },
+        )
+
+        val failure = assertFailsWith<JetWhaleMcpArgumentException> {
+            command.run(arguments("rootId" to "window-1", "nodeId" to -4, "attributeId" to "bounds", "value" to "1,1,2,2"))
+        }
+
+        assertTrue(failure.message!!.contains("read-only"), failure.message!!)
+        assertEquals(false, reached)
+    }
+
+    @Test
+    fun `setViewAttribute reports a refusal from the app rather than throwing`() {
+        val command = SetViewAttributeCommand(
+            getAttributes = { response(attribute("alpha", ViewAttributeValue.FloatValue(1f), group = "Appearance")) },
+            setAttribute = { ViewAttributeResult(applied = false, message = "the app rejected the change") },
+        )
+
+        val result = command.run(arguments("rootId" to "window-1", "nodeId" to -4, "attributeId" to "alpha", "value" to "0.5"))
+
+        assertEquals(false, result["applied"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("the app rejected the change", result["message"]?.jsonPrimitive?.content)
+    }
+}
+
+@OptIn(ExperimentalJetWhaleApi::class)
+class ViewAttributeValueParsingTest {
+    @Test
+    fun `reads a boolean, an int and a float as their own type`() {
+        assertEquals(
+            ViewAttributeValue.BooleanValue(true),
+            parseViewAttributeValue("enabled", ViewAttributeValue.BooleanValue(false), "true"),
+        )
+        assertEquals(
+            ViewAttributeValue.IntValue(3),
+            parseViewAttributeValue("maxLines", ViewAttributeValue.IntValue(1), "3"),
+        )
+        assertEquals(
+            ViewAttributeValue.FloatValue(0.5f),
+            parseViewAttributeValue("alpha", ViewAttributeValue.FloatValue(1f), "0.5"),
+        )
+    }
+
+    @Test
+    fun `takes a text value exactly as typed, spaces included`() {
+        assertEquals(
+            ViewAttributeValue.TextValue("  two words  "),
+            parseViewAttributeValue("text", ViewAttributeValue.TextValue("old"), "  two words  "),
+        )
+    }
+
+    @Test
+    fun `reads a dimension as a pixel figure`() {
+        assertEquals(
+            ViewAttributeValue.DimensionValue(px = 48f, dp = 48f),
+            parseViewAttributeValue("padding.left", ViewAttributeValue.DimensionValue(px = 0f, dp = 0f), "48"),
+        )
+    }
+
+    @Test
+    fun `accepts either shape for a layout size, which reads as either`() {
+        // Written where it currently reads as a length…
+        assertEquals(
+            ViewAttributeValue.EnumValue("MATCH_PARENT", emptyList()),
+            parseViewAttributeValue("layout.width", ViewAttributeValue.DimensionValue(px = 100f, dp = 50f), "match_parent"),
+        )
+        // …and where it currently reads as one of the two constants.
+        assertEquals(
+            ViewAttributeValue.DimensionValue(px = 100f, dp = 100f),
+            parseViewAttributeValue("layout.width", ViewAttributeValue.EnumValue("WRAP_CONTENT", listOf("MATCH_PARENT", "WRAP_CONTENT")), "100"),
+        )
+    }
+
+    @Test
+    fun `matches an enum option whatever case it was typed in`() {
+        assertEquals(
+            ViewAttributeValue.EnumValue("INVISIBLE", listOf("VISIBLE", "INVISIBLE", "GONE")),
+            parseViewAttributeValue("visibility", ViewAttributeValue.EnumValue("VISIBLE", listOf("VISIBLE", "INVISIBLE", "GONE")), "invisible"),
+        )
+    }
+
+    @Test
+    fun `names the options when an enum value is not one of them`() {
+        val failure = assertFailsWith<JetWhaleMcpArgumentException> {
+            parseViewAttributeValue("visibility", ViewAttributeValue.EnumValue("VISIBLE", listOf("VISIBLE", "GONE")), "hidden")
+        }
+
+        assertTrue(failure.message!!.contains("VISIBLE, GONE"), failure.message!!)
+    }
+
+    @Test
+    fun `says what a number should have looked like`() {
+        val failure = assertFailsWith<JetWhaleMcpArgumentException> {
+            parseViewAttributeValue("maxLines", ViewAttributeValue.IntValue(1), "a few")
+        }
+
+        assertTrue(failure.message!!.contains("expected a whole number"), failure.message!!)
+    }
+
+    @Test
+    fun `reads a color as AARRGGBB, and a six-digit one as opaque`() {
+        assertEquals(0x80FF0000.toInt(), parseArgb("#80FF0000"))
+        assertEquals(0xFF0000FFu.toInt(), parseArgb("#0000FF"))
+        assertEquals(0xFF0000FFu.toInt(), parseArgb("0000ff"))
+    }
+
+    @Test
+    fun `refuses a color that is not hex or is the wrong length`() {
+        assertNull(parseArgb("#GGGGGG"))
+        assertNull(parseArgb("#FFF"))
+        assertNull(parseArgb("blue"))
+    }
+
+    @Test
+    fun `writes a color back in the notation it is read in`() {
+        assertEquals("#80FF0000", formatArgb(0x80FF0000.toInt()))
+        assertEquals("#FF0000FF", formatArgb(0xFF0000FFu.toInt()))
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommandsTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommandsTest.kt
@@ -46,6 +46,13 @@ private fun response(vararg attributes: ViewAttribute): ViewAttributeResponse = 
     ),
 )
 
+private fun layoutSize(constant: String?, px: Float?, dp: Float?): ViewAttributeValue.LayoutSizeValue = ViewAttributeValue.LayoutSizeValue(
+    constant = constant,
+    px = px,
+    dp = dp,
+    constants = listOf("MATCH_PARENT", "WRAP_CONTENT"),
+)
+
 private fun arguments(vararg pairs: Pair<String, Any>): JsonObject = buildJsonObject {
     for ((key, value) in pairs) {
         when (value) {
@@ -78,6 +85,54 @@ class ViewAttributeCommandsTest {
         assertEquals("dimension", rows[1]["type"]?.jsonPrimitive?.content)
         assertEquals("48.0", rows[1]["value"]?.jsonPrimitive?.content)
         assertEquals(24f, rows[1]["dp"]?.jsonPrimitive?.content?.toFloat())
+    }
+
+    @Test
+    fun `getViewAttributes shows a layout size's constants even while it reads as one of them`() {
+        val command = GetViewAttributesCommand(
+            getAttributes = {
+                response(
+                    attribute("layout.width", layoutSize(constant = "WRAP_CONTENT", px = null, dp = null), group = "Layout"),
+                    attribute("layout.height", layoutSize(constant = null, px = 500f, dp = 250f), group = "Layout"),
+                )
+            },
+        )
+
+        val rows = command.run(arguments("rootId" to "window-1", "nodeId" to -4))["attributes"]!!.jsonArray.map { it.jsonObject }
+
+        assertEquals("layoutSize", rows[0]["type"]?.jsonPrimitive?.content)
+        assertEquals("WRAP_CONTENT", rows[0]["value"]?.jsonPrimitive?.content)
+        assertEquals(listOf("MATCH_PARENT", "WRAP_CONTENT"), rows[0]["constants"]!!.jsonArray.map { it.jsonPrimitive.content })
+        assertNull(rows[0]["dp"])
+        // …and the same constants are offered while it reads as a length.
+        assertEquals("500.0", rows[1]["value"]?.jsonPrimitive?.content)
+        assertEquals(listOf("MATCH_PARENT", "WRAP_CONTENT"), rows[1]["constants"]!!.jsonArray.map { it.jsonPrimitive.content })
+        assertEquals(250f, rows[1]["dp"]?.jsonPrimitive?.content?.toFloat())
+    }
+
+    @Test
+    fun `setViewAttribute takes a plain string for a layout size, constant or number`() {
+        val sent = mutableListOf<ViewAttributeValue>()
+        val command = SetViewAttributeCommand(
+            getAttributes = { response(attribute("layout.width", layoutSize(constant = "WRAP_CONTENT", px = null, dp = null), group = "Layout")) },
+            setAttribute = { request ->
+                sent += request.value
+                ViewAttributeResult(applied = true)
+            },
+        )
+
+        for (text in listOf("wrap_content", "match_parent", "500")) {
+            command.run(arguments("rootId" to "window-1", "nodeId" to -4, "attributeId" to "layout.width", "value" to text))
+        }
+
+        assertEquals(
+            listOf<ViewAttributeValue>(
+                layoutSize(constant = "WRAP_CONTENT", px = null, dp = null),
+                layoutSize(constant = "MATCH_PARENT", px = null, dp = null),
+                layoutSize(constant = null, px = 500f, dp = 500f),
+            ),
+            sent,
+        )
     }
 
     @Test
@@ -213,17 +268,45 @@ class ViewAttributeValueParsingTest {
     }
 
     @Test
-    fun `accepts either shape for a layout size, which reads as either`() {
-        // Written where it currently reads as a length…
-        assertEquals(
-            ViewAttributeValue.EnumValue("MATCH_PARENT", emptyList()),
-            parseViewAttributeValue("layout.width", ViewAttributeValue.DimensionValue(px = 100f, dp = 50f), "match_parent"),
-        )
-        // …and where it currently reads as one of the two constants.
-        assertEquals(
-            ViewAttributeValue.DimensionValue(px = 100f, dp = 100f),
-            parseViewAttributeValue("layout.width", ViewAttributeValue.EnumValue("WRAP_CONTENT", listOf("MATCH_PARENT", "WRAP_CONTENT")), "100"),
-        )
+    fun `reads a layout size as a constant or as a length, whichever it currently is`() {
+        val wrapping = layoutSize(constant = "WRAP_CONTENT", px = null, dp = null)
+        val fixed = layoutSize(constant = null, px = 100f, dp = 50f)
+
+        // A constant, in whatever case it was typed, from either starting point…
+        assertEquals(layoutSize(constant = "MATCH_PARENT", px = null, dp = null), parseViewAttributeValue("layout.width", fixed, "match_parent"))
+        assertEquals(layoutSize(constant = "WRAP_CONTENT", px = null, dp = null), parseViewAttributeValue("layout.width", fixed, "wrap_content"))
+        // …and a length, likewise.
+        assertEquals(layoutSize(constant = null, px = 500f, dp = 500f), parseViewAttributeValue("layout.width", wrapping, "500"))
+        assertEquals(layoutSize(constant = null, px = 500f, dp = 500f), parseViewAttributeValue("layout.width", fixed, "500"))
+    }
+
+    @Test
+    fun `names both the constants and the length a layout size could have been`() {
+        val failure = assertFailsWith<JetWhaleMcpArgumentException> {
+            parseViewAttributeValue("layout.width", layoutSize(constant = "WRAP_CONTENT", px = null, dp = null), "as wide as it likes")
+        }
+
+        assertTrue(failure.message!!.contains("MATCH_PARENT, WRAP_CONTENT"), failure.message!!)
+        assertTrue(failure.message!!.contains("a length in pixels"), failure.message!!)
+    }
+
+    @Test
+    fun `refuses a dimension that is not a number rather than passing it on as a name`() {
+        val failure = assertFailsWith<JetWhaleMcpArgumentException> {
+            parseViewAttributeValue("padding.left", ViewAttributeValue.DimensionValue(px = 0f, dp = 0f), "banana")
+        }
+
+        assertTrue(failure.message!!.contains("invalid value for padding.left"), failure.message!!)
+        assertTrue(failure.message!!.contains("expected a length in pixels"), failure.message!!)
+    }
+
+    @Test
+    fun `refuses a number for an enum, whose options are the whole of what it takes`() {
+        val failure = assertFailsWith<JetWhaleMcpArgumentException> {
+            parseViewAttributeValue("visibility", ViewAttributeValue.EnumValue("VISIBLE", listOf("VISIBLE", "INVISIBLE", "GONE")), "500")
+        }
+
+        assertTrue(failure.message!!.contains("VISIBLE, INVISIBLE, GONE"), failure.message!!)
     }
 
     @Test

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeSerializationTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeSerializationTest.kt
@@ -1,0 +1,77 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
+import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The attribute protocol on the wire. Host and agent are built against the same types, so what has
+ * to hold is that every value variant survives the trip and that each keeps its own discriminator —
+ * a variant that decoded as another one would silently write the wrong property.
+ */
+class ViewAttributeSerializationTest {
+    private val json = Json
+
+    private val variants = listOf(
+        ViewAttributeValue.BooleanValue(true) to "bool",
+        ViewAttributeValue.IntValue(-3) to "int",
+        ViewAttributeValue.FloatValue(0.5f) to "float",
+        ViewAttributeValue.TextValue("two words") to "text",
+        ViewAttributeValue.ColorValue(0x80FF0000.toInt()) to "color",
+        ViewAttributeValue.DimensionValue(px = 48f, dp = 24f) to "dimension",
+        ViewAttributeValue.EnumValue("GONE", listOf("VISIBLE", "INVISIBLE", "GONE")) to "enum",
+    )
+
+    @Test
+    fun `every value variant round-trips as itself`() {
+        for ((value, _) in variants) {
+            assertEquals(value, json.decodeFromString<ViewAttributeValue>(json.encodeToString<ViewAttributeValue>(value)))
+        }
+    }
+
+    @Test
+    fun `every value variant travels under its own discriminator`() {
+        for ((value, discriminator) in variants) {
+            val encoded = json.parseToJsonElement(json.encodeToString<ViewAttributeValue>(value)).jsonObject
+            assertEquals(discriminator, encoded["type"]?.jsonPrimitive?.content)
+        }
+    }
+
+    @Test
+    fun `a snapshot round-trips with its attributes`() {
+        val snapshot = ViewAttributeSnapshot(
+            rootId = "window-1",
+            nodeId = -4,
+            viewClass = "android.widget.TextView",
+            attributes = variants.mapIndexed { index, (value, name) ->
+                ViewAttribute(id = "attribute-$index", label = name, group = "State", value = value, editable = index % 2 == 0)
+            },
+        )
+
+        assertEquals(snapshot, json.decodeFromString<ViewAttributeSnapshot>(json.encodeToString(snapshot)))
+    }
+
+    @Test
+    fun `the requests and their answers round-trip`() {
+        val get = GetViewAttributes(rootId = "window-1", nodeId = -4)
+        assertEquals(get, json.decodeFromString<GetViewAttributes>(json.encodeToString(get)))
+
+        val set = SetViewAttribute(rootId = "window-1", nodeId = -4, attributeId = "visibility", value = ViewAttributeValue.EnumValue("GONE", listOf("GONE")))
+        assertEquals(set, json.decodeFromString<SetViewAttribute>(json.encodeToString(set)))
+
+        val absent = ViewAttributeResponse(snapshot = null, message = "this root has no View attributes")
+        assertEquals(absent, json.decodeFromString<ViewAttributeResponse>(json.encodeToString(absent)))
+
+        val refused = ViewAttributeResult(applied = false, message = "read-only")
+        assertEquals(refused, json.decodeFromString<ViewAttributeResult>(json.encodeToString(refused)))
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeSerializationTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeSerializationTest.kt
@@ -18,6 +18,8 @@ import kotlin.test.assertEquals
  * to hold is that every value variant survives the trip and that each keeps its own discriminator —
  * a variant that decoded as another one would silently write the wrong property.
  */
+private val LAYOUT_SIZE_CONSTANTS = listOf("MATCH_PARENT", "WRAP_CONTENT")
+
 class ViewAttributeSerializationTest {
     private val json = Json
 
@@ -29,6 +31,9 @@ class ViewAttributeSerializationTest {
         ViewAttributeValue.ColorValue(0x80FF0000.toInt()) to "color",
         ViewAttributeValue.DimensionValue(px = 48f, dp = 24f) to "dimension",
         ViewAttributeValue.EnumValue("GONE", listOf("VISIBLE", "INVISIBLE", "GONE")) to "enum",
+        // Both cases of the one variant, because it is the pair of them that has to survive.
+        ViewAttributeValue.LayoutSizeValue(constant = "WRAP_CONTENT", px = null, dp = null, constants = LAYOUT_SIZE_CONSTANTS) to "layoutSize",
+        ViewAttributeValue.LayoutSizeValue(constant = null, px = 500f, dp = 250f, constants = LAYOUT_SIZE_CONSTANTS) to "layoutSize",
     )
 
     @Test

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeStoreTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeStoreTest.kt
@@ -1,0 +1,238 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
+import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The store is driven on [Dispatchers.Unconfined], so a coroutine it launches runs as far as its
+ * first real suspension point before `launch` returns — a fake that answers straight away leaves
+ * the store settled by the time the call under test is over, with no scheduler to pump.
+ */
+private fun scope(): CoroutineScope = CoroutineScope(Dispatchers.Unconfined)
+
+private fun attribute(id: String, value: ViewAttributeValue): ViewAttribute = ViewAttribute(id = id, label = id, group = "State", value = value, editable = true)
+
+private fun snapshotOf(rootId: String, nodeId: Int, vararg attributes: ViewAttribute): ViewAttributeResponse = ViewAttributeResponse(
+    snapshot = ViewAttributeSnapshot(
+        rootId = rootId,
+        nodeId = nodeId,
+        viewClass = "android.widget.TextView",
+        attributes = attributes.toList(),
+    ),
+)
+
+private val alpha = attribute("alpha", ViewAttributeValue.FloatValue(1f))
+
+class ViewAttributeStoreTest {
+    @Test
+    fun `selecting a node reads its attributes once, and selecting it again reads nothing`() {
+        val reads = mutableListOf<GetViewAttributes>()
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { request ->
+                reads += request
+                snapshotOf(request.rootId, request.nodeId, alpha)
+            },
+            write = { error("not written") },
+        )
+
+        store.select(rootId = "window-1", nodeId = -4)
+        store.select(rootId = "window-1", nodeId = -4)
+
+        assertEquals(listOf(GetViewAttributes(rootId = "window-1", nodeId = -4)), reads)
+        assertEquals(listOf(alpha), store.attributes)
+        assertNull(store.message)
+    }
+
+    @Test
+    fun `selecting another node reads that one instead`() {
+        val reads = mutableListOf<Int>()
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { request ->
+                reads += request.nodeId
+                snapshotOf(request.rootId, request.nodeId, alpha)
+            },
+            write = { error("not written") },
+        )
+
+        store.select(rootId = "window-1", nodeId = -4)
+        store.select(rootId = "window-1", nodeId = -9)
+
+        assertEquals(listOf(-4, -9), reads)
+        assertEquals(NodeKey(rootId = "window-1", nodeId = -9), store.node)
+    }
+
+    @Test
+    fun `a node with no attributes to report shows what the app said instead`() {
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { ViewAttributeResponse(snapshot = null, message = "this node has no View attributes") },
+            write = { error("not written") },
+        )
+
+        store.select(rootId = "window-1", nodeId = -4)
+
+        assertNull(store.attributes)
+        assertEquals("this node has no View attributes", store.message)
+    }
+
+    @Test
+    fun `an app that does not answer the read is reported as such`() {
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { throw JetWhaleMessagingException("timed out") },
+            write = { error("not written") },
+        )
+
+        store.select(rootId = "window-1", nodeId = -4)
+
+        assertNull(store.attributes)
+        assertEquals("The app did not answer: timed out", store.message)
+    }
+
+    @Test
+    fun `clearing forgets the node it was holding`() {
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { request -> snapshotOf(request.rootId, request.nodeId, alpha) },
+            write = { error("not written") },
+        )
+
+        store.select(rootId = "window-1", nodeId = -4)
+        store.clear()
+
+        assertNull(store.node)
+        assertNull(store.attributes)
+    }
+
+    @Test
+    fun `a value the attribute cannot take is reported and never written`() {
+        val writes = mutableListOf<SetViewAttribute>()
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { request -> snapshotOf(request.rootId, request.nodeId, alpha) },
+            write = { request ->
+                writes += request
+                ViewAttributeResult(applied = true)
+            },
+        )
+        store.select(rootId = "window-1", nodeId = -4)
+
+        store.commit(alpha, "half")
+
+        assertTrue(writes.isEmpty())
+        assertTrue(store.writeFailed)
+        assertEquals("invalid value for alpha: \"half\" (expected a number)", store.writeStatus)
+    }
+
+    @Test
+    fun `a write shows the value that came back rather than the one that was asked for`() {
+        val clamped = attribute("alpha", ViewAttributeValue.FloatValue(1f))
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { request -> snapshotOf(request.rootId, request.nodeId, alpha) },
+            write = { ViewAttributeResult(applied = true, attribute = clamped) },
+        )
+        store.select(rootId = "window-1", nodeId = -4)
+
+        store.commit(alpha, "4")
+
+        assertEquals(listOf(clamped), store.attributes)
+        assertEquals("alpha: 1.0", store.writeStatus)
+        assertEquals(false, store.writeFailed)
+    }
+
+    @Test
+    fun `a write the app refuses says so`() {
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { request -> snapshotOf(request.rootId, request.nodeId, alpha) },
+            write = { ViewAttributeResult(applied = false, message = "this view ignores alpha") },
+        )
+        store.select(rootId = "window-1", nodeId = -4)
+
+        store.commit(alpha, "0.5")
+
+        assertTrue(store.writeFailed)
+        assertEquals("alpha: this view ignores alpha", store.writeStatus)
+    }
+
+    @Test
+    fun `two writes made in quick succession reach the app in the order they were made`() = runBlocking {
+        val started = mutableListOf<String>()
+        val first = CompletableDeferred<Unit>()
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { request -> snapshotOf(request.rootId, request.nodeId, alpha) },
+            write = { request ->
+                val text = (request.value as ViewAttributeValue.FloatValue).value.toString()
+                started += text
+                // The first write is held open, so the second one would overtake it were the two
+                // not serialised.
+                if (started.size == 1) first.await()
+                ViewAttributeResult(applied = true, attribute = attribute("alpha", request.value))
+            },
+        )
+        store.select(rootId = "window-1", nodeId = -4)
+
+        store.commit(alpha, "0.25")
+        store.commit(alpha, "0.75")
+        assertEquals(listOf("0.25"), started)
+
+        first.complete(Unit)
+
+        assertEquals(listOf("0.25", "0.75"), started)
+        assertEquals("alpha: 0.75", store.writeStatus)
+    }
+
+    @Test
+    fun `a write to the node the panel is showing is reflected in it`() = runBlocking {
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { request -> snapshotOf(request.rootId, request.nodeId, alpha) },
+            write = { request -> ViewAttributeResult(applied = true, attribute = attribute("alpha", request.value)) },
+        )
+        store.select(rootId = "window-1", nodeId = -4)
+
+        val result = store.writeAttribute(
+            SetViewAttribute(rootId = "window-1", nodeId = -4, attributeId = "alpha", value = ViewAttributeValue.FloatValue(0.5f)),
+        )
+
+        assertTrue(result.applied)
+        assertEquals(listOf(attribute("alpha", ViewAttributeValue.FloatValue(0.5f))), store.attributes)
+        assertEquals("alpha: 0.5", store.writeStatus)
+    }
+
+    @Test
+    fun `a write to another node leaves the one the panel is showing alone`() = runBlocking {
+        val store = ViewAttributeStore(
+            scope = scope(),
+            read = { request -> snapshotOf(request.rootId, request.nodeId, alpha) },
+            write = { request -> ViewAttributeResult(applied = true, attribute = attribute("alpha", request.value)) },
+        )
+        store.select(rootId = "window-1", nodeId = -4)
+
+        val result = store.writeAttribute(
+            SetViewAttribute(rootId = "window-1", nodeId = -9, attributeId = "alpha", value = ViewAttributeValue.FloatValue(0.5f)),
+        )
+
+        assertTrue(result.applied)
+        assertEquals(listOf(alpha), store.attributes)
+        assertNull(store.writeStatus)
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeStoreTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeStoreTest.kt
@@ -54,8 +54,8 @@ class ViewAttributeStoreTest {
         store.select(rootId = "window-1", nodeId = -4)
 
         assertEquals(listOf(GetViewAttributes(rootId = "window-1", nodeId = -4)), reads)
-        assertEquals(listOf(alpha), store.attributes)
-        assertNull(store.message)
+        assertEquals(listOf(alpha), store.state.attributes)
+        assertNull(store.state.message)
     }
 
     @Test
@@ -87,8 +87,8 @@ class ViewAttributeStoreTest {
 
         store.select(rootId = "window-1", nodeId = -4)
 
-        assertNull(store.attributes)
-        assertEquals("this node has no View attributes", store.message)
+        assertNull(store.state.attributes)
+        assertEquals("this node has no View attributes", store.state.message)
     }
 
     @Test
@@ -101,8 +101,8 @@ class ViewAttributeStoreTest {
 
         store.select(rootId = "window-1", nodeId = -4)
 
-        assertNull(store.attributes)
-        assertEquals("The app did not answer: timed out", store.message)
+        assertNull(store.state.attributes)
+        assertEquals("The app did not answer: timed out", store.state.message)
     }
 
     @Test
@@ -117,7 +117,7 @@ class ViewAttributeStoreTest {
         store.clear()
 
         assertNull(store.node)
-        assertNull(store.attributes)
+        assertNull(store.state.attributes)
     }
 
     @Test
@@ -136,8 +136,8 @@ class ViewAttributeStoreTest {
         store.commit(alpha, "half")
 
         assertTrue(writes.isEmpty())
-        assertTrue(store.writeFailed)
-        assertEquals("invalid value for alpha: \"half\" (expected a number)", store.writeStatus)
+        assertTrue(store.state.writeFailed)
+        assertEquals("invalid value for alpha: \"half\" (expected a number)", store.state.writeStatus)
     }
 
     @Test
@@ -152,9 +152,9 @@ class ViewAttributeStoreTest {
 
         store.commit(alpha, "4")
 
-        assertEquals(listOf(clamped), store.attributes)
-        assertEquals("alpha: 1.0", store.writeStatus)
-        assertEquals(false, store.writeFailed)
+        assertEquals(listOf(clamped), store.state.attributes)
+        assertEquals("alpha: 1.0", store.state.writeStatus)
+        assertEquals(false, store.state.writeFailed)
     }
 
     @Test
@@ -168,8 +168,8 @@ class ViewAttributeStoreTest {
 
         store.commit(alpha, "0.5")
 
-        assertTrue(store.writeFailed)
-        assertEquals("alpha: this view ignores alpha", store.writeStatus)
+        assertTrue(store.state.writeFailed)
+        assertEquals("alpha: this view ignores alpha", store.state.writeStatus)
     }
 
     @Test
@@ -197,7 +197,7 @@ class ViewAttributeStoreTest {
         first.complete(Unit)
 
         assertEquals(listOf("0.25", "0.75"), started)
-        assertEquals("alpha: 0.75", store.writeStatus)
+        assertEquals("alpha: 0.75", store.state.writeStatus)
     }
 
     @Test
@@ -214,8 +214,8 @@ class ViewAttributeStoreTest {
         )
 
         assertTrue(result.applied)
-        assertEquals(listOf(attribute("alpha", ViewAttributeValue.FloatValue(0.5f))), store.attributes)
-        assertEquals("alpha: 0.5", store.writeStatus)
+        assertEquals(listOf(attribute("alpha", ViewAttributeValue.FloatValue(0.5f))), store.state.attributes)
+        assertEquals("alpha: 0.5", store.state.writeStatus)
     }
 
     @Test
@@ -232,7 +232,7 @@ class ViewAttributeStoreTest {
         )
 
         assertTrue(result.applied)
-        assertEquals(listOf(alpha), store.attributes)
-        assertNull(store.writeStatus)
+        assertEquals(listOf(alpha), store.state.attributes)
+        assertNull(store.state.writeStatus)
     }
 }

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeTypeTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeTypeTest.kt
@@ -1,0 +1,77 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeType
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
+import com.kitakkun.jetwhale.plugins.semantics.protocol.type
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins [ViewAttributeType] to what actually travels.
+ *
+ * The type list is what the tool descriptions are built from, so it is only worth having if it
+ * cannot fall out of step with the wire format or with what a read reports.
+ */
+class ViewAttributeTypeTest {
+
+    /** One value of every type, so a new variant makes the `when` in `sampleOf` fail to compile. */
+    private fun sampleOf(type: ViewAttributeType): ViewAttributeValue = when (type) {
+        ViewAttributeType.Bool -> ViewAttributeValue.BooleanValue(value = true)
+
+        ViewAttributeType.Int -> ViewAttributeValue.IntValue(value = 2)
+
+        ViewAttributeType.Float -> ViewAttributeValue.FloatValue(value = 0.5f)
+
+        ViewAttributeType.Text -> ViewAttributeValue.TextValue(value = "sample")
+
+        ViewAttributeType.Color -> ViewAttributeValue.ColorValue(argb = 0xFF102030.toInt())
+
+        ViewAttributeType.Dimension -> ViewAttributeValue.DimensionValue(px = 48f, dp = 16f)
+
+        ViewAttributeType.Enum -> ViewAttributeValue.EnumValue(value = "ONE", options = listOf("ONE", "TWO"))
+
+        ViewAttributeType.LayoutSize -> ViewAttributeValue.LayoutSizeValue(
+            constant = null,
+            px = 500f,
+            dp = 166.7f,
+            constants = listOf("MATCH_PARENT", "WRAP_CONTENT"),
+        )
+    }
+
+    private fun attributeOf(type: ViewAttributeType) = ViewAttribute(
+        id = "sample",
+        label = "sample",
+        group = "State",
+        value = sampleOf(type),
+        editable = true,
+    )
+
+    @Test
+    fun `every type's wire name is the serial name its value is encoded under`() {
+        for (type in ViewAttributeType.entries) {
+            val encoded = Json.encodeToJsonElement(ViewAttributeValue.serializer(), sampleOf(type))
+            assertEquals(type.wireName, encoded.jsonObject.getValue("type").jsonPrimitive.content, "for $type")
+        }
+    }
+
+    @Test
+    fun `every type declares the fields a read reports beside the value`() {
+        val alwaysPresent = setOf("id", "label", "group", "type", "value")
+        for (type in ViewAttributeType.entries) {
+            val reported = attributeOf(type).toMcpJson().keys - alwaysPresent
+            assertEquals(type.extraFields.toSet(), reported, "for $type")
+        }
+    }
+
+    @Test
+    fun `every type is named in the value a read reports it under`() {
+        for (type in ViewAttributeType.entries) {
+            assertEquals(type, sampleOf(type).type, "for $type")
+            assertEquals(type.wireName, sampleOf(type).typeName, "for $type")
+        }
+    }
+}

--- a/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
+++ b/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
@@ -128,6 +128,35 @@ public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeRoot$
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttributes : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttributes$Companion;
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttributes;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttributes;Ljava/lang/String;IILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttributes;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodeId ()I
+	public final fun getRootId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttributes$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttributes$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttributes;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttributes;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttributes$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction : java/lang/Enum {
 	public static final field Click Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
 	public static final field Collapse Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
@@ -324,6 +353,39 @@ public final class com/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeA
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/SetViewAttribute : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/SetViewAttribute$Companion;
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/SetViewAttribute;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/SetViewAttribute;Ljava/lang/String;ILjava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/SetViewAttribute;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributeId ()Ljava/lang/String;
+	public final fun getNodeId ()I
+	public final fun getRootId ()Ljava/lang/String;
+	public final fun getValue ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/SetViewAttribute$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/SetViewAttribute$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/SetViewAttribute;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/SetViewAttribute;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/SetViewAttribute$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public abstract interface class com/kitakkun/jetwhale/plugins/semantics/protocol/UiNode {
 	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/UiNode$Companion;
 	public abstract fun getActions ()Ljava/util/List;
@@ -345,6 +407,337 @@ public abstract interface class com/kitakkun/jetwhale/plugins/semantics/protocol
 }
 
 public final class com/kitakkun/jetwhale/plugins/semantics/protocol/UiNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;
+	public final fun component5 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;Z)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;ZILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEditable ()Z
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getValue ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResponse {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResponse$Companion;
+	public fun <init> (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResponse;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResponse;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getSnapshot ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResult {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResult$Companion;
+	public fun <init> (ZLjava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;)V
+	public synthetic fun <init> (ZLjava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;
+	public final fun copy (ZLjava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResult;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResult;ZLjava/lang/String;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApplied ()Z
+	public final fun getAttribute ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribute;
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot$Companion;
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;Ljava/util/List;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;Ljava/lang/String;ILjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributes ()Ljava/util/List;
+	public final fun getNodeId ()I
+	public final fun getRootId ()Ljava/lang/String;
+	public final fun getViewClass ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$Companion;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$BooleanValue : com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$BooleanValue$Companion;
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$BooleanValue;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$BooleanValue;ZILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$BooleanValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$BooleanValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$BooleanValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$BooleanValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$BooleanValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$BooleanValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$ColorValue : com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$ColorValue$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$ColorValue;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$ColorValue;IILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$ColorValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgb ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$ColorValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$ColorValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$ColorValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$ColorValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$ColorValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$DimensionValue : com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$DimensionValue$Companion;
+	public fun <init> (FF)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun copy (FF)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$DimensionValue;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$DimensionValue;FFILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$DimensionValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDp ()F
+	public final fun getPx ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$DimensionValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$DimensionValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$DimensionValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$DimensionValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$DimensionValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$EnumValue : com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$EnumValue$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$EnumValue;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$EnumValue;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$EnumValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$EnumValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$EnumValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$EnumValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$EnumValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$EnumValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$FloatValue : com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$FloatValue$Companion;
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$FloatValue;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$FloatValue;FILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$FloatValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$FloatValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$FloatValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$FloatValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$FloatValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$FloatValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$IntValue : com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$IntValue$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$IntValue;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$IntValue;IILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$IntValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$IntValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$IntValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$IntValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$IntValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$IntValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue : com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue;Ljava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
+++ b/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
@@ -540,6 +540,23 @@ public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribut
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType : java/lang/Enum {
+	public static final field Bool Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
+	public static final field Color Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
+	public static final field Dimension Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
+	public static final field Enum Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
+	public static final field Float Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
+	public static final field Int Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
+	public static final field LayoutSize Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
+	public static final field Text Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getExtraFields ()Ljava/util/List;
+	public final fun getWireName ()Ljava/lang/String;
+	public final fun getWrittenAs ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
+	public static fun values ()[Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
+}
+
 public abstract interface class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
 	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$Companion;
 }
@@ -772,6 +789,10 @@ public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/Vi
 
 public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributesKt {
+	public static final fun getType (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeType;
 }
 
 public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewNode : com/kitakkun/jetwhale/plugins/semantics/protocol/UiNode {

--- a/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
+++ b/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
@@ -714,6 +714,39 @@ public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttribut
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$LayoutSizeValue : com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$LayoutSizeValue$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Float;
+	public final fun component3 ()Ljava/lang/Float;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/util/List;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$LayoutSizeValue;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$LayoutSizeValue;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/util/List;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$LayoutSizeValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConstant ()Ljava/lang/String;
+	public final fun getConstants ()Ljava/util/List;
+	public final fun getDp ()Ljava/lang/Float;
+	public final fun getPx ()Ljava/lang/Float;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$LayoutSizeValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$LayoutSizeValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$LayoutSizeValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$LayoutSizeValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$LayoutSizeValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue : com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue {
 	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributeValue$TextValue$Companion;
 	public fun <init> (Ljava/lang/String;)V

--- a/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
+++ b/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
@@ -30,6 +30,29 @@ final enum class com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction : k
     }
 }
 
+final enum class com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType : kotlin/Enum<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType|null[0]
+    enum entry Bool // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.Bool|null[0]
+    enum entry Color // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.Color|null[0]
+    enum entry Dimension // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.Dimension|null[0]
+    enum entry Enum // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.Enum|null[0]
+    enum entry Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.Float|null[0]
+    enum entry Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.Int|null[0]
+    enum entry LayoutSize // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.LayoutSize|null[0]
+    enum entry Text // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.Text|null[0]
+
+    final val entries // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.entries.<get-entries>|<get-entries>#static(){}[0]
+    final val extraFields // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.extraFields|{}extraFields[0]
+        final fun <get-extraFields>(): kotlin.collections/List<kotlin/String> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.extraFields.<get-extraFields>|<get-extraFields>(){}[0]
+    final val wireName // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.wireName|{}wireName[0]
+        final fun <get-wireName>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.wireName.<get-wireName>|<get-wireName>(){}[0]
+    final val writtenAs // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.writtenAs|{}writtenAs[0]
+        final fun <get-writtenAs>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.writtenAs.<get-writtenAs>|<get-writtenAs>(){}[0]
+
+    final fun valueOf(kotlin/String): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType.values|values#static(){}[0]
+}
+
 sealed interface com.kitakkun.jetwhale.plugins.semantics.protocol/UiNode { // com.kitakkun.jetwhale.plugins.semantics.protocol/UiNode|null[0]
     abstract val actions // com.kitakkun.jetwhale.plugins.semantics.protocol/UiNode.actions|{}actions[0]
         abstract fun <get-actions>(): kotlin.collections/List<kotlin/String> // com.kitakkun.jetwhale.plugins.semantics.protocol/UiNode.actions.<get-actions>|<get-actions>(){}[0]
@@ -926,3 +949,6 @@ final class com.kitakkun.jetwhale.plugins.semantics.protocol/ViewNode : com.kita
         final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewNode> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewNode.Companion.serializer|serializer(){}[0]
     }
 }
+
+final val com.kitakkun.jetwhale.plugins.semantics.protocol/type // com.kitakkun.jetwhale.plugins.semantics.protocol/type|@com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue{}type[0]
+    final fun (com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue).<get-type>(): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeType // com.kitakkun.jetwhale.plugins.semantics.protocol/type.<get-type>|<get-type>@com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue(){}[0]

--- a/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
+++ b/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
@@ -235,6 +235,43 @@ sealed interface com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeV
         }
     }
 
+    final class LayoutSizeValue : com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue|null[0]
+        constructor <init>(kotlin/String?, kotlin/Float?, kotlin/Float?, kotlin.collections/List<kotlin/String>) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.<init>|<init>(kotlin.String?;kotlin.Float?;kotlin.Float?;kotlin.collections.List<kotlin.String>){}[0]
+
+        final val constant // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.constant|{}constant[0]
+            final fun <get-constant>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.constant.<get-constant>|<get-constant>(){}[0]
+        final val constants // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.constants|{}constants[0]
+            final fun <get-constants>(): kotlin.collections/List<kotlin/String> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.constants.<get-constants>|<get-constants>(){}[0]
+        final val dp // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.dp|{}dp[0]
+            final fun <get-dp>(): kotlin/Float? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.dp.<get-dp>|<get-dp>(){}[0]
+        final val px // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.px|{}px[0]
+            final fun <get-px>(): kotlin/Float? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.px.<get-px>|<get-px>(){}[0]
+
+        final fun component1(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.component1|component1(){}[0]
+        final fun component2(): kotlin/Float? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.component2|component2(){}[0]
+        final fun component3(): kotlin/Float? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.component3|component3(){}[0]
+        final fun component4(): kotlin.collections/List<kotlin/String> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.component4|component4(){}[0]
+        final fun copy(kotlin/String? = ..., kotlin/Float? = ..., kotlin/Float? = ..., kotlin.collections/List<kotlin/String> = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.copy|copy(kotlin.String?;kotlin.Float?;kotlin.Float?;kotlin.collections.List<kotlin.String>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue.LayoutSizeValue){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.Companion|null[0]
+            final val $childSerializers // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.Companion.$childSerializers|{}$childSerializers[0]
+
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.LayoutSizeValue.Companion.serializer|serializer(){}[0]
+        }
+    }
+
     final class TextValue : com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue|null[0]
         constructor <init>(kotlin/String) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.<init>|<init>(kotlin.String){}[0]
 

--- a/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
+++ b/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
@@ -70,6 +70,203 @@ sealed interface com.kitakkun.jetwhale.plugins.semantics.protocol/UiNode { // co
     }
 }
 
+sealed interface com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue|null[0]
+    final class BooleanValue : com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue|null[0]
+        constructor <init>(kotlin/Boolean) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.<init>|<init>(kotlin.Boolean){}[0]
+
+        final val value // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.value|{}value[0]
+            final fun <get-value>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.component1|component1(){}[0]
+        final fun copy(kotlin/Boolean = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.copy|copy(kotlin.Boolean){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue.BooleanValue){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.BooleanValue.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class ColorValue : com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue|null[0]
+        constructor <init>(kotlin/Int) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.<init>|<init>(kotlin.Int){}[0]
+
+        final val argb // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.argb|{}argb[0]
+            final fun <get-argb>(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.argb.<get-argb>|<get-argb>(){}[0]
+
+        final fun component1(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.component1|component1(){}[0]
+        final fun copy(kotlin/Int = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.copy|copy(kotlin.Int){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue.ColorValue){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.ColorValue.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class DimensionValue : com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue|null[0]
+        constructor <init>(kotlin/Float, kotlin/Float) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.<init>|<init>(kotlin.Float;kotlin.Float){}[0]
+
+        final val dp // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.dp|{}dp[0]
+            final fun <get-dp>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.dp.<get-dp>|<get-dp>(){}[0]
+        final val px // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.px|{}px[0]
+            final fun <get-px>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.px.<get-px>|<get-px>(){}[0]
+
+        final fun component1(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.component1|component1(){}[0]
+        final fun component2(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.component2|component2(){}[0]
+        final fun copy(kotlin/Float = ..., kotlin/Float = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.copy|copy(kotlin.Float;kotlin.Float){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue.DimensionValue){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.DimensionValue.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class EnumValue : com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue|null[0]
+        constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
+
+        final val options // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.options|{}options[0]
+            final fun <get-options>(): kotlin.collections/List<kotlin/String> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.options.<get-options>|<get-options>(){}[0]
+        final val value // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.value|{}value[0]
+            final fun <get-value>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.component1|component1(){}[0]
+        final fun component2(): kotlin.collections/List<kotlin/String> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.component2|component2(){}[0]
+        final fun copy(kotlin/String = ..., kotlin.collections/List<kotlin/String> = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.copy|copy(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue.EnumValue){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.Companion|null[0]
+            final val $childSerializers // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.Companion.$childSerializers|{}$childSerializers[0]
+
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.EnumValue.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class FloatValue : com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue|null[0]
+        constructor <init>(kotlin/Float) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.<init>|<init>(kotlin.Float){}[0]
+
+        final val value // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.value|{}value[0]
+            final fun <get-value>(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.component1|component1(){}[0]
+        final fun copy(kotlin/Float = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.copy|copy(kotlin.Float){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue.FloatValue){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.FloatValue.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class IntValue : com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue|null[0]
+        constructor <init>(kotlin/Int) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.<init>|<init>(kotlin.Int){}[0]
+
+        final val value // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.value|{}value[0]
+            final fun <get-value>(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.component1|component1(){}[0]
+        final fun copy(kotlin/Int = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.copy|copy(kotlin.Int){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue.IntValue){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.IntValue.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class TextValue : com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue|null[0]
+        constructor <init>(kotlin/String) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.<init>|<init>(kotlin.String){}[0]
+
+        final val value // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.value|{}value[0]
+            final fun <get-value>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.component1|component1(){}[0]
+        final fun copy(kotlin/String = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.copy|copy(kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.$serializer|null[0]
+            final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue.TextValue){}[0]
+        }
+
+        final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.TextValue.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
 final class com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot> { // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree|null[0]
     constructor <init>(com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeCaptureOptions = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/CaptureNodeTree.<init>|<init>(com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions){}[0]
 
@@ -218,6 +415,35 @@ final class com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot { // co
         final val $childSerializers // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.Companion.$childSerializers|{}$childSerializers[0]
 
         final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot> // com.kitakkun.jetwhale.plugins.semantics.protocol/ComposeRoot.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse> { // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes|null[0]
+    constructor <init>(kotlin/String, kotlin/Int) // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.<init>|<init>(kotlin.String;kotlin.Int){}[0]
+
+    final val nodeId // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.nodeId|{}nodeId[0]
+        final fun <get-nodeId>(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.nodeId.<get-nodeId>|<get-nodeId>(){}[0]
+    final val rootId // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.rootId|{}rootId[0]
+        final fun <get-rootId>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.rootId.<get-rootId>|<get-rootId>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Int = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.copy|copy(kotlin.String;kotlin.Int){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes> { // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes) // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes> // com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes.Companion.serializer|serializer(){}[0]
     }
 }
 
@@ -407,6 +633,181 @@ final class com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction :
         final val $childSerializers // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.Companion.$childSerializers|{}$childSerializers[0]
 
         final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction> // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult> { // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute|null[0]
+    constructor <init>(kotlin/String, kotlin/Int, kotlin/String, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue) // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.<init>|<init>(kotlin.String;kotlin.Int;kotlin.String;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue){}[0]
+
+    final val attributeId // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.attributeId|{}attributeId[0]
+        final fun <get-attributeId>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.attributeId.<get-attributeId>|<get-attributeId>(){}[0]
+    final val nodeId // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.nodeId|{}nodeId[0]
+        final fun <get-nodeId>(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.nodeId.<get-nodeId>|<get-nodeId>(){}[0]
+    final val rootId // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.rootId|{}rootId[0]
+        final fun <get-rootId>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.rootId.<get-rootId>|<get-rootId>(){}[0]
+    final val value // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.value|{}value[0]
+        final fun <get-value>(): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.component2|component2(){}[0]
+    final fun component3(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.component3|component3(){}[0]
+    final fun component4(): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.component4|component4(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Int = ..., kotlin/String = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.copy|copy(kotlin.String;kotlin.Int;kotlin.String;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute> { // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute) // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute> // com.kitakkun.jetwhale.plugins.semantics.protocol/SetViewAttribute.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute|null[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/String, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue, kotlin/Boolean) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue;kotlin.Boolean){}[0]
+
+    final val editable // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.editable|{}editable[0]
+        final fun <get-editable>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.editable.<get-editable>|<get-editable>(){}[0]
+    final val group // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.group|{}group[0]
+        final fun <get-group>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.group.<get-group>|<get-group>(){}[0]
+    final val id // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.id|{}id[0]
+        final fun <get-id>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.id.<get-id>|<get-id>(){}[0]
+    final val label // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.label|{}label[0]
+        final fun <get-label>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.label.<get-label>|<get-label>(){}[0]
+    final val value // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.value|{}value[0]
+        final fun <get-value>(): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.component1|component1(){}[0]
+    final fun component2(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.component2|component2(){}[0]
+    final fun component3(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.component3|component3(){}[0]
+    final fun component4(): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.component4|component4(){}[0]
+    final fun component5(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.component5|component5(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue = ..., kotlin/Boolean = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.copy|copy(kotlin.String;kotlin.String;kotlin.String;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue;kotlin.Boolean){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse|null[0]
+    constructor <init>(com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot?, kotlin/String? = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.<init>|<init>(com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot?;kotlin.String?){}[0]
+
+    final val message // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.message|{}message[0]
+        final fun <get-message>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.message.<get-message>|<get-message>(){}[0]
+    final val snapshot // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.snapshot|{}snapshot[0]
+        final fun <get-snapshot>(): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.snapshot.<get-snapshot>|<get-snapshot>(){}[0]
+
+    final fun component1(): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.component2|component2(){}[0]
+    final fun copy(com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot? = ..., kotlin/String? = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.copy|copy(com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot?;kotlin.String?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResponse.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult|null[0]
+    constructor <init>(kotlin/Boolean, kotlin/String? = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute? = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.<init>|<init>(kotlin.Boolean;kotlin.String?;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute?){}[0]
+
+    final val applied // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.applied|{}applied[0]
+        final fun <get-applied>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.applied.<get-applied>|<get-applied>(){}[0]
+    final val attribute // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.attribute|{}attribute[0]
+        final fun <get-attribute>(): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.attribute.<get-attribute>|<get-attribute>(){}[0]
+    final val message // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.message|{}message[0]
+        final fun <get-message>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.message.<get-message>|<get-message>(){}[0]
+
+    final fun component1(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.component2|component2(){}[0]
+    final fun component3(): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute? // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.component3|component3(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin/String? = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute? = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.copy|copy(kotlin.Boolean;kotlin.String?;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot|null[0]
+    constructor <init>(kotlin/String, kotlin/Int, kotlin/String, kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute>) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.<init>|<init>(kotlin.String;kotlin.Int;kotlin.String;kotlin.collections.List<com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute>){}[0]
+
+    final val attributes // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.attributes|{}attributes[0]
+        final fun <get-attributes>(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.attributes.<get-attributes>|<get-attributes>(){}[0]
+    final val nodeId // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.nodeId|{}nodeId[0]
+        final fun <get-nodeId>(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.nodeId.<get-nodeId>|<get-nodeId>(){}[0]
+    final val rootId // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.rootId|{}rootId[0]
+        final fun <get-rootId>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.rootId.<get-rootId>|<get-rootId>(){}[0]
+    final val viewClass // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.viewClass|{}viewClass[0]
+        final fun <get-viewClass>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.viewClass.<get-viewClass>|<get-viewClass>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.component2|component2(){}[0]
+    final fun component3(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.component4|component4(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Int = ..., kotlin/String = ..., kotlin.collections/List<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttribute> = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.copy|copy(kotlin.String;kotlin.Int;kotlin.String;kotlin.collections.List<com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot> { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot) // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.Companion|null[0]
+        final val $childSerializers // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot> // com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot.Companion.serializer|serializer(){}[0]
     }
 }
 

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributes.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributes.kt
@@ -1,0 +1,117 @@
+package com.kitakkun.jetwhale.plugins.semantics.protocol
+
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleRequest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// Reading and writing the platform attributes of one `ViewNode` — what an Android `View` exposes
+// beyond the semantics every `UiNode` reports.
+//
+// Attributes travel on their own request rather than inside a `NodeTreeSnapshot`: a tree of two
+// hundred nodes must not carry thirty attributes each, and a host only ever shows the attributes of
+// the one node a user selected.
+//
+// A `ComposeNode` has none. A semantics node is a projection of composition state, so a write to it
+// lasts until the next recomposition overwrites it — which is why a root read through its
+// `SemanticsOwner` answers "not supported" instead.
+
+/** One attribute's current value; the variant also says how a host should edit it. */
+@Serializable
+sealed interface ViewAttributeValue {
+    @Serializable
+    @SerialName("bool")
+    data class BooleanValue(val value: Boolean) : ViewAttributeValue
+
+    @Serializable
+    @SerialName("int")
+    data class IntValue(val value: Int) : ViewAttributeValue
+
+    @Serializable
+    @SerialName("float")
+    data class FloatValue(val value: Float) : ViewAttributeValue
+
+    @Serializable
+    @SerialName("text")
+    data class TextValue(val value: String) : ViewAttributeValue
+
+    /** Straight ARGB, as `View` itself stores colors. */
+    @Serializable
+    @SerialName("color")
+    data class ColorValue(val argb: Int) : ViewAttributeValue
+
+    /**
+     * A length in pixels; [dp] is the same length at the root's density, for reading. A write reads
+     * [px] only, so a caller that has no density to hand may repeat the pixel figure in [dp].
+     */
+    @Serializable
+    @SerialName("dimension")
+    data class DimensionValue(val px: Float, val dp: Float) : ViewAttributeValue
+
+    /** One of [options]; `layout.width`'s options include `MATCH_PARENT` / `WRAP_CONTENT`. */
+    @Serializable
+    @SerialName("enum")
+    data class EnumValue(val value: String, val options: List<String>) : ViewAttributeValue
+}
+
+@Serializable
+data class ViewAttribute(
+    /** Stable identifier a [SetViewAttribute] names, e.g. `visibility`, `padding.left`. */
+    val id: String,
+    val label: String,
+    /** Section a host groups this under: `State`, `Layout`, `Appearance`, `Text`, `Info`. */
+    val group: String,
+    val value: ViewAttributeValue,
+    /** `false` when this view exposes the attribute but nothing can write it back. */
+    val editable: Boolean,
+)
+
+@Serializable
+data class ViewAttributeSnapshot(
+    val rootId: String,
+    val nodeId: Int,
+    val viewClass: String,
+    val attributes: List<ViewAttribute>,
+)
+
+/**
+ * Reads every attribute the node addressed by [rootId]/[nodeId] exposes.
+ *
+ * Answered per node, on demand: a host asks when a selection changes, so a capture stays as small
+ * as it is today.
+ */
+@SerialName("view/get_attributes")
+@Serializable
+data class GetViewAttributes(
+    val rootId: String,
+    val nodeId: Int,
+) : JetWhaleRequest<ViewAttributeResponse>
+
+/** Separate from the snapshot so a node that has gone away is an answer, not a transport failure. */
+@Serializable
+data class ViewAttributeResponse(
+    val snapshot: ViewAttributeSnapshot?,
+    val message: String? = null,
+)
+
+/**
+ * Writes one attribute of one node.
+ *
+ * The write is temporary in the same way the Android Studio Layout Inspector's is: the app owns the
+ * property, and a relayout, a rebind or the app writing it itself takes the value back.
+ */
+@SerialName("view/set_attribute")
+@Serializable
+data class SetViewAttribute(
+    val rootId: String,
+    val nodeId: Int,
+    val attributeId: String,
+    val value: ViewAttributeValue,
+) : JetWhaleRequest<ViewAttributeResult>
+
+@Serializable
+data class ViewAttributeResult(
+    val applied: Boolean,
+    val message: String? = null,
+    /** The attribute as it reads back after the write, so a host shows what actually took effect. */
+    val attribute: ViewAttribute? = null,
+)

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributes.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributes.kt
@@ -47,10 +47,35 @@ sealed interface ViewAttributeValue {
     @SerialName("dimension")
     data class DimensionValue(val px: Float, val dp: Float) : ViewAttributeValue
 
-    /** One of [options]; `layout.width`'s options include `MATCH_PARENT` / `WRAP_CONTENT`. */
+    /** One of [options], and nothing else. */
     @Serializable
     @SerialName("enum")
     data class EnumValue(val value: String, val options: List<String>) : ViewAttributeValue
+
+    /**
+     * A `layout.width` / `layout.height`, which is either one of the constants that name a rule or a
+     * length — and can be moved between the two.
+     *
+     * Both cases are one variant rather than an [EnumValue] and a [DimensionValue] taking turns,
+     * because the variant is what a host picks an editor from: were the shape to follow the current
+     * value, a size reading `WRAP_CONTENT` would offer no way to type a length, and a size reading
+     * as a length no way to get back.
+     *
+     * @param constant one of [constants] when the size names a rule, `null` when it is a length.
+     * @param px the length in pixels, `null` when [constant] is set. A write reads [px] only, so a
+     *   caller that has no density to hand may repeat the pixel figure in [dp].
+     * @param dp the same length at the root's density, for reading.
+     * @param constants the rules this size accepts, whichever case it is in — so an editor can
+     *   offer them while the size is a length.
+     */
+    @Serializable
+    @SerialName("layoutSize")
+    data class LayoutSizeValue(
+        val constant: String?,
+        val px: Float?,
+        val dp: Float?,
+        val constants: List<String>,
+    ) : ViewAttributeValue
 }
 
 @Serializable

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributes.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/ViewAttributes.kt
@@ -78,6 +78,49 @@ sealed interface ViewAttributeValue {
     ) : ViewAttributeValue
 }
 
+/**
+ * What a [ViewAttributeValue] variant is called on the wire, how a caller writes one as text, and
+ * the fields a read reports beside the value.
+ *
+ * One list rather than one per module. The same three facts are needed where a read is rendered,
+ * where a rejected write explains itself, and in the MCP tool's own description — and written out
+ * separately they drift: the description went out of step with what a read actually returned.
+ * [wireName] is pinned to the variant's `@SerialName` by a test.
+ */
+enum class ViewAttributeType(
+    val wireName: String,
+    /** How a caller writes a value of this type as text. */
+    val writtenAs: String,
+    /** What a read adds beside `value` for this type. */
+    val extraFields: List<String>,
+) {
+    Bool("bool", "\"true\"", emptyList()),
+    Int("int", "\"24\"", emptyList()),
+    Float("float", "\"0.5\"", emptyList()),
+    Text("text", "any text", emptyList()),
+    Color("color", "\"#AARRGGBB\"", emptyList()),
+    Dimension("dimension", "a length in pixels, \"48\"", listOf("dp")),
+    Enum("enum", "one of the entry's \"options\"", listOf("options")),
+    LayoutSize(
+        "layoutSize",
+        "one of the entry's \"constants\" (\"WRAP_CONTENT\", \"MATCH_PARENT\") or a length in pixels, whichever it currently reads as",
+        listOf("constants", "dp"),
+    ),
+}
+
+/** The type [this] travels as. */
+val ViewAttributeValue.type: ViewAttributeType
+    get() = when (this) {
+        is ViewAttributeValue.BooleanValue -> ViewAttributeType.Bool
+        is ViewAttributeValue.IntValue -> ViewAttributeType.Int
+        is ViewAttributeValue.FloatValue -> ViewAttributeType.Float
+        is ViewAttributeValue.TextValue -> ViewAttributeType.Text
+        is ViewAttributeValue.ColorValue -> ViewAttributeType.Color
+        is ViewAttributeValue.DimensionValue -> ViewAttributeType.Dimension
+        is ViewAttributeValue.EnumValue -> ViewAttributeType.Enum
+        is ViewAttributeValue.LayoutSizeValue -> ViewAttributeType.LayoutSize
+    }
+
 @Serializable
 data class ViewAttribute(
     /** Stable identifier a [SetViewAttribute] names, e.g. `visibility`, `padding.left`. */


### PR DESCRIPTION
> Stacked on #243 (Android View support / sealed `UiNode`). Review the last commit only; retarget to `main` after #243 merges.

## Summary

Flipper-style live attribute editing for **`ViewNode`s**: select a View node and the inspector shows its platform attributes, and a curated set of them can be written back and take effect immediately. Also exposed over MCP as `getViewAttributes` / `setViewAttribute`.

**Compose nodes deliberately have none.** A semantics node is a projection of composition state, so a write would be undone by the next recomposition — asking for a Compose node's attributes returns a message saying exactly that, rather than failing.

## Separation

This is additive, not woven into the existing capture:

- **The node tree is untouched.** No attribute travels in a `NodeTreeSnapshot`; they are fetched per node by requests of their own, so a 200-node capture does not grow by 34 attributes a node. `ViewTreeCapture.kt`, `SemanticsTreeCapture.kt`, `NodeModels.kt`, `ComposeNodeMessages.kt`, `ViewActionDispatch.kt`, `SemanticsOwnerNodeSource.kt`, `NodeTree.kt`, `TreeRow.kt`, `NodeMcpJson.kt` and `FindNodesCommand.kt` are all unmodified.
- **An optional capability, not a wider `ComposeNodeSource`.** New `interface ViewAttributeSource`; `AndroidWindowNodeSource` implements it, desktop's source does not and gains no no-op methods. Nothing in `jvmMain` changed.
- New protocol / agent / host code lives in its own files. The only edits to existing files are two `onRequest` lines, the `ViewAttributeSource` implementation, two messenger calls plus two MCP commands in the host plugin, and rendering the panel when `node is ViewNode`.

## What can be edited

34 attributes in five groups — State (`visibility`, `enabled`, `selected`, `activated`, `clickable`, `focusable`), Layout (`layout.width/height`, `padding.*`, `margin.*`, `minWidth/Height`), Appearance (`alpha`, `backgroundColor`, `elevation`, `translationX/Y`, `rotation`, `scaleX/Y`), Text (`text`, `hint`, `textSize`, `textColor`, `maxLines`) and read-only Info (`id`, `class`, `bounds`, `focused`).

Values are typed (`bool`, `int`, `float`, `text`, `color`, `dimension`, `enum`), so the host renders a switch, a field, a dropdown or a colour swatch per attribute, and the MCP tools accept a plain string (`"GONE"`, `"#FF0000FF"`, `"0.5"`, `"wrap_content"`). An attribute that does not apply to a view is simply absent — `backgroundColor` appears only for a `ColorDrawable` background, `margin.*` only under a `MarginLayoutParams`.

**It is an allowlist, not reflection.** Reflection is what makes this kind of feature fragile, and non-SDK interface restrictions (API 28+) block most of what it would reach. **Edits are temporary** — a relayout, a rebind, or the app writing the property itself takes the value back — and the panel, the docs and both tool descriptions say so.

## Testing
- `:jetwhale-plugins:semantics:{protocol,agent,host}:check`, `:demo:android:assembleDebug`, `spotlessCheck`, ABI dumps — pass.
- Emulator smoke run over MCP: `getViewAttributes` on a `TextView` node (34 attributes, correct `editable` flags, `backgroundColor` absent for a view with no background); `text`, `visibility` → `GONE` → back, `textColor` → `#FF0000FF` (confirmed by screenshot), `layout.width` as both `WRAP_CONTENT` and a pixel value, `alpha = "5"` clamped to `1.0`. Error cases: unknown `attributeId` (lists what the view exposes), a wrong value for the variant, writing a read-only attribute, and `getViewAttributes` on a Compose node id (answers the explanation, does not fail).
- GUI run: the panel renders in the redesigned detail pane, and selecting `GONE` from its dropdown made the demo's `TextView` disappear on the device.
- Not exercised: `margin.*` / `padding.*` writes on-device, `backgroundColor` against a real background, and the `textSize` sp figure at a non-default font scale.
