### PR TITLE
fix(host-ui): draw the focus ring inside a component's bounds by default

### DIFF
--- a/jetwhale-host-ui/README.md
+++ b/jetwhale-host-ui/README.md
@@ -93,8 +93,10 @@ does less, the name differs so the difference is not a surprise.
 - **Interaction feedback**: components draw no ripple; a hover tint and an accent focus ring take
   its place. The ring marks whatever holds focus — a click moves focus on desktop,
   so the control last clicked keeps it until focus moves on. `Modifier.jwFocusRing(interactionSource,
-  shape)` gives a custom control the same ring; it is drawn just outside the bounds, so a parent
-  that clips (`JwPanel`, `JwDialog`) trims it on a row flush with the edge.
+  shape)` gives a custom control the same ring; it is drawn just inside the bounds, so no parent
+  that clips (`JwPanel`, `JwDialog`) can trim it. `JwFocusRingStyle.Outset` moves it just outside
+  instead, for a small control — a switch, a checkbox, an icon button — whose painted surface
+  leaves no room for a ring inside it.
 - **Content color and text style flow down**: a control that paints a background provides
   `LocalJwContentColor` and `LocalJwTextStyle` for its content, and `JwText` / `JwIcon` read them.
   Use `JwText` rather than Material's `Text` inside Jw components, or the text keeps Material's

--- a/jetwhale-host-ui/api/jetwhale-host-ui.api
+++ b/jetwhale-host-ui/api/jetwhale-host-ui.api
@@ -191,6 +191,14 @@ public final class com/kitakkun/jetwhale/host/ui/JwEmptyStateKt {
 	public static final fun JwEmptyState (Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class com/kitakkun/jetwhale/host/ui/JwFocusRingStyle : java/lang/Enum {
+	public static final field Inset Lcom/kitakkun/jetwhale/host/ui/JwFocusRingStyle;
+	public static final field Outset Lcom/kitakkun/jetwhale/host/ui/JwFocusRingStyle;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kitakkun/jetwhale/host/ui/JwFocusRingStyle;
+	public static fun values ()[Lcom/kitakkun/jetwhale/host/ui/JwFocusRingStyle;
+}
+
 public final class com/kitakkun/jetwhale/host/ui/JwFormFieldKt {
 	public static final fun JwFormField (Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
@@ -224,7 +232,7 @@ public final class com/kitakkun/jetwhale/host/ui/JwIcons {
 }
 
 public final class com/kitakkun/jetwhale/host/ui/JwInteractionKt {
-	public static final fun jwFocusRing (Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/InteractionSource;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
+	public static final fun jwFocusRing (Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/InteractionSource;Landroidx/compose/ui/graphics/Shape;Lcom/kitakkun/jetwhale/host/ui/JwFocusRingStyle;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 }
 
 public final class com/kitakkun/jetwhale/host/ui/JwKeyValueRowDefaults {

--- a/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwButton.kt
+++ b/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwButton.kt
@@ -117,7 +117,7 @@ public fun JwButton(
     Row(
         modifier = modifier
             .height(JwMetrics.controlHeight)
-            .jwFocusRing(interactionSource, JwShapes.small)
+            .jwFocusRing(interactionSource, JwShapes.small, JwFocusRingStyle.Outset)
             .clip(JwShapes.small)
             .background(background)
             .border(JwMetrics.borderWidth, borderColor, JwShapes.small)

--- a/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwCheckbox.kt
+++ b/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwCheckbox.kt
@@ -62,7 +62,7 @@ public fun JwCheckbox(
         label = label,
         enabled = enabled,
         modifier = modifier
-            .jwFocusRing(interactionSource, JwShapes.small)
+            .jwFocusRing(interactionSource, JwShapes.small, JwFocusRingStyle.Outset)
             .clip(JwShapes.small)
             .toggleable(
                 value = checked,
@@ -99,7 +99,7 @@ public fun JwTriStateCheckbox(
         label = label,
         enabled = enabled,
         modifier = modifier
-            .jwFocusRing(interactionSource, JwShapes.small)
+            .jwFocusRing(interactionSource, JwShapes.small, JwFocusRingStyle.Outset)
             .clip(JwShapes.small)
             .triStateToggleable(
                 state = state,

--- a/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwIconButton.kt
+++ b/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwIconButton.kt
@@ -73,7 +73,7 @@ public fun JwIconButton(
             modifier = Modifier
                 .size(size)
                 .then(if (tooltip != null) Modifier.semantics { contentDescription = tooltip } else Modifier)
-                .jwFocusRing(interactionSource, JwShapes.small)
+                .jwFocusRing(interactionSource, JwShapes.small, JwFocusRingStyle.Outset)
                 .clip(JwShapes.small)
                 .background(background)
                 .clickable(

--- a/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwInteraction.kt
+++ b/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwInteraction.kt
@@ -16,6 +16,23 @@ import androidx.compose.ui.unit.dp
 /** Space between a control's edge and its focus ring. */
 private val FocusRingGap = 1.dp
 
+/** Where a focus ring sits relative to the control's own bounds. */
+public enum class JwFocusRingStyle {
+    /**
+     * Just inside the control's bounds, so no ancestor can clip the ring away. Right for a row, a
+     * button with padding, or any surface with room to spare inside its edge.
+     */
+    Inset,
+
+    /**
+     * Just outside the control's bounds. Right for a small control whose whole surface is painted
+     * — a switch track, a checkbox, an icon button, a filled tag — where a ring drawn inside would
+     * land on the control itself. It needs an ancestor that does not clip, and space around the
+     * control for the ring to occupy.
+     */
+    Outset,
+}
+
 /**
  * Draws the accent focus ring every Jw control shows while it holds focus. On desktop a click
  * moves focus too, so the ring also marks the control last clicked until focus moves on — the
@@ -23,15 +40,21 @@ private val FocusRingGap = 1.dp
  * keyboard user gets; apply it to a custom control built on the same
  * [InteractionSource] as its `clickable`.
  *
- * The ring sits just outside the control's bounds, so it stays visible on a control filled with
- * the accent color itself. Place it before any `clip` in the modifier chain, or the clip cuts it
- * off; a parent that clips, such as [JwPanel], trims the ring of a row flush with its edge.
+ * Place it before any `clip` in the modifier chain, or the clip cuts it off.
  *
  * @param interactionSource the control's interaction source; the ring follows its focus state.
  * @param shape the control's shape, so the ring hugs its corners.
+ * @param style [JwFocusRingStyle.Inset] by default, because a shared component cannot know what
+ * its container does: a ring drawn outside survives only where no ancestor clips, and a row inside
+ * a scrolling panel loses it at the panel's edges. Pass [JwFocusRingStyle.Outset] for a small
+ * control whose painted surface leaves no room for a ring inside it.
  */
 @Composable
-public fun Modifier.jwFocusRing(interactionSource: InteractionSource, shape: Shape): Modifier {
+public fun Modifier.jwFocusRing(
+    interactionSource: InteractionSource,
+    shape: Shape,
+    style: JwFocusRingStyle = JwFocusRingStyle.Inset,
+): Modifier {
     val focused by interactionSource.collectIsFocusedAsState()
     if (!focused) return this
     val color = JwTheme.colors.accent
@@ -39,9 +62,19 @@ public fun Modifier.jwFocusRing(interactionSource: InteractionSource, shape: Sha
         drawContent()
         val stroke = JwMetrics.focusStrokeWidth.toPx()
         val gap = FocusRingGap.toPx()
-        val inset = stroke / 2f + gap
-        val outline = shape.createOutline(Size(size.width + inset * 2f, size.height + inset * 2f), layoutDirection, this)
-        translate(-inset, -inset) {
+        // Never past the center of a control smaller than the ring's own offset, which would ask
+        // for an outline of negative size.
+        val offset = (stroke / 2f + gap).coerceAtMost(minOf(size.width, size.height) / 2f)
+        val ringSize = when (style) {
+            JwFocusRingStyle.Inset -> Size(size.width - offset * 2f, size.height - offset * 2f)
+            JwFocusRingStyle.Outset -> Size(size.width + offset * 2f, size.height + offset * 2f)
+        }
+        val translation = when (style) {
+            JwFocusRingStyle.Inset -> offset
+            JwFocusRingStyle.Outset -> -offset
+        }
+        val outline = shape.createOutline(ringSize, layoutDirection, this)
+        translate(translation, translation) {
             drawOutline(outline = outline, color = color, style = Stroke(width = stroke))
         }
     }

--- a/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwSnackbar.kt
+++ b/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwSnackbar.kt
@@ -219,7 +219,7 @@ private fun SnackbarAction(label: String, onClick: () -> Unit) {
     Box(
         modifier = Modifier
             .height(JwMetrics.controlHeight)
-            .jwFocusRing(interactionSource, JwShapes.small)
+            .jwFocusRing(interactionSource, JwShapes.small, JwFocusRingStyle.Outset)
             .clip(JwShapes.small)
             .background(if (hovered) JwTheme.colors.onTooltip.copy(alpha = ACTION_HOVER_ALPHA) else Color.Transparent)
             .clickable(

--- a/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwSwitch.kt
+++ b/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwSwitch.kt
@@ -60,7 +60,7 @@ public fun JwSwitch(
     Box(
         modifier = modifier
             .size(width = TrackWidth, height = TrackHeight)
-            .jwFocusRing(interactionSource, CircleShape)
+            .jwFocusRing(interactionSource, CircleShape, JwFocusRingStyle.Outset)
             .clip(CircleShape)
             .semantics { this.contentDescription = contentDescription }
             .background(trackColor)

--- a/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwTag.kt
+++ b/jetwhale-host-ui/src/main/kotlin/com/kitakkun/jetwhale/host/ui/JwTag.kt
@@ -78,7 +78,7 @@ public fun JwTag(
     Row(
         modifier = modifier
             .height(JwTagDefaults.height)
-            .then(if (onClick != null) Modifier.jwFocusRing(interactionSource, shape) else Modifier)
+            .then(if (onClick != null) Modifier.jwFocusRing(interactionSource, shape, JwFocusRingStyle.Outset) else Modifier)
             .clip(shape)
             .then(if (background != null) Modifier.background(background, shape) else Modifier)
             .then(if (style == JwTagStyle.Outlined) Modifier.border(JwMetrics.borderWidth, tone.color.copy(alpha = 0.6f), shape) else Modifier)


### PR DESCRIPTION
## The defect

`Modifier.jwFocusRing` inflated the outline by `stroke/2 + gap` and translated it by `-inset`, i.e. it drew **outside** the bounds it was applied to. That only survives when no ancestor clips.

A `JwTreeRow` is `fillMaxWidth()` inside a clipping scroll panel, so the focused row's ring lost its left, right and top edges and the surviving bottom stroke read as a stray line bleeding into the next row. The same happened to `JwListItem` (the MCP tools dialog's list), and — found while going through the call sites — to `JwTab` (the strip is a `horizontalScroll` Row, which clips) and `JwSegmentedButtons` (the parent Row does `.clip(shape)`).

| before | after |
|---|---|
| ring reduced to one stray line | a complete rounded rectangle inside the row |

## The fix

```kotlin
public enum class JwFocusRingStyle { Inset, Outset }
```

`jwFocusRing(interactionSource, shape, style = JwFocusRingStyle.Inset)`. **`Inset` is the default because a shared component cannot know what its container clips** — the safe placement has to be the one you get without thinking about it. The KDoc says which to pick.

`Outset` is kept, and passed explicitly, for the controls that paint their own surface edge to edge, where a ring inside would land *on* the control rather than around it: `JwButton` (`Primary` is filled with the accent itself), `JwCheckbox` / `JwTriStateCheckbox`, `JwSwitch` (a small filled track), `JwIconButton`, `JwTag` (18 dp, filled in `Filled` style) and the `JwSnackbar` action (the strip gives it padding on every side and does not clip).

Everything else takes the default: `JwTreeRow`, `JwListItem`, both `JwDropdown` sites, `JwSectionHeader`, `JwTab`, `JwSegmentedButtons`.

The draw block also clamps the offset to `min(size)/2`, so a control smaller than the ring offset cannot ask for an outline of negative size.

## Testing
- `:jetwhale-host-ui:check`, `:jetwhale-host-ui:checkKotlinAbi`, `:jetwhale-host:app:test`, `spotlessCheck` — pass. ABI dump regenerated for the new enum and the changed signature.
- Verified by rendering `JwTreeRow` and `JwListItem` focused, in the reported condition (a panel with no content padding, a clipping `verticalScroll` column, full-width rows), before and after the change.
- Not verified in the live host window: driving the running app needs UI-automation permission this environment does not have. No regression test was added — the module's only screenshot tests have no focused state; a focused row in `JwGallery` would be the natural guard if you want one.
