### PR TITLE
refactor(semantics): split the inspector into a presenter and a view

### DIFF
--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -235,6 +235,32 @@ actually exposes. There is also a **Copy `adb shell input tap`** button for the 
 drive the app through the input system. Select an Android `View` node and its editable attributes
 appear below that — see [Editing View attributes](#editing-view-attributes).
 
+### Highlighting on the device
+
+Turn on **Highlight** and the app draws a translucent box over the node you have selected; hovering a
+row shows that node instead for as long as the pointer is on it, and the selection comes back when it
+leaves. It works for Compose nodes and Android `View` nodes alike — both report their bounds in the
+same window coordinates — and a node in a dialog is highlighted in the dialog's own window.
+
+Three things to know:
+
+- **It is off by default, on purpose.** The box is drawn into the app itself, so anything that takes
+  a screenshot of the device while it is up captures the box too — a `screencap`, the Android Device
+  plugin, a QA run. Turn it on to find something, turn it off before you capture.
+- **It never appears in the captured tree.** The box is a window overlay (`View.getOverlay()`), drawn
+  after the root view's children but not one of them, so the tree you are reading is not changed by
+  reading it.
+- **It follows the node, or goes away.** The box is put back where the node is as the window
+  redraws, so scrolling the app, a relayout, or a rotation the activity handles itself does not leave
+  it behind; a node that can no longer be found takes the box down rather than stranding it. A box on
+  screen is always in the right place.
+- **It clears itself.** The app drops a highlight it has not heard about for 30 seconds, so a host
+  that crashes or is killed cannot leave a box on the app's screen for the rest of the session.
+  Closing the inspector, disabling the plugin and disconnecting all clear it straight away.
+
+There is deliberately no MCP tool for this. An agent reads a node's bounds from the tree already, and
+a highlight would only put a box into the screenshots it takes.
+
 ## MCP tools
 
 The plugin contributes five tools to the host's [MCP server](/guide/mcp-server). As with every

--- a/jetwhale-plugins/semantics/agent/api/agent.klib.api
+++ b/jetwhale-plugins/semantics/agent/api/agent.klib.api
@@ -18,6 +18,10 @@ abstract interface com.kitakkun.jetwhale.plugins.semantics.agent/ComposeUiThread
     abstract suspend fun <#A1: kotlin/Any?> await(kotlin/Function0<#A1>): #A1 // com.kitakkun.jetwhale.plugins.semantics.agent/ComposeUiThread.await|await(kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
 }
 
+abstract interface com.kitakkun.jetwhale.plugins.semantics.agent/NodeHighlightSource { // com.kitakkun.jetwhale.plugins.semantics.agent/NodeHighlightSource|null[0]
+    abstract suspend fun highlight(kotlin/Int?, kotlin.time/Duration): com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult // com.kitakkun.jetwhale.plugins.semantics.agent/NodeHighlightSource.highlight|highlight(kotlin.Int?;kotlin.time.Duration){}[0]
+}
+
 abstract interface com.kitakkun.jetwhale.plugins.semantics.agent/ViewAttributeSource { // com.kitakkun.jetwhale.plugins.semantics.agent/ViewAttributeSource|null[0]
     abstract suspend fun attributes(kotlin/Int): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeSnapshot? // com.kitakkun.jetwhale.plugins.semantics.agent/ViewAttributeSource.attributes|attributes(kotlin.Int){}[0]
     abstract suspend fun setAttribute(kotlin/Int, kotlin/String, com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeValue): com.kitakkun.jetwhale.plugins.semantics.protocol/ViewAttributeResult // com.kitakkun.jetwhale.plugins.semantics.agent/ViewAttributeSource.setAttribute|setAttribute(kotlin.Int;kotlin.String;com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue){}[0]

--- a/jetwhale-plugins/semantics/agent/api/jvm/agent.api
+++ b/jetwhale-plugins/semantics/agent/api/jvm/agent.api
@@ -43,6 +43,10 @@ public final class com/kitakkun/jetwhale/plugins/semantics/agent/MainDispatcherC
 	public fun await (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class com/kitakkun/jetwhale/plugins/semantics/agent/NodeHighlightSource {
+	public abstract fun highlight-8Mi8wO0 (Ljava/lang/Integer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsOwnerNodeSource : com/kitakkun/jetwhale/plugins/semantics/agent/ComposeNodeSource {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/kitakkun/jetwhale/plugins/semantics/agent/ComposeUiThread;)V

--- a/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/AndroidWindowNodeSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/AndroidWindowNodeSource.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.plugins.semantics.agent
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.geometry.Offset
@@ -10,6 +11,7 @@ import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.getAllSemanticsNodes
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
@@ -17,6 +19,8 @@ import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeSnapshot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeValue
 import java.lang.ref.WeakReference
+import kotlin.math.roundToInt
+import kotlin.time.Duration
 
 /**
  * Reads one Android **window** — its `View` hierarchy and every composition inside it — as a single
@@ -34,10 +38,14 @@ import java.lang.ref.WeakReference
  */
 internal class AndroidWindowNodeSource(rootView: View) :
     ComposeNodeSource,
-    ViewAttributeSource {
+    ViewAttributeSource,
+    NodeHighlightSource {
     override val sourceId: String = "android-window-${System.identityHashCode(rootView).toString(16)}"
 
     private val rootViewRef = WeakReference(rootView)
+
+    // At most one box per window, so pointing at another node moves this one.
+    private val highlightOverlay = NodeHighlightOverlay()
 
     // A detached window has nothing readable to report, and reading a composition inside it can
     // throw, so the attachment check gates every call rather than only the registration.
@@ -93,6 +101,37 @@ internal class AndroidWindowNodeSource(rootView: View) :
         view.writeAttribute(attributeId = attributeId, value = value)
     }
 
+    // -- NodeHighlightSource ---------------------------------------------------
+    //
+    // A window is the only root that can be pointed at: it has a decor view to hang an overlay on.
+    // The drawing lives in NodeHighlightOverlay.kt; this only resolves the node's bounds and hops to
+    // the UI thread, the same way the other two capabilities do.
+
+    override suspend fun highlight(nodeId: Int?, ttl: Duration): HighlightResult = AndroidComposeUiThread.await {
+        if (nodeId == null) {
+            highlightOverlay.clear()
+            return@await HighlightResult(shown = false)
+        }
+        val rootView = attachedRootView()
+            ?: return@await HighlightResult(shown = false, message = "the window is no longer readable")
+        // Passed as a lookup rather than as the bounds it currently reports: a scroll or a relayout
+        // moves the node, and the overlay follows it by asking again.
+        val resolveBounds = { rootView.highlightBoundsOf(nodeId) }
+        val bounds = resolveBounds()
+            ?: return@await HighlightResult(
+                shown = false,
+                message = "unknown nodeId: $nodeId (the node may have left this window; capture the tree again)",
+            )
+        if (bounds.isEmpty) {
+            return@await HighlightResult(
+                shown = false,
+                message = "node $nodeId has no area in this window (it is invisible, unmeasured, or fully clipped)",
+            )
+        }
+        highlightOverlay.show(rootView = rootView, resolveBounds = resolveBounds, ttl = ttl)
+        HighlightResult(shown = true)
+    }
+
     private fun unknownNode(nodeId: Int): NodeActionResult = NodeActionResult(
         performed = false,
         message = "unknown nodeId: $nodeId (the node may have left this window; capture the tree again)",
@@ -107,6 +146,25 @@ internal class AndroidWindowNodeSource(rootView: View) :
  * view here, which is the right answer for both callers.
  */
 private fun viewInWindow(nodeId: Int, rootView: View): View? = ViewNodeIds.viewOf(nodeId)?.takeIf { it.rootView === rootView }
+
+/**
+ * Where the node [nodeId] names sits in this window, in pixels, or `null` when the window has no such
+ * node.
+ *
+ * Both halves of the tree already report their bounds in the window's space — a `View`'s
+ * `getLocationInWindow`, a semantics node's `boundsInWindow` — which is the same space the overlay on
+ * the window's root view draws in, so nothing has to be converted.
+ */
+private fun View.highlightBoundsOf(nodeId: Int): Rect? = if (nodeId < 0) {
+    viewInWindow(nodeId, this)?.let { view ->
+        val location = IntArray(2).also(view::getLocationInWindow)
+        Rect(location[0], location[1], location[0] + view.width, location[1] + view.height)
+    }
+} else {
+    findSemanticsNode(nodeId)?.boundsInWindow?.let {
+        Rect(it.left.roundToInt(), it.top.roundToInt(), it.right.roundToInt(), it.bottom.roundToInt())
+    }
+}
 
 /**
  * Searches every composition in the window for a semantics node.

--- a/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/NodeHighlightOverlay.kt
+++ b/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/NodeHighlightOverlay.kt
@@ -1,0 +1,195 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.ColorFilter
+import android.graphics.Paint
+import android.graphics.PixelFormat
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.view.ViewTreeObserver
+import java.lang.ref.WeakReference
+import kotlin.time.Duration
+
+/**
+ * The box the host draws over one node, as a **window overlay**.
+ *
+ * `View.getOverlay()` is drawn by the host view after its children but is not in its child list, so
+ * the plugin's own `for (index in 0 until childCount)` walk in `ViewTreeCapture` cannot see it — the
+ * highlight never appears in the tree it is highlighting. A child view would, and would change the
+ * very structure a user is reading.
+ *
+ * It goes on the window's root view, which sits at (0,0) in its window, so the window-relative bounds
+ * every node already reports are the overlay's coordinate space and need no conversion. A dialog is
+ * its own window with its own root, and gets its own overlay through its own source.
+ *
+ * One overlay per root: showing another node moves the existing drawable rather than stacking a
+ * second one. Everything here must be called on the main thread.
+ *
+ * The invariant it holds is that a box on screen is always in the right place. Bounds are resolved
+ * when the highlight is asked for, and anything that moves the node afterwards — a scroll, a
+ * relayout, a rotation an activity handles itself rather than being recreated for — would otherwise
+ * leave the box behind, so the node is re-resolved as the window redraws and the highlight is taken
+ * down as soon as the node cannot be found any more.
+ */
+internal class NodeHighlightOverlay {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    // The root view is held weakly: an overlay that is up keeps nothing alive, so a screen that goes
+    // away between the show and the TTL costs nothing. A collected root has no overlay left to clear.
+    private var attachedRootRef: WeakReference<View>? = null
+    private var drawable: NodeHighlightDrawable? = null
+
+    // Re-read rather than remembered, so a node that moves is followed instead of frozen where it
+    // was when the host asked for it.
+    private var resolveBounds: (() -> Rect?)? = null
+
+    private val expire = Runnable { clear() }
+
+    private var reResolvePosted = false
+    private val reResolve = Runnable {
+        reResolvePosted = false
+        moveToCurrentBounds()
+    }
+
+    /**
+     * A pre-draw hook rather than a layout one: a Compose list scrolling under the box lays nothing
+     * out — it only draws — so a layout listener would watch the box drift. The work itself is a
+     * posted, throttled re-resolve, so a frame here costs one boolean.
+     */
+    private val preDrawListener = ViewTreeObserver.OnPreDrawListener {
+        if (!reResolvePosted) {
+            reResolvePosted = true
+            mainHandler.postDelayed(reResolve, RE_RESOLVE_THROTTLE_MILLIS)
+        }
+        true
+    }
+
+    // A window that goes away while a highlight is up would otherwise keep the drawable registered on
+    // a detached root, and the next show would find state that no longer matches the screen.
+    private val detachListener = object : View.OnAttachStateChangeListener {
+        override fun onViewAttachedToWindow(view: View) = Unit
+        override fun onViewDetachedFromWindow(view: View) = clear()
+    }
+
+    /**
+     * Draws the box over the node [resolveBounds] reports — window pixels, `null` once the node is
+     * gone — on [rootView], replacing whatever was showing, and schedules it to clear itself after
+     * [ttl].
+     */
+    fun show(rootView: View, resolveBounds: () -> Rect?, ttl: Duration) {
+        val current = attachedRootRef?.get()
+        if (current !== rootView) {
+            clear()
+            val created = NodeHighlightDrawable(strokeWidthPx = BORDER_WIDTH_DP * rootView.resources.displayMetrics.density)
+            rootView.overlay.add(created)
+            rootView.addOnAttachStateChangeListener(detachListener)
+            rootView.viewTreeObserver.addOnPreDrawListener(preDrawListener)
+            attachedRootRef = WeakReference(rootView)
+            drawable = created
+        }
+        this.resolveBounds = resolveBounds
+        moveToCurrentBounds()
+
+        mainHandler.removeCallbacks(expire)
+        val ttlMs = ttl.inWholeMilliseconds
+        if (ttlMs > 0) mainHandler.postDelayed(expire, ttlMs)
+    }
+
+    /** Takes the box down and stops watching the window. Doing this with nothing showing is a no-op. */
+    fun clear() {
+        mainHandler.removeCallbacks(expire)
+        mainHandler.removeCallbacks(reResolve)
+        reResolvePosted = false
+        val rootView = attachedRootRef?.get()
+        val current = drawable
+        if (rootView != null && current != null) {
+            rootView.overlay.remove(current)
+            rootView.removeOnAttachStateChangeListener(detachListener)
+            // A dead observer belongs to a window that is gone; there is nothing left to unregister
+            // from, and asking it to remove would throw.
+            rootView.viewTreeObserver.takeIf { it.isAlive }?.removeOnPreDrawListener(preDrawListener)
+            rootView.invalidate()
+        }
+        attachedRootRef = null
+        drawable = null
+        resolveBounds = null
+    }
+
+    /**
+     * Puts the box where the node is now, or takes it down when the node can no longer be found —
+     * a box in the wrong place says something false, whereas no box says nothing.
+     */
+    private fun moveToCurrentBounds() {
+        val rootView = attachedRootRef?.get() ?: return
+        val current = drawable ?: return
+        val bounds = resolveBounds?.invoke()
+        if (bounds == null || bounds.isEmpty) {
+            clear()
+            return
+        }
+        // Only when it actually moved: the invalidate below causes the next frame, whose pre-draw
+        // would otherwise schedule the next re-resolve, and so on for as long as the box is up.
+        if (current.bounds != bounds) {
+            current.bounds = bounds
+            rootView.invalidate()
+        }
+    }
+}
+
+/**
+ * How long a run of frames is coalesced into one re-resolve.
+ *
+ * A Compose node is found by walking the semantics tree, which is too much to do per frame during an
+ * animation; a tenth of a second is short enough that the box is not visibly behind the content it
+ * is drawn over.
+ */
+private const val RE_RESOLVE_THROTTLE_MILLIS = 100L
+
+/**
+ * A translucent fill with a solid border.
+ *
+ * One style only: hover and selection are never shown at the same time, so a second colour would
+ * carry no information. The magenta is hard-coded because it has to read against whatever the app
+ * happens to be drawing — it is far enough from the greys, blues and whites of ordinary app chrome to
+ * stay visible on both light and dark content.
+ */
+private class NodeHighlightDrawable(private val strokeWidthPx: Float) : Drawable() {
+    private val fillPaint = Paint().apply {
+        style = Paint.Style.FILL
+        color = FILL_COLOR
+        isAntiAlias = true
+    }
+    private val borderPaint = Paint().apply {
+        style = Paint.Style.STROKE
+        color = BORDER_COLOR
+        strokeWidth = strokeWidthPx
+        isAntiAlias = true
+    }
+
+    override fun draw(canvas: Canvas) {
+        val box = bounds
+        canvas.drawRect(box, fillPaint)
+        // A stroke straddles the line it is drawn on, so it is inset by half its width to sit inside
+        // the node's bounds instead of spilling a pixel over the neighbours.
+        val inset = strokeWidthPx / 2f
+        canvas.drawRect(box.left + inset, box.top + inset, box.right - inset, box.bottom - inset, borderPaint)
+    }
+
+    override fun setAlpha(alpha: Int) = Unit
+
+    override fun setColorFilter(colorFilter: ColorFilter?) = Unit
+
+    @Deprecated("Deprecated in Drawable, but still abstract, so it has to be implemented.")
+    override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
+}
+
+private const val BORDER_WIDTH_DP = 2f
+
+private val BORDER_COLOR = Color.argb(0xFF, 0xFF, 0x3D, 0x71)
+
+/** Light enough to read the highlighted content through, solid enough to find at a glance. */
+private val FILL_COLOR = Color.argb(0x40, 0xFF, 0x3D, 0x71)

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/JetWhaleSemanticsAgentPlugin.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/JetWhaleSemanticsAgentPlugin.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.agent.sdk.JetWhaleAgentPlugin
 import com.kitakkun.jetwhale.plugins.semantics.protocol.CaptureNodeTree
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeRoot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.GetViewAttributes
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightNode
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
@@ -12,17 +13,22 @@ import com.kitakkun.jetwhale.plugins.semantics.protocol.SetViewAttribute
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessageHandlers
 import com.kitakkun.jetwhale.protocol.messaging.reply
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.TimeSource
 
 /**
  * Platform-agnostic core of the Compose Semantics Inspector agent plugin.
  *
- * It answers host requests — capture the semantics tree, invoke one node's action, and read or write
- * a `View` node's platform attributes — by delegating to the [ComposeNodeSource]s registered in
- * [ComposeNodeSourceRegistry]. The attribute requests need the optional [ViewAttributeSource]
- * capability, which only the Android window source has. Register the plugin with the agent runtime,
- * and install a platform probe so the registry has roots to read:
+ * It answers host requests — capture the semantics tree, invoke one node's action, read or write a
+ * `View` node's platform attributes, and draw a box over one node on the device — by delegating to
+ * the [ComposeNodeSource]s registered in [ComposeNodeSourceRegistry]. The last two need the optional
+ * [ViewAttributeSource] and [NodeHighlightSource] capabilities, which only the Android window source
+ * has. Register the plugin with the agent runtime, and install a platform probe so the registry has
+ * roots to read:
  *
  * ```kotlin
  * // Android, Application.onCreate()
@@ -52,7 +58,25 @@ class JetWhaleSemanticsAgentPlugin : JetWhaleAgentPlugin() {
         onRequest { request: SetViewAttribute ->
             reply(writeViewAttribute(request))
         }
+        onRequest { request: HighlightNode ->
+            reply(showHighlight(request))
+        }
     }
+
+    // A highlight is drawn into the app's own window, so it must not outlive the host that asked for
+    // it: a dropped connection and a disabled plugin both take it down. The agent-side TTL stays as
+    // the net for a host that dies without either happening.
+    override suspend fun onDisconnected() {
+        clearAllHighlights()
+    }
+
+    override fun onDeactivate() {
+        // Deactivation is not a suspending hook and clearing hops to the app's UI thread, so it runs
+        // on a scope of its own rather than blocking the runtime's teardown. Nothing waits on it.
+        teardownScope.launch { clearAllHighlights() }
+    }
+
+    private val teardownScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     private suspend fun capture(options: NodeTreeCaptureOptions): NodeTreeSnapshot {
         val started = TimeSource.Monotonic.markNow()

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/NodeHighlightRequests.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/NodeHighlightRequests.kt
@@ -1,0 +1,51 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightResult
+import kotlinx.coroutines.CancellationException
+import kotlin.time.Duration.Companion.milliseconds
+
+// Answers the highlight request, kept apart from the capture and action handlers because the
+// capability is optional: a root can be pointed at on the device only when its source implements
+// NodeHighlightSource.
+
+/** Shows one node on the device, or clears the root's highlight, saying why when it cannot. */
+internal suspend fun showHighlight(request: HighlightNode): HighlightResult {
+    val source = sourceOf(request.rootId)
+        ?: return HighlightResult(shown = false, message = unknownRoot(request.rootId))
+    val highlightSource = source as? NodeHighlightSource
+        ?: return HighlightResult(shown = false, message = ROOT_WITHOUT_HIGHLIGHT)
+    return try {
+        highlightSource.highlight(nodeId = request.nodeId, ttl = request.ttlMs.milliseconds)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        HighlightResult(shown = false, message = "highlighting failed: ${e.describeFailure()}")
+    }
+}
+
+/**
+ * Takes every highlight down.
+ *
+ * Called when the host disconnects or disables the plugin: the box belongs to a host that is looking
+ * at the tree, so it must not outlive one that has stopped. The per-root TTL stays regardless — it is
+ * the net for a host that dies without saying so.
+ */
+internal suspend fun clearAllHighlights() {
+    for (source in ComposeNodeSourceRegistry.sources) {
+        val highlightSource = source as? NodeHighlightSource ?: continue
+        try {
+            highlightSource.highlight(nodeId = null, ttl = CLEAR_TTL)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            // A root that cannot be reached has nothing left to clear: its window is gone, and with
+            // it the overlay. One unreachable root must not stop the others from being cleared.
+        }
+    }
+}
+
+/** Nothing is left up by a clear, so the TTL a clear carries is only there to satisfy the signature. */
+private val CLEAR_TTL = 0.milliseconds
+
+private const val ROOT_WITHOUT_HIGHLIGHT: String = "this root cannot be highlighted (it is a composition read through its SemanticsOwner, which has no window to draw in)"

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/NodeHighlightSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/NodeHighlightSource.kt
@@ -1,0 +1,21 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightResult
+import kotlin.time.Duration
+
+/**
+ * A node source that can point at one of its nodes on the device itself.
+ *
+ * Optional, like [ViewAttributeSource]: a source with nowhere to draw — a composition read through
+ * its `SemanticsOwner` alone — does not implement it, and the plugin answers "not supported" for its
+ * roots rather than every source carrying a no-op.
+ */
+interface NodeHighlightSource {
+    /**
+     * Shows [nodeId], or clears the highlight when it is `null`.
+     *
+     * The highlight clears itself once [ttl] passes without another call renewing it, so a host that
+     * dies cannot leave a box on the app's screen for the rest of the process's life.
+     */
+    suspend fun highlight(nodeId: Int?, ttl: Duration): HighlightResult
+}

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeRequests.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewAttributeRequests.kt
@@ -41,10 +41,13 @@ internal suspend fun writeViewAttribute(request: SetViewAttribute): ViewAttribut
     }
 }
 
-private fun sourceOf(rootId: String): ComposeNodeSource? = ComposeNodeSourceRegistry.sources.firstOrNull { it.sourceId == rootId }
+// The three below are the plumbing every optional-capability handler needs, so they are shared with
+// NodeHighlightRequests.kt rather than repeated there.
+
+internal fun sourceOf(rootId: String): ComposeNodeSource? = ComposeNodeSourceRegistry.sources.firstOrNull { it.sourceId == rootId }
+
+internal fun unknownRoot(rootId: String): String = "unknown rootId: $rootId (the root may have been detached; capture the tree again)"
+
+internal fun Throwable.describeFailure(): String = message?.takeIf { it.isNotBlank() } ?: (this::class.simpleName ?: "unknown error")
 
 private const val ROOT_WITHOUT_ATTRIBUTES: String = "this root has no View attributes (it is a composition read through its SemanticsOwner)"
-
-private fun unknownRoot(rootId: String): String = "unknown rootId: $rootId (the root may have been detached; capture the tree again)"
-
-private fun Throwable.describeFailure(): String = message?.takeIf { it.isNotBlank() } ?: (this::class.simpleName ?: "unknown error")

--- a/jetwhale-plugins/semantics/host/build.gradle.kts
+++ b/jetwhale-plugins/semantics/host/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     testImplementation(libs.kotlinTest)
     testImplementation(libs.kotlinxSerializationJson)
     testImplementation(compose.desktop.currentOs)
+    // The presenter is a composable, so testing it means composing it.
+    testImplementation(libs.jetbrainsComposeUiTestJUnit4)
     testImplementation(libs.material3)
 }
 

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
@@ -106,9 +106,12 @@ private class ComposeNodeInspectorHostPlugin :
     // JetWhaleHostPluginUi
     // -------------------------------------------------------------------------
 
+    // The Root of the plugin's UI: it reads the plugin's own state, hands it to the presenter, and
+    // renders what comes back. Everything the screen holds is the presenter's; everything that has
+    // to outlive the composition — the attribute store, the highlight controller — is the plugin's.
     @Composable
     override fun Content() {
-        ComposeSemanticsInspectorScreen(
+        val uiState = composeSemanticsInspectorPresenter(
             snapshot = snapshot,
             capturing = capturing,
             roundTripMs = roundTripMs,
@@ -150,6 +153,7 @@ private class ComposeNodeInspectorHostPlugin :
             highlightStatus = highlightController.statusMessage,
             onHighlightTargetChange = highlightController::setTarget,
         )
+        ComposeSemanticsInspectorScreen(uiState = uiState)
     }
 
     // -------------------------------------------------------------------------

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
@@ -88,6 +88,20 @@ private class ComposeNodeInspectorHostPlugin :
         )
     }
 
+    // Owned by the plugin rather than the screen so the box can be taken down when the instance goes
+    // away, which the screen's own composition scope is not around to do. Built lazily because
+    // pluginScope is bound by the runtime after the instance is constructed.
+    private val highlightController by lazy {
+        NodeHighlightController(
+            scope = pluginScope,
+            send = { request -> messenger.request(request) },
+        )
+    }
+
+    override fun onDispose() {
+        highlightController.clearAsync()
+    }
+
     // -------------------------------------------------------------------------
     // JetWhaleHostPluginUi
     // -------------------------------------------------------------------------
@@ -133,6 +147,8 @@ private class ComposeNodeInspectorHostPlugin :
                 }
             },
             onCommitViewAttribute = viewAttributes::commit,
+            highlightStatus = highlightController.statusMessage,
+            onHighlightTargetChange = highlightController::setTarget,
         )
     }
 

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPresenter.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPresenter.kt
@@ -1,0 +1,240 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.kitakkun.jetwhale.host.sdk.rememberPersistent
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
+import com.kitakkun.jetwhale.plugins.semantics.protocol.UiNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/** What the tree pane says when it has no row to draw. */
+internal data class EmptyTreeMessage(val title: String, val description: String?)
+
+/**
+ * Everything [ComposeSemanticsInspectorScreen] draws, and everything it fires.
+ *
+ * The screen is a function of this value: it holds no state of its own and runs no effect, so the
+ * rows, the summary line and the empty-state wording are all decided in
+ * [composeSemanticsInspectorPresenter] and merely rendered here.
+ */
+internal data class ComposeSemanticsInspectorUiState(
+    val capturing: Boolean,
+    val merged: Boolean,
+    val interactiveOnly: Boolean,
+    val includeInvisible: Boolean,
+    val autoRefresh: Boolean,
+    val highlightOnDevice: Boolean,
+    val search: String,
+    /** The flattened tree, already filtered and collapsed. */
+    val rows: List<TreeRow>,
+    /** Why [rows] is empty; only read when it is. */
+    val emptyMessage: EmptyTreeMessage,
+    val selectedKey: NodeKey?,
+    /** The selected node as the current snapshot holds it, or `null` when the snapshot has no such node. */
+    val selectedNode: UiNode?,
+    val statusSummary: String,
+    val warnings: List<String>,
+    val errorMessage: String?,
+    val actionStatus: String?,
+    /** Only ever set when the app refused to show the highlight. */
+    val highlightStatus: String?,
+    val viewAttributes: ViewAttributesUiState,
+    val onRefresh: () -> Unit,
+    val onMergedChange: (Boolean) -> Unit,
+    val onInteractiveOnlyChange: (Boolean) -> Unit,
+    val onIncludeInvisibleChange: (Boolean) -> Unit,
+    val onAutoRefreshChange: (Boolean) -> Unit,
+    val onHighlightOnDeviceChange: (Boolean) -> Unit,
+    val onSearchChange: (String) -> Unit,
+    val onSelect: (NodeKey) -> Unit,
+    val onHoverChange: (NodeKey, Boolean) -> Unit,
+    val onToggleExpanded: (NodeKey) -> Unit,
+    val onPerformAction: (PerformNodeAction) -> Unit,
+    val onCommitViewAttribute: (ViewAttribute, String) -> Unit,
+)
+
+/**
+ * The inspector's own state — how the tree is captured, how it is filtered, and which node is being
+ * looked at — and everything derived from it.
+ *
+ * The screen is left with nothing to remember and no effect to run, which is what makes both the
+ * rows and the wording testable without a composition. What stays on the plugin instance stays
+ * there for reasons a presenter cannot cover: the attribute store is shared with the MCP tools, so
+ * an agent's write lands in the panel too, and the highlight controller has to be able to take the
+ * box down when the plugin instance is disposed.
+ *
+ * @param onCapture suspends until the capture is done, which is what lets auto-refresh pace itself
+ *   against the app rather than queue requests it cannot drain.
+ * @param onSelectedNodeChange reported rather than acted on: what a selection is worth reading from
+ *   the app is the plugin's decision.
+ * @param onHighlightTargetChange which node the device should be drawing a box over. Sending it,
+ *   holding it against the app's timeout and taking it down again all outlive this composition, so
+ *   they are the plugin's.
+ */
+@Composable
+internal fun composeSemanticsInspectorPresenter(
+    snapshot: NodeTreeSnapshot?,
+    capturing: Boolean,
+    roundTripMs: Long?,
+    errorMessage: String?,
+    actionStatus: String?,
+    viewAttributes: ViewAttributesUiState,
+    highlightStatus: String?,
+    onCapture: suspend (NodeTreeCaptureOptions) -> Unit,
+    onPerformAction: (PerformNodeAction) -> Unit,
+    onSelectedNodeChange: (NodeKey?) -> Unit,
+    onCommitViewAttribute: (ViewAttribute, String) -> Unit,
+    onHighlightTargetChange: (NodeKey?) -> Unit,
+): ComposeSemanticsInspectorUiState {
+    var merged by rememberPersistent("merged-tree", default = true)
+    var interactiveOnly by rememberPersistent("interactive-only", default = false)
+    var includeInvisible by rememberPersistent("include-invisible", default = false)
+    var autoRefresh by rememberPersistent("auto-refresh", default = false)
+    // Off by default, deliberately: the box is drawn into the app itself, so it would otherwise turn
+    // up in any `screencap` taken while the inspector is open — a QA run's screenshots included.
+    var highlightOnDevice by rememberPersistent("highlight-on-device", default = false)
+    val scope = rememberCoroutineScope()
+    var search by remember { mutableStateOf("") }
+    var selectedKey by remember { mutableStateOf<NodeKey?>(null) }
+    // Whether the pointer is over a row is a fact about the view and nothing outside it reads it;
+    // only the highlight target derived from it leaves.
+    var hoveredKey by remember { mutableStateOf<NodeKey?>(null) }
+    var collapsedKeys by remember { mutableStateOf(emptySet<NodeKey>()) }
+
+    val options = NodeTreeCaptureOptions(merged = merged, includeInvisible = includeInvisible, maxDepth = null)
+
+    // Capture once when the screen opens, and again whenever an option changes what would be
+    // captured — an option the user toggled should show its effect without a second click.
+    LaunchedEffect(merged, includeInvisible) {
+        onCapture(options)
+    }
+    LaunchedEffect(autoRefresh, merged, includeInvisible) {
+        if (!autoRefresh) return@LaunchedEffect
+        while (true) {
+            delay(AUTO_REFRESH_INTERVAL_MILLIS)
+            // Awaited, not fired and forgotten: captures are serialised on the app's main thread,
+            // so a fixed-interval loop against a slow app would queue requests faster than they
+            // drain and leave the view showing an ever-older tree.
+            onCapture(options)
+        }
+    }
+
+    val highlighted = highlightTarget(enabled = highlightOnDevice, selected = selectedKey, hovered = hoveredKey)
+    LaunchedEffect(highlighted) { onHighlightTargetChange(highlighted) }
+    DisposableEffect(Unit) {
+        onDispose { onHighlightTargetChange(null) }
+    }
+
+    val rows = remember(snapshot, search, interactiveOnly, collapsedKeys) {
+        buildTreeRows(
+            roots = snapshot?.roots.orEmpty(),
+            collapsedKeys = collapsedKeys,
+            predicate = { node ->
+                (!interactiveOnly || node.isInteractive) && node.matchesFreeText(search)
+            },
+        )
+    }
+    val selectedNode = selectedKey?.let { key ->
+        snapshot?.roots?.firstOrNull { it.rootId == key.rootId }?.findNode(key.nodeId)
+    }
+
+    LaunchedEffect(selectedKey) {
+        onSelectedNodeChange(selectedKey)
+    }
+
+    return ComposeSemanticsInspectorUiState(
+        capturing = capturing,
+        merged = merged,
+        interactiveOnly = interactiveOnly,
+        includeInvisible = includeInvisible,
+        autoRefresh = autoRefresh,
+        highlightOnDevice = highlightOnDevice,
+        search = search,
+        rows = rows,
+        emptyMessage = emptyTreeMessage(snapshot = snapshot, search = search, interactiveOnly = interactiveOnly),
+        selectedKey = selectedKey,
+        selectedNode = selectedNode,
+        statusSummary = captureSummary(
+            snapshot = snapshot,
+            rowCount = rows.count { it is TreeRow.NodeRow },
+            roundTripMs = roundTripMs,
+        ),
+        warnings = snapshot?.warnings.orEmpty(),
+        errorMessage = errorMessage,
+        actionStatus = actionStatus,
+        highlightStatus = highlightStatus,
+        viewAttributes = viewAttributes,
+        onRefresh = { scope.launch { onCapture(options) } },
+        onMergedChange = { merged = it },
+        onInteractiveOnlyChange = { interactiveOnly = it },
+        onIncludeInvisibleChange = { includeInvisible = it },
+        onAutoRefreshChange = { autoRefresh = it },
+        onHighlightOnDeviceChange = { highlightOnDevice = it },
+        onSearchChange = { search = it },
+        onSelect = { selectedKey = it },
+        onHoverChange = { key, hovered ->
+            // A row that reports leaving must not clear a hover another row has already taken over —
+            // the pointer arrives before the old row lets go.
+            hoveredKey = if (hovered) key else hoveredKey.takeIf { it != key }
+        },
+        onToggleExpanded = { key ->
+            collapsedKeys = if (key in collapsedKeys) collapsedKeys - key else collapsedKeys + key
+        },
+        onPerformAction = onPerformAction,
+        onCommitViewAttribute = onCommitViewAttribute,
+    )
+}
+
+private const val AUTO_REFRESH_INTERVAL_MILLIS = 1_000L
+
+/**
+ * The status line's summary of the last capture.
+ *
+ * Both durations are shown because the point of reading the tree this way rather than through `adb`
+ * is the latency, and the two numbers say where any of it went.
+ */
+internal fun captureSummary(snapshot: NodeTreeSnapshot?, rowCount: Int, roundTripMs: Long?): String = when (snapshot) {
+    null -> "Not captured yet."
+
+    else -> buildString {
+        append("${snapshot.roots.size} root(s) · $rowCount shown of ${snapshot.nodeCount()} · ")
+        append("${snapshot.captureDurationMs} ms on device")
+        roundTripMs?.let { append(" · $it ms round trip") }
+    }
+}
+
+/**
+ * Why the tree pane has nothing to draw.
+ *
+ * A filter that matched nothing is told apart from an app that reported nothing, because the two
+ * call for opposite things: relaxing the filter, or installing a probe.
+ */
+internal fun emptyTreeMessage(
+    snapshot: NodeTreeSnapshot?,
+    search: String,
+    interactiveOnly: Boolean,
+): EmptyTreeMessage = when {
+    snapshot == null -> EmptyTreeMessage(
+        title = "Not captured yet",
+        description = "Press Refresh to capture the app's node tree.",
+    )
+
+    snapshot.roots.isEmpty() -> EmptyTreeMessage(
+        title = "No Compose root reported",
+        description = "Install a probe: installJetWhaleSemanticsProbe(application), or call JetWhaleSemanticsProbe() inside your composition.",
+    )
+
+    search.isNotBlank() || interactiveOnly -> EmptyTreeMessage(title = "No node matches the current filter", description = null)
+
+    else -> EmptyTreeMessage(title = "The app's Compose roots are empty", description = null)
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -1,6 +1,9 @@
 package com.kitakkun.jetwhale.plugins.semantics.host
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -16,6 +19,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
@@ -87,14 +91,20 @@ internal fun ComposeSemanticsInspectorScreen(
     onPerformAction: (PerformNodeAction) -> Unit,
     onSelectedNodeChange: (NodeKey?) -> Unit,
     onCommitViewAttribute: (ViewAttribute, String) -> Unit,
+    highlightStatus: String?,
+    onHighlightTargetChange: (NodeKey?) -> Unit,
 ) {
     var merged by rememberPersistent("merged-tree", default = true)
     var interactiveOnly by rememberPersistent("interactive-only", default = false)
     var includeInvisible by rememberPersistent("include-invisible", default = false)
     var autoRefresh by rememberPersistent("auto-refresh", default = false)
+    // Off by default, deliberately: the box is drawn into the app itself, so it would otherwise turn
+    // up in any `screencap` taken while the inspector is open — a QA run's screenshots included.
+    var highlightOnDevice by rememberPersistent("highlight-on-device", default = false)
     val scope = rememberCoroutineScope()
     var search by remember { mutableStateOf("") }
     var selectedKey by remember { mutableStateOf<NodeKey?>(null) }
+    var hoveredKey by remember { mutableStateOf<NodeKey?>(null) }
     val collapsedKeys = remember { mutableStateMapOf<NodeKey, Unit>() }
 
     val options = NodeTreeCaptureOptions(merged = merged, includeInvisible = includeInvisible, maxDepth = null)
@@ -113,6 +123,15 @@ internal fun ComposeSemanticsInspectorScreen(
             // drain and leave the view showing an ever-older tree.
             onCapture(options)
         }
+    }
+
+    val highlighted = highlightTarget(enabled = highlightOnDevice, selected = selectedKey, hovered = hoveredKey)
+    // What to point at is a question about the view — which row is selected, which one the pointer is
+    // over — so the screen answers it and reports the answer. Sending it, holding it against the
+    // app's timeout and taking it down again all outlive this composition, so they are the plugin's.
+    LaunchedEffect(highlighted) { onHighlightTargetChange(highlighted) }
+    DisposableEffect(Unit) {
+        onDispose { onHighlightTargetChange(null) }
     }
 
     val rows = remember(snapshot, search, interactiveOnly, collapsedKeys.keys.toSet()) {
@@ -143,12 +162,14 @@ internal fun ComposeSemanticsInspectorScreen(
             interactiveOnly = interactiveOnly,
             includeInvisible = includeInvisible,
             autoRefresh = autoRefresh,
+            highlightOnDevice = highlightOnDevice,
             search = search,
             onRefresh = { scope.launch { onCapture(options) } },
             onMergedChange = { merged = it },
             onInteractiveOnlyChange = { interactiveOnly = it },
             onIncludeInvisibleChange = { includeInvisible = it },
             onAutoRefreshChange = { autoRefresh = it },
+            onHighlightOnDeviceChange = { highlightOnDevice = it },
             onSearchChange = { search = it },
         )
         StatusLine(
@@ -157,6 +178,7 @@ internal fun ComposeSemanticsInspectorScreen(
             roundTripMs = roundTripMs,
             errorMessage = errorMessage,
             actionStatus = actionStatus,
+            highlightStatus = highlightStatus,
         )
         JwHorizontalDivider()
         JwSplitPane(
@@ -170,6 +192,11 @@ internal fun ComposeSemanticsInspectorScreen(
                         rows = rows,
                         selectedKey = selectedKey,
                         onSelect = { selectedKey = it },
+                        onHoverChange = { key, hovered ->
+                            // A row that reports leaving must not clear a hover another row has
+                            // already taken over — the pointer arrives before the old row lets go.
+                            hoveredKey = if (hovered) key else hoveredKey.takeIf { it != key }
+                        },
                         onToggleExpanded = { key ->
                             if (collapsedKeys.remove(key) == null) collapsedKeys[key] = Unit
                         },
@@ -207,12 +234,14 @@ private fun Toolbar(
     interactiveOnly: Boolean,
     includeInvisible: Boolean,
     autoRefresh: Boolean,
+    highlightOnDevice: Boolean,
     search: String,
     onRefresh: () -> Unit,
     onMergedChange: (Boolean) -> Unit,
     onInteractiveOnlyChange: (Boolean) -> Unit,
     onIncludeInvisibleChange: (Boolean) -> Unit,
     onAutoRefreshChange: (Boolean) -> Unit,
+    onHighlightOnDeviceChange: (Boolean) -> Unit,
     onSearchChange: (String) -> Unit,
 ) {
     FlowRow(
@@ -234,6 +263,7 @@ private fun Toolbar(
         JwCheckbox(checked = merged, onCheckedChange = onMergedChange, label = "Merged")
         JwCheckbox(checked = interactiveOnly, onCheckedChange = onInteractiveOnlyChange, label = "Interactive only")
         JwCheckbox(checked = includeInvisible, onCheckedChange = onIncludeInvisibleChange, label = "Include invisible")
+        JwCheckbox(checked = highlightOnDevice, onCheckedChange = onHighlightOnDeviceChange, label = "Highlight")
         JwSearchField(
             value = search,
             onValueChange = onSearchChange,
@@ -251,6 +281,7 @@ private fun StatusLine(
     roundTripMs: Long?,
     errorMessage: String?,
     actionStatus: String?,
+    highlightStatus: String?,
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         val summary = when (snapshot) {
@@ -266,6 +297,9 @@ private fun StatusLine(
         snapshot?.warnings?.forEach { warning -> JwStatusLine(text = warning, tone = JwTone.Warning) }
         errorMessage?.let { JwStatusLine(text = it, tone = JwTone.Error) }
         actionStatus?.let { JwStatusLine(text = it, tone = JwTone.Accent) }
+        // Only ever set when the app refused to show the highlight; a highlight that is up says so
+        // by being on the device.
+        highlightStatus?.let { JwStatusLine(text = "Highlight: $it", tone = JwTone.Warning) }
     }
 }
 
@@ -285,6 +319,7 @@ private fun TreeList(
     rows: List<TreeRow>,
     selectedKey: NodeKey?,
     onSelect: (NodeKey) -> Unit,
+    onHoverChange: (NodeKey, Boolean) -> Unit,
     onToggleExpanded: (NodeKey) -> Unit,
 ) {
     LazyColumn(Modifier.fillMaxSize()) {
@@ -296,6 +331,7 @@ private fun TreeList(
                     row = row,
                     selected = selectedKey == NodeKey(row.rootId, row.node.id),
                     onSelect = { onSelect(NodeKey(row.rootId, row.node.id)) },
+                    onHoverChange = { hovered -> onHoverChange(NodeKey(row.rootId, row.node.id), hovered) },
                     onToggleExpanded = { onToggleExpanded(NodeKey(row.rootId, row.node.id)) },
                 )
             }
@@ -323,10 +359,17 @@ private fun NodeRow(
     row: TreeRow.NodeRow,
     selected: Boolean,
     onSelect: () -> Unit,
+    onHoverChange: (Boolean) -> Unit,
     onToggleExpanded: () -> Unit,
 ) {
     val label = row.node.displayLabel()
+    // JwTreeRow tracks hover for its own tint through an interaction source it keeps to itself, so
+    // the row is made hoverable a second time here rather than the component growing a callback.
+    val hoverInteractionSource = remember { MutableInteractionSource() }
+    val hovered by hoverInteractionSource.collectIsHoveredAsState()
+    LaunchedEffect(hovered) { onHoverChange(hovered) }
     JwTreeRow(
+        modifier = Modifier.hoverable(hoverInteractionSource),
         text = label,
         depth = row.depth,
         expandable = row.expandable,

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -19,13 +19,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,7 +30,6 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.kitakkun.jetwhale.host.sdk.rememberPersistent
 import com.kitakkun.jetwhale.host.ui.JwButton
 import com.kitakkun.jetwhale.host.ui.JwButtonStyle
 import com.kitakkun.jetwhale.host.ui.JwCheckbox
@@ -56,14 +52,10 @@ import com.kitakkun.jetwhale.host.ui.LocalJwContentColor
 import com.kitakkun.jetwhale.host.ui.rememberJwSplitPaneState
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ComposeNode
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction
-import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
-import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
 import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
 import com.kitakkun.jetwhale.plugins.semantics.protocol.UiNode
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttribute
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewNode
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
 /**
@@ -74,149 +66,67 @@ import kotlin.math.roundToInt
  * pays only when someone is looking. Auto-refresh exists for watching a screen change, but is off by
  * default for the same reason.
  *
- * Data in, events out: everything the screen draws arrives as a value, and everything it wants done
- * leaves as a callback. Which node is selected is the screen's own business — it is where the tree
- * is clicked — so it is reported upward rather than asked for, and the plugin decides what reading
- * to do about it.
+ * Purely a view: everything it draws arrives in [uiState] and everything it wants done leaves
+ * through the callbacks [uiState] carries. Which node is selected, what the tree is filtered by and
+ * what a capture asks for are all decided in [composeSemanticsInspectorPresenter].
  */
 @Composable
-internal fun ComposeSemanticsInspectorScreen(
-    snapshot: NodeTreeSnapshot?,
-    capturing: Boolean,
-    roundTripMs: Long?,
-    errorMessage: String?,
-    actionStatus: String?,
-    viewAttributes: ViewAttributesUiState,
-    onCapture: suspend (NodeTreeCaptureOptions) -> Unit,
-    onPerformAction: (PerformNodeAction) -> Unit,
-    onSelectedNodeChange: (NodeKey?) -> Unit,
-    onCommitViewAttribute: (ViewAttribute, String) -> Unit,
-    highlightStatus: String?,
-    onHighlightTargetChange: (NodeKey?) -> Unit,
-) {
-    var merged by rememberPersistent("merged-tree", default = true)
-    var interactiveOnly by rememberPersistent("interactive-only", default = false)
-    var includeInvisible by rememberPersistent("include-invisible", default = false)
-    var autoRefresh by rememberPersistent("auto-refresh", default = false)
-    // Off by default, deliberately: the box is drawn into the app itself, so it would otherwise turn
-    // up in any `screencap` taken while the inspector is open — a QA run's screenshots included.
-    var highlightOnDevice by rememberPersistent("highlight-on-device", default = false)
-    val scope = rememberCoroutineScope()
-    var search by remember { mutableStateOf("") }
-    var selectedKey by remember { mutableStateOf<NodeKey?>(null) }
-    var hoveredKey by remember { mutableStateOf<NodeKey?>(null) }
-    val collapsedKeys = remember { mutableStateMapOf<NodeKey, Unit>() }
-
-    val options = NodeTreeCaptureOptions(merged = merged, includeInvisible = includeInvisible, maxDepth = null)
-
-    // Capture once when the screen opens, and again whenever an option changes what would be
-    // captured — an option the user toggled should show its effect without a second click.
-    LaunchedEffect(merged, includeInvisible) {
-        onCapture(options)
-    }
-    LaunchedEffect(autoRefresh, merged, includeInvisible) {
-        if (!autoRefresh) return@LaunchedEffect
-        while (true) {
-            delay(AUTO_REFRESH_INTERVAL_MILLIS)
-            // Awaited, not fired and forgotten: captures are serialised on the app's main thread,
-            // so a fixed-interval loop against a slow app would queue requests faster than they
-            // drain and leave the view showing an ever-older tree.
-            onCapture(options)
-        }
-    }
-
-    val highlighted = highlightTarget(enabled = highlightOnDevice, selected = selectedKey, hovered = hoveredKey)
-    // What to point at is a question about the view — which row is selected, which one the pointer is
-    // over — so the screen answers it and reports the answer. Sending it, holding it against the
-    // app's timeout and taking it down again all outlive this composition, so they are the plugin's.
-    LaunchedEffect(highlighted) { onHighlightTargetChange(highlighted) }
-    DisposableEffect(Unit) {
-        onDispose { onHighlightTargetChange(null) }
-    }
-
-    val rows = remember(snapshot, search, interactiveOnly, collapsedKeys.keys.toSet()) {
-        buildTreeRows(
-            roots = snapshot?.roots.orEmpty(),
-            collapsedKeys = collapsedKeys.keys.toSet(),
-            predicate = { node ->
-                (!interactiveOnly || node.isInteractive) && node.matchesFreeText(search)
-            },
-        )
-    }
-    val selectedNode = selectedKey?.let { key ->
-        snapshot?.roots?.firstOrNull { it.rootId == key.rootId }?.findNode(key.nodeId)
-    }
-
-    // Reported rather than acted on: what a selection is worth reading from the app is the plugin's
-    // decision, and this screen has no way to read anything anyway.
-    LaunchedEffect(selectedKey) {
-        onSelectedNodeChange(selectedKey)
-    }
-
+internal fun ComposeSemanticsInspectorScreen(uiState: ComposeSemanticsInspectorUiState) {
     // The host hands the plugin an unpainted scene, so the screen paints its own background;
     // without it the areas no child covers fall back to white and fight a dark theme.
     Column(Modifier.fillMaxSize().background(JwTheme.colors.surface)) {
         Toolbar(
-            capturing = capturing,
-            merged = merged,
-            interactiveOnly = interactiveOnly,
-            includeInvisible = includeInvisible,
-            autoRefresh = autoRefresh,
-            highlightOnDevice = highlightOnDevice,
-            search = search,
-            onRefresh = { scope.launch { onCapture(options) } },
-            onMergedChange = { merged = it },
-            onInteractiveOnlyChange = { interactiveOnly = it },
-            onIncludeInvisibleChange = { includeInvisible = it },
-            onAutoRefreshChange = { autoRefresh = it },
-            onHighlightOnDeviceChange = { highlightOnDevice = it },
-            onSearchChange = { search = it },
+            capturing = uiState.capturing,
+            merged = uiState.merged,
+            interactiveOnly = uiState.interactiveOnly,
+            includeInvisible = uiState.includeInvisible,
+            autoRefresh = uiState.autoRefresh,
+            highlightOnDevice = uiState.highlightOnDevice,
+            search = uiState.search,
+            onRefresh = uiState.onRefresh,
+            onMergedChange = uiState.onMergedChange,
+            onInteractiveOnlyChange = uiState.onInteractiveOnlyChange,
+            onIncludeInvisibleChange = uiState.onIncludeInvisibleChange,
+            onAutoRefreshChange = uiState.onAutoRefreshChange,
+            onHighlightOnDeviceChange = uiState.onHighlightOnDeviceChange,
+            onSearchChange = uiState.onSearchChange,
         )
         StatusLine(
-            snapshot = snapshot,
-            rowCount = rows.count { it is TreeRow.NodeRow },
-            roundTripMs = roundTripMs,
-            errorMessage = errorMessage,
-            actionStatus = actionStatus,
-            highlightStatus = highlightStatus,
+            summary = uiState.statusSummary,
+            warnings = uiState.warnings,
+            errorMessage = uiState.errorMessage,
+            actionStatus = uiState.actionStatus,
+            highlightStatus = uiState.highlightStatus,
         )
         JwHorizontalDivider()
         JwSplitPane(
             modifier = Modifier.fillMaxSize(),
             state = rememberJwSplitPaneState(TREE_PANE_FRACTION),
             first = {
-                if (rows.isEmpty()) {
-                    EmptyTreeMessage(snapshot = snapshot, search = search, interactiveOnly = interactiveOnly)
+                if (uiState.rows.isEmpty()) {
+                    JwEmptyState(title = uiState.emptyMessage.title, description = uiState.emptyMessage.description)
                 } else {
                     TreeList(
-                        rows = rows,
-                        selectedKey = selectedKey,
-                        onSelect = { selectedKey = it },
-                        onHoverChange = { key, hovered ->
-                            // A row that reports leaving must not clear a hover another row has
-                            // already taken over — the pointer arrives before the old row lets go.
-                            hoveredKey = if (hovered) key else hoveredKey.takeIf { it != key }
-                        },
-                        onToggleExpanded = { key ->
-                            if (collapsedKeys.remove(key) == null) collapsedKeys[key] = Unit
-                        },
+                        rows = uiState.rows,
+                        selectedKey = uiState.selectedKey,
+                        onSelect = uiState.onSelect,
+                        onHoverChange = uiState.onHoverChange,
+                        onToggleExpanded = uiState.onToggleExpanded,
                     )
                 }
             },
             second = {
                 NodeDetail(
-                    rootId = selectedKey?.rootId,
-                    node = selectedNode,
-                    viewAttributes = viewAttributes,
-                    onPerformAction = onPerformAction,
-                    onCommitViewAttribute = onCommitViewAttribute,
+                    rootId = uiState.selectedKey?.rootId,
+                    node = uiState.selectedNode,
+                    viewAttributes = uiState.viewAttributes,
+                    onPerformAction = uiState.onPerformAction,
+                    onCommitViewAttribute = uiState.onCommitViewAttribute,
                 )
             },
         )
     }
 }
-
-private const val AUTO_REFRESH_INTERVAL_MILLIS = 1_000L
 
 /** The tree gets a little more than half; node labels are longer than property rows. */
 private const val TREE_PANE_FRACTION = 0.58f
@@ -276,42 +186,21 @@ private fun Toolbar(
 
 @Composable
 private fun StatusLine(
-    snapshot: NodeTreeSnapshot?,
-    rowCount: Int,
-    roundTripMs: Long?,
+    summary: String,
+    warnings: List<String>,
     errorMessage: String?,
     actionStatus: String?,
     highlightStatus: String?,
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
-        val summary = when (snapshot) {
-            null -> "Not captured yet."
-
-            else -> buildString {
-                append("${snapshot.roots.size} root(s) · $rowCount shown of ${snapshot.nodeCount()} · ")
-                append("${snapshot.captureDurationMs} ms on device")
-                roundTripMs?.let { append(" · $it ms round trip") }
-            }
-        }
         JwStatusLine(text = summary)
-        snapshot?.warnings?.forEach { warning -> JwStatusLine(text = warning, tone = JwTone.Warning) }
+        warnings.forEach { warning -> JwStatusLine(text = warning, tone = JwTone.Warning) }
         errorMessage?.let { JwStatusLine(text = it, tone = JwTone.Error) }
         actionStatus?.let { JwStatusLine(text = it, tone = JwTone.Accent) }
         // Only ever set when the app refused to show the highlight; a highlight that is up says so
         // by being on the device.
         highlightStatus?.let { JwStatusLine(text = "Highlight: $it", tone = JwTone.Warning) }
     }
-}
-
-@Composable
-private fun EmptyTreeMessage(snapshot: NodeTreeSnapshot?, search: String, interactiveOnly: Boolean) {
-    val (title, description) = when {
-        snapshot == null -> "Not captured yet" to "Press Refresh to capture the app's node tree."
-        snapshot.roots.isEmpty() -> "No Compose root reported" to "Install a probe: installJetWhaleSemanticsProbe(application), or call JetWhaleSemanticsProbe() inside your composition."
-        search.isNotBlank() || interactiveOnly -> "No node matches the current filter" to null
-        else -> "The app's Compose roots are empty" to null
-    }
-    JwEmptyState(title = title, description = description)
 }
 
 @Composable

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeHighlightController.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeHighlightController.kt
@@ -1,0 +1,139 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightResult
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Which node the device should be drawing a box over, given what the user is doing.
+ *
+ * Hover wins over selection while the pointer is on a row, because that is the question being asked
+ * at that moment — "which one is this?" — and the selection is still there when the pointer leaves.
+ * The toggle is checked here rather than at every call site so that turning it off is one answer:
+ * nothing.
+ */
+internal fun highlightTarget(enabled: Boolean, selected: NodeKey?, hovered: NodeKey?): NodeKey? = when {
+    !enabled -> null
+    else -> hovered ?: selected
+}
+
+/**
+ * Keeps the device's highlight in step with the host's tree view.
+ *
+ * It owns the one fact the screen cannot recompute — which root is currently showing a box — because
+ * a root only ever clears its own overlay: moving the highlight from a dialog to the screen behind it
+ * has to tell the dialog to stop showing one.
+ */
+internal class NodeHighlightController(
+    /** Outlives the tree view, so leaving the screen can still take the box down. */
+    private val scope: CoroutineScope,
+    private val send: suspend (HighlightNode) -> HighlightResult,
+) {
+    private var shownIn: String? = null
+
+    /** Keeps the current target alive; a new target replaces it. */
+    private var holding: Job? = null
+
+    /** Why the app is not showing what was asked for, for the screen's status line. */
+    var statusMessage: String? by mutableStateOf(null)
+        private set
+
+    /**
+     * Points the device at [target], or takes the box down when it is `null`.
+     *
+     * The waiting lives here rather than in the screen that reported the target. A pointer crossing
+     * rows on its way somewhere must not send a request per row, and the app drops a highlight it
+     * has not heard about for [HIGHLIGHT_TTL_MILLIS], so one left standing has to be renewed for as
+     * long as it stands — neither is something a composition should be holding open.
+     */
+    fun setTarget(target: NodeKey?) {
+        holding?.cancel()
+        holding = scope.launch {
+            // Only a target waits: taking the box down is an answer the user already committed to.
+            if (target != null) delay(HIGHLIGHT_HOVER_DEBOUNCE_MILLIS)
+            if (!show(target)) return@launch
+            while (true) {
+                delay(HIGHLIGHT_RENEWAL_MILLIS)
+                if (!show(target)) return@launch
+            }
+        }
+    }
+
+    /**
+     * Draws [target] on the device, or clears the highlight when it is `null`.
+     *
+     * @return whether the app is showing it — `false` for a root that refused, so a caller renewing
+     *   the highlight stops asking rather than repeating a request that will not start working.
+     */
+    suspend fun show(target: NodeKey?): Boolean {
+        val leaving = shownIn
+        if (leaving != null && leaving != target?.rootId) {
+            clearIn(leaving)
+        }
+        if (target == null) {
+            statusMessage = null
+            return false
+        }
+        val result = try {
+            send(HighlightNode(rootId = target.rootId, nodeId = target.nodeId, ttlMs = HIGHLIGHT_TTL_MILLIS))
+        } catch (e: JetWhaleMessagingException) {
+            shownIn = null
+            statusMessage = "Highlight failed: ${e.message}"
+            return false
+        }
+        shownIn = if (result.shown) target.rootId else null
+        statusMessage = if (result.shown) null else result.message
+        return result.shown
+    }
+
+    /** Takes the box down, wherever it is. Safe to call with nothing showing. */
+    suspend fun clear() {
+        show(null)
+    }
+
+    /**
+     * Takes the box down without waiting for the app to answer, for the callers that cannot suspend:
+     * the tree view leaving the composition and the plugin instance being disposed.
+     */
+    fun clearAsync() {
+        holding?.cancel()
+        scope.launch { clear() }
+    }
+
+    private suspend fun clearIn(rootId: String) {
+        shownIn = null
+        try {
+            send(HighlightNode(rootId = rootId, nodeId = null, ttlMs = HIGHLIGHT_TTL_MILLIS))
+        } catch (e: JetWhaleMessagingException) {
+            // The window that was showing the box is unreachable, which is also how it stops showing
+            // one: the overlay went away with it, and the agent's own TTL covers the rest.
+            statusMessage = "Clearing the highlight failed: ${e.message}"
+        }
+    }
+}
+
+/**
+ * How long the app keeps a highlight without hearing from the host again.
+ *
+ * Long enough that a user reading a row is never left without the box, short enough that a host that
+ * crashed does not leave one in the app for the rest of the session.
+ */
+internal const val HIGHLIGHT_TTL_MILLIS: Long = 30_000
+
+/** Renewed well inside the TTL so a slow round trip cannot let it lapse while the row is still selected. */
+internal const val HIGHLIGHT_RENEWAL_MILLIS: Long = HIGHLIGHT_TTL_MILLIS / 3
+
+/**
+ * How long the pointer has to rest on a row before it is highlighted.
+ *
+ * Without it, running the pointer down the tree would send a request per row it crossed, each one a
+ * hop to the app's main thread.
+ */
+internal const val HIGHLIGHT_HOVER_DEBOUNCE_MILLIS: Long = 80

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPresenterTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPresenterTest.kt
@@ -1,0 +1,346 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import com.kitakkun.jetwhale.host.sdk.JetWhalePluginStorage
+import com.kitakkun.jetwhale.host.sdk.LocalJetWhalePluginStorage
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeSnapshot
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.serialization.KSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The inspector's own state, tested where it now lives: in the presenter rather than in the view.
+ *
+ * The five toolbar toggles are persisted, so the keys they are stored under are part of the
+ * plugin's on-disk data — renaming one would silently reset that toggle for everyone who had set
+ * it. They are asserted here as literals for that reason.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ComposeSemanticsInspectorPresenterTest {
+
+    // -- the tree ---------------------------------------------------------------
+
+    @Test
+    fun `collapsing a node hides its children, and expanding it brings them back`() = runPresenter(snapshot = twoLevelTree) { state ->
+        assertEquals(listOf(1, 2, 3), state().nodeIds())
+
+        state().onToggleExpanded(NodeKey(ROOT_ID, 1))
+        waitForIdle()
+        assertEquals(listOf(1), state().nodeIds())
+
+        state().onToggleExpanded(NodeKey(ROOT_ID, 1))
+        waitForIdle()
+        assertEquals(listOf(1, 2, 3), state().nodeIds())
+    }
+
+    @Test
+    fun `the search box keeps the matching nodes and the ancestors that hold them`() = runPresenter(snapshot = twoLevelTree) { state ->
+        state().onSearchChange("Cancel")
+        waitForIdle()
+
+        assertEquals(listOf(1, 3), state().nodeIds())
+    }
+
+    @Test
+    fun `showing only the interactive nodes drops the rest`() = runPresenter(snapshot = twoLevelTree) { state ->
+        state().onInteractiveOnlyChange(true)
+        waitForIdle()
+
+        // Node 1 is kept although it is not interactive itself: dropping an ancestor would reparent
+        // the match and lose the structure that makes the tree readable.
+        assertEquals(listOf(1, 2), state().nodeIds())
+        assertTrue(state().interactiveOnly)
+    }
+
+    // -- selection --------------------------------------------------------------
+
+    @Test
+    fun `selecting a node reports it upward and resolves it against the snapshot`() {
+        val selected = mutableListOf<NodeKey?>()
+        runPresenter(snapshot = twoLevelTree, onSelectedNodeChange = { selected += it }) { state ->
+            state().onSelect(NodeKey(ROOT_ID, 3))
+            waitForIdle()
+
+            assertEquals(NodeKey(ROOT_ID, 3), state().selectedKey)
+            assertEquals(3, state().selectedNode?.id)
+            assertEquals(listOf(null, NodeKey(ROOT_ID, 3)), selected)
+        }
+    }
+
+    @Test
+    fun `nothing is selected to begin with`() = runPresenter(snapshot = twoLevelTree) { state ->
+        assertNull(state().selectedKey)
+        assertNull(state().selectedNode)
+    }
+
+    // -- captures ---------------------------------------------------------------
+
+    @Test
+    fun `the screen captures once when it opens`() {
+        val captures = mutableListOf<NodeTreeCaptureOptions>()
+        runPresenter(onCapture = { captures += it }) { _ ->
+            waitForIdle()
+            assertEquals(listOf(NodeTreeCaptureOptions(merged = true, includeInvisible = false, maxDepth = null)), captures)
+        }
+    }
+
+    @Test
+    fun `a toggle that changes what would be captured captures again`() {
+        val captures = mutableListOf<NodeTreeCaptureOptions>()
+        runPresenter(onCapture = { captures += it }) { state ->
+            waitForIdle()
+
+            state().onIncludeInvisibleChange(true)
+            waitUntil { captures.size == 2 }
+
+            assertEquals(NodeTreeCaptureOptions(merged = true, includeInvisible = true, maxDepth = null), captures.last())
+        }
+    }
+
+    @Test
+    fun `a toggle that only filters the tree captures nothing`() {
+        val captures = mutableListOf<NodeTreeCaptureOptions>()
+        runPresenter(snapshot = twoLevelTree, onCapture = { captures += it }) { state ->
+            waitForIdle()
+
+            state().onInteractiveOnlyChange(true)
+            state().onSearchChange("Cancel")
+            waitForIdle()
+
+            assertEquals(1, captures.size)
+        }
+    }
+
+    // -- persisted toggles ------------------------------------------------------
+
+    @Test
+    fun `the toggles are stored under the keys they have always used`() {
+        val storage = InMemoryPluginStorage()
+        runPresenter(storage = storage) { state ->
+            state().onMergedChange(false)
+            state().onInteractiveOnlyChange(true)
+            state().onIncludeInvisibleChange(true)
+            state().onAutoRefreshChange(true)
+            state().onHighlightOnDeviceChange(true)
+
+            waitUntil { storage.peek("highlight-on-device") == true }
+            assertEquals(false, storage.peek("merged-tree"))
+            assertEquals(true, storage.peek("interactive-only"))
+            assertEquals(true, storage.peek("include-invisible"))
+            assertEquals(true, storage.peek("auto-refresh"))
+        }
+    }
+
+    @Test
+    fun `a stored toggle is what the inspector opens with`() {
+        val storage = InMemoryPluginStorage(
+            "merged-tree" to false,
+            "interactive-only" to true,
+            "include-invisible" to true,
+            "auto-refresh" to true,
+            "highlight-on-device" to true,
+        )
+        runPresenter(storage = storage) { state ->
+            waitUntil { !state().merged }
+
+            assertTrue(state().interactiveOnly)
+            assertTrue(state().includeInvisible)
+            assertTrue(state().autoRefresh)
+            assertTrue(state().highlightOnDevice)
+        }
+    }
+
+    @Test
+    fun `an inspector opened for the first time starts on the defaults`() = runPresenter { state ->
+        assertTrue(state().merged)
+        assertEquals(false, state().interactiveOnly)
+        assertEquals(false, state().includeInvisible)
+        assertEquals(false, state().autoRefresh)
+        // Off deliberately: the box is drawn into the app, so it would otherwise turn up in any
+        // screenshot taken while the inspector is open.
+        assertEquals(false, state().highlightOnDevice)
+    }
+
+    // -- the highlight ----------------------------------------------------------
+
+    @Test
+    fun `the device is pointed at the hovered row, and at nothing once the toggle is off`() {
+        val targets = mutableListOf<NodeKey?>()
+        runPresenter(snapshot = twoLevelTree, onHighlightTargetChange = { targets += it }) { state ->
+            state().onHighlightOnDeviceChange(true)
+            state().onHoverChange(NodeKey(ROOT_ID, 2), true)
+            waitUntil { targets.lastOrNull() == NodeKey(ROOT_ID, 2) }
+
+            state().onHighlightOnDeviceChange(false)
+            waitUntil { targets.lastOrNull() == null }
+        }
+    }
+
+    @Test
+    fun `a row that reports leaving does not clear a hover another row has taken over`() {
+        val targets = mutableListOf<NodeKey?>()
+        runPresenter(snapshot = twoLevelTree, onHighlightTargetChange = { targets += it }) { state ->
+            state().onHighlightOnDeviceChange(true)
+            state().onHoverChange(NodeKey(ROOT_ID, 2), true)
+            waitUntil { targets.lastOrNull() == NodeKey(ROOT_ID, 2) }
+
+            // The pointer arrives on the next row before the one it left reports leaving.
+            state().onHoverChange(NodeKey(ROOT_ID, 3), true)
+            state().onHoverChange(NodeKey(ROOT_ID, 2), false)
+            waitForIdle()
+
+            assertEquals(NodeKey(ROOT_ID, 3), targets.last())
+        }
+    }
+}
+
+/** The status line and the empty pane, which the presenter decides and the view merely draws. */
+class InspectorWordingTest {
+    @Test
+    fun `a tree that has not been captured says so`() {
+        assertEquals("Not captured yet.", captureSummary(snapshot = null, rowCount = 0, roundTripMs = null))
+    }
+
+    @Test
+    fun `the summary counts the shown rows against the captured ones`() {
+        assertEquals(
+            "1 root(s) · 2 shown of 3 · 1 ms on device",
+            captureSummary(snapshot = twoLevelTree, rowCount = 2, roundTripMs = null),
+        )
+    }
+
+    @Test
+    fun `a round trip is reported beside the time spent on the device`() {
+        assertEquals(
+            "1 root(s) · 3 shown of 3 · 1 ms on device · 7 ms round trip",
+            captureSummary(snapshot = twoLevelTree, rowCount = 3, roundTripMs = 7),
+        )
+    }
+
+    @Test
+    fun `an empty pane before the first capture points at the Refresh button`() {
+        val message = emptyTreeMessage(snapshot = null, search = "", interactiveOnly = false)
+        assertEquals("Not captured yet", message.title)
+        assertEquals("Press Refresh to capture the app's node tree.", message.description)
+    }
+
+    @Test
+    fun `an app that reported no root is told to install a probe`() {
+        val message = emptyTreeMessage(snapshot = snapshot(), search = "", interactiveOnly = false)
+        assertEquals("No Compose root reported", message.title)
+        assertTrue(message.description.orEmpty().contains("installJetWhaleSemanticsProbe"))
+    }
+
+    @Test
+    fun `a filter that matched nothing is told apart from an app with nothing to show`() {
+        assertEquals(
+            "No node matches the current filter",
+            emptyTreeMessage(snapshot = twoLevelTree, search = "nothing here", interactiveOnly = false).title,
+        )
+        assertEquals(
+            "No node matches the current filter",
+            emptyTreeMessage(snapshot = twoLevelTree, search = "", interactiveOnly = true).title,
+        )
+        assertEquals(
+            "The app's Compose roots are empty",
+            emptyTreeMessage(snapshot = twoLevelTree, search = "", interactiveOnly = false).title,
+        )
+    }
+}
+
+private const val ROOT_ID = "window-1"
+
+/**
+ * A root holding a plain container and, under it, one node that can be operated and one that cannot,
+ * so a collapse has something to hide and each filter has something to drop.
+ */
+private val twoLevelTree: NodeTreeSnapshot = snapshot(
+    root(
+        rootId = ROOT_ID,
+        node = node(
+            id = 1,
+            children = listOf(
+                node(id = 2, role = "Button", text = "Continue", actions = listOf("OnClick"), isClickable = true),
+                node(id = 3, text = "Cancel"),
+            ),
+        ),
+    ),
+)
+
+private fun ComposeSemanticsInspectorUiState.nodeIds(): List<Int> = rows.filterIsInstance<TreeRow.NodeRow>().map { it.node.id }
+
+/**
+ * Composes the presenter and runs [block] against the state it returns.
+ *
+ * The state is handed over as a getter rather than a value: every intent the test fires produces a
+ * new one, and a captured value would go stale the moment the test used it.
+ */
+@OptIn(ExperimentalTestApi::class)
+private fun runPresenter(
+    snapshot: NodeTreeSnapshot? = null,
+    storage: JetWhalePluginStorage = InMemoryPluginStorage(),
+    onCapture: (NodeTreeCaptureOptions) -> Unit = {},
+    onSelectedNodeChange: (NodeKey?) -> Unit = {},
+    onHighlightTargetChange: (NodeKey?) -> Unit = {},
+    block: suspend ComposeUiTest.(state: () -> ComposeSemanticsInspectorUiState) -> Unit,
+) = runComposeUiTest {
+    lateinit var uiState: ComposeSemanticsInspectorUiState
+    setContent {
+        CompositionLocalProvider(LocalJetWhalePluginStorage provides storage) {
+            uiState = composeSemanticsInspectorPresenter(
+                snapshot = snapshot,
+                capturing = false,
+                roundTripMs = null,
+                errorMessage = null,
+                actionStatus = null,
+                viewAttributes = ViewAttributesUiState.Empty,
+                highlightStatus = null,
+                onCapture = { options -> onCapture(options) },
+                onPerformAction = {},
+                onSelectedNodeChange = onSelectedNodeChange,
+                onCommitViewAttribute = { _, _ -> },
+                onHighlightTargetChange = onHighlightTargetChange,
+            )
+        }
+    }
+    block { uiState }
+}
+
+/** Minimal in-memory [JetWhalePluginStorage] so `rememberPersistent` has something to bind to. */
+@Suppress("UNCHECKED_CAST")
+private class InMemoryPluginStorage(vararg initial: Pair<String, Any?>) : JetWhalePluginStorage {
+    private val values = MutableStateFlow(initial.toMap())
+
+    /** Reads without suspending, so a `waitUntil` condition can watch a write land. */
+    fun peek(key: String): Any? = values.value[key]
+
+    override suspend fun <T> put(key: String, value: T, serializer: KSerializer<T>) {
+        values.update { it + (key to value) }
+    }
+
+    override suspend fun <T> get(key: String, serializer: KSerializer<T>): T? = values.value[key] as T?
+
+    override fun <T> getFlow(key: String, serializer: KSerializer<T>): Flow<T?> = values.map { it[key] as T? }
+
+    override suspend fun contains(key: String): Boolean = values.value.containsKey(key)
+
+    override suspend fun remove(key: String) {
+        values.update { it - key }
+    }
+
+    override suspend fun clear() {
+        values.value = emptyMap()
+    }
+
+    override val keysFlow: Flow<Set<String>> get() = values.map { it.keys }
+}

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeHighlightControllerTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeHighlightControllerTest.kt
@@ -1,0 +1,157 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightResult
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The decisions behind the on-device highlight, driven without a composition: what the host wants
+ * shown, and what it actually sends to get there.
+ */
+class NodeHighlightControllerTest {
+    private val firstRoot = NodeKey(rootId = "window-1", nodeId = -4)
+    private val secondRoot = NodeKey(rootId = "window-2", nodeId = 12)
+
+    // -- highlightTarget -------------------------------------------------------
+
+    @Test
+    fun `the selected node is highlighted when nothing is hovered`() {
+        assertEquals(firstRoot, highlightTarget(enabled = true, selected = firstRoot, hovered = null))
+    }
+
+    @Test
+    fun `a hovered row overrides the selection`() {
+        assertEquals(secondRoot, highlightTarget(enabled = true, selected = firstRoot, hovered = secondRoot))
+    }
+
+    @Test
+    fun `leaving a hovered row goes back to the selection`() {
+        val whileHovering = highlightTarget(enabled = true, selected = firstRoot, hovered = secondRoot)
+        val afterLeaving = highlightTarget(enabled = true, selected = firstRoot, hovered = null)
+        assertEquals(secondRoot, whileHovering)
+        assertEquals(firstRoot, afterLeaving)
+    }
+
+    @Test
+    fun `the toggle being off highlights nothing at all`() {
+        assertEquals(null, highlightTarget(enabled = false, selected = firstRoot, hovered = secondRoot))
+    }
+
+    @Test
+    fun `nothing is highlighted with nothing selected and nothing hovered`() {
+        assertEquals(null, highlightTarget(enabled = true, selected = null, hovered = null))
+    }
+
+    // -- NodeHighlightController ----------------------------------------------
+
+    @Test
+    fun `showing a node sends it with the shared time to live`() = runBlocking {
+        val recorder = Recorder()
+        val controller = recorder.controller()
+
+        assertTrue(controller.show(firstRoot))
+        assertEquals(
+            listOf(HighlightNode(rootId = "window-1", nodeId = -4, ttlMs = HIGHLIGHT_TTL_MILLIS)),
+            recorder.sent,
+        )
+        assertNull(controller.statusMessage)
+    }
+
+    @Test
+    fun `moving the highlight to another root clears the one being left`() = runBlocking {
+        val recorder = Recorder()
+        val controller = recorder.controller()
+
+        controller.show(firstRoot)
+        controller.show(secondRoot)
+
+        assertEquals(
+            listOf(
+                HighlightNode(rootId = "window-1", nodeId = -4, ttlMs = HIGHLIGHT_TTL_MILLIS),
+                HighlightNode(rootId = "window-1", nodeId = null, ttlMs = HIGHLIGHT_TTL_MILLIS),
+                HighlightNode(rootId = "window-2", nodeId = 12, ttlMs = HIGHLIGHT_TTL_MILLIS),
+            ),
+            recorder.sent,
+        )
+    }
+
+    @Test
+    fun `moving the highlight within one root does not clear it first`() = runBlocking {
+        val recorder = Recorder()
+        val controller = recorder.controller()
+
+        controller.show(firstRoot)
+        controller.show(firstRoot.copy(nodeId = -9))
+
+        assertEquals(listOf(-4, -9), recorder.sent.map { it.nodeId })
+    }
+
+    @Test
+    fun `clearing sends a null node id to the root that was showing one`() = runBlocking {
+        val recorder = Recorder()
+        val controller = recorder.controller()
+
+        controller.show(firstRoot)
+        controller.clear()
+
+        assertEquals(HighlightNode(rootId = "window-1", nodeId = null, ttlMs = HIGHLIGHT_TTL_MILLIS), recorder.sent.last())
+    }
+
+    @Test
+    fun `clearing with nothing showing sends nothing`() = runBlocking {
+        val recorder = Recorder()
+
+        recorder.controller().clear()
+
+        assertTrue(recorder.sent.isEmpty())
+    }
+
+    @Test
+    fun `a root that refuses keeps its message and is not worth renewing`() = runBlocking {
+        val recorder = Recorder(answer = { HighlightResult(shown = false, message = "unknown nodeId: -4") })
+        val controller = recorder.controller()
+
+        assertFalse(controller.show(firstRoot))
+        assertEquals("unknown nodeId: -4", controller.statusMessage)
+    }
+
+    @Test
+    fun `a refusal leaves nothing to clear on the next node`() = runBlocking {
+        val recorder = Recorder(answer = { HighlightResult(shown = false, message = "no window") })
+        val controller = recorder.controller()
+
+        controller.show(firstRoot)
+        controller.show(secondRoot)
+
+        assertEquals(listOf("window-1", "window-2"), recorder.sent.map { it.rootId })
+    }
+
+    @Test
+    fun `an app that does not answer reports the failure instead of throwing`() = runBlocking {
+        val recorder = Recorder(answer = { throw JetWhaleMessagingException("the session is gone") })
+        val controller = recorder.controller()
+
+        assertFalse(controller.show(firstRoot))
+        assertEquals("Highlight failed: the session is gone", controller.statusMessage)
+    }
+
+    private class Recorder(private val answer: (HighlightNode) -> HighlightResult = { HighlightResult(shown = true) }) {
+        val sent = mutableListOf<HighlightNode>()
+
+        fun controller(): NodeHighlightController = NodeHighlightController(
+            scope = CoroutineScope(Dispatchers.Unconfined),
+            send = { request ->
+                sent += request
+                answer(request)
+            },
+        )
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeHighlightSerializationTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeHighlightSerializationTest.kt
@@ -1,0 +1,39 @@
+package com.kitakkun.jetwhale.plugins.semantics.host
+
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightNode
+import com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightResult
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The highlight protocol on the wire. What has to hold is that a clear survives the trip: `nodeId`
+ * is the one field whose absence means something — "take the box down" — and a null that decoded as
+ * anything else would leave a box on the app's screen.
+ */
+class NodeHighlightSerializationTest {
+    private val json = Json
+
+    @Test
+    fun `a request naming a node round-trips`() {
+        val request = HighlightNode(rootId = "window-1", nodeId = -4, ttlMs = 30_000)
+        assertEquals(request, json.decodeFromString<HighlightNode>(json.encodeToString(request)))
+    }
+
+    @Test
+    fun `a request that clears the highlight round-trips with its null nodeId`() {
+        val request = HighlightNode(rootId = "window-1", nodeId = null, ttlMs = 30_000)
+        val decoded = json.decodeFromString<HighlightNode>(json.encodeToString(request))
+        assertEquals(request, decoded)
+        assertEquals(null, decoded.nodeId)
+    }
+
+    @Test
+    fun `both answers round-trip`() {
+        val shown = HighlightResult(shown = true)
+        assertEquals(shown, json.decodeFromString<HighlightResult>(json.encodeToString(shown)))
+
+        val refused = HighlightResult(shown = false, message = "unknown nodeId: -4")
+        assertEquals(refused, json.decodeFromString<HighlightResult>(json.encodeToString(refused)))
+    }
+}

--- a/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
+++ b/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
@@ -157,6 +157,67 @@ public final class com/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttri
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/HighlightNode : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightNode$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;J)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightNode;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightNode;Ljava/lang/String;Ljava/lang/Integer;JILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodeId ()Ljava/lang/Integer;
+	public final fun getRootId ()Ljava/lang/String;
+	public final fun getTtlMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/HighlightNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/HighlightNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/HighlightResult {
+	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightResult$Companion;
+	public fun <init> (ZLjava/lang/String;)V
+	public synthetic fun <init> (ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightResult;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightResult;ZLjava/lang/String;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getShown ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/kitakkun/jetwhale/plugins/semantics/protocol/HighlightResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/kitakkun/jetwhale/plugins/semantics/protocol/HighlightResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/kitakkun/jetwhale/plugins/semantics/protocol/HighlightResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction : java/lang/Enum {
 	public static final field Click Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
 	public static final field Collapse Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;

--- a/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
+++ b/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
@@ -507,6 +507,67 @@ final class com.kitakkun.jetwhale.plugins.semantics.protocol/GetViewAttributes :
     }
 }
 
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult> { // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode|null[0]
+    constructor <init>(kotlin/String, kotlin/Int?, kotlin/Long) // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.<init>|<init>(kotlin.String;kotlin.Int?;kotlin.Long){}[0]
+
+    final val nodeId // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.nodeId|{}nodeId[0]
+        final fun <get-nodeId>(): kotlin/Int? // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.nodeId.<get-nodeId>|<get-nodeId>(){}[0]
+    final val rootId // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.rootId|{}rootId[0]
+        final fun <get-rootId>(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.rootId.<get-rootId>|<get-rootId>(){}[0]
+    final val ttlMs // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.ttlMs|{}ttlMs[0]
+        final fun <get-ttlMs>(): kotlin/Long // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.ttlMs.<get-ttlMs>|<get-ttlMs>(){}[0]
+
+    final fun component1(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.component1|component1(){}[0]
+    final fun component2(): kotlin/Int? // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.component2|component2(){}[0]
+    final fun component3(): kotlin/Long // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.component3|component3(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Int? = ..., kotlin/Long = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.copy|copy(kotlin.String;kotlin.Int?;kotlin.Long){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode> { // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode) // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightNode){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode> // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightNode.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult { // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult|null[0]
+    constructor <init>(kotlin/Boolean, kotlin/String? = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.<init>|<init>(kotlin.Boolean;kotlin.String?){}[0]
+
+    final val message // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.message|{}message[0]
+        final fun <get-message>(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.message.<get-message>|<get-message>(){}[0]
+    final val shown // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.shown|{}shown[0]
+        final fun <get-shown>(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.shown.<get-shown>|<get-shown>(){}[0]
+
+    final fun component1(): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.component2|component2(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin/String? = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.copy|copy(kotlin.Boolean;kotlin.String?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult> { // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.$serializer|null[0]
+        final val descriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult) // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.kitakkun.jetwhale.plugins.semantics.protocol.HighlightResult){}[0]
+    }
+
+    final object Companion { // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult> // com.kitakkun.jetwhale.plugins.semantics.protocol/HighlightResult.Companion.serializer|serializer(){}[0]
+    }
+}
+
 final class com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult|null[0]
     constructor <init>(kotlin/Boolean, kotlin/String? = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult.<init>|<init>(kotlin.Boolean;kotlin.String?){}[0]
 

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeHighlight.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeHighlight.kt
@@ -1,0 +1,33 @@
+package com.kitakkun.jetwhale.plugins.semantics.protocol
+
+import com.kitakkun.jetwhale.protocol.messaging.JetWhaleRequest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// Pointing at one node on the device itself, so that reading a row in the host and finding the thing
+// it names on screen is one step rather than a hunt through the layout.
+//
+// Only a root that has somewhere to draw can answer this — an Android window. A composition read
+// through its `SemanticsOwner` alone reports `shown = false` with a message saying so.
+
+/**
+ * Draws a box over one node on the device, or clears it.
+ *
+ * @param nodeId `null` clears whatever this root is showing.
+ * @param ttlMs the highlight clears itself after this long without being renewed, so a host that
+ *   goes away cannot leave a box on the app's screen for the rest of the process's life.
+ */
+@SerialName("node/highlight")
+@Serializable
+data class HighlightNode(
+    val rootId: String,
+    val nodeId: Int?,
+    val ttlMs: Long,
+) : JetWhaleRequest<HighlightResult>
+
+/** Separate from the request so a node that has gone away is an answer, not a transport failure. */
+@Serializable
+data class HighlightResult(
+    val shown: Boolean,
+    val message: String? = null,
+)


### PR DESCRIPTION
> Stacked on #251 → #248. Review the last commit only; retarget as those merge.

## Summary

The inspector's screen was doing a presenter's job: it held the inspection session (`selectedKey`, `search`, `collapsedKeys`, the five toggles) and ran the effects that capture the tree, drive auto-refresh, tell the attribute store which node is selected and report the highlight target.

This moves that into a `@Composable` presenter, matching the convention the host's own screens already use (`ServerSettingsScreenRoot` → `serverSettingsScreenPresenter` → `ServerSettingsScreen`, and `toolingScaffoldPresenter`):

```kotlin
override fun Content() {
    val uiState = composeSemanticsInspectorPresenter(…)
    ComposeSemanticsInspectorScreen(uiState = uiState)
}
```

`ComposeSemanticsInspectorScreen` now takes one `UiState` and has no `remember`, no effects and no coroutine scope. What stays in the view is input mechanics — a row's `MutableInteractionSource`, a text field's draft — the same category as `TextEditor`'s.

## Notes

- **Callbacks travel in the UI state.** The settings screens pass them through `ScreenChannel` from `host.architecture`, which is not on a plugin's classpath (a plugin sees `jetwhale-host-sdk` and `jetwhale-host-ui`). Putting the lambdas in the state is what kept the view free of `remember` without reimplementing that machinery; it is also what Circuit does with `eventSink`. A sealed `Event` + one `onEvent` lambda would be the alternative if you prefer it.
- **`onCapture` stays `suspend`** — auto-refresh has to await each capture for backpressure. The scope that drives it moved from the view to the presenter.
- **The attribute store and highlight controller stay plugin-owned**, for reasons a presenter does not change: the store is shared with the MCP tools so an agent's write updates the panel, and the controller must be able to clear the box when the plugin instance is disposed.
- **Persistence is untouched** — `rememberPersistent` with `merged-tree`, `interactive-only`, `include-invisible`, `auto-refresh`, `highlight-on-device` and the same defaults. A test pins those literal keys.

## Testing
- `:jetwhale-plugins:semantics:{protocol,agent,host}:check`, `:demo:android:assembleDebug`, `spotlessCheck`, `checkKotlinAbi` — pass. 19 new tests (13 presenter, 6 wording); the presenter is composable, so the module gained `ui-test-junit4`, the dependency the network host module already uses.
- GUI pass on the emulator: every toolbar toggle still filters or re-captures as before (`24 of 27` for interactive-only, `33 of 33` unmerged, `35 of 35` with invisible); Auto samples every 1.5 s and stops when switched off; Refresh captures; collapse is per node and survives; selecting a View node loads its attributes and `visibility → INVISIBLE` made the demo's button vanish on the device; search filters while keeping ancestors and the selection.
- Navigating to Settings and back keeps the search, selection and collapsed rows — worth knowing that this retention comes from `DefaultPluginComposeSceneService` caching the scene, not from this change; it was checked to confirm the refactor did not lose it.
- Not verified: a host restart to watch a persisted toggle come back (the keys and helper are byte-identical, and the round trip is unit-tested against a fake storage).
