### PR TITLE
chore: bump version to 1.0.0-alpha12

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jetwhale = "1.0.0-alpha11"
+jetwhale = "1.0.0-alpha12"
 mavenPublish = "0.37.0"
 
 # kotlin


### PR DESCRIPTION
Bumps the `jetwhale` version in `gradle/libs.versions.toml` from `1.0.0-alpha11` to `1.0.0-alpha12` ahead of the next release.