### PR TITLE
Stop the MCP permission tree taking clicks a launch override ignores

### DIFF
--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -240,7 +240,9 @@ Starting the host with `--mcp-allow-all-permissions` allows everything for that 
 This is for automated QA, where a run that has to enable a plugin or restart a server would
 otherwise stop at a checkbox nobody is there to tick. Nothing is written back, so your own host keeps
 whatever you chose, and the settings screen and `jetwhale.getStatus` both show the lifted state
-rather than disagreeing with what the agent can actually do. Setting it requires being able to start
+rather than disagreeing with what the agent can actually do. Because nothing you pick can win against
+the override for that process, the permission tree is read-only for such a launch and says why —
+restart without the flag to edit it again. Setting it requires being able to start
 the host process — already more than the unauthenticated MCP port grants — so it opens no door that
 was closed to that caller.
 

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultMcpPermissionsSnapshotSubscriptionKey.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/settings/DefaultMcpPermissionsSnapshotSubscriptionKey.kt
@@ -2,6 +2,7 @@ package com.kitakkun.jetwhale.host.data.settings
 
 import com.kitakkun.jetwhale.host.mcp.McpServerService
 import com.kitakkun.jetwhale.host.model.McpCapablePlugins
+import com.kitakkun.jetwhale.host.model.McpPermissionOverride
 import com.kitakkun.jetwhale.host.model.McpPermissionPlugin
 import com.kitakkun.jetwhale.host.model.McpPermissionsRepository
 import com.kitakkun.jetwhale.host.model.McpPermissionsSnapshot
@@ -20,6 +21,7 @@ class DefaultMcpPermissionsSnapshotSubscriptionKey(
     private val permissionsRepository: McpPermissionsRepository,
     private val pluginFactoryRepository: PluginFactoryRepository,
     private val mcpServerService: McpServerService,
+    private val launchOverride: McpPermissionOverride,
 ) : McpPermissionsSnapshotSubscriptionKey by buildSubscriptionKey(
     id = SubscriptionId("mcp_permissions_view"),
     subscribe = {
@@ -42,6 +44,7 @@ class DefaultMcpPermissionsSnapshotSubscriptionKey(
                         )
                     }
                     .sortedBy { it.displayName },
+                isOverriddenForLaunch = launchOverride.allowAll,
             )
         }
     },

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/McpPermissionsSnapshot.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/McpPermissionsSnapshot.kt
@@ -25,6 +25,13 @@ data class McpPermissionPlugin(
 data class McpPermissionsSnapshot(
     val permissions: McpPermissions,
     val plugins: List<McpPermissionPlugin>,
+    /**
+     * True while this launch was started with `--mcp-allow-all-permissions`. [permissions] then
+     * reports what the override grants rather than what is stored, and nothing the user picks can
+     * change it for this process — so the screen has to say so and refuse the edit, instead of
+     * taking a click that goes nowhere.
+     */
+    val isOverriddenForLaunch: Boolean,
 )
 
 typealias McpPermissionsSnapshotSubscriptionKey = SubscriptionKey<McpPermissionsSnapshot>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values-ja/strings.xml
@@ -80,6 +80,7 @@
     <string name="mcp_setup_json_label">JSON 設定</string>
     <string name="mcp_permission_title">権限</string>
     <string name="mcp_permission_note">このMCPサーバーに接続したAIエージェントに許可する操作です。観測とナビゲーションは既定でオン、プラグイン管理とサーバー変更は既定でオフです（プラグインのインストールは JetWhale に新しいコードを読み込み、デバッグサーバーの再起動は全セッションを切断するためです）。</string>
+    <string name="mcp_permission_launch_override_note">このホストは --mcp-allow-all-permissions 付きで起動されているため、この起動中はすべてのツールが許可され、チェックボックスは変更できません。編集するにはフラグなしで再起動してください。保存済みの選択はそのまま残ります。</string>
     <string name="mcp_permission_host_label">ホスト</string>
     <string name="mcp_permission_group_observe">Observe — ステータス、ホストログ、インストール済みプラグイン</string>
     <string name="mcp_permission_group_navigate">Navigate — メインウィンドウの画面切り替え</string>

--- a/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/feature/settings/src/main/composeResources/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="mcp_setup_json_label">JSON config</string>
     <string name="mcp_permission_title">Permissions</string>
     <string name="mcp_permission_note">What an AI agent connected to this MCP server may do. Observing and navigating are on by default; managing plugins and changing servers are not, because installing a plugin runs new code in JetWhale and restarting the debug server disconnects every session.</string>
+    <string name="mcp_permission_launch_override_note">This host was started with --mcp-allow-all-permissions, so every tool is allowed for this launch and these boxes cannot be changed. Restart without the flag to edit them; your stored choices are untouched.</string>
     <string name="mcp_permission_host_label">Host</string>
     <string name="mcp_permission_group_observe">Observe — status, host logs, installed plugins</string>
     <string name="mcp_permission_group_navigate">Navigate — switch the main window to another screen</string>

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/McpPermissionsTreeView.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/McpPermissionsTreeView.kt
@@ -24,6 +24,7 @@ import com.kitakkun.jetwhale.host.settings.mcp_permission_group_navigate
 import com.kitakkun.jetwhale.host.settings.mcp_permission_group_observe
 import com.kitakkun.jetwhale.host.settings.mcp_permission_group_settings_and_servers
 import com.kitakkun.jetwhale.host.settings.mcp_permission_host_label
+import com.kitakkun.jetwhale.host.settings.mcp_permission_launch_override_note
 import com.kitakkun.jetwhale.host.settings.mcp_permission_no_plugins
 import com.kitakkun.jetwhale.host.settings.mcp_permission_note
 import com.kitakkun.jetwhale.host.settings.mcp_permission_plugin_inspect
@@ -57,6 +58,12 @@ data class McpPluginPermissionUiState(
 data class McpPermissionsUiState(
     val allowedHostGroups: Set<McpHostToolGroup>,
     val plugins: List<McpPluginPermissionUiState>,
+    /**
+     * True while a launch flag allows every tool. The tree then shows what the launch actually
+     * grants and takes no input: a stored choice cannot win against the override for this process,
+     * so an editable box here would swallow the click and change nothing on screen.
+     */
+    val isOverriddenForLaunch: Boolean,
 )
 
 @Composable
@@ -85,8 +92,20 @@ fun McpPermissionsTreeView(
             style = JwTheme.textStyles.bodySmall,
             color = JwTheme.colors.textSecondary,
         )
+        if (uiState.isOverriddenForLaunch) {
+            JwText(
+                text = stringResource(Res.string.mcp_permission_launch_override_note),
+                style = JwTheme.textStyles.bodySmall,
+                color = JwTheme.colors.warning,
+            )
+        }
         tree.forEach { node ->
-            PermissionNodeView(node = node, depth = 0, expanded = expanded)
+            PermissionNodeView(
+                node = node,
+                depth = 0,
+                expanded = expanded,
+                enabled = !uiState.isOverriddenForLaunch,
+            )
         }
     }
 }
@@ -207,9 +226,10 @@ private fun PermissionNodeView(
     node: PermissionNode,
     depth: Int,
     expanded: MutableMap<String, Boolean>,
+    enabled: Boolean,
 ) {
     when (node) {
-        is PermissionNode.Leaf -> LeafRow(node = node, depth = depth)
+        is PermissionNode.Leaf -> LeafRow(node = node, depth = depth, enabled = enabled)
 
         is PermissionNode.Branch -> {
             val isExpanded = expanded[node.id] ?: node.startExpanded
@@ -217,6 +237,7 @@ private fun PermissionNodeView(
                 node = node,
                 depth = depth,
                 isExpanded = isExpanded,
+                enabled = enabled,
                 onToggleExpanded = { expanded[node.id] = !isExpanded },
             )
             if (isExpanded) {
@@ -229,7 +250,12 @@ private fun PermissionNodeView(
                     )
                 }
                 node.children.forEach { child ->
-                    PermissionNodeView(node = child, depth = depth + 1, expanded = expanded)
+                    PermissionNodeView(
+                        node = child,
+                        depth = depth + 1,
+                        expanded = expanded,
+                        enabled = enabled,
+                    )
                 }
             }
         }
@@ -241,6 +267,7 @@ private fun BranchRow(
     node: PermissionNode.Branch,
     depth: Int,
     isExpanded: Boolean,
+    enabled: Boolean,
     onToggleExpanded: () -> Unit,
 ) {
     val leaves = node.leaves
@@ -256,7 +283,7 @@ private fun BranchRow(
         JwTriStateCheckbox(
             state = toggleStateOf(leaves.map { it.allowed }),
             label = null,
-            enabled = leaves.isNotEmpty(),
+            enabled = enabled && leaves.isNotEmpty(),
             // A partially-ticked parent turns everything on: the alternative — clearing a mixed
             // selection — throws away choices the user made one by one.
             onClick = {
@@ -297,11 +324,12 @@ private fun BranchRow(
 }
 
 @Composable
-private fun LeafRow(node: PermissionNode.Leaf, depth: Int) {
+private fun LeafRow(node: PermissionNode.Leaf, depth: Int, enabled: Boolean) {
     JwCheckbox(
         checked = node.allowed,
         onCheckedChange = node.onSetAllowed,
         label = node.label,
+        enabled = enabled,
         modifier = Modifier.padding(start = INDENT_STEP * depth),
     )
 }

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenPresenter.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenPresenter.kt
@@ -316,6 +316,7 @@ fun serverSettingsScreenPresenter(
                     },
                 )
             },
+            isOverriddenForLaunch = mcpPermissionsSnapshot.isOverriddenForLaunch,
         ),
         isDebugApplyVisible = isDebugDirty || isDebugStartFailed,
         isMcpApplyVisible = isMcpDirty || isMcpStartFailed,

--- a/jetwhale-host/feature/settings/src/test/kotlin/com/kitakkun/jetwhale/host/settings/server/McpPermissionsTreeViewTest.kt
+++ b/jetwhale-host/feature/settings/src/test/kotlin/com/kitakkun/jetwhale/host/settings/server/McpPermissionsTreeViewTest.kt
@@ -1,0 +1,63 @@
+package com.kitakkun.jetwhale.host.settings.server
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import com.kitakkun.jetwhale.host.model.McpHostToolGroup
+import com.kitakkun.jetwhale.host.ui.JwTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The tree's input rules. A launch started with `--mcp-allow-all-permissions` reports every tool as
+ * allowed no matter what is stored, so a box left editable there takes a click and changes nothing.
+ */
+@OptIn(ExperimentalTestApi::class)
+class McpPermissionsTreeViewTest {
+    @Test
+    fun `a host group box reports the value it was clicked to`() = runTreeView(isOverriddenForLaunch = false) { calls ->
+        onNodeWithText(OBSERVE_LABEL, substring = true).performClick()
+
+        assertEquals(listOf(McpHostToolGroup.OBSERVE to false), calls)
+    }
+
+    @Test
+    fun `a launch override leaves nothing to click`() = runTreeView(isOverriddenForLaunch = true) { calls ->
+        onNodeWithText(OBSERVE_LABEL, substring = true).assertIsNotEnabled()
+
+        onNodeWithText(OBSERVE_LABEL, substring = true).performClick()
+
+        assertTrue(calls.isEmpty(), "an overridden launch cannot store a choice, so it must not take one")
+    }
+}
+
+/** The first words of `mcp_permission_group_observe`, which is all the selector needs. */
+private const val OBSERVE_LABEL = "Observe"
+
+@OptIn(ExperimentalTestApi::class)
+private fun runTreeView(
+    isOverriddenForLaunch: Boolean,
+    body: androidx.compose.ui.test.ComposeUiTest.(calls: List<Pair<McpHostToolGroup, Boolean>>) -> Unit,
+) = runComposeUiTest {
+    val calls = mutableListOf<Pair<McpHostToolGroup, Boolean>>()
+    setContent {
+        JwTheme(darkTheme = true) {
+            McpPermissionsTreeView(
+                uiState = McpPermissionsUiState(
+                    allowedHostGroups = setOf(McpHostToolGroup.OBSERVE),
+                    plugins = emptyList(),
+                    isOverriddenForLaunch = isOverriddenForLaunch,
+                ),
+                onSetHostGroupAllowed = { group, allowed -> calls += group to allowed },
+                onSetPluginInspectAllowed = { _, _ -> },
+                onSetPluginInteractAllowed = { _, _ -> },
+                onSetPluginToolAllowed = { _, _ -> },
+            )
+        }
+    }
+    waitForIdle()
+    body(calls)
+}

--- a/jetwhale-host/feature/settings/src/test/kotlin/com/kitakkun/jetwhale/host/settings/server/McpPermissionsTreeViewTest.kt
+++ b/jetwhale-host/feature/settings/src/test/kotlin/com/kitakkun/jetwhale/host/settings/server/McpPermissionsTreeViewTest.kt
@@ -28,6 +28,9 @@ class McpPermissionsTreeViewTest {
     fun `a launch override leaves nothing to click`() = runTreeView(isOverriddenForLaunch = true) { calls ->
         onNodeWithText(OBSERVE_LABEL, substring = true).assertIsNotEnabled()
 
+        // Clicked rather than only asserted disabled: performClick injects a pointer event at the
+        // node's center instead of invoking the OnClick semantics action, so a disabled box takes it
+        // and does nothing. Dropping the click would leave the test passing on an editable tree.
         onNodeWithText(OBSERVE_LABEL, substring = true).performClick()
 
         assertTrue(calls.isEmpty(), "an overridden launch cannot store a choice, so it must not take one")

--- a/jetwhale-host/feature/settings/src/test/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenPresenterTest.kt
+++ b/jetwhale-host/feature/settings/src/test/kotlin/com/kitakkun/jetwhale/host/settings/server/ServerSettingsScreenPresenterTest.kt
@@ -187,7 +187,7 @@ private fun runPresenter(
                     mcpServerStatus = McpServerStatus.Stopped,
                     debuggerSettings = settingsFlow.collectAsStateValue(),
                     sslCertificates = emptyList<SslCertificateEntry>(),
-                    mcpPermissionsSnapshot = McpPermissionsSnapshot(emptyPermissions, emptyList()),
+                    mcpPermissionsSnapshot = McpPermissionsSnapshot(emptyPermissions, emptyList(), isOverriddenForLaunch = false),
                 )
             }
         }


### PR DESCRIPTION
## What was wrong

A host started with `--mcp-allow-all-permissions` reports every tool as allowed no matter what is
stored: `McpPermissions.allOverriddenBy` swaps the stored value for `AllowAll` where the permissions
are read. The settings tree kept its checkboxes editable anyway, so a click was written to the store,
the read came straight back overridden, and the box never moved. From the user's side the control was
simply dead.

That flag is what the QA launch instructions use, so this is the state an agent-driven QA session
looks at.

## What this changes

While the override applies, the tree is read-only and says why: which flag is in force, that
restarting without it restores editing, and that stored choices are untouched. Refusing the edit is
honest where swallowing it was not — nothing the user picks can win against the override for that
process.

- `McpPermissionsSnapshot` carries `isOverriddenForLaunch`, filled by the subscription key from the
  injected `McpPermissionOverride`.
- The presenter passes it into `McpPermissionsUiState`; every leaf and tri-state box in the tree is
  disabled from it, and a warning-colored note is shown above the tree (en/ja).
- `McpPermissionOverride`'s KDoc and the MCP server guide now describe the read-only tree.

## Verification

The other layers were cleared first — the checkbox component, the presenter, the mutation key and the
repository each round-trip a click correctly. The failure only appears with the override.

Driven against the real DI graph (`JetWhaleAppGraph`), a real DataStore and the real settings UI:

- with `McpPermissionOverride.None`, clicking "Observe" stores `mcp_allowed_host_groups` and the box
  turns off;
- with `allowAll = true`, before this change the box stayed `ToggleableState = 'On'` after the click
  (the reported bug); after it, the box is disabled and nothing is written.

`McpPermissionsTreeViewTest` keeps the regression: the second case fails if the tree is left enabled.