### PR TITLE
Keep one SWR cache for the process

### DIFF
--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/di/JetWhaleAppGraph.kt
@@ -32,6 +32,7 @@ import com.kitakkun.jetwhale.protocol.serialization.JetWhaleJson
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
 import kotlinx.serialization.json.Json
 import soil.query.SwrCachePlus
 import soil.query.SwrCachePlusPolicy
@@ -77,7 +78,12 @@ interface JetWhaleAppGraph : ScreenContext {
         ): JetWhaleAppGraph
     }
 
+    // One cache for the process. Unscoped, every read of `swrClient` built another SwrCachePlus with
+    // a CoroutineScope of its own — and JetWhaleApp reads it from composition, so each recomposition
+    // leaked one and handed the subtree a cache that shared no query, mutation or subscription with
+    // the one the composition before it used.
     @Provides
+    @SingleIn(AppScope::class)
     fun provideSwrClient(): SwrClientPlus = SwrCachePlus(SwrCachePlusPolicy(SwrCacheScope()))
 
     @Provides


### PR DESCRIPTION
## What was wrong

`JetWhaleAppGraph.provideSwrClient` carried no scope annotation, so every read of `swrClient` built
another `SwrCachePlus`, each with a `SwrCacheScope` of its own (a supervisor job plus a
single-threaded dispatcher).

`JetWhaleApp` reads it from composition to feed `SwrClientProvider`, so every recomposition of that
composable leaked one cache and its coroutine scope, and published through the composition locals a
client that shared no query, mutation or subscription state with the one the composition before it
had used. Nothing looked broken because `rememberMutation` / `rememberSubscription` key their
`remember` on the key id: existing refs kept working against the cache they were created with, while
the scopes piled up behind them.

`DefaultDynamicPluginBridgeProvider` injects the same type, so the plugin bridge was also running a
second cache of its own.

## What this changes

`@SingleIn(AppScope::class)` on the provider — one cache for the process. The plugin bridge now
shares it with the host UI; the keys it resolves (theme, appearance) are the host's own, so there was
nothing to isolate.

Found while investigating the MCP permission checkbox (#256); it was not the cause of that bug.