### PR TITLE
Delete comments that only restate the code

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,43 @@
+# Comment Rules
+
+Make the code say it. Write a comment only for what the code cannot carry.
+
+A comment that restates what the next line does costs twice: it slows a reader who must check it
+against the code, and it drifts out of date the moment the code changes. If that is all it would
+say, leave it out.
+
+## Before writing a comment
+
+Try, in this order:
+
+1. **Rename.** A name that states the intent (`isDebugStartFailed`, `MAX_TEMPLATE_DEPTH`) removes
+   the need for the sentence.
+2. **Restructure.** Extract the block into a function whose name is the comment; split a class whose
+   sections needed banners.
+3. **Let the test name speak.** Backtick test names carry the intent; do not repeat them above the
+   assertions.
+
+Only then write the comment.
+
+## Worth a comment
+
+- A constraint from outside the file: a platform or library behavior the call site cannot show
+  (`NsdManager requires the trailing dot`, `save() buffers the whole body`).
+- A deliberate trade-off, where the alternative is not obviously worse.
+- Why something is *absent* — a call that is deliberately not made, an empty branch that is a
+  decision rather than an omission.
+- A wire-visible placeholder that looks dead but must stay.
+
+## Not worth a comment
+
+- Narration of the next statement.
+- Section banners (`// ----- Public API -----`).
+- `// do nothing` on an empty block: write `Unit`, or `{}`, and let it read as deliberate.
+- History: what the code used to do, which bug a line fixed, what a review changed. That lives in
+  git and in the PR.
+- Anything a named constant, function or test name already says.
+
+## KDoc
+
+Public API keeps its KDoc — it is documentation for callers, not commentary. The same bar applies to
+its prose: describe the contract, not the implementation line by line.

--- a/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
+++ b/jetwhale-agent-runtime/src/jvmTest/kotlin/com/kitakkun/jetwhale/agent/runtime/MessagingServiceResolutionTest.kt
@@ -163,8 +163,8 @@ class MessagingServiceResolutionTest {
         val socketClient = RecordingSocketClient(reachable = setOf(reachable))
         var firstCall = true
         val service = service(socketClient) {
-            // Resolution is not supposed to throw, but one escaping used to take the loop down with
-            // it, leaving the agent silently dead for the life of the process.
+            // Resolution is not supposed to throw, but one escaping must not take the loop down
+            // with it and leave the agent silently dead for the life of the process.
             if (firstCall) {
                 firstCall = false
                 throw IllegalStateException("resolver blew up")

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/ApplicationLifecycleOwner.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/ApplicationLifecycleOwner.kt
@@ -64,8 +64,7 @@ class ApplicationLifecycleOwner(
             // malicious jar dropped into ~/.jetwhale/plugins from auto-running in the host process.
             pluginTrustService.loadTrustedPlugins()
 
-            // Loads dev plugins (if any) and starts watching the dev directory for hot reload.
-            // No-op unless the jetwhale.devPluginsDir system property is set.
+            // A no-op unless the jetwhale.devPluginsDir system property is set.
             pluginHotReloadService.start()
 
             mutableApplicationStateFlow.update { ApplicationState.INITIALIZED }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -87,7 +87,6 @@ fun JetWhaleApp() {
     }
 
     LaunchedEffect(Unit) {
-        // dispose plugin scenes when the debug websocket server is stopped, as all plugin sessions will be closed
         appGraph.debugWebSocketServer.serverStoppedFlow.collect {
             backStack.removeAll { navKey ->
                 navKey is PluginNavKey || navKey is PluginPopoutNavKey
@@ -99,19 +98,16 @@ fun JetWhaleApp() {
 
     LaunchedEffect(backStack) {
         appGraph.debugWebSocketServer.sessionClosedFlow.collect {
-            // automatically remove closed plugin sessions from back stack
             backStack.removeAll { navKey ->
                 navKey is PluginNavKey && navKey.sessionId == it
             }
-            // dispose compose scenes when plugin sessions are closed
-            // this cannot be done in the debugWebSocketServer directly because of circular dependencies
+            // Not done inside debugWebSocketServer itself: that would be a dependency cycle.
             appGraph.pluginComposeSceneService.disposePluginSceneForSession(it)
         }
     }
 
     LaunchedEffect(backStack) {
         appGraph.enabledPluginsRepository.disabledPluginIdFlow.collect { disabledPluginId ->
-            // automatically remove disabled plugin entries from back stack
             backStack.removeAll { navKey ->
                 when (navKey) {
                     is PluginNavKey -> navKey.pluginId == disabledPluginId

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/Main.kt
@@ -85,7 +85,6 @@ fun main(args: Array<String>) = runBlocking {
             additionalPluginDirectories = AdditionalPluginDirectories(cliOptions.pluginDirs),
         )
 
-    // Start capturing logs
     appGraph.logCaptureService.startCapture()
 
     appGraph.applicationLifecycleOwner.initialize()
@@ -175,9 +174,7 @@ fun main(args: Array<String>) = runBlocking {
                     ApplicationLifecycleOwner.ApplicationState.NONE,
                     ApplicationLifecycleOwner.ApplicationState.INITIALIZED,
                     ApplicationLifecycleOwner.ApplicationState.STOPPED,
-                    -> {
-                        // show nothing
-                    }
+                    -> Unit
                 }
             }
 

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsParser.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/cli/CommandLineArgumentsParser.kt
@@ -70,9 +70,7 @@ class CommandLineArgumentsParser {
 
                 "--headless" -> headless = true
 
-                else -> {
-                    // Ignore unknown arguments
-                }
+                else -> Unit
             }
         }
 

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/AiActivityIndicatorView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/AiActivityIndicatorView.kt
@@ -187,7 +187,6 @@ fun AiActivityIndicatorView(
                     tint = if (uiState.isOperating) JwTheme.colors.aiAccent else JwTheme.colors.textSecondary,
                     modifier = Modifier.alpha(pulseAlpha),
                 )
-                // Animate the height so the tool-name line slides in and out instead of snapping.
                 Column(modifier = Modifier.animateContentSize()) {
                     JwText(
                         text = stringResource(Res.string.ai_agent_connected),

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ExpandedToolingDrawerView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ExpandedToolingDrawerView.kt
@@ -346,9 +346,7 @@ private fun PluginList(
                 underAiControl = plugin.underAiControl,
                 exposesMcpTools = plugin.exposesMcpTools,
                 onClickMcpBadge = { onOpenMcpTools(plugin.id) },
-                onClick = {
-                    // do nothing
-                },
+                onClick = {},
                 popupMenuContent = { dismiss ->
                     JwMenuItem(
                         text = stringResource(Res.string.enable),
@@ -377,9 +375,7 @@ private fun PluginList(
                 underAiControl = plugin.underAiControl,
                 exposesMcpTools = plugin.exposesMcpTools,
                 onClickMcpBadge = { onOpenMcpTools(plugin.id) },
-                onClick = {
-                    // do nothing
-                },
+                onClick = {},
                 modifier = Modifier.animateItem(),
             )
         }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/McpToolsScreen.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/McpToolsScreen.kt
@@ -126,8 +126,6 @@ fun McpToolsScreen(
     JwSurface(color = JwTheme.colors.elevatedBackground, shape = JwShapes.large) {
         Column(
             modifier = Modifier
-                // Take most of the window so tool descriptions and history are readable, but stop
-                // growing past a comfortable reading width on a large display.
                 .fillMaxSize(MCP_TOOLS_DIALOG_WINDOW_FRACTION)
                 .sizeIn(
                     minWidth = 640.dp,
@@ -363,7 +361,6 @@ private fun McpToolsPane(
     val selected = filtered.firstOrNull { it.key == selectedToolKey } ?: filtered.firstOrNull()
 
     Row(modifier = modifier) {
-        // Left pane: search + tool list.
         Column(modifier = Modifier.width(320.dp)) {
             JwSearchField(
                 value = query,
@@ -377,7 +374,6 @@ private fun McpToolsPane(
                 items(filtered, key = { it.key }) { row ->
                     val isSelected = row.key == selected?.key
                     JwListItem(selected = isSelected, onClick = { onSelectTool(row.key) }) {
-                        // Takes the free space so the count sits against the right edge.
                         Column(modifier = Modifier.weight(1f)) {
                             JwText(
                                 text = row.tool.name.substringAfterLast('.'),
@@ -404,7 +400,6 @@ private fun McpToolsPane(
             }
         }
         JwVerticalDivider(modifier = Modifier.padding(horizontal = 12.dp))
-        // Right pane: the selected tool's detail.
         Column(
             modifier = Modifier
                 .weight(1f)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/DefaultLogCaptureService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/DefaultLogCaptureService.kt
@@ -25,7 +25,7 @@ class DefaultLogCaptureService : LogCaptureService {
     private var originalErr: PrintStream? = null
     private var isCapturing = false
 
-    private val maxLogEntries = 10000 // Limit to prevent memory issues
+    private val maxLogEntries = 10000
 
     override fun startCapture() {
         if (isCapturing) return

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustServiceTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/plugin/DefaultPluginTrustServiceTest.kt
@@ -151,9 +151,7 @@ class DefaultPluginTrustServiceTest {
         val diskFactory = FakePluginFactoryRepository()
         val diskService = DefaultPluginTrustService(AppDataDirectoryProvider(AdditionalPluginDirectories(emptyList())), diskRepository, diskFactory, diskSigner)
 
-        // Approve with signing off: the registry is written unsigned.
         diskService.trustAndLoad(jar.absolutePath)
-        // Turn signing on: a key is provisioned and the existing registry is re-signed.
         diskService.setSigningEnabled(true)
 
         // Fresh start with the same (now-present) key. Without the re-sign the unsigned registry would

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerService.kt
@@ -188,10 +188,6 @@ class DefaultMcpServerService(
         toolRegistry.unregister(pluginId, sessionId)
     }
 
-    // ---------------------------------------------------------------------------
-    // MCP Server factory — creates a new Server instance per SSE connection
-    // ---------------------------------------------------------------------------
-
     private fun createMcpServer(): Server {
         val server = Server(
             serverInfo = Implementation(name = "jetwhale", version = "1.0.0"),

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/DefaultMcpServerServiceTest.kt
@@ -234,7 +234,6 @@ class DefaultMcpServerServiceTest {
 
         service.start(host, port)
         try {
-            // Emit Ready event after server started (simulates Android device connecting later)
             eventFlow.emit(PluginInstanceEvent.Ready(testPluginId, testSessionId))
 
             // The event is handled asynchronously by the service's collector, so the registration

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ClickToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ClickToolTest.kt
@@ -16,7 +16,6 @@ class ClickToolTest {
     @Test
     fun `dispatchClick returns false when scene has no clickable elements`() {
         val scene = createTestScene()
-        // Render once to sync the semantics tree
         renderTestScene(scene)
 
         val result = dispatchClick(scene, 100f, 100f)
@@ -33,7 +32,6 @@ class ClickToolTest {
                     .clickable { clicked = true },
             )
         }
-        // Render to build the semantics tree and lay out nodes
         renderTestScene(scene)
 
         val result = dispatchClick(scene, 100f, 100f)

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/DragToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/DragToolTest.kt
@@ -57,7 +57,6 @@ class DragToolTest {
                         awaitPointerEventScope {
                             while (true) {
                                 val event = awaitPointerEvent()
-                                // Filter only Press/Move/Release to avoid Enter/Exit noise
                                 if (event.type !in listOf(PointerEventType.Press, PointerEventType.Move, PointerEventType.Release)) continue
                                 val pos = event.changes.firstOrNull()?.position ?: continue
                                 receivedEvents += ReceivedEvent(event.type, pos)
@@ -118,13 +117,11 @@ class DragToolTest {
             "Expected at least ${steps - 1} drag events, got ${dragPositions.size}",
         )
 
-        // Positions should be monotonically increasing toward the end
         for (i in 1 until dragPositions.size) {
             assertTrue(dragPositions[i].x >= dragPositions[i - 1].x, "Drag X should be non-decreasing at step $i")
             assertTrue(dragPositions[i].y >= dragPositions[i - 1].y, "Drag Y should be non-decreasing at step $i")
         }
 
-        // Last position should be at or near the end
         assertEquals(400f, dragPositions.last().x, 0.01f, "Last drag position X should be at endX")
         assertEquals(400f, dragPositions.last().y, 0.01f, "Last drag position Y should be at endY")
     }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/ScreenshotToolTest.kt
@@ -69,7 +69,6 @@ class ScreenshotToolTest {
 
     @Test
     fun `captureScreenshot renders colors of side-by-side boxes correctly`() {
-        // Two 50x50 boxes: red on the left, blue on the right
         val scene = createTestScene {
             Row {
                 Box(modifier = Modifier.size(50.dp).background(Color.Red))
@@ -83,7 +82,6 @@ class ScreenshotToolTest {
         scene.render(Canvas(imageBitmap))
         val pixels = imageBitmap.toPixelMap()
 
-        // Sample the center of each box
         assertEquals(Color.Red, pixels[25, 25], "Expected red at center of left box")
         assertEquals(Color.Blue, pixels[75, 25], "Expected blue at center of right box")
     }

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/TypeToolTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/TypeToolTest.kt
@@ -138,7 +138,6 @@ class TypeToolTest {
         dispatchTyping(scene, "hello")
         assertEquals("hello", textState.text.toString())
 
-        // Focus the text field so it can receive key events
         fun findFocusableNode(node: SemanticsNode): SemanticsNode? {
             node.children.forEach { child -> findFocusableNode(child)?.let { return it } }
             return if (node.config.getOrNull(SemanticsActions.RequestFocus) != null) node else null

--- a/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreenRoot.kt
+++ b/jetwhale-host/feature/plugin/src/main/kotlin/com/kitakkun/jetwhale/host/plugin/PluginScreenRoot.kt
@@ -67,7 +67,6 @@ fun PluginScreenRoot() {
                             PluginScreenErrorFallback(
                                 pluginId = screenContext.pluginId,
                                 errorBoundaryContext = it,
-                                // force recompose when reset is clicked
                                 onClickReset = { reset = !reset },
                             )
                         },

--- a/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/logviewer/components/LogViewerToolbar.kt
+++ b/jetwhale-host/feature/settings/src/main/kotlin/com/kitakkun/jetwhale/host/settings/logviewer/components/LogViewerToolbar.kt
@@ -32,7 +32,6 @@ fun LogViewerToolbar(
     onClearLogs: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // A flat bar with a hairline under it, like every other toolbar in the host.
     Column(modifier = modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier

--- a/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostPluginFactory.kt
+++ b/jetwhale-plugins/example/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/example/host/ExampleHostPluginFactory.kt
@@ -61,10 +61,6 @@ private class ExampleHostPlugin :
         )
     }
 
-    // -------------------------------------------------------------------------
-    // JetWhaleMcpCapablePlugin
-    // -------------------------------------------------------------------------
-
     override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
         object : JetWhaleMcpCommand() {
             override val name = "com.kitakkun.jetwhale.example.sendPing"

--- a/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
+++ b/jetwhale-plugins/network/agent-ktor/src/jvmTest/kotlin/com/kitakkun/jetwhale/plugins/network/agent/ktor/JetWhaleNetworkKtorPluginTest.kt
@@ -148,9 +148,8 @@ class JetWhaleNetworkKtorPluginTest {
 
         val response = client.get("http://example/todos/1")
 
-        // Before the fix, the synthesized call carried the Send-pipeline's StandaloneCoroutine as its
-        // callContext Job, so reading the mocked body threw "StandaloneCoroutine cannot be cast to
-        // CompletableJob".
+        // Reading a mocked body needs the synthesized call's context Job to be a CompletableJob,
+        // which the Send pipeline's own StandaloneCoroutine is not.
         assertEquals(200, response.status.value)
         assertEquals("{\"ok\":true}", response.bodyAsText())
     }

--- a/jetwhale-plugins/network/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin.kt
+++ b/jetwhale-plugins/network/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/agent/JetWhaleNetworkAgentPlugin.kt
@@ -70,10 +70,6 @@ class JetWhaleNetworkAgentPlugin(
         }
     }
 
-    // ---------------------------------------------------------------------------------------
-    // Adapter-facing capture API (transport-agnostic)
-    // ---------------------------------------------------------------------------------------
-
     /** Generates a transaction id correlating a request with its response/failure. */
     @OptIn(ExperimentalUuidApi::class)
     fun newTransactionId(): String = Uuid.random().toString()

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/JsonBodyView.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/JsonBodyView.kt
@@ -74,10 +74,6 @@ internal fun BodyBlock(label: String, body: String?, truncated: Boolean) {
 
 private enum class BodyMode { Tree, Raw }
 
-// ---------------------------------------------------------------------------------------
-// Accordion tree
-// ---------------------------------------------------------------------------------------
-
 @Composable
 private fun JsonTreeNode(element: JsonElement, label: String?, colors: JsonColors, depth: Int = 0) {
     when (element) {
@@ -159,10 +155,6 @@ private fun JsonLeaf(label: String?, primitive: JsonPrimitive, colors: JsonColor
         modifier = Modifier.padding(start = (depth * 16 + 16).dp, top = 1.dp, bottom = 1.dp),
     )
 }
-
-// ---------------------------------------------------------------------------------------
-// Raw (syntax-highlighted, pretty-printed)
-// ---------------------------------------------------------------------------------------
 
 private fun highlightedJson(element: JsonElement, colors: JsonColors): AnnotatedString = buildAnnotatedString { appendJson(element, 0, colors) }
 

--- a/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
+++ b/jetwhale-plugins/network/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/network/host/NetworkHostPluginFactory.kt
@@ -139,10 +139,6 @@ private class NetworkHostPlugin :
         )
     }
 
-    // -------------------------------------------------------------------------
-    // JetWhaleMcpCapablePlugin
-    // -------------------------------------------------------------------------
-
     override val mcpCommands: List<JetWhaleMcpCommand> = listOf(
         ListTransactionsCommand(transactions = { transactions.toList() }, redactForMcp = { it.redactedForMcp() }),
         GetTransactionCommand(transactions = { transactions.toList() }, redactForMcp = { it.redactedForMcp() }),

--- a/jetwhale-plugins/network/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/protocol/NetworkMessages.kt
+++ b/jetwhale-plugins/network/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/network/protocol/NetworkMessages.kt
@@ -5,8 +5,6 @@ import com.kitakkun.jetwhale.protocol.messaging.JetWhaleRequest
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-// -- Events: agent (debuggee) -> host ----------------------------------------
-
 @SerialName("network/request_sent")
 @Serializable
 data class RequestSent(val request: CapturedHttpRequest) : JetWhaleEvent
@@ -19,8 +17,6 @@ data class ResponseReceived(val response: CapturedHttpResponse) : JetWhaleEvent
 @Serializable
 data class RequestFailed(val failure: HttpRequestFailure) : JetWhaleEvent
 
-// -- Requests: host -> agent (debuggee) --------------------------------------
-
 @SerialName("network/set_mock_rules")
 @Serializable
 data class SetMockRules(val rules: List<MockRule>) : JetWhaleRequest<Ack>
@@ -28,8 +24,6 @@ data class SetMockRules(val rules: List<MockRule>) : JetWhaleRequest<Ack>
 @SerialName("network/set_mocking_enabled")
 @Serializable
 data class SetMockingEnabled(val enabled: Boolean) : JetWhaleRequest<Ack>
-
-// -- Preparation messages (sent from the host's onPrepare) --------------------
 
 /**
  * Host -> agent, on connect: fetches the mock configuration the agent holds (it is the source of
@@ -48,8 +42,6 @@ data object GetMockConfig : JetWhaleRequest<MockConfig>
 @SerialName("network/get_redaction_config")
 @Serializable
 data object GetRedactionConfig : JetWhaleRequest<RedactionConfig>
-
-// -- Replies -----------------------------------------------------------------
 
 @SerialName("network/ack")
 @Serializable

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
@@ -88,10 +88,6 @@ private class ComposeNodeInspectorHostPlugin :
         )
     }
 
-    // -------------------------------------------------------------------------
-    // JetWhaleHostPluginUi
-    // -------------------------------------------------------------------------
-
     @Composable
     override fun Content() {
         ComposeSemanticsInspectorScreen(
@@ -135,10 +131,6 @@ private class ComposeNodeInspectorHostPlugin :
             onCommitViewAttribute = viewAttributes::commit,
         )
     }
-
-    // -------------------------------------------------------------------------
-    // JetWhaleMcpCapablePlugin
-    // -------------------------------------------------------------------------
 
     // Lazy for the same reason the store is: reading this list builds the store, and the store needs
     // pluginScope. The runtime asks for the commands well after it has bound one.

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ViewAttributeCommands.kt
@@ -23,8 +23,7 @@ import kotlinx.serialization.json.put
 // rather than the tree, and because only View nodes have anything to answer.
 
 // Both tools describe the value types from ViewAttributeType rather than spelling them out, so a
-// type added there cannot leave the descriptions behind — which is how they came to advertise a
-// shape a read no longer had.
+// type added there cannot leave the descriptions behind.
 private val WRITTEN_AS_BY_TYPE = ViewAttributeType.entries.joinToString(", ") { "${it.wireName} takes ${it.writtenAs}" }
 
 private val EXTRA_FIELDS_BY_TYPE = ViewAttributeType.entries


### PR DESCRIPTION
## Why

A comment that narrates the statement under it costs twice: a reader has to verify it against the
code before trusting it, and it drifts out of date the moment that code changes. Where the code
already says the thing, the comment is noise.

## What was removed

All 691 Kotlin files were read for line comments (~1700 lines). What went:

- **Narration of the next statement** — `// Start capturing logs` above `logCaptureService.startCapture()`,
  `// automatically remove closed plugin sessions from back stack` above the `removeAll` that does it.
- **Decorative section banners** — `// ----- JetWhaleMcpCapablePlugin -----` and friends. The
  declarations below them already say what they are; in `NetworkMessages.kt` the direction banners
  repeat what `JetWhaleEvent` / `JetWhaleRequest` state in the type.
- **`// do nothing` on empty blocks** — written as `Unit` or `{}` instead, which reads as deliberate
  without a sentence saying so.
- **Two comments framed as history** (`// Before the fix, ...`) — rewritten as the constraint that
  still holds. History belongs in git.

## What was kept

Comments that carry what the code cannot: a platform or library behavior the call site cannot show
(`NsdManager requires the trailing dot`, `save() buffers the whole body`), a deliberate trade-off,
why something is deliberately *absent*, and the wire-protocol placeholder that looks dead but must
stay. Most of this repository's comments are of that kind and are untouched.

## The rule

`.claude/rules/comments.md` records the bar so it does not have to be re-litigated: rename, then
restructure, then let a test name speak — and only comment what is left.

## Verification

`spotlessCheck` plus the tests and compilation of every module touched (host app, core:data,
core:mcp, feature:settings, feature:plugin, the network and semantics plugins, agent-runtime).