### PR TITLE
fix(semantics): a scrollable is not obstructed by its own descendant

### DIFF
--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -258,7 +258,8 @@ touch. That catches what is worth catching:
 
 The last two differ because the gesture does: a tap stops at the deepest node that takes it, while
 a drag is seen by every scrollable on the way down. So `obscuredBy` on a scrollable only ever names
-something outside it — a sibling drawn on top, or another window.
+something outside it — a sibling drawn on top, or another window. A node that accepts both — a
+scrollable that is also clickable — reads `hittable: true` when either gesture gets through.
 
 Two things a capture cannot see, and both make it *optimistic* — a node can read as reachable that a
 finger would not reach:

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -239,9 +239,9 @@ appear below that — see [Editing View attributes](#editing-view-attributes).
 
 ## Can a finger reach it?
 
-Every captured node says whether a tap aimed at it would actually arrive. A node that accepts touch
-input but cannot receive one is marked `"hittable": false`, with `obscuredBy` naming what takes the
-tap instead, and the tree view tags the row **unreachable**.
+Every captured node says whether a gesture aimed at it would actually arrive. A node that accepts
+touch input but cannot receive one is marked `"hittable": false`, with `obscuredBy` naming what takes
+the touch instead, and the tree view tags the row **unreachable**.
 
 It is worked out from the capture alone — no tap sent, nothing to wait for — by walking the windows
 from the top down and, within a window, the last-drawn node first, the way the platform dispatches a
@@ -253,6 +253,12 @@ touch. That catches what is worth catching:
 | behind a modal window, anywhere on screen | `hittable: false`, `obscuredBy` that window's root |
 | scrolled out of its container | `hittable: false`, no `obscuredBy` — no area to aim at |
 | under a later sibling that takes touches | `hittable: false`, `obscuredBy` that sibling |
+| a clickable row whose center is its own button | `hittable: false`, `obscuredBy` that button — the tap is consumed there |
+| a list whose center is one of its own rows | `hittable: true` — a drag starting on the row still scrolls the list |
+
+The last two differ because the gesture does: a tap stops at the deepest node that takes it, while
+a drag is seen by every scrollable on the way down. So `obscuredBy` on a scrollable only ever names
+something outside it — a sibling drawn on top, or another window.
 
 Two things a capture cannot see, and both make it *optimistic* — a node can read as reachable that a
 finger would not reach:

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -435,7 +435,7 @@ private fun NodeDetail(
             if (!node.isHittable) {
                 PropertyRow(
                     "reachable by touch",
-                    node.obscuredBy?.let { "no — #${it.nodeId} takes the tap (${it.rootId})" } ?: "no — nothing to aim at",
+                    node.obscuredBy?.let { "no — #${it.nodeId} takes the touch (${it.rootId})" } ?: "no — nothing to aim at",
                     wrap = true,
                 )
             }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
@@ -35,7 +35,7 @@ internal class FindNodesCommand(
         "Keep only nodes that expose an action, are editable, or scroll. Defaults to true when no other criterion is given, false otherwise.",
     )
     private val hittableOnly by booleanOrNull(
-        "Keep only nodes a tap actually reaches — not covered by another node or window, and not clipped away. " +
+        "Keep only nodes a gesture they accept actually reaches — not covered by another node or window, and not clipped away. " +
             "Off by default, so a node that is on screen but unreachable still turns up, marked \"hittable\": false.",
     )
     private val exact by booleanOrNull("Compare whole values instead of substrings. Defaults to false.")

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTree.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTree.kt
@@ -102,7 +102,7 @@ internal data class NodeQuery(
     val resourceId: String? = null,
     val role: String? = null,
     val interactiveOnly: Boolean = false,
-    /** Keep only nodes a tap actually reaches — see [UiNode.isHittable]. */
+    /** Keep only nodes a gesture they accept actually reaches — see [UiNode.isHittable]. */
     val hittableOnly: Boolean = false,
     /** Compare whole values instead of substrings. Substring matching is the default because a
      *  caller usually knows part of a label, not its exact composition. */

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeHitTesting.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeHitTesting.kt
@@ -107,12 +107,17 @@ private fun UiNode.resolveHits(rootId: String, winnerAt: (x: Float, y: Float) ->
     if (boundsInScreen.isEmpty) return withHits(isHittable = false, obscuredBy = null, children = resolvedChildren)
 
     val self = NodeRef(rootId, id)
-    return when (val winner = winnerAt(boundsInScreen.centerX, boundsInScreen.centerY)) {
-        is NodeHitTesting.TouchTarget.Node -> withHits(
-            isHittable = winner.ref == self,
-            obscuredBy = winner.ref.takeIf { it != self },
-            children = resolvedChildren,
-        )
+    val centerX = boundsInScreen.centerX
+    val centerY = boundsInScreen.centerY
+    return when (val winner = winnerAt(centerX, centerY)) {
+        is NodeHitTesting.TouchTarget.Node -> {
+            val reached = winner.ref == self || (isScrollable && winner.ref == descendantWinnerAt(rootId, centerX, centerY))
+            withHits(
+                isHittable = reached,
+                obscuredBy = winner.ref.takeUnless { reached },
+                children = resolvedChildren,
+            )
+        }
 
         // Named rather than left blank: the window is what a caller looks at next.
         is NodeHitTesting.TouchTarget.Window -> withHits(isHittable = false, obscuredBy = winner.rootNode, children = resolvedChildren)
@@ -120,6 +125,18 @@ private fun UiNode.resolveHits(rootId: String, winnerAt: (x: Float, y: Float) ->
         NodeHitTesting.TouchTarget.Nothing -> withHits(isHittable = false, obscuredBy = null, children = resolvedChildren)
     }
 }
+
+/**
+ * The node this subtree alone would dispatch a touch at the point to, or `null` when none of it
+ * accepts one there. Equal to the window's winner exactly when that winner lies in this subtree.
+ *
+ * A scrollable asks this because a gesture is not consumed by the leaf alone: Compose delivers
+ * pointer events to every pointer-input node from the root down to the hit leaf, and an Android
+ * `ViewGroup` sees them first in `onInterceptTouchEvent`. A drag that starts on a row still scrolls
+ * the list around it, so a descendant taking the touch obstructs nothing. A click is different: a
+ * clickable descendant consumes the tap and the ancestor's click never fires.
+ */
+private fun UiNode.descendantWinnerAt(rootId: String, screenX: Float, screenY: Float): NodeRef? = topmostAt(screenX, screenY)?.let { NodeRef(rootId, it.id) }
 
 private fun UiNode.withHits(isHittable: Boolean, obscuredBy: NodeRef?, children: List<UiNode>): UiNode = when (this) {
     is ComposeNode -> copy(isHittable = isHittable, obscuredBy = obscuredBy, children = children)

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeModels.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeModels.kt
@@ -151,7 +151,11 @@ sealed interface UiNode {
      * What counts as reaching depends on the gesture. A tap is consumed by the deepest node that
      * takes it, so a clickable node is obstructed by its own clickable child. A drag is seen by every
      * scrollable on the way down, so a scrollable is obstructed only by something outside its
-     * subtree — a sibling drawn on top, or another window.
+     * subtree — a sibling drawn on top, or another window. A node that accepts more than one
+     * gesture is hittable when any of them reaches it: a scrollable that is also clickable reads
+     * `true` with its center on its own button, although the click would land on the button. One
+     * flag cannot say which gesture gets through; that it errs towards reachable is in keeping
+     * with the rest of this answer.
      *
      * Only a node that accepts touch input is tested; anything else reports `true`, having nothing
      * to be obstructed for. Being hittable is about delivery, not about what the node does with the

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeModels.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeModels.kt
@@ -144,8 +144,14 @@ sealed interface UiNode {
     val isVisible: Boolean
 
     /**
-     * `false` when a tap at the center of [boundsInScreen] would not reach this node — it is
-     * covered, clipped away, or behind another window. [obscuredBy] then names what takes the tap.
+     * `false` when a gesture this node accepts, started at the center of [boundsInScreen], would not
+     * reach it — it is covered, clipped away, or behind another window. [obscuredBy] then names
+     * what takes the touch.
+     *
+     * What counts as reaching depends on the gesture. A tap is consumed by the deepest node that
+     * takes it, so a clickable node is obstructed by its own clickable child. A drag is seen by every
+     * scrollable on the way down, so a scrollable is obstructed only by something outside its
+     * subtree — a sibling drawn on top, or another window.
      *
      * Only a node that accepts touch input is tested; anything else reports `true`, having nothing
      * to be obstructed for. Being hittable is about delivery, not about what the node does with the
@@ -156,7 +162,7 @@ sealed interface UiNode {
      */
     val isHittable: Boolean
 
-    /** What receives a tap aimed at this node instead of it, when [isHittable] is `false`. */
+    /** What takes the touch aimed at this node instead of it, when [isHittable] is `false`. */
     val obscuredBy: NodeRef?
 
     /** Children of either type: an Android tree crosses between the two wherever the real UI does. */

--- a/jetwhale-plugins/semantics/protocol/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeHitTestingTest.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeHitTestingTest.kt
@@ -65,6 +65,44 @@ class NodeHitTestingTest {
     }
 
     @Test
+    fun `a list is not obstructed by the row its center lands on`() {
+        val roots = NodeHitTesting.resolve(
+            listOf(
+                root(
+                    list(
+                        id = 1,
+                        at = rect(0f, 0f, 100f, 200f),
+                        children = listOf(button(id = 2, at = rect(0f, 80f, 100f, 120f))),
+                    ),
+                ),
+            ),
+        )
+
+        assertTrue(roots.node(1).isHittable, "a drag starting on the row still scrolls the list")
+        assertNull(roots.node(1).obscuredBy)
+        assertTrue(roots.node(2).isHittable)
+    }
+
+    @Test
+    fun `a list is still obstructed by a sibling drawn over its center`() {
+        val roots = NodeHitTesting.resolve(
+            listOf(
+                root(
+                    list(
+                        id = 1,
+                        at = rect(0f, 0f, 100f, 200f),
+                        children = listOf(button(id = 2, at = rect(0f, 80f, 100f, 120f))),
+                    ),
+                    button(id = 3, at = rect(0f, 80f, 100f, 120f)),
+                ),
+            ),
+        )
+
+        assertEquals(false, roots.node(1).isHittable)
+        assertEquals(NodeRef(ROOT_ID, 3), roots.node(1).obscuredBy)
+    }
+
+    @Test
     fun `a node clipped out of its scroll container has no area to tap`() {
         val roots = NodeHitTesting.resolve(
             listOf(root(button(id = 1, at = rect(0f, 0f, 100f, 50f), inScreen = rect(0f, 0f, 0f, 0f)))),
@@ -219,6 +257,15 @@ private fun button(
     boundsInScreen = inScreen,
     isClickable = true,
     actions = listOf("OnClick"),
+    children = children,
+)
+
+private fun list(id: Int, at: NodeBounds, children: List<UiNode>) = ComposeNode(
+    id = id,
+    bounds = at,
+    boundsInScreen = at,
+    isScrollable = true,
+    actions = listOf("ScrollBy"),
     children = children,
 )
 

--- a/jetwhale-plugins/semantics/protocol/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeHitTestingTest.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeHitTestingTest.kt
@@ -84,6 +84,25 @@ class NodeHitTestingTest {
     }
 
     @Test
+    fun `a list that is also clickable reads reachable while its row takes the tap`() {
+        val roots = NodeHitTesting.resolve(
+            listOf(
+                root(
+                    list(
+                        id = 1,
+                        at = rect(0f, 0f, 100f, 200f),
+                        children = listOf(button(id = 2, at = rect(0f, 80f, 100f, 120f))),
+                        isClickable = true,
+                    ),
+                ),
+            ),
+        )
+
+        assertTrue(roots.node(1).isHittable, "one flag answers for every gesture the node accepts, and the drag gets through")
+        assertNull(roots.node(1).obscuredBy)
+    }
+
+    @Test
     fun `a list is still obstructed by a sibling drawn over its center`() {
         val roots = NodeHitTesting.resolve(
             listOf(
@@ -260,12 +279,13 @@ private fun button(
     children = children,
 )
 
-private fun list(id: Int, at: NodeBounds, children: List<UiNode>) = ComposeNode(
+private fun list(id: Int, at: NodeBounds, children: List<UiNode>, isClickable: Boolean = false) = ComposeNode(
     id = id,
     bounds = at,
     boundsInScreen = at,
+    isClickable = isClickable,
     isScrollable = true,
-    actions = listOf("ScrollBy"),
+    actions = listOfNotNull("ScrollBy", "OnClick".takeIf { isClickable }),
     children = children,
 )
 


### PR DESCRIPTION
## Summary

Fixes #260.

`NodeHitTesting.resolveHits` sampled a node's center and counted it hittable only when the dispatch winner was the node itself. A scrollable container whose center is covered by its own clickable row — the normal state of any filled list — was therefore reported `"hittable": false` with `obscuredBy` pointing at its own descendant, and `hittableOnly: true` filtered it out entirely.

## What changed

A tap and a drag are consumed differently, so hittability is now decided per capability:

- **scrollable**: hittable when the center's winner lies in the node's own subtree. Compose delivers pointer events to every pointer-input node from the root down to the hit leaf, and an Android `ViewGroup` sees them first in `onInterceptTouchEvent`, so a drag starting on a row still scrolls the list.
- **clickable / editable / toggleable / long-clickable**: the strict self-winner rule stays. A tap consumed by a clickable descendant never fires the ancestor's click.

The subtree check reuses `topmostAt` from the node itself and compares the result with the window-wide winner, so it costs a walk down one path rather than a scan of the subtree.

`obscuredBy` on a scrollable now only ever names something outside it — a sibling drawn on top, or another window.

Docs and the `isHittable` / `obscuredBy` KDoc are reworded from "a tap" to "a gesture the node accepts", and the guide's table gains the clickable-row vs. list contrast.

## Tests

Two new cases in `NodeHitTestingTest`:

- a list is not obstructed by the row its center lands on
- a list is still obstructed by a sibling drawn over its center

The existing "a child takes the tap from the clickable row it sits in" case is unchanged and still passes.

`:jetwhale-plugins:semantics:{protocol,host,agent}` tests: 104 passed, 0 failed. `spotlessKotlinCheck` passes.
