### PR TITLE
feat(semantics)!: answer "can the user operate it" with one operable flag

### DIFF
--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -14,8 +14,9 @@ browse it in the host and hand it to an AI agent over [MCP](/guide/mcp-server).
 - 🪟 Dialogs and popups appear as their own roots, because that is what they are in Compose
 - 🤝 On Android, the Android `View`s around and inside the composition are in the same tree, and a
   `View`'s attributes can be read and edited live — see [Android View support](#android-view-support)
-- 🖐 Whether a tap aimed at a node would actually arrive, worked out from the capture rather than by
-  tapping — see [Can a finger reach it?](#can-a-finger-reach-it)
+- 🖐 Whether the user could operate a node right now — enabled, and reached by a gesture it
+  accepts — worked out from the capture rather than by tapping — see
+  [Can the user operate it?](#can-the-user-operate-it)
 - 🤖 Six MCP tools so an agent can see the screen structurally instead of guessing at pixels
 
 ## What the tree contains
@@ -237,11 +238,21 @@ actually exposes. There is also a **Copy `adb shell input tap`** button for the 
 drive the app through the input system. Select an Android `View` node and its editable attributes
 appear below that — see [Editing View attributes](#editing-view-attributes).
 
+## Can the user operate it?
+
+The question an agent has before it acts is one word: `interactable`. A node is interactable when it
+offers something to do (an action, editable content, or scrolling), is enabled, and a gesture it
+accepts actually reaches it. A node that offers something to do but fails one of those is marked
+`"interactable": false`, with `enabled`, `hittable` and `obscuredBy` saying which; the tree view tags
+the row **not interactable**. `findNodes(interactableOnly: true)` keeps only the nodes that pass.
+
+A label is never marked either way: there is nothing on it to operate.
+
 ## Can a finger reach it?
 
-Every captured node says whether a gesture aimed at it would actually arrive. A node that accepts
-touch input but cannot receive one is marked `"hittable": false`, with `obscuredBy` naming what takes
-the touch instead, and the tree view tags the row **unreachable**.
+The reachability half of that answer is its own flag. Every captured node says whether a gesture
+aimed at it would actually arrive. A node that accepts touch input but cannot receive one is marked
+`"hittable": false`, with `obscuredBy` naming what takes the touch instead.
 
 It is worked out from the capture alone — no tap sent, nothing to wait for — by walking the windows
 from the top down and, within a window, the last-drawn node first, the way the platform dispatches a
@@ -322,7 +333,9 @@ point.
 Criteria (`text`, `contentDescription`, `testTag`, `resourceId`, `role`) are combined with AND and
 match case-insensitively by substring unless `exact` is set — `resourceId` is the exception, always
 compared whole, because a resource id is an identifier rather than a label. With no criteria at all
-it lists everything interactive on screen — a good way to answer "what can I do here?".
+it lists everything interactive on screen — a good way to answer "what can I do here?". Add
+`interactableOnly: true` to narrow that to what the user could operate right now — see
+[Can the user operate it?](#can-the-user-operate-it).
 
 An Android `View` node is marked with `"kind": "View"` and carries its `viewClass` and `resourceId` —
 see [Android View support](#android-view-support).

--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -240,11 +240,11 @@ appear below that — see [Editing View attributes](#editing-view-attributes).
 
 ## Can the user operate it?
 
-The question an agent has before it acts is one word: `interactable`. A node is interactable when it
+The question an agent has before it acts is one word: `operable`. A node is operable when it
 offers something to do (an action, editable content, or scrolling), is enabled, and a gesture it
 accepts actually reaches it. A node that offers something to do but fails one of those is marked
-`"interactable": false`, with `enabled`, `hittable` and `obscuredBy` saying which; the tree view tags
-the row **not interactable**. `findNodes(interactableOnly: true)` keeps only the nodes that pass.
+`"operable": false`, with `enabled`, `hittable` and `obscuredBy` saying which; the tree view tags
+the row **not operable**. `findNodes(operableOnly: true)` keeps only the nodes that pass.
 
 A label is never marked either way: there is nothing on it to operate.
 
@@ -334,7 +334,7 @@ Criteria (`text`, `contentDescription`, `testTag`, `resourceId`, `role`) are com
 match case-insensitively by substring unless `exact` is set — `resourceId` is the exception, always
 compared whole, because a resource id is an identifier rather than a label. With no criteria at all
 it lists everything interactive on screen — a good way to answer "what can I do here?". Add
-`interactableOnly: true` to narrow that to what the user could operate right now — see
+`operableOnly: true` to narrow that to what the user could operate right now — see
 [Can the user operate it?](#can-the-user-operate-it).
 
 An Android `View` node is marked with `"kind": "View"` and carries its `viewClass` and `resourceId` —

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -345,10 +345,10 @@ private fun NodeRow(
             if (row.node.isInteractive) {
                 JwTag(text = row.node.actionSummary(), tone = JwTone.Accent)
             }
-            // A node that offers an action a finger cannot reach is the one worth spotting from the
-            // tree, without opening it.
-            if (!row.node.isHittable) {
-                JwTag(text = "unreachable", tone = JwTone.Warning)
+            // A node that offers something to do but cannot be operated is the one worth spotting
+            // from the tree, without opening it.
+            if (row.node.isInteractive && !row.node.isInteractable) {
+                JwTag(text = "not interactable", tone = JwTone.Warning)
             }
             // A node with no semantics of its own is already labelled by its id; repeating it here
             // would render "#12 #12".
@@ -432,12 +432,8 @@ private fun NodeDetail(
                 wrap = true,
             )
             PropertyRow("actions", node.actions.joinToString(", ").ifEmpty { "—" }, wrap = true)
-            if (!node.isHittable) {
-                PropertyRow(
-                    "reachable by touch",
-                    node.obscuredBy?.let { "no — #${it.nodeId} takes the touch (${it.rootId})" } ?: "no — nothing to aim at",
-                    wrap = true,
-                )
+            if (node.isInteractive && !node.isInteractable) {
+                PropertyRow("interactable", "no — ${node.whyNotInteractable()}", wrap = true)
             }
         }
 
@@ -553,4 +549,9 @@ private val NodeAction.semanticsKeyName: String
 @Composable
 private fun PropertyRow(label: String, value: String, wrap: Boolean = false) {
     JwKeyValueRow(key = label, value = value, keyWidth = PropertyKeyWidth, monospace = true, wrap = wrap)
+}
+
+private fun UiNode.whyNotInteractable(): String {
+    if (!isEnabled) return "disabled"
+    return obscuredBy?.let { "#${it.nodeId} takes the touch (${it.rootId})" } ?: "nothing to aim at"
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -347,8 +347,8 @@ private fun NodeRow(
             }
             // A node that offers something to do but cannot be operated is the one worth spotting
             // from the tree, without opening it.
-            if (row.node.isInteractive && !row.node.isInteractable) {
-                JwTag(text = "not interactable", tone = JwTone.Warning)
+            if (row.node.isInteractive && !row.node.isOperable) {
+                JwTag(text = "not operable", tone = JwTone.Warning)
             }
             // A node with no semantics of its own is already labelled by its id; repeating it here
             // would render "#12 #12".
@@ -432,8 +432,8 @@ private fun NodeDetail(
                 wrap = true,
             )
             PropertyRow("actions", node.actions.joinToString(", ").ifEmpty { "—" }, wrap = true)
-            if (node.isInteractive && !node.isInteractable) {
-                PropertyRow("interactable", "no — ${node.whyNotInteractable()}", wrap = true)
+            if (node.isInteractive && !node.isOperable) {
+                PropertyRow("operable", "no — ${node.whyNotOperable()}", wrap = true)
             }
         }
 
@@ -551,7 +551,7 @@ private fun PropertyRow(label: String, value: String, wrap: Boolean = false) {
     JwKeyValueRow(key = label, value = value, keyWidth = PropertyKeyWidth, monospace = true, wrap = wrap)
 }
 
-private fun UiNode.whyNotInteractable(): String {
+private fun UiNode.whyNotOperable(): String {
     if (!isEnabled) return "disabled"
     return obscuredBy?.let { "#${it.nodeId} takes the touch (${it.rootId})" } ?: "nothing to aim at"
 }

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
@@ -34,10 +34,10 @@ internal class FindNodesCommand(
     private val interactiveOnly by booleanOrNull(
         "Keep only nodes that expose an action, are editable, or scroll. Defaults to true when no other criterion is given, false otherwise.",
     )
-    private val interactableOnly by booleanOrNull(
+    private val operableOnly by booleanOrNull(
         "Keep only nodes the user could operate right now: interactive, enabled, and reached by a gesture they accept — " +
             "not disabled, covered by another node or window, or clipped away. Off by default, so such a node still turns up, " +
-            "marked \"interactable\": false with \"enabled\", \"hittable\" and \"obscuredBy\" saying why.",
+            "marked \"operable\": false with \"enabled\", \"hittable\" and \"obscuredBy\" saying why.",
     )
     private val exact by booleanOrNull("Compare whole values instead of substrings. Defaults to false.")
     private val merged by booleanOrNull("Search the merged tree (default true). See getNodeTree.")
@@ -54,7 +54,7 @@ internal class FindNodesCommand(
             testTag = arguments[testTag],
             resourceId = arguments[resourceId],
             role = arguments[role],
-            interactableOnly = arguments[interactableOnly] ?: false,
+            operableOnly = arguments[operableOnly] ?: false,
             exact = arguments[exact] ?: false,
         )
         // With no criterion at all, "every node on screen" is never the useful answer; the caller is

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/FindNodesCommand.kt
@@ -34,9 +34,10 @@ internal class FindNodesCommand(
     private val interactiveOnly by booleanOrNull(
         "Keep only nodes that expose an action, are editable, or scroll. Defaults to true when no other criterion is given, false otherwise.",
     )
-    private val hittableOnly by booleanOrNull(
-        "Keep only nodes a gesture they accept actually reaches — not covered by another node or window, and not clipped away. " +
-            "Off by default, so a node that is on screen but unreachable still turns up, marked \"hittable\": false.",
+    private val interactableOnly by booleanOrNull(
+        "Keep only nodes the user could operate right now: interactive, enabled, and reached by a gesture they accept — " +
+            "not disabled, covered by another node or window, or clipped away. Off by default, so such a node still turns up, " +
+            "marked \"interactable\": false with \"enabled\", \"hittable\" and \"obscuredBy\" saying why.",
     )
     private val exact by booleanOrNull("Compare whole values instead of substrings. Defaults to false.")
     private val merged by booleanOrNull("Search the merged tree (default true). See getNodeTree.")
@@ -53,7 +54,7 @@ internal class FindNodesCommand(
             testTag = arguments[testTag],
             resourceId = arguments[resourceId],
             role = arguments[role],
-            hittableOnly = arguments[hittableOnly] ?: false,
+            interactableOnly = arguments[interactableOnly] ?: false,
             exact = arguments[exact] ?: false,
         )
         // With no criterion at all, "every node on screen" is never the useful answer; the caller is

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJson.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJson.kt
@@ -80,8 +80,9 @@ internal fun UiNode.toMcpJson(rootId: String? = null, includeChildren: Boolean =
     if (isEditable) put("editable", true)
     if (isScrollable) put("scrollable", true)
     if (!isVisible) put("visible", false)
-    // A node that accepts touch but cannot receive one is the surprising case, and the reason a
-    // caller reaches for coordinates at all: it says the tap would land somewhere else.
+    // Something to operate that cannot be operated is the surprising case; the flags below say why.
+    if (isInteractive && !isInteractable) put("interactable", false)
+    // The reason a caller reaches for coordinates at all: the touch would land somewhere else.
     if (!isHittable) {
         put("hittable", false)
         obscuredBy?.let { obstruction ->

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJson.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJson.kt
@@ -81,7 +81,7 @@ internal fun UiNode.toMcpJson(rootId: String? = null, includeChildren: Boolean =
     if (isScrollable) put("scrollable", true)
     if (!isVisible) put("visible", false)
     // Something to operate that cannot be operated is the surprising case; the flags below say why.
-    if (isInteractive && !isInteractable) put("interactable", false)
+    if (isInteractive && !isOperable) put("operable", false)
     // The reason a caller reaches for coordinates at all: the touch would land somewhere else.
     if (!isHittable) {
         put("hittable", false)

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTree.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTree.kt
@@ -74,7 +74,7 @@ internal val UiNode.isInteractive: Boolean
  * gesture it accepts reaches it. The one answer an agent wants before it acts; the three facts it
  * is made of say why when it is `false`.
  */
-internal val UiNode.isInteractable: Boolean
+internal val UiNode.isOperable: Boolean
     get() = isInteractive && isEnabled && isHittable
 
 /** How a node should read in a list: its own label if it has one, otherwise its role or id. */
@@ -110,15 +110,15 @@ internal data class NodeQuery(
     val resourceId: String? = null,
     val role: String? = null,
     val interactiveOnly: Boolean = false,
-    /** Keep only nodes the user could operate right now — see [UiNode.isInteractable]. */
-    val interactableOnly: Boolean = false,
+    /** Keep only nodes the user could operate right now — see [UiNode.isOperable]. */
+    val operableOnly: Boolean = false,
     /** Compare whole values instead of substrings. Substring matching is the default because a
      *  caller usually knows part of a label, not its exact composition. */
     val exact: Boolean = false,
 ) {
     val isEmpty: Boolean
         get() = text == null && contentDescription == null && testTag == null && resourceId == null && role == null &&
-            !interactiveOnly && !interactableOnly
+            !interactiveOnly && !operableOnly
 }
 
 /**
@@ -128,7 +128,7 @@ internal data class NodeQuery(
  */
 internal fun UiNode.matches(query: NodeQuery): Boolean {
     if (query.interactiveOnly && !isInteractive) return false
-    if (query.interactableOnly && !isInteractable) return false
+    if (query.operableOnly && !isOperable) return false
     if (!fieldMatches(query.text, listOfNotNull(text, editableText), query.exact)) return false
     if (!fieldMatches(query.contentDescription, listOfNotNull(contentDescription), query.exact)) return false
     if (!fieldMatches(query.testTag, listOfNotNull((this as? ComposeNode)?.testTag), query.exact)) return false

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTree.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTree.kt
@@ -69,6 +69,14 @@ internal fun NodeTreeSnapshot?.viewAttributeNode(selected: NodeKey?): NodeKey? {
 internal val UiNode.isInteractive: Boolean
     get() = actions.isNotEmpty() || isClickable || isEditable || isScrollable
 
+/**
+ * `true` when the user could operate the node right now: it is [isInteractive], enabled, and a
+ * gesture it accepts reaches it. The one answer an agent wants before it acts; the three facts it
+ * is made of say why when it is `false`.
+ */
+internal val UiNode.isInteractable: Boolean
+    get() = isInteractive && isEnabled && isHittable
+
 /** How a node should read in a list: its own label if it has one, otherwise its role or id. */
 internal fun UiNode.displayLabel(): String {
     val label = text ?: contentDescription ?: editableText ?: (this as? ComposeNode)?.testTag
@@ -102,15 +110,15 @@ internal data class NodeQuery(
     val resourceId: String? = null,
     val role: String? = null,
     val interactiveOnly: Boolean = false,
-    /** Keep only nodes a gesture they accept actually reaches — see [UiNode.isHittable]. */
-    val hittableOnly: Boolean = false,
+    /** Keep only nodes the user could operate right now — see [UiNode.isInteractable]. */
+    val interactableOnly: Boolean = false,
     /** Compare whole values instead of substrings. Substring matching is the default because a
      *  caller usually knows part of a label, not its exact composition. */
     val exact: Boolean = false,
 ) {
     val isEmpty: Boolean
         get() = text == null && contentDescription == null && testTag == null && resourceId == null && role == null &&
-            !interactiveOnly && !hittableOnly
+            !interactiveOnly && !interactableOnly
 }
 
 /**
@@ -120,7 +128,7 @@ internal data class NodeQuery(
  */
 internal fun UiNode.matches(query: NodeQuery): Boolean {
     if (query.interactiveOnly && !isInteractive) return false
-    if (query.hittableOnly && !isHittable) return false
+    if (query.interactableOnly && !isInteractable) return false
     if (!fieldMatches(query.text, listOfNotNull(text, editableText), query.exact)) return false
     if (!fieldMatches(query.contentDescription, listOfNotNull(contentDescription), query.exact)) return false
     if (!fieldMatches(query.testTag, listOfNotNull((this as? ComposeNode)?.testTag), query.exact)) return false

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJsonTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJsonTest.kt
@@ -54,23 +54,23 @@ class NodeMcpJsonTest {
         val json = node(id = 7, isClickable = true).toMcpJson()
 
         assertNull(json["hittable"])
-        assertNull(json["interactable"])
+        assertNull(json["operable"])
     }
 
     @Test
     fun `something to operate that cannot be operated says so, next to the reason`() {
         val disabled = node(id = 7, isClickable = true, isEnabled = false).toMcpJson()
-        assertEquals(false, disabled["interactable"]?.jsonPrimitive?.content?.toBoolean())
+        assertEquals(false, disabled["operable"]?.jsonPrimitive?.content?.toBoolean())
         assertEquals(false, disabled["enabled"]?.jsonPrimitive?.content?.toBoolean())
 
         val obstructed = node(id = 8, isClickable = true, isHittable = false).toMcpJson()
-        assertEquals(false, obstructed["interactable"]?.jsonPrimitive?.content?.toBoolean())
+        assertEquals(false, obstructed["operable"]?.jsonPrimitive?.content?.toBoolean())
         assertEquals(false, obstructed["hittable"]?.jsonPrimitive?.content?.toBoolean())
     }
 
     @Test
-    fun `a label is never called uninteractable, having nothing to operate`() {
-        assertNull(node(id = 1, text = "label", isEnabled = false).toMcpJson()["interactable"])
+    fun `a label is never called inoperable, having nothing to operate`() {
+        assertNull(node(id = 1, text = "label", isEnabled = false).toMcpJson()["operable"])
     }
 
     @Test

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJsonTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeMcpJsonTest.kt
@@ -51,7 +51,26 @@ class NodeMcpJsonTest {
 
     @Test
     fun `a reachable node stays silent about it`() {
-        assertNull(node(id = 7, isClickable = true).toMcpJson()["hittable"])
+        val json = node(id = 7, isClickable = true).toMcpJson()
+
+        assertNull(json["hittable"])
+        assertNull(json["interactable"])
+    }
+
+    @Test
+    fun `something to operate that cannot be operated says so, next to the reason`() {
+        val disabled = node(id = 7, isClickable = true, isEnabled = false).toMcpJson()
+        assertEquals(false, disabled["interactable"]?.jsonPrimitive?.content?.toBoolean())
+        assertEquals(false, disabled["enabled"]?.jsonPrimitive?.content?.toBoolean())
+
+        val obstructed = node(id = 8, isClickable = true, isHittable = false).toMcpJson()
+        assertEquals(false, obstructed["interactable"]?.jsonPrimitive?.content?.toBoolean())
+        assertEquals(false, obstructed["hittable"]?.jsonPrimitive?.content?.toBoolean())
+    }
+
+    @Test
+    fun `a label is never called uninteractable, having nothing to operate`() {
+        assertNull(node(id = 1, text = "label", isEnabled = false).toMcpJson()["interactable"])
     }
 
     @Test

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTreeTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTreeTest.kt
@@ -90,16 +90,16 @@ class NodeTreeTest {
     }
 
     @Test
-    fun `isInteractable needs something to do, an enabled node, and a gesture that reaches it`() {
-        assertTrue(node(id = 1, isClickable = true).isInteractable)
-        assertFalse(node(id = 2, isClickable = true, isEnabled = false).isInteractable)
-        assertFalse(node(id = 3, isClickable = true, isHittable = false).isInteractable)
-        assertFalse(node(id = 4, text = "just a label").isInteractable, "a label offers nothing to operate")
+    fun `isOperable needs something to do, an enabled node, and a gesture that reaches it`() {
+        assertTrue(node(id = 1, isClickable = true).isOperable)
+        assertFalse(node(id = 2, isClickable = true, isEnabled = false).isOperable)
+        assertFalse(node(id = 3, isClickable = true, isHittable = false).isOperable)
+        assertFalse(node(id = 4, text = "just a label").isOperable, "a label offers nothing to operate")
     }
 
     @Test
-    fun `matches rejects a disabled or obstructed node when interactableOnly is set`() {
-        val query = NodeQuery(interactableOnly = true)
+    fun `matches rejects a disabled or obstructed node when operableOnly is set`() {
+        val query = NodeQuery(operableOnly = true)
 
         assertTrue(node(id = 1, isClickable = true).matches(query))
         assertFalse(node(id = 2, isClickable = true, isEnabled = false).matches(query))

--- a/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTreeTest.kt
+++ b/jetwhale-plugins/semantics/host/src/test/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/NodeTreeTest.kt
@@ -90,6 +90,24 @@ class NodeTreeTest {
     }
 
     @Test
+    fun `isInteractable needs something to do, an enabled node, and a gesture that reaches it`() {
+        assertTrue(node(id = 1, isClickable = true).isInteractable)
+        assertFalse(node(id = 2, isClickable = true, isEnabled = false).isInteractable)
+        assertFalse(node(id = 3, isClickable = true, isHittable = false).isInteractable)
+        assertFalse(node(id = 4, text = "just a label").isInteractable, "a label offers nothing to operate")
+    }
+
+    @Test
+    fun `matches rejects a disabled or obstructed node when interactableOnly is set`() {
+        val query = NodeQuery(interactableOnly = true)
+
+        assertTrue(node(id = 1, isClickable = true).matches(query))
+        assertFalse(node(id = 2, isClickable = true, isEnabled = false).matches(query))
+        assertFalse(node(id = 3, isClickable = true, isHittable = false).matches(query))
+        assertFalse(node(id = 4, text = "label").matches(query))
+    }
+
+    @Test
     fun `matches combines criteria with AND and compares case-insensitively by substring`() {
         val target = node(id = 1, role = "Button", text = "Send message", testTag = "send-button", isClickable = true, actions = listOf("OnClick"))
 


### PR DESCRIPTION
## Summary

Closes #262. Follow-up to #261.

An agent reading `findNodes` / `getNodeTree` wants one answer before it acts: can the user operate this node right now? That was spread over three independent facts — does the node offer something to do, is it enabled, does a gesture it accepts reach it — and the caller had to combine them.

## What changed

- **`operable`** on every node in the MCP JSON, derived as `interactive && enabled && hittable`. Only the surprising side is emitted: `"operable": false` on an interactive node that fails one of the three, next to `enabled`, `hittable` and `obscuredBy` saying why. A label is never marked either way.
- **`findNodes`: `hittableOnly` → `operableOnly`** (breaking, no shim — alpha). It keeps only nodes the user could operate right now. `interactiveOnly` stays as "has something to do", disabled or not.
- **Inspector**: the tree tags such a row **not operable** (was **unreachable**, which missed disabled nodes), and the detail pane names the reason — disabled, what takes the touch, or nothing to aim at.
- `hittable` / `obscuredBy` and `nodeAt` are unchanged; they remain the hit-test view and explain *why* something is not operable.

The wire model is untouched: `isOperable` is computed on the host where the JSON is built, so the agent keeps reporting facts it can capture.

### Naming

`operable` rather than `interactable`: the latter differs from the existing `interactive` by two letters while meaning a neighboring thing, which is a trap for an agent reading the tool schema. `operable` is WCAG's word for exactly this and shares no stem with `interactive`.

## Docs

The guide gains a "Can the user operate it?" section ahead of "Can a finger reach it?", and `findNodes` mentions `operableOnly`.

## Tests

- `NodeTreeTest`: `isOperable` needs all three facts; `operableOnly` rejects disabled, obstructed and non-interactive nodes.
- `NodeMcpJsonTest`: `operable: false` appears next to its reason; a reachable node and a label stay silent.

`:jetwhale-plugins:semantics:host` tests: 82 passed, 0 failed. `spotlessKotlinCheck` passes.
