### PR TITLE
fix(host): keep the follow banner up between calls so the plugin stops jumping

### DIFF
--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -165,8 +165,10 @@ working.
 
 Only a tool call that names a plugin moves the window; host-level calls (navigation, settings,
 status) leave it alone, and so does a plugin already popped out into its own window — it is visible
-where it is. While the window is following, a banner above the plugin names the tool running and
-offers **Stop following**, which turns the setting off without a trip back to this page.
+where it is. While the setting is on and an agent is connected, a banner above the plugin offers
+**Stop following**, which turns the setting off without a trip back to this page; while a call is
+moving the window it also names the tool running. The banner stays up between calls on purpose, so
+the plugin under it keeps its place through a burst of operations instead of jumping at every one.
 
 ## Plugins
 

--- a/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values-ja/strings.xml
@@ -34,6 +34,7 @@
     <string name="disable">無効化</string>
     <string name="ai_agent_connected">AI エージェント接続中</string>
     <string name="ai_agent_operating">AI エージェントが操作中</string>
+    <string name="follow_ai_operation_armed">AI エージェント接続中 — 操作されたプラグインに追従します</string>
     <string name="following_ai_operation">AI エージェントに追従中 — %1$s</string>
     <string name="stop_following_ai_operation">追従をやめる</string>
     <string name="plugin_exposes_mcp_tools">AI エージェントに MCP tools を公開中</string>

--- a/jetwhale-host/app/src/main/composeResources/values/strings.xml
+++ b/jetwhale-host/app/src/main/composeResources/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="disable">Disable</string>
     <string name="ai_agent_connected">AI agent connected</string>
     <string name="ai_agent_operating">AI agent is operating</string>
+    <string name="follow_ai_operation_armed">AI agent connected — the window will follow what it operates</string>
     <string name="following_ai_operation">Following the AI agent — %1$s</string>
     <string name="stop_following_ai_operation">Stop following</string>
     <string name="plugin_exposes_mcp_tools">Exposes MCP tools to AI agents</string>

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/component/FollowingAiOperationBanner.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/component/FollowingAiOperationBanner.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.kitakkun.jetwhale.host.Res
+import com.kitakkun.jetwhale.host.follow_ai_operation_armed
 import com.kitakkun.jetwhale.host.following_ai_operation
 import com.kitakkun.jetwhale.host.stop_following_ai_operation
 import com.kitakkun.jetwhale.host.ui.JwBanner
@@ -21,16 +22,23 @@ import com.kitakkun.jetwhale.host.ui.JwTone
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Says that the window moved on its own, and offers the switch that stops it.
+ * Says that the window moves on its own while an agent operates, and offers the switch that stops it.
  *
  * It sits above the content rather than over it — a following window is showing a plugin the user
- * wants to watch, and a floating snackbar would cover exactly the thing it is announcing. Expanding
- * the banner pushes the plugin down instead, so nothing is hidden.
+ * wants to watch, and a floating snackbar would cover exactly the thing it is announcing.
+ *
+ * The strip stays up for the whole time a follow could happen, not just during one: while it is
+ * [visible] only its tone and text change as calls come and go, so the plugin below keeps its place
+ * through a burst of operations. Expanding and collapsing — the one thing that moves the plugin —
+ * happens only when an agent connects or leaves, or the mode is switched.
+ *
+ * @param followingToolName the tool whose call is moving the window right now, or `null` while the
+ * strip is only standing by.
  */
 @Composable
 fun FollowingAiOperationBanner(
     visible: Boolean,
-    toolName: String,
+    followingToolName: String?,
     onClickStopFollowing: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -43,8 +51,10 @@ fun FollowingAiOperationBanner(
         JwBanner(
             // The tool name is what the agent is doing right now; the plugin it targets is already
             // on screen, so naming it here would only repeat what the user sees.
-            text = stringResource(Res.string.following_ai_operation, toolName),
-            tone = JwTone.Warning,
+            text = followingToolName
+                ?.let { stringResource(Res.string.following_ai_operation, it) }
+                ?: stringResource(Res.string.follow_ai_operation_armed),
+            tone = if (followingToolName != null) JwTone.Warning else JwTone.Info,
             icon = { JwIcon(imageVector = Icons.Default.SmartToy, contentDescription = null) },
             actions = {
                 JwButton(
@@ -59,10 +69,20 @@ fun FollowingAiOperationBanner(
 
 @Preview
 @Composable
-private fun FollowingAiOperationBannerPreview() {
+private fun FollowingAiOperationBannerArmedPreview() {
     FollowingAiOperationBanner(
         visible = true,
-        toolName = "jetwhale.click",
+        followingToolName = null,
+        onClickStopFollowing = {},
+    )
+}
+
+@Preview
+@Composable
+private fun FollowingAiOperationBannerFollowingPreview() {
+    FollowingAiOperationBanner(
+        visible = true,
+        followingToolName = "jetwhale.click",
         onClickStopFollowing = {},
     )
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/AiActivityIndicatorView.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/AiActivityIndicatorView.kt
@@ -246,6 +246,7 @@ private fun AiActivityIndicatorConnectedPreview() {
         uiState = AiActivityUiState(
             isAgentConnected = true,
             operatingToolName = null,
+            isFollowModeOn = true,
             isFollowingOperation = false,
         ),
     )
@@ -258,6 +259,7 @@ private fun AiActivityIndicatorOperatingPreview() {
         uiState = AiActivityUiState(
             isAgentConnected = true,
             operatingToolName = "jetwhale.click",
+            isFollowModeOn = true,
             isFollowingOperation = true,
         ),
     )

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/JetWhaleToolingScaffold.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/JetWhaleToolingScaffold.kt
@@ -74,8 +74,8 @@ fun ToolingScaffold(
             // Above the content, not over it: the plugin below is the thing the follow just
             // brought into view, so an overlay would cover what it announces.
             FollowingAiOperationBanner(
-                visible = uiState.aiActivity.isFollowingOperation,
-                toolName = uiState.aiActivity.operatingToolName.orEmpty(),
+                visible = uiState.aiActivity.showsFollowBanner,
+                followingToolName = uiState.aiActivity.operatingToolName.takeIf { uiState.aiActivity.isFollowingOperation },
                 onClickStopFollowing = onClickStopFollowingAiOperation,
             )
             // The snackbar is overlaid on the content area only: messages stay clear of the sidebar

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -74,11 +74,14 @@ internal fun newlyConnectedSessions(
 }
 
 /**
- * Whether following this call is something the user would see happen in the main window.
+ * Whether this call puts the agent's work on the main window's screen.
  *
- * Mirrors what [com.kitakkun.jetwhale.host.model.FollowAiOperationService] decides, so the banner
- * announces a move rather than merely an agent being busy. A call that named no session is followed
- * against the drawer's own selection, which is where [selectedSessionId] comes in.
+ * Deliberately wider than what [com.kitakkun.jetwhale.host.model.FollowAiOperationService] navigates
+ * on: the service skips a plugin the window already shows, but the banner should still say the
+ * agent is driving what the user is looking at — a burst of calls to one plugin moves the window
+ * once and keeps operating it. Only a popped-out plugin is excluded, as it is watched in its own
+ * window. A call that named no session is judged against the drawer's own selection, which is where
+ * [selectedSessionId] comes in.
  */
 internal fun McpToolInvocation?.movesTheWindow(
     selectedSessionId: String,

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldPresenter.kt
@@ -206,6 +206,7 @@ fun toolingScaffoldPresenter(
         aiActivity = AiActivityUiState(
             isAgentConnected = mcpActivity.hasConnectedClient,
             operatingToolName = activeInvocation?.toolName,
+            isFollowModeOn = followAiOperationEnabled,
             // Announce only what the window actually does: a call that names no plugin never moves
             // it, and a plugin popped out into its own window is watched there, not here.
             isFollowingOperation = followAiOperationEnabled && activeInvocation.movesTheWindow(selectedSessionId, isPluginPoppedOut),

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldUiState.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldUiState.kt
@@ -15,8 +15,10 @@ data class AiActivityUiState(
     /** Whether the window is set to move to whatever plugin an agent operates. */
     val isFollowModeOn: Boolean,
     /**
-     * Whether the window is following the operation on screen right now — the mode is on and the
-     * call in flight names a plugin. Only then is there a movement to announce and offer to stop.
+     * Whether what is on the main window's screen is there under the agent's direction right now —
+     * the mode is on and the call in flight names a plugin that this window shows or has just moved
+     * to. The follow banner turns to its warning state and names the tool for as long as this holds.
+     * A plugin popped out into its own window is watched there, so a call to it does not count.
      */
     val isFollowingOperation: Boolean,
 ) {

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldUiState.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/drawer/ToolingScaffoldUiState.kt
@@ -12,6 +12,8 @@ import kotlinx.collections.immutable.ImmutableList
 data class AiActivityUiState(
     val isAgentConnected: Boolean,
     val operatingToolName: String?,
+    /** Whether the window is set to move to whatever plugin an agent operates. */
+    val isFollowModeOn: Boolean,
     /**
      * Whether the window is following the operation on screen right now — the mode is on and the
      * call in flight names a plugin. Only then is there a movement to announce and offer to stop.
@@ -20,10 +22,18 @@ data class AiActivityUiState(
 ) {
     val isOperating: Boolean get() = operatingToolName != null
 
+    /**
+     * Whether the strip that announces a follow is on screen. It stays up for as long as a follow
+     * could happen — the mode is on and an agent is connected — rather than for each call, so the
+     * plugin under it keeps its place through a burst of operations instead of jumping at every one.
+     */
+    val showsFollowBanner: Boolean get() = isFollowModeOn && isAgentConnected
+
     companion object {
         val Idle = AiActivityUiState(
             isAgentConnected = false,
             operatingToolName = null,
+            isFollowModeOn = false,
             isFollowingOperation = false,
         )
     }

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/drawer/FollowBannerVisibilityTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/drawer/FollowBannerVisibilityTest.kt
@@ -81,3 +81,25 @@ class FollowBannerVisibilityTest {
         )
     }
 }
+
+class FollowBannerPresenceTest {
+    private fun state(isAgentConnected: Boolean, isFollowModeOn: Boolean, operatingToolName: String? = null) = AiActivityUiState(
+        isAgentConnected = isAgentConnected,
+        operatingToolName = operatingToolName,
+        isFollowModeOn = isFollowModeOn,
+        isFollowingOperation = operatingToolName != null,
+    )
+
+    @Test
+    fun `the strip is up whenever a follow could happen, call or no call`() {
+        assertTrue(state(isAgentConnected = true, isFollowModeOn = true).showsFollowBanner)
+        assertTrue(state(isAgentConnected = true, isFollowModeOn = true, operatingToolName = "jetwhale.click").showsFollowBanner)
+    }
+
+    @Test
+    fun `the strip is down when nothing could move the window`() {
+        assertFalse(state(isAgentConnected = false, isFollowModeOn = true).showsFollowBanner)
+        assertFalse(state(isAgentConnected = true, isFollowModeOn = false).showsFollowBanner)
+        assertFalse(AiActivityUiState.Idle.showsFollowBanner)
+    }
+}


### PR DESCRIPTION
## What was wrong

The banner that announces "the window is following an AI agent" was shown per MCP call: it expanded when a call started and collapsed when the 1.5 s linger ran out. Since it sits above the plugin content and pushes it down, a burst of agent calls made the plugin area jump at every operation.

## What this changes

- The strip stays up for as long as a follow **could** happen — the follow setting is on and an agent is connected — rather than for each call. While it is up only its tone and text change:
  - standing by: info tone, "AI agent connected — the window will follow what it operates", with **Stop following**
  - during a call that moves the window: warning tone, "Following the AI agent — `<tool>`", as before
- The only remaining layout movement is on agent connect / disconnect or switching the setting.
- `AiActivityUiState` gains `isFollowModeOn` and a derived `showsFollowBanner`; `FollowingAiOperationBanner` takes `followingToolName: String?` instead of a `visible` flag per call.
- `docs/guide/host-settings.md` describes the new behavior.

## Trade-off

An info strip is now present whenever an agent is connected with the setting on. The alternative — reserving blank space — would look broken, and the strip carries the **Stop following** switch, which was previously reachable only during the 1.5 s a call lingered.

## Tests

`FollowBannerPresenceTest` pins when the strip is up and down. `:jetwhale-host:app:test`: 34 passed. `spotlessKotlinCheck` passes.
