### PR TITLE
fix(host): keep dialogs and popouts up when the window follows an agent

### DIFF
--- a/docs/guide/host-settings.md
+++ b/docs/guide/host-settings.md
@@ -165,7 +165,8 @@ working.
 
 Only a tool call that names a plugin moves the window; host-level calls (navigation, settings,
 status) leave it alone, and so does a plugin already popped out into its own window — it is visible
-where it is. While the setting is on and an agent is connected, a banner above the plugin offers
+where it is. The move changes what the main window shows underneath: a dialog you have open —
+Settings, the MCP tools browser — stays open on top of it, as do the popout windows. While the setting is on and an agent is connected, a banner above the plugin offers
 **Stop following**, which turns the setting off without a trip back to this page; while a call is
 moving the window it also names the tool running. The banner stays up between calls on purpose, so
 the plugin under it keeps its place through a burst of operations instead of jumping at every one.

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -168,6 +168,11 @@ Navigating to `PLUGIN` also selects that session in the sidebar, which is what a
 `jetwhale.screenshot` of the same plugin will show. The call waits up to two seconds for the window
 to confirm, and reports `applied: false` with a reason if it does not.
 
+`HOME` and `PLUGIN` are the window's *content*; `SETTINGS`, `INFO` and `LOG_VIEWER` open over it. A
+dialog the user has open stays open when the content under it changes, so a `HOME` or `PLUGIN`
+request is confirmed against the content and reports the dialog still on top as `overlay`.
+`jetwhale.getStatus` reports both: `ui.destination` is what is on top, `ui.content` what is under it.
+
 `jetwhale.getStatus` can report destinations the tool cannot request — `DISABLED_PLUGIN`, `LICENSES`
 and `MCP_TOOLS`. The tools browser in particular exists so a *person* can watch what an agent is
 doing, so an agent has no reason to send itself there.

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/JetWhaleApp.kt
@@ -31,6 +31,7 @@ import com.kitakkun.jetwhale.host.navigation.InfoNavKey
 import com.kitakkun.jetwhale.host.navigation.JetWhaleNavDisplay
 import com.kitakkun.jetwhale.host.navigation.LicensesNavKey
 import com.kitakkun.jetwhale.host.navigation.LogViewerNavKey
+import com.kitakkun.jetwhale.host.navigation.OverlayNavKey
 import com.kitakkun.jetwhale.host.navigation.PluginNavKey
 import com.kitakkun.jetwhale.host.navigation.PluginPopoutNavKey
 import com.kitakkun.jetwhale.host.navigation.SettingsNavKey
@@ -39,6 +40,7 @@ import com.kitakkun.jetwhale.host.navigation.bringPluginBackToMainWindow
 import com.kitakkun.jetwhale.host.navigation.followPluginToSession
 import com.kitakkun.jetwhale.host.navigation.isPluginPoppedOut
 import com.kitakkun.jetwhale.host.navigation.openMcpTools
+import com.kitakkun.jetwhale.host.navigation.showBelowOverlays
 import com.kitakkun.jetwhale.host.navigation.toHostDestination
 import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import com.kitakkun.jetwhale.host.theme.AppEnvironment
@@ -153,7 +155,7 @@ fun JetWhaleApp() {
                                     },
                                     onClickInfo = { backStack.addSingleTop(InfoNavKey) },
                                     onClickPlugin = { pluginId, sessionId ->
-                                        backStack.addSingleTop(PluginNavKey(pluginId, sessionId))
+                                        backStack.showBelowOverlays(PluginNavKey(pluginId, sessionId))
                                     },
                                     onOpenMcpTools = { pluginId, sessionId ->
                                         backStack.openMcpTools(pluginId = pluginId, sessionId = sessionId)
@@ -170,9 +172,9 @@ fun JetWhaleApp() {
                                     isPoppedOut = backStack::isPluginPoppedOut,
                                     onClickBringBack = backStack::bringPluginBackToMainWindow,
                                     onNavigateHome = {
-                                        // Popouts live in their own windows; going home in the main
-                                        // window must not close them.
-                                        backStack.removeAll { it !is EmptyPluginNavKey && it !is PluginPopoutNavKey }
+                                        // Home is what the main window shows underneath; a dialog the
+                                        // user has open and the popout windows are not its to close.
+                                        backStack.removeAll { it !is EmptyPluginNavKey && it !is OverlayNavKey }
                                     },
                                     onNavigateSettings = { page ->
                                         backStack.addSingleTop(SettingsNavKey(initialPage = page))

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMapping.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMapping.kt
@@ -1,6 +1,7 @@
 package com.kitakkun.jetwhale.host.navigation
 
 import androidx.navigation3.runtime.NavKey
+import com.kitakkun.jetwhale.host.model.HostContent
 import com.kitakkun.jetwhale.host.model.HostDestination
 import com.kitakkun.jetwhale.host.model.HostDestinationKind
 import com.kitakkun.jetwhale.host.model.HostSettingsSection
@@ -14,22 +15,31 @@ import com.kitakkun.jetwhale.host.settings.SettingsScreenSection
  * than leaking into `core/model`.
  *
  * The top-most entry that is not a popout wins: popouts render in their own windows and are
- * reported alongside whatever the main window shows.
+ * reported alongside whatever the main window shows. A dialog on top is the destination, and the
+ * content it is drawn over is reported as [HostDestination.content], so a caller that changed the
+ * content under it can see that it did.
  */
 fun List<NavKey>.toHostDestination(): HostDestination {
     val poppedOut = filterIsInstance<PluginPopoutNavKey>().map { PoppedOutPlugin(it.pluginId, it.sessionId) }
+    val content = when (val top = lastOrNull { it !is OverlayNavKey }) {
+        is PluginNavKey -> HostContent(HostDestinationKind.PLUGIN, top.pluginId, top.sessionId)
+        DisabledPluginNavKey -> HostContent(HostDestinationKind.DISABLED_PLUGIN)
+        else -> HostContent(HostDestinationKind.HOME)
+    }
     return when (val top = lastOrNull { it !is PluginPopoutNavKey }) {
         is PluginNavKey -> HostDestination(
             kind = HostDestinationKind.PLUGIN,
             pluginId = top.pluginId,
             sessionId = top.sessionId,
             poppedOutPlugins = poppedOut,
+            content = content,
         )
 
         is SettingsNavKey -> HostDestination(
             kind = HostDestinationKind.SETTINGS,
             settingsSection = top.initialPage.toHostSettingsSection(),
             poppedOutPlugins = poppedOut,
+            content = content,
         )
 
         is McpToolsNavKey -> HostDestination(
@@ -37,17 +47,18 @@ fun List<NavKey>.toHostDestination(): HostDestination {
             pluginId = top.pluginId,
             sessionId = top.sessionId,
             poppedOutPlugins = poppedOut,
+            content = content,
         )
 
-        InfoNavKey -> HostDestination(HostDestinationKind.INFO, poppedOutPlugins = poppedOut)
+        InfoNavKey -> HostDestination(HostDestinationKind.INFO, poppedOutPlugins = poppedOut, content = content)
 
-        LicensesNavKey -> HostDestination(HostDestinationKind.LICENSES, poppedOutPlugins = poppedOut)
+        LicensesNavKey -> HostDestination(HostDestinationKind.LICENSES, poppedOutPlugins = poppedOut, content = content)
 
-        LogViewerNavKey -> HostDestination(HostDestinationKind.LOG_VIEWER, poppedOutPlugins = poppedOut)
+        LogViewerNavKey -> HostDestination(HostDestinationKind.LOG_VIEWER, poppedOutPlugins = poppedOut, content = content)
 
-        DisabledPluginNavKey -> HostDestination(HostDestinationKind.DISABLED_PLUGIN, poppedOutPlugins = poppedOut)
+        DisabledPluginNavKey -> HostDestination(HostDestinationKind.DISABLED_PLUGIN, poppedOutPlugins = poppedOut, content = content)
 
-        else -> HostDestination(HostDestinationKind.HOME, poppedOutPlugins = poppedOut)
+        else -> HostDestination(HostDestinationKind.HOME, poppedOutPlugins = poppedOut, content = content)
     }
 }
 

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
@@ -4,19 +4,26 @@ import androidx.navigation3.runtime.NavKey
 import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import kotlinx.serialization.Serializable
 
+/**
+ * A key whose entry is drawn over the main window's content — a dialog or a window of its own —
+ * rather than as that content. Navigating the content underneath must leave these where they are:
+ * see [showBelowOverlays].
+ */
+sealed interface OverlayNavKey : NavKey
+
 @Serializable
 data object EmptyPluginNavKey : NavKey
 
 @Serializable
 data class SettingsNavKey(
     val initialPage: SettingsScreenPage = SettingsScreenPage.Appearance,
-) : NavKey
+) : OverlayNavKey
 
 @Serializable
-data object LicensesNavKey : NavKey
+data object LicensesNavKey : OverlayNavKey
 
 @Serializable
-data object InfoNavKey : NavKey
+data object InfoNavKey : OverlayNavKey
 
 @Serializable
 data class PluginNavKey(
@@ -29,13 +36,13 @@ data class PluginPopoutNavKey(
     val pluginId: String,
     val sessionId: String,
     val pluginName: String,
-) : NavKey
+) : OverlayNavKey
 
 @Serializable
 data object DisabledPluginNavKey : NavKey
 
 @Serializable
-data object LogViewerNavKey : NavKey
+data object LogViewerNavKey : OverlayNavKey
 
 /**
  * The MCP tools browser. [pluginId] and [sessionId] seed the screen's filters — null means
@@ -46,4 +53,4 @@ data object LogViewerNavKey : NavKey
 data class McpToolsNavKey(
     val pluginId: String?,
     val sessionId: String?,
-) : NavKey
+) : OverlayNavKey

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
@@ -1,15 +1,36 @@
 package com.kitakkun.jetwhale.host.navigation
 
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation3.runtime.NavKey
 import com.kitakkun.jetwhale.host.settings.SettingsScreenPage
 import kotlinx.serialization.Serializable
 
 /**
  * A key whose entry is drawn over the main window's content — a dialog or a window of its own —
- * rather than as that content. Navigating the content underneath must leave these where they are:
- * see [showBelowOverlays].
+ * rather than as that content. [presentation] is the one statement of how: the entry in NavEntries
+ * takes its scene metadata from it, and [showBelowOverlays] leaves every such key where it is when
+ * the content underneath changes.
  */
-sealed interface OverlayNavKey : NavKey
+sealed interface OverlayNavKey : NavKey {
+    val presentation: OverlayPresentation
+}
+
+sealed interface OverlayPresentation {
+    data class Dialog(val properties: DialogProperties) : OverlayPresentation
+
+    data class Window(val properties: WindowProperties) : OverlayPresentation
+
+    val metadata: Map<String, Any>
+        get() = when (this) {
+            is Dialog -> StableDialogSceneStrategy.dialog(properties)
+            is Window -> WindowSceneStrategy.window(properties)
+        }
+}
+
+private val FULL_WIDTH_DIALOG = OverlayPresentation.Dialog(
+    DialogProperties(usePlatformDefaultWidth = false),
+)
 
 @Serializable
 data object EmptyPluginNavKey : NavKey
@@ -17,13 +38,23 @@ data object EmptyPluginNavKey : NavKey
 @Serializable
 data class SettingsNavKey(
     val initialPage: SettingsScreenPage = SettingsScreenPage.Appearance,
-) : OverlayNavKey
+) : OverlayNavKey {
+    override val presentation: OverlayPresentation get() = PRESENTATION
+
+    companion object {
+        val PRESENTATION: OverlayPresentation = FULL_WIDTH_DIALOG
+    }
+}
 
 @Serializable
-data object LicensesNavKey : OverlayNavKey
+data object LicensesNavKey : OverlayNavKey {
+    override val presentation: OverlayPresentation = FULL_WIDTH_DIALOG
+}
 
 @Serializable
-data object InfoNavKey : OverlayNavKey
+data object InfoNavKey : OverlayNavKey {
+    override val presentation: OverlayPresentation = OverlayPresentation.Dialog(DialogProperties())
+}
 
 @Serializable
 data class PluginNavKey(
@@ -36,13 +67,25 @@ data class PluginPopoutNavKey(
     val pluginId: String,
     val sessionId: String,
     val pluginName: String,
-) : OverlayNavKey
+) : OverlayNavKey {
+    override val presentation: OverlayPresentation get() = PRESENTATION
+
+    companion object {
+        val PRESENTATION: OverlayPresentation = OverlayPresentation.Window(
+            WindowProperties(width = 800.dp, height = 600.dp),
+        )
+    }
+}
 
 @Serializable
 data object DisabledPluginNavKey : NavKey
 
 @Serializable
-data object LogViewerNavKey : OverlayNavKey
+data object LogViewerNavKey : OverlayNavKey {
+    override val presentation: OverlayPresentation = OverlayPresentation.Window(
+        WindowProperties(width = 1000.dp, height = 700.dp),
+    )
+}
 
 /**
  * The MCP tools browser. [pluginId] and [sessionId] seed the screen's filters — null means
@@ -53,4 +96,11 @@ data object LogViewerNavKey : OverlayNavKey
 data class McpToolsNavKey(
     val pluginId: String?,
     val sessionId: String?,
-) : OverlayNavKey
+) : OverlayNavKey {
+    override val presentation: OverlayPresentation get() = PRESENTATION
+
+    companion object {
+        // The browser sizes itself; the platform default width would squeeze it to a narrow column.
+        val PRESENTATION: OverlayPresentation = FULL_WIDTH_DIALOG
+    }
+}

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/JetWhaleNavKeys.kt
@@ -48,12 +48,12 @@ data class SettingsNavKey(
 
 @Serializable
 data object LicensesNavKey : OverlayNavKey {
-    override val presentation: OverlayPresentation = FULL_WIDTH_DIALOG
+    override val presentation: OverlayPresentation get() = FULL_WIDTH_DIALOG
 }
 
 @Serializable
 data object InfoNavKey : OverlayNavKey {
-    override val presentation: OverlayPresentation = OverlayPresentation.Dialog(DialogProperties())
+    override val presentation: OverlayPresentation get() = OverlayPresentation.Dialog(DialogProperties())
 }
 
 @Serializable
@@ -82,7 +82,7 @@ data object DisabledPluginNavKey : NavKey
 
 @Serializable
 data object LogViewerNavKey : OverlayNavKey {
-    override val presentation: OverlayPresentation = OverlayPresentation.Window(
+    override val presentation: OverlayPresentation get() = OverlayPresentation.Window(
         WindowProperties(width = 1000.dp, height = 700.dp),
     )
 }

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
@@ -23,14 +23,9 @@ fun <T : NavKey> NavBackStack<T>.addSingleTop(index: Int, navKey: T) {
  */
 fun NavBackStack<NavKey>.showBelowOverlays(navKey: NavKey) {
     removeIf { it == navKey }
-    add(indexOfFirstTrailingOverlay(), navKey)
-}
-
-/** Index of the first key in the run of overlays at the top of the stack, or the size when there is none. */
-private fun NavBackStack<NavKey>.indexOfFirstTrailingOverlay(): Int {
     var index = size
     while (index > 0 && this[index - 1] is OverlayNavKey) index--
-    return index
+    add(index, navKey)
 }
 
 /**

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavBackStackExtensions.kt
@@ -14,6 +14,26 @@ fun <T : NavKey> NavBackStack<T>.addSingleTop(index: Int, navKey: T) {
 }
 
 /**
+ * Shows [navKey] as the main window's content without disturbing what is drawn over it.
+ *
+ * The overlays at the top of the stack — dialogs and popout windows, see [OverlayNavKey] — are
+ * rendered only while they sit above the content, so appending the key would push them under it
+ * and take them down. An agent following its own operations, or a caller navigating over MCP,
+ * changes what the window shows underneath; a settings dialog the user has open is theirs to close.
+ */
+fun NavBackStack<NavKey>.showBelowOverlays(navKey: NavKey) {
+    removeIf { it == navKey }
+    add(indexOfFirstTrailingOverlay(), navKey)
+}
+
+/** Index of the first key in the run of overlays at the top of the stack, or the size when there is none. */
+private fun NavBackStack<NavKey>.indexOfFirstTrailingOverlay(): Int {
+    var index = size
+    while (index > 0 && this[index - 1] is OverlayNavKey) index--
+    return index
+}
+
+/**
  * Shows the MCP tools browser, seeded with the scope it was opened from.
  *
  * At most one browser window exists: opening it from a different scope re-seeds the filters rather
@@ -40,7 +60,7 @@ fun NavBackStack<NavKey>.isPluginPoppedOut(pluginId: String, sessionId: String):
  * Docks a popped-out plugin: shows it in the main window and closes its popout window.
  */
 fun NavBackStack<NavKey>.bringPluginBackToMainWindow(pluginId: String, sessionId: String) {
-    addSingleTop(
+    showBelowOverlays(
         PluginNavKey(
             pluginId = pluginId,
             sessionId = sessionId,

--- a/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavEntries.kt
+++ b/jetwhale-host/app/src/main/kotlin/com/kitakkun/jetwhale/host/navigation/NavEntries.kt
@@ -6,8 +6,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.retain.retain
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.DialogProperties
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import com.kitakkun.jetwhale.host.LocalComposeWindow
@@ -29,7 +27,7 @@ fun EntryProviderScope<NavKey>.infoEntry(
     onClickOSSLicenses: () -> Unit,
 ) {
     entry<InfoNavKey>(
-        metadata = StableDialogSceneStrategy.dialog(),
+        metadata = InfoNavKey.presentation.metadata,
     ) {
         InfoScreen(
             onClickOSSLicenses = onClickOSSLicenses,
@@ -69,12 +67,7 @@ fun EntryProviderScope<NavKey>.pluginEntries(
         }
     }
     entry<PluginPopoutNavKey>(
-        metadata = WindowSceneStrategy.window(
-            WindowProperties(
-                width = 800.dp,
-                height = 600.dp,
-            ),
-        ),
+        metadata = PluginPopoutNavKey.PRESENTATION.metadata,
     ) { navKey ->
         val window = LocalComposeWindow.current
 
@@ -116,11 +109,7 @@ fun EntryProviderScope<NavKey>.settingsEntry(
     onOpenLogViewer: () -> Unit,
 ) {
     entry<SettingsNavKey>(
-        metadata = StableDialogSceneStrategy.dialog(
-            dialogProperties = DialogProperties(
-                usePlatformDefaultWidth = false,
-            ),
-        ),
+        metadata = SettingsNavKey.PRESENTATION.metadata,
     ) { navKey ->
         context(
             retain {
@@ -141,11 +130,7 @@ fun EntryProviderScope<NavKey>.licensesEntry(
     onClickBack: () -> Unit,
 ) {
     entry<LicensesNavKey>(
-        metadata = StableDialogSceneStrategy.dialog(
-            dialogProperties = DialogProperties(
-                usePlatformDefaultWidth = false,
-            ),
-        ),
+        metadata = LicensesNavKey.presentation.metadata,
     ) {
         context(
             retain {
@@ -162,12 +147,7 @@ fun EntryProviderScope<NavKey>.licensesEntry(
 context(appGraph: JetWhaleAppGraph)
 fun EntryProviderScope<NavKey>.logViewerEntry() {
     entry<LogViewerNavKey>(
-        metadata = WindowSceneStrategy.window(
-            WindowProperties(
-                width = 1000.dp,
-                height = 700.dp,
-            ),
-        ),
+        metadata = LogViewerNavKey.presentation.metadata,
     ) {
         val window = LocalComposeWindow.current
         val windowTitle = stringResource(Res.string.log_viewer_window_title)
@@ -189,12 +169,7 @@ fun EntryProviderScope<NavKey>.logViewerEntry() {
 context(appGraph: JetWhaleAppGraph)
 fun EntryProviderScope<NavKey>.mcpToolsEntry() {
     entry<McpToolsNavKey>(
-        // The browser sizes itself; the platform default width would squeeze it to a narrow column.
-        metadata = StableDialogSceneStrategy.dialog(
-            dialogProperties = DialogProperties(
-                usePlatformDefaultWidth = false,
-            ),
-        ),
+        metadata = McpToolsNavKey.PRESENTATION.metadata,
     ) { navKey ->
         context(
             retain {

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMappingTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMappingTest.kt
@@ -10,7 +10,7 @@ class HostNavigationMappingTest {
     private val plugin = PluginNavKey(pluginId = "plugin-1", sessionId = "session-1")
 
     @Test
-    fun `a dialog on top is the destination, and the plugin under it is the content`() {
+    fun `a dialog on top is the destination and the plugin under it is the content`() {
         val destination = listOf<NavKey>(EmptyPluginNavKey, plugin, SettingsNavKey()).toHostDestination()
 
         assertEquals(HostDestinationKind.SETTINGS, destination.kind)

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMappingTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/navigation/HostNavigationMappingTest.kt
@@ -1,0 +1,46 @@
+package com.kitakkun.jetwhale.host.navigation
+
+import androidx.navigation3.runtime.NavKey
+import com.kitakkun.jetwhale.host.model.HostContent
+import com.kitakkun.jetwhale.host.model.HostDestinationKind
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HostNavigationMappingTest {
+    private val plugin = PluginNavKey(pluginId = "plugin-1", sessionId = "session-1")
+
+    @Test
+    fun `a dialog on top is the destination, and the plugin under it is the content`() {
+        val destination = listOf<NavKey>(EmptyPluginNavKey, plugin, SettingsNavKey()).toHostDestination()
+
+        assertEquals(HostDestinationKind.SETTINGS, destination.kind)
+        assertEquals(HostContent(HostDestinationKind.PLUGIN, "plugin-1", "session-1"), destination.content)
+    }
+
+    @Test
+    fun `with nothing over it the plugin is both`() {
+        val destination = listOf<NavKey>(EmptyPluginNavKey, plugin).toHostDestination()
+
+        assertEquals(HostDestinationKind.PLUGIN, destination.kind)
+        assertEquals(HostContent(HostDestinationKind.PLUGIN, "plugin-1", "session-1"), destination.content)
+    }
+
+    @Test
+    fun `a popout is neither the destination nor the content`() {
+        val popout = PluginPopoutNavKey(pluginId = "plugin-2", sessionId = "session-1", pluginName = "Two")
+        val destination = listOf<NavKey>(EmptyPluginNavKey, plugin, popout).toHostDestination()
+
+        assertEquals(HostDestinationKind.PLUGIN, destination.kind)
+        assertEquals("plugin-1", destination.pluginId)
+        assertEquals(HostContent(HostDestinationKind.PLUGIN, "plugin-1", "session-1"), destination.content)
+        assertEquals(listOf("plugin-2"), destination.poppedOutPlugins.map { it.pluginId })
+    }
+
+    @Test
+    fun `an empty stack under a dialog is home`() {
+        val destination = listOf<NavKey>(EmptyPluginNavKey, InfoNavKey).toHostDestination()
+
+        assertEquals(HostDestinationKind.INFO, destination.kind)
+        assertEquals(HostContent(HostDestinationKind.HOME), destination.content)
+    }
+}

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/navigation/ShowBelowOverlaysTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/navigation/ShowBelowOverlaysTest.kt
@@ -1,0 +1,61 @@
+package com.kitakkun.jetwhale.host.navigation
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Content navigation — a drawer click, an agent's follow, an MCP navigate — changes what the main
+ * window shows underneath and leaves every dialog and popout window where it is.
+ */
+class ShowBelowOverlaysTest {
+    private val plugin = PluginNavKey(pluginId = "plugin-1", sessionId = "session-1")
+    private val otherPlugin = PluginNavKey(pluginId = "plugin-2", sessionId = "session-1")
+    private val popout = PluginPopoutNavKey(pluginId = "plugin-3", sessionId = "session-1", pluginName = "Three")
+
+    @Test
+    fun `a plugin shown under an open settings dialog leaves the dialog up`() {
+        val backStack = NavBackStack<NavKey>(EmptyPluginNavKey, otherPlugin, SettingsNavKey())
+
+        backStack.showBelowOverlays(plugin)
+
+        assertEquals(listOf(EmptyPluginNavKey, otherPlugin, plugin, SettingsNavKey()), backStack.toList())
+    }
+
+    @Test
+    fun `every overlay at the top stays above the new content`() {
+        val backStack = NavBackStack<NavKey>(EmptyPluginNavKey, popout, SettingsNavKey(), LogViewerNavKey)
+
+        backStack.showBelowOverlays(plugin)
+
+        assertEquals(listOf(EmptyPluginNavKey, plugin, popout, SettingsNavKey(), LogViewerNavKey), backStack.toList())
+    }
+
+    @Test
+    fun `with nothing over the content the key goes on top`() {
+        val backStack = NavBackStack<NavKey>(EmptyPluginNavKey, otherPlugin)
+
+        backStack.showBelowOverlays(plugin)
+
+        assertEquals(listOf(EmptyPluginNavKey, otherPlugin, plugin), backStack.toList())
+    }
+
+    @Test
+    fun `showing a plugin already in the stack moves it up to the content top`() {
+        val backStack = NavBackStack<NavKey>(EmptyPluginNavKey, plugin, otherPlugin, SettingsNavKey())
+
+        backStack.showBelowOverlays(plugin)
+
+        assertEquals(listOf(EmptyPluginNavKey, otherPlugin, plugin, SettingsNavKey()), backStack.toList())
+    }
+
+    @Test
+    fun `an overlay below the content top is content history, not something to preserve on top`() {
+        val backStack = NavBackStack<NavKey>(EmptyPluginNavKey, SettingsNavKey(), otherPlugin)
+
+        backStack.showBelowOverlays(plugin)
+
+        assertEquals(listOf(EmptyPluginNavKey, SettingsNavKey(), otherPlugin, plugin), backStack.toList())
+    }
+}

--- a/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/navigation/ShowBelowOverlaysTest.kt
+++ b/jetwhale-host/app/src/test/kotlin/com/kitakkun/jetwhale/host/navigation/ShowBelowOverlaysTest.kt
@@ -51,7 +51,7 @@ class ShowBelowOverlaysTest {
     }
 
     @Test
-    fun `an overlay below the content top is content history, not something to preserve on top`() {
+    fun `an overlay below the content top is content history rather than something to preserve on top`() {
         val backStack = NavBackStack<NavKey>(EmptyPluginNavKey, SettingsNavKey(), otherPlugin)
 
         backStack.showBelowOverlays(plugin)

--- a/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultFollowAiOperationService.kt
+++ b/jetwhale-host/core/data/src/main/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultFollowAiOperationService.kt
@@ -62,6 +62,8 @@ class DefaultFollowAiOperationService(
 private fun HostDestination.alreadyShows(invocation: McpToolInvocation, pluginId: String): Boolean {
     val matchesSession = { sessionId: String? -> invocation.sessionId == null || invocation.sessionId == sessionId }
     val poppedOut = poppedOutPlugins.any { it.pluginId == pluginId && matchesSession(it.sessionId) }
-    val onScreen = kind == HostDestinationKind.PLUGIN && this.pluginId == pluginId && matchesSession(this.sessionId)
+    // Judged on the content, not the top: a plugin under a dialog the user has open is on screen the
+    // moment the dialog closes, and following would only reopen the same plugin under it.
+    val onScreen = content.kind == HostDestinationKind.PLUGIN && content.pluginId == pluginId && matchesSession(content.sessionId)
     return poppedOut || onScreen
 }

--- a/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultFollowAiOperationServiceTest.kt
+++ b/jetwhale-host/core/data/src/test/kotlin/com/kitakkun/jetwhale/host/data/navigation/DefaultFollowAiOperationServiceTest.kt
@@ -2,6 +2,7 @@ package com.kitakkun.jetwhale.host.data.navigation
 
 import com.kitakkun.jetwhale.host.data.server.DefaultMcpActivityRepository
 import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
+import com.kitakkun.jetwhale.host.model.HostContent
 import com.kitakkun.jetwhale.host.model.HostDestination
 import com.kitakkun.jetwhale.host.model.HostDestinationKind
 import com.kitakkun.jetwhale.host.model.HostNavigationRequest
@@ -109,6 +110,22 @@ class DefaultFollowAiOperationServiceTest {
                 kind = HostDestinationKind.PLUGIN,
                 pluginId = "plugin-1",
                 sessionId = "session-1",
+            ),
+        )
+        val following = startFollowing()
+
+        startCall("jetwhale.click", pluginId = "plugin-1", sessionId = "session-1")
+
+        assertNull(awaitNoRequest())
+        following.cancel()
+    }
+
+    @Test
+    fun `the plugin under a dialog the user has open is not navigated to again`() = runBlocking {
+        navigationService.updateDestination(
+            HostDestination(
+                kind = HostDestinationKind.SETTINGS,
+                content = HostContent(HostDestinationKind.PLUGIN, "plugin-1", "session-1"),
             ),
         )
         val following = startFollowing()

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommand.kt
@@ -4,7 +4,6 @@ import com.kitakkun.jetwhale.host.mcp.HostMcpCommand
 import com.kitakkun.jetwhale.host.mcp.JetWhaleMcpTool
 import com.kitakkun.jetwhale.host.model.DebugSessionRepository
 import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
-import com.kitakkun.jetwhale.host.model.HostContent
 import com.kitakkun.jetwhale.host.model.HostDestination
 import com.kitakkun.jetwhale.host.model.HostDestinationKind
 import com.kitakkun.jetwhale.host.model.HostNavigationRequest
@@ -67,20 +66,25 @@ class HostNavigationCommand(
                 ),
             )
 
-        // A request for content is confirmed against the content, so what is reported is the content
-        // — with the dialog still open over it named separately, since the caller may want it gone.
-        val shown = if (request.isForContent) applied.content else HostContent(applied.kind, applied.pluginId, applied.sessionId)
-        return Json.encodeToString(
+        val result = if (request.isForContent) {
             NavigateResult(
                 applied = true,
-                destination = shown.kind.name,
-                pluginId = shown.pluginId,
-                sessionId = shown.sessionId,
+                destination = applied.content.kind.name,
+                pluginId = applied.content.pluginId,
+                sessionId = applied.content.sessionId,
+                poppedOut = applied.poppedOutPlugins.any { it.pluginId == applied.content.pluginId && it.sessionId == applied.content.sessionId },
+                overlay = applied.kind.name.takeIf { it != applied.content.kind.name },
+            )
+        } else {
+            NavigateResult(
+                applied = true,
+                destination = applied.kind.name,
+                pluginId = applied.pluginId,
+                sessionId = applied.sessionId,
                 settingsSection = applied.settingsSection?.name,
-                poppedOut = applied.poppedOutPlugins.any { it.pluginId == shown.pluginId && it.sessionId == shown.sessionId },
-                overlay = applied.kind.name.takeIf { request.isForContent && applied.kind != applied.content.kind },
-            ),
-        )
+            )
+        }
+        return Json.encodeToString(result)
     }
 
     private suspend fun JetWhaleMcpArguments.toRequest(): HostNavigationRequest = when (this[destination]) {

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommand.kt
@@ -4,6 +4,7 @@ import com.kitakkun.jetwhale.host.mcp.HostMcpCommand
 import com.kitakkun.jetwhale.host.mcp.JetWhaleMcpTool
 import com.kitakkun.jetwhale.host.model.DebugSessionRepository
 import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.HostContent
 import com.kitakkun.jetwhale.host.model.HostDestination
 import com.kitakkun.jetwhale.host.model.HostDestinationKind
 import com.kitakkun.jetwhale.host.model.HostNavigationRequest
@@ -66,14 +67,18 @@ class HostNavigationCommand(
                 ),
             )
 
+        // A request for content is confirmed against the content, so what is reported is the content
+        // — with the dialog still open over it named separately, since the caller may want it gone.
+        val shown = if (request.isForContent) applied.content else HostContent(applied.kind, applied.pluginId, applied.sessionId)
         return Json.encodeToString(
             NavigateResult(
                 applied = true,
-                destination = applied.kind.name,
-                pluginId = applied.pluginId,
-                sessionId = applied.sessionId,
+                destination = shown.kind.name,
+                pluginId = shown.pluginId,
+                sessionId = shown.sessionId,
                 settingsSection = applied.settingsSection?.name,
-                poppedOut = applied.poppedOutPlugins.any { it.pluginId == applied.pluginId && it.sessionId == applied.sessionId },
+                poppedOut = applied.poppedOutPlugins.any { it.pluginId == shown.pluginId && it.sessionId == shown.sessionId },
+                overlay = applied.kind.name.takeIf { request.isForContent && applied.kind != applied.content.kind },
             ),
         )
     }
@@ -113,8 +118,16 @@ class HostNavigationCommand(
     }
 }
 
+/** Home and a plugin are the window's content; the rest open over it. */
+private val HostNavigationRequest.isForContent: Boolean
+    get() = this is HostNavigationRequest.Home || this is HostNavigationRequest.Plugin
+
+/**
+ * Whether the window shows what was asked for. Content is judged under whatever dialog the user has
+ * open: navigating to it leaves the dialog up, and the request still did what it said.
+ */
 private fun HostNavigationRequest.matches(destination: HostDestination): Boolean = when (this) {
-    HostNavigationRequest.Home -> destination.kind == HostDestinationKind.HOME
+    HostNavigationRequest.Home -> destination.content.kind == HostDestinationKind.HOME
 
     HostNavigationRequest.Info -> destination.kind == HostDestinationKind.INFO
 
@@ -123,9 +136,9 @@ private fun HostNavigationRequest.matches(destination: HostDestination): Boolean
     is HostNavigationRequest.Settings -> destination.kind == HostDestinationKind.SETTINGS && destination.settingsSection == section
 
     is HostNavigationRequest.Plugin ->
-        destination.kind == HostDestinationKind.PLUGIN &&
-            destination.pluginId == pluginId &&
-            (sessionId == null || destination.sessionId == sessionId)
+        destination.content.kind == HostDestinationKind.PLUGIN &&
+            destination.content.pluginId == pluginId &&
+            (sessionId == null || destination.content.sessionId == sessionId)
 }
 
 @Serializable
@@ -136,5 +149,7 @@ data class NavigateResult(
     val sessionId: String? = null,
     val settingsSection: String? = null,
     val poppedOut: Boolean = false,
+    /** The dialog still open over the content a HOME or PLUGIN request was applied under, if any. */
+    val overlay: String? = null,
     val reason: String? = null,
 )

--- a/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommand.kt
+++ b/jetwhale-host/core/mcp/src/main/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommand.kt
@@ -101,6 +101,7 @@ private fun HostViewState.toJson() = UiStateJson(
     pluginId = destination.pluginId,
     sessionId = destination.sessionId,
     settingsSection = destination.settingsSection?.name,
+    content = ContentJson(destination.content.kind.name, destination.content.pluginId, destination.content.sessionId),
     poppedOutPlugins = destination.poppedOutPlugins.map { PoppedOutPluginJson(it.pluginId, it.sessionId) },
     selectedSessionId = selectedSessionId,
     selectedPluginId = selectedPluginId,
@@ -160,9 +161,18 @@ data class UiStateJson(
     val pluginId: String? = null,
     val sessionId: String? = null,
     val settingsSection: String? = null,
+    /** What the main window shows under [destination] when that is a dialog; otherwise the same thing. */
+    val content: ContentJson,
     val poppedOutPlugins: List<PoppedOutPluginJson> = emptyList(),
     val selectedSessionId: String? = null,
     val selectedPluginId: String? = null,
+)
+
+@Serializable
+data class ContentJson(
+    val destination: String,
+    val pluginId: String? = null,
+    val sessionId: String? = null,
 )
 
 @Serializable

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommandTest.kt
@@ -3,6 +3,7 @@ package com.kitakkun.jetwhale.host.mcp.tools.host
 import com.kitakkun.jetwhale.host.model.DebugSession
 import com.kitakkun.jetwhale.host.model.DebugSessionRepository
 import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.HostContent
 import com.kitakkun.jetwhale.host.model.HostDestination
 import com.kitakkun.jetwhale.host.model.HostDestinationKind
 import com.kitakkun.jetwhale.host.model.HostNavigationService
@@ -34,6 +35,7 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class HostNavigationCommandTest {
@@ -131,6 +133,50 @@ class HostNavigationCommandTest {
 
         assertTrue(result.applied)
         assertTrue(result.poppedOut)
+    }
+
+    @Test
+    fun `navigate to a plugin is confirmed under a dialog the user has open, and names the dialog`() = runBlocking {
+        currentView.value = viewState(
+            HostDestination(
+                kind = HostDestinationKind.SETTINGS,
+                settingsSection = HostSettingsSection.GENERAL,
+                content = HostContent(HostDestinationKind.PLUGIN, "com.example.agent", "session-1"),
+            ),
+        )
+
+        val result = command
+            .execute(arguments("destination" to JsonPrimitive("PLUGIN"), "pluginId" to JsonPrimitive("com.example.agent")))
+            .decode()
+
+        assertTrue(result.applied)
+        assertEquals("PLUGIN", result.destination)
+        assertEquals("com.example.agent", result.pluginId)
+        assertEquals("SETTINGS", result.overlay)
+    }
+
+    @Test
+    fun `navigate home is confirmed under a dialog too`() = runBlocking {
+        currentView.value = viewState(HostDestination(kind = HostDestinationKind.INFO, content = HostContent(HostDestinationKind.HOME)))
+
+        val result = command.execute(arguments("destination" to JsonPrimitive("HOME"))).decode()
+
+        assertTrue(result.applied)
+        assertEquals("HOME", result.destination)
+        assertEquals("INFO", result.overlay)
+    }
+
+    @Test
+    fun `a dialog request is confirmed on the dialog itself, and names no overlay`() = runBlocking {
+        currentView.value = viewState(
+            HostDestination(kind = HostDestinationKind.INFO, content = HostContent(HostDestinationKind.PLUGIN, "com.example.agent", "session-1")),
+        )
+
+        val result = command.execute(arguments("destination" to JsonPrimitive("INFO"))).decode()
+
+        assertTrue(result.applied)
+        assertEquals("INFO", result.destination)
+        assertNull(result.overlay)
     }
 
     @Test

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostNavigationCommandTest.kt
@@ -136,7 +136,7 @@ class HostNavigationCommandTest {
     }
 
     @Test
-    fun `navigate to a plugin is confirmed under a dialog the user has open, and names the dialog`() = runBlocking {
+    fun `navigate to a plugin is confirmed under a dialog the user has open and names the dialog`() = runBlocking {
         currentView.value = viewState(
             HostDestination(
                 kind = HostDestinationKind.SETTINGS,
@@ -153,6 +153,7 @@ class HostNavigationCommandTest {
         assertEquals("PLUGIN", result.destination)
         assertEquals("com.example.agent", result.pluginId)
         assertEquals("SETTINGS", result.overlay)
+        assertNull(result.settingsSection)
     }
 
     @Test
@@ -167,7 +168,7 @@ class HostNavigationCommandTest {
     }
 
     @Test
-    fun `a dialog request is confirmed on the dialog itself, and names no overlay`() = runBlocking {
+    fun `a dialog request is confirmed on the dialog itself and names no overlay`() = runBlocking {
         currentView.value = viewState(
             HostDestination(kind = HostDestinationKind.INFO, content = HostContent(HostDestinationKind.PLUGIN, "com.example.agent", "session-1")),
         )

--- a/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommandTest.kt
+++ b/jetwhale-host/core/mcp/src/test/kotlin/com/kitakkun/jetwhale/host/mcp/tools/host/HostStatusCommandTest.kt
@@ -8,9 +8,11 @@ import com.kitakkun.jetwhale.host.model.DebugWebSocketServer
 import com.kitakkun.jetwhale.host.model.DebugWebSocketServerStatus
 import com.kitakkun.jetwhale.host.model.DebuggerSettingsRepository
 import com.kitakkun.jetwhale.host.model.EnabledPluginsRepository
+import com.kitakkun.jetwhale.host.model.HostContent
 import com.kitakkun.jetwhale.host.model.HostDestination
 import com.kitakkun.jetwhale.host.model.HostDestinationKind
 import com.kitakkun.jetwhale.host.model.HostNavigationService
+import com.kitakkun.jetwhale.host.model.HostSettingsSection
 import com.kitakkun.jetwhale.host.model.HostVersionInfo
 import com.kitakkun.jetwhale.host.model.HostViewState
 import com.kitakkun.jetwhale.host.model.McpHostToolGroup
@@ -126,6 +128,24 @@ class HostStatusCommandTest {
         assertEquals("PLUGIN", ui.destination)
         assertEquals("com.example", ui.pluginId)
         assertEquals("s1", ui.selectedSessionId)
+    }
+
+    @Test
+    fun `getStatus reports the content under a dialog the host window has open`() = runBlocking {
+        currentView.value = HostViewState(
+            destination = HostDestination(
+                kind = HostDestinationKind.SETTINGS,
+                settingsSection = HostSettingsSection.GENERAL,
+                content = HostContent(HostDestinationKind.PLUGIN, "com.example", "s1"),
+            ),
+            selectedSessionId = "s1",
+            selectedPluginId = "com.example",
+        )
+
+        val ui = requireNotNull(command.execute(arguments()).decode().ui)
+        assertEquals("SETTINGS", ui.destination)
+        assertEquals("PLUGIN", ui.content.destination)
+        assertEquals("com.example", ui.content.pluginId)
     }
 
     @Test

--- a/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/HostNavigationService.kt
+++ b/jetwhale-host/core/model/src/main/kotlin/com/kitakkun/jetwhale/host/model/HostNavigationService.kt
@@ -32,6 +32,18 @@ data class HostDestination(
     val sessionId: String? = null,
     val settingsSection: HostSettingsSection? = null,
     val poppedOutPlugins: List<PoppedOutPlugin> = emptyList(),
+    /**
+     * What the main window shows as its content, under whatever dialog is open over it. Defaults
+     * to the top itself, which is right whenever nothing is drawn over the content.
+     */
+    val content: HostContent = HostContent(kind, pluginId, sessionId),
+)
+
+/** The main window's content — a plugin, or the empty home — as distinct from a dialog over it. */
+data class HostContent(
+    val kind: HostDestinationKind,
+    val pluginId: String? = null,
+    val sessionId: String? = null,
 )
 
 data class HostViewState(


### PR DESCRIPTION
## What was wrong

Following an AI agent appended `PluginNavKey` to the back stack. A dialog — Settings, Info, Licenses, the MCP tools browser — is only rendered as an overlay while it is the last entry, so the follow pushed it under the plugin and it vanished. An MCP `navigate` to a plugin did the same, and `navigate HOME` removed the dialog outright.

## What this changes

- **A key says how it is presented.** `OverlayNavKey` carries `presentation: OverlayPresentation` — `Dialog(DialogProperties)` or `Window(WindowProperties)` — on the six keys drawn over the content. `NavEntries` derives each entry's scene metadata from it, so the dialog and window properties are declared once, on the key, and read by both the entry provider and the back-stack helper. The presentation is a getter-only property, so nothing new is serialized.
- **`NavBackStack.showBelowOverlays(key)`** removes any existing copy of the key and inserts it just below the run of overlays at the top of the stack. NavDisplay peels overlay scenes from the top one by one, so every dialog and window stays up while the content underneath changes. Used for plugin content from every path — drawer click, agent follow, MCP `navigate`, bringing a popout back — and `navigate HOME` now removes only content keys.
- **The destination reports both layers.** `HostDestination` gains `content: HostContent` — what the main window shows under a dialog (defaults to the top itself when nothing is over it). `navigate HOME`/`PLUGIN` are confirmed against the content and report a dialog still on top as `overlay`; `SETTINGS`/`INFO`/`LOG_VIEWER` are confirmed on the top as before. `getStatus` reports `ui.destination` (top) and `ui.content`. The follow service judges "already on screen" on the content, so it does not re-navigate under a dialog at every call.
- Guides: `host-settings.md` says a dialog you have open stays open during a follow; `mcp-server.md` describes content vs. overlay for `navigate` and `getStatus`.

## Tests

- `ShowBelowOverlaysTest`: a dialog on top, a run of several overlays, no overlay, re-showing a key already in the stack, an overlay buried under content.
- `HostNavigationMappingTest`: dialog on top → destination is the dialog, content is the plugin; popouts are neither.
- `HostNavigationCommandTest`: PLUGIN and HOME confirmed under a dialog with `overlay` named; a dialog request names no overlay.
- `HostStatusCommandTest`: both layers reported. `DefaultFollowAiOperationServiceTest`: a plugin under a dialog is not navigated to again.

`:jetwhale-host:{core:mcp,core:data,app}:test` pass.
