### PR TITLE
feat(semantics): add BringIntoView and ScrollToIndex node actions

### DIFF
--- a/docs/guide/compose-semantics-inspector.md
+++ b/docs/guide/compose-semantics-inspector.md
@@ -69,9 +69,11 @@ degrading.
 
 `performNodeAction` works on a `View` node too, running the view's own API rather than a synthesised
 tap: `Click` → `performClick()`, `LongClick` → `performLongClick()`, `SetText` / `InsertText` on an
-`EditText`, `ImeAction` → `onEditorAction`, `ScrollBy` → `scrollBy`, `RequestFocus` →
-`requestFocus()`. `Dismiss`, `Expand` and `Collapse` have no `View` counterpart and come back
-`performed: false` saying so. As always, only what a node lists in `actions` can be invoked.
+`EditText`, `ImeAction` → `onEditorAction`, `ScrollBy` → `scrollBy`, `ScrollToIndex` →
+`RecyclerView.scrollToPosition` / `ListView.setSelection`, `BringIntoView` →
+`requestRectangleOnScreen`, `RequestFocus` → `requestFocus()`. `Dismiss`, `Expand` and `Collapse`
+have no `View` counterpart and come back `performed: false` saying so. As always, only what a node
+lists in `actions` can be invoked — except `BringIntoView`, which every node takes.
 
 ### Editing View attributes
 
@@ -355,8 +357,9 @@ node's own bounds — see [Can a finger reach it?](#can-a-finger-reach-it).
 ### `com.kitakkun.jetwhale.semantics.performNodeAction`
 
 Invokes a node's own semantics action: `Click`, `LongClick`, `SetText`, `InsertText`, `ImeAction`,
-`ScrollBy`, `RequestFocus`, `Dismiss`, `Expand`, `Collapse`. On an Android `View` node it runs the
-view's own equivalent — see [Android View support](#android-view-support).
+`ScrollBy`, `ScrollToIndex`, `RequestFocus`, `Dismiss`, `Expand`, `Collapse` — plus `BringIntoView`,
+which is not the node's own but works on any node. On an Android `View` node it runs the view's own
+equivalent — see [Android View support](#android-view-support).
 
 This runs the action the node itself declared, so it needs no coordinates and cannot land on
 whatever moved into that spot in the meantime — prefer it over `adb shell input tap`. `rootId` is
@@ -373,6 +376,37 @@ findNodes(testTag: "login-button")     → { "nodes": [{ "rootId": "compose-root
 performNodeAction(nodeId: 42, action: "Click")
 findNodes()                            → the new screen's interactive nodes
 ```
+
+#### Getting a node on screen
+
+A node that exists but sits outside the viewport is a poor target for a screenshot or a finger.
+`BringIntoView` scrolls it in the way accessibility's "show on screen" does: every scrollable ancestor
+is scrolled by the least amount that reveals the whole node, innermost first, and on Android the
+window's `View`s around the composition are scrolled too — so it crosses a `LazyColumn` inside a
+`ScrollView`, or a `RecyclerView` inside an `AndroidView { }`, in one call. No gesture, no
+coordinates, and a node that is already fully visible reports `performed: true` with a note saying
+nothing moved.
+
+```
+findNodes(text: "Terms of service")    → { "nodes": [{ "id": 87, "isVisible": false, … }] }
+performNodeAction(nodeId: 87, action: "BringIntoView")
+getNodeTree()                          → node 87 now has on-screen bounds
+```
+
+`BringIntoView` needs the node to exist, and a lazy container only composes the items near its
+viewport — an item far down a `LazyColumn` has no node yet. `ScrollToIndex` is the step before:
+invoke it on the *container* with the item's `index`, then capture again and the item is there.
+`LazyColumn`, `LazyRow`, the lazy grids and `Pager` expose it; on the View side so do `RecyclerView`
+and `ListView`.
+
+```
+findNodes(testTag: "feed")             → { "nodes": [{ "id": 12, "actions": ["ScrollBy", "ScrollToIndex", …] }] }
+performNodeAction(nodeId: 12, action: "ScrollToIndex", index: 240)
+findNodes(text: "Item 240")            → now composed, and BringIntoView can finish the job if needed
+```
+
+Both scrolls are applied by the container on its next frame, so a capture taken in the same breath
+still shows the old bounds — capture again after.
 
 ### `com.kitakkun.jetwhale.semantics.getViewAttributes`
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ kotlinxDatetime = "0.8.0"
 androidGradlePlugin = "9.3.1"
 androidxCoreKtx = "1.19.0"
 androidxActivity = "1.13.0"
+androidxRecyclerView = "1.4.0"
 
 jetbrainsCompose = "1.11.1"
 material3 = "1.11.0-alpha07"
@@ -70,6 +71,7 @@ kotlinxDatetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.r
 androidxCoreKtx = { module = "androidx.core:core-ktx", version.ref = "androidxCoreKtx" }
 androidxActivityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidxActivityKtx = { module = "androidx.activity:activity-ktx", version.ref = "androidxActivity" }
+androidxRecyclerView = { module = "androidx.recyclerview:recyclerview", version.ref = "androidxRecyclerView" }
 androidxDatastorePreferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidxDatastore" }
 androidxDatastoreCoreOkio = { module = "androidx.datastore:datastore-core-okio", version.ref = "androidxDatastore" }
 

--- a/jetwhale-plugins/semantics/agent/build.gradle.kts
+++ b/jetwhale-plugins/semantics/agent/build.gradle.kts
@@ -56,6 +56,12 @@ kotlin {
             api(libs.jetbrainsComposeUi)
             implementation(libs.kotlinxCoroutinesCore)
         }
+        androidMain.dependencies {
+            // `ScrollToIndex` on a View node drives a RecyclerView when the app has one. Compile-only:
+            // the agent must not pull the library into an app that does not use it, and the code
+            // checks for the class before touching it.
+            compileOnly(libs.androidxRecyclerView)
+        }
         commonTest.dependencies {
             implementation(libs.kotlinTest)
         }

--- a/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/AndroidWindowNodeSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/AndroidWindowNodeSource.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.getAllSemanticsNodes
@@ -71,8 +72,8 @@ internal class AndroidWindowNodeSource(rootView: View) :
             val view = viewInWindow(request.nodeId, rootView) ?: return@await unknownNode(request.nodeId)
             view.performViewAction(request)
         } else {
-            val node = rootView.findSemanticsNode(request.nodeId) ?: return@await unknownNode(request.nodeId)
-            node.performSemanticsAction(request)
+            val found = rootView.findSemanticsNode(request.nodeId) ?: return@await unknownNode(request.nodeId)
+            found.node.performSemanticsAction(request, revealInHost = found.hostView::requestRectangleOnScreenNow)
         }
     }
 
@@ -111,17 +112,33 @@ internal class AndroidWindowNodeSource(rootView: View) :
 private fun viewInWindow(nodeId: Int, rootView: View): View? = ViewNodeIds.viewOf(nodeId)?.takeIf { it.rootView === rootView }
 
 /**
+ * A semantics node together with the view its composition is drawn into — the view whose
+ * coordinate space the node's root coordinates are, and the one to ask when the window's own
+ * `View`s have to scroll for the node.
+ */
+private class SemanticsNodeInWindow(val node: SemanticsNode, val hostView: View)
+
+/**
  * Searches every composition in the window for a semantics node.
  *
  * A node id addresses the same layout node in both trees, but a node merged into its parent is only
  * present in the unmerged one — so a lookup that missed in the merged tree still has somewhere to
  * look. The merged tree comes first because its config carries the actions a caller saw advertised.
  */
-private fun View.findSemanticsNode(id: Int): SemanticsNode? = composeRootsInWindow().firstNotNullOfOrNull { root ->
+private fun View.findSemanticsNode(id: Int): SemanticsNodeInWindow? = composeRootsInWindow().firstNotNullOfOrNull { root ->
     val owner = root.semanticsOwner
-    owner.getAllSemanticsNodes(mergingEnabled = true, skipDeactivatedNodes = true).firstOrNull { it.id == id }
+    val node = owner.getAllSemanticsNodes(mergingEnabled = true, skipDeactivatedNodes = true).firstOrNull { it.id == id }
         ?: owner.getAllSemanticsNodes(mergingEnabled = false, skipDeactivatedNodes = true).firstOrNull { it.id == id }
+    node?.let { SemanticsNodeInWindow(node = it, hostView = root.view) }
 }
+
+/**
+ * Scrolls the window's `View`s so that [bounds], in this view's own coordinates, is on screen —
+ * `ScrollView`, `RecyclerView` and a Compose `AndroidView { }` holder all answer
+ * `requestChildRectangleOnScreen`, so one call climbs the whole way up. Immediate rather than
+ * animated, so the next capture already sees the result.
+ */
+private fun View.requestRectangleOnScreenNow(bounds: Rect): Boolean = requestRectangleOnScreen(bounds.toOutwardAndroidRect(), true)
 
 /**
  * Every composition in this view's subtree, outermost first. A composition's own children are not

--- a/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewActionDispatch.kt
+++ b/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewActionDispatch.kt
@@ -1,9 +1,12 @@
 package com.kitakkun.jetwhale.plugins.semantics.agent
 
+import android.graphics.Rect
 import android.view.View
 import android.view.inputmethod.EditorInfo
+import android.widget.AbsListView
 import android.widget.EditText
 import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
 import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
@@ -70,6 +73,13 @@ internal fun View.performViewAction(request: PerformNodeAction): NodeActionResul
             NodeActionResult(performed = true)
         }
 
+        NodeAction.ScrollToIndex -> {
+            val index = request.index ?: return NodeActionResult(performed = false, message = "ScrollToIndex requires the 'index' argument")
+            scrollToIndex(index)
+        }
+
+        NodeAction.BringIntoView -> bringIntoView()
+
         NodeAction.RequestFocus -> {
             if (!isFocusable) return notSupported("the view is not focusable")
             performed(requestFocus(), "requestFocus() returned false")
@@ -98,12 +108,58 @@ private val NodeAction.requiresEnabledView: Boolean
         -> true
 
         NodeAction.ScrollBy,
+        NodeAction.ScrollToIndex,
+        NodeAction.BringIntoView,
         NodeAction.RequestFocus,
         NodeAction.Dismiss,
         NodeAction.Expand,
         NodeAction.Collapse,
         -> false
     }
+
+/**
+ * `requestRectangleOnScreen` is the platform's own "show on screen": every scrolling parent —
+ * `ScrollView`, `RecyclerView`, and the holder Compose puts around an `AndroidView { }` — answers
+ * `requestChildRectangleOnScreen`, so the one call climbs out through Compose containers too.
+ * Immediate rather than animated, so the next capture already sees the result.
+ */
+private fun View.bringIntoView(): NodeActionResult {
+    val whole = Rect(0, 0, width, height)
+    if (whole.isEmpty) return notSupported("the view has no size to bring into view")
+    val visible = Rect()
+    if (getLocalVisibleRect(visible) && visible == whole) {
+        return NodeActionResult(performed = true, message = "the view is already in view")
+    }
+    return performed(requestRectangleOnScreen(whole, true), "no ancestor scrolled the view into view")
+}
+
+/**
+ * The item-position scroll of the two list widgets the platform and AndroidX offer. `RecyclerView`
+ * is checked only when the app ships it: the agent compiles against it without bundling it, and
+ * an `is` check on a class the app does not have would blow up rather than answer `false`.
+ */
+private fun View.scrollToIndex(index: Int): NodeActionResult = when {
+    this is AbsListView -> {
+        if (index !in 0 until count) {
+            notSupported("index $index is out of bounds [0, $count)")
+        } else {
+            setSelection(index)
+            NodeActionResult(performed = true)
+        }
+    }
+
+    isRecyclerViewAvailable && this is RecyclerView -> {
+        val itemCount = adapter?.itemCount ?: 0
+        if (index !in 0 until itemCount) {
+            notSupported("index $index is out of bounds [0, $itemCount)")
+        } else {
+            scrollToPosition(index)
+            NodeActionResult(performed = true)
+        }
+    }
+
+    else -> notSupported("the view is not a RecyclerView or a ListView")
+}
 
 private fun performed(handled: Boolean, declined: String): NodeActionResult = NodeActionResult(performed = handled, message = if (handled) null else declined)
 

--- a/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewTreeCapture.kt
+++ b/jetwhale-plugins/semantics/agent/src/androidMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ViewTreeCapture.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
+import android.widget.AbsListView
 import android.widget.Checkable
 import android.widget.EditText
 import android.widget.TextView
@@ -12,10 +13,13 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.node.InteroperableComposeUiNode
 import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.semantics.SemanticsNode
+import androidx.recyclerview.widget.RecyclerView
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeBounds
 import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeTreeCaptureOptions
 import com.kitakkun.jetwhale.plugins.semantics.protocol.UiNode
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewNode
+import kotlin.math.ceil
+import kotlin.math.floor
 
 /**
  * Converts an Android `View` subtree into the transport model, descending into every composition it
@@ -146,7 +150,20 @@ private fun View.viewActionNames(): List<String> = buildList {
         add("PerformImeAction")
     }
     if (isScrollable()) add("ScrollBy")
+    if (hasItemPositions()) add("ScrollToIndex")
     if (isFocusable) add("RequestFocus")
+}
+
+/** Whether the view is a list that can be told which item to show — the View side of `ScrollToIndex`. */
+internal fun View.hasItemPositions(): Boolean = this is AbsListView || (isRecyclerViewAvailable && this is RecyclerView)
+
+/**
+ * The agent compiles against `RecyclerView` without bundling it, so an app that does not ship the
+ * library must never reach an `is RecyclerView` check: the class fails to resolve and the check
+ * throws instead of answering `false`.
+ */
+internal val isRecyclerViewAvailable: Boolean by lazy {
+    runCatching { Class.forName("androidx.recyclerview.widget.RecyclerView") }.isSuccess
 }
 
 /**
@@ -208,4 +225,15 @@ private fun NodeBounds.translated(offsetX: Float, offsetY: Float): NodeBounds = 
     top = top + offsetY,
     right = right + offsetX,
     bottom = bottom + offsetY,
+)
+
+/**
+ * The smallest integer rectangle that covers [this] — a request to show it must not lose the
+ * fraction of a pixel at either edge.
+ */
+internal fun androidx.compose.ui.geometry.Rect.toOutwardAndroidRect(): Rect = Rect(
+    floor(left).toInt(),
+    floor(top).toInt(),
+    ceil(right).toInt(),
+    ceil(bottom).toInt(),
 )

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ScrollIntoView.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ScrollIntoView.kt
@@ -1,0 +1,120 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.boundsInParent
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.toSize
+import com.kitakkun.jetwhale.plugins.semantics.protocol.NodeActionResult
+import kotlin.math.abs
+import kotlin.math.sign
+
+/**
+ * Scrolls every scrollable ancestor of this node by the least amount that shows the whole node,
+ * then asks [revealInHost] to do the same for whatever holds the composition.
+ *
+ * This is what Compose itself does for accessibility's "show on screen": walk up to each ancestor
+ * with a `ScrollBy` action, compute how far the node sits outside that ancestor's viewport, scroll
+ * by that, and carry the movement into the next ancestor's calculation. Each `ScrollBy` is applied
+ * by the container on its next frame, so the node's bounds read the same until then — which is
+ * why the movement is carried by hand rather than re-read.
+ *
+ * @param revealInHost given the bounds the node will have in root coordinates once the scrolls
+ *   above have landed, scrolls whatever contains the composition — the Android `View`s around it —
+ *   and says whether anything moved. A composition that fills its window has nothing outside it and
+ *   answers `false`.
+ */
+internal fun SemanticsNode.scrollIntoView(revealInHost: (boundsInRoot: Rect) -> Boolean): NodeActionResult {
+    var containersScrolled = 0
+    var containersDeclined = 0
+    var carried = Offset.Zero
+    var ancestor = parent
+    while (ancestor != null) {
+        // A merged ancestor's config can carry a ScrollBy folded in from a scrollable descendant
+        // that is not on this node's path; Compose reads the unmerged config here, which is
+        // internal. A scrollable inside a merging container is rare enough to live with.
+        val scrollBy = ancestor.config.getOrNull(SemanticsActions.ScrollBy)?.action
+        if (scrollBy != null) {
+            val delta = ancestor.alongItsAxes(
+                scrollDeltaToReveal(
+                    target = Rect(positionInRoot + carried, size.toSize()),
+                    viewport = ancestor.viewportInRoot(),
+                ),
+            )
+            if (delta != Offset.Zero) {
+                val oriented = ancestor.inItsScrollDirection(delta)
+                val handled = scrollBy(oriented.x, oriented.y)
+                if (handled) containersScrolled++ else containersDeclined++
+                carried -= delta
+            }
+        }
+        ancestor = ancestor.parent
+    }
+
+    val hostScrolled = revealInHost(Rect(positionInRoot + carried, size.toSize()))
+
+    return when {
+        containersScrolled > 0 || hostScrolled -> NodeActionResult(
+            performed = true,
+            message = "scrolled ${containersScrolled + (if (hostScrolled) 1 else 0)} container(s); the scroll lands on the next frame, so capture the tree again to see the new bounds",
+        )
+
+        containersDeclined > 0 -> NodeActionResult(
+            performed = false,
+            message = "a scrollable ancestor declined to scroll (it may be at its end, or scrolling may be disabled)",
+        )
+
+        else -> NodeActionResult(performed = true, message = "the node is already in view")
+    }
+}
+
+/**
+ * Where a scrollable's viewport sits in root coordinates. The clipping that matters is the
+ * scrollable's own — its size in its direct parent — not what any further ancestor clips away, so
+ * the bounds in the parent are taken and only translated to root.
+ */
+private fun SemanticsNode.viewportInRoot(): Rect {
+    val coordinates = layoutInfo.coordinates
+    val parentInRoot = coordinates.parentLayoutCoordinates?.positionInRoot() ?: Offset.Zero
+    return coordinates.boundsInParent().translate(parentInRoot)
+}
+
+/**
+ * How far [target] has to move, in root coordinates, to end up inside [viewport]: the smaller of
+ * the two moves that would align either edge, and nothing on an axis where the target already fits
+ * or overhangs the viewport on both sides.
+ */
+internal fun scrollDeltaToReveal(target: Rect, viewport: Rect): Offset = Offset(
+    x = leastAligningDelta(target.left - viewport.left, target.right - viewport.right),
+    y = leastAligningDelta(target.top - viewport.top, target.bottom - viewport.bottom),
+)
+
+private fun leastAligningDelta(alignStart: Float, alignEnd: Float): Float = when {
+    sign(alignStart) != sign(alignEnd) -> 0f
+    abs(alignStart) < abs(alignEnd) -> alignStart
+    else -> alignEnd
+}
+
+/** [delta] with the axes this container cannot scroll along zeroed: a `LazyRow` is not asked to move down. */
+private fun SemanticsNode.alongItsAxes(delta: Offset): Offset = Offset(
+    x = if (config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange) == null) 0f else delta.x,
+    y = if (config.getOrNull(SemanticsProperties.VerticalScrollAxisRange) == null) 0f else delta.y,
+)
+
+/**
+ * `ScrollBy` counts in the container's own direction: a `reverseScrolling` container and a
+ * right-to-left layout both flip the sign of a move meant in root coordinates.
+ */
+private fun SemanticsNode.inItsScrollDirection(delta: Offset): Offset {
+    var x = delta.x
+    var y = delta.y
+    if (config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange)?.reverseScrolling == true) x = -x
+    if (layoutInfo.layoutDirection == LayoutDirection.Rtl) x = -x
+    if (config.getOrNull(SemanticsProperties.VerticalScrollAxisRange)?.reverseScrolling == true) y = -y
+    return Offset(x, y)
+}

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ScrollIntoView.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ScrollIntoView.kt
@@ -30,6 +30,11 @@ import kotlin.math.sign
  *   answers `false`.
  */
 internal fun SemanticsNode.scrollIntoView(revealInHost: (boundsInRoot: Rect) -> Boolean): NodeActionResult {
+    // A node that is not placed has no position to compute a scroll from — a capture taken with
+    // includeInvisible, or a node that left the layout since.
+    if (!layoutInfo.isPlaced) {
+        return NodeActionResult(performed = false, message = "the node is not laid out, so there is nothing to scroll to")
+    }
     var containersScrolled = 0
     var containersDeclined = 0
     var carried = Offset.Zero
@@ -89,7 +94,6 @@ internal fun SemanticsNode.scrollIntoView(revealInHost: (boundsInRoot: Rect) -> 
  */
 private val SemanticsNode.isWhollyUnclipped: Boolean
     get() {
-        if (!layoutInfo.isPlaced) return false
         val unclipped = Rect(positionInRoot, size.toSize())
         val clipped = boundsInRoot
         return abs(clipped.left - unclipped.left) < CLIP_TOLERANCE_PX &&

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ScrollIntoView.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ScrollIntoView.kt
@@ -48,9 +48,12 @@ internal fun SemanticsNode.scrollIntoView(revealInHost: (boundsInRoot: Rect) -> 
             )
             if (delta != Offset.Zero) {
                 val oriented = ancestor.inItsScrollDirection(delta)
-                val handled = scrollBy(oriented.x, oriented.y)
-                if (handled) containersScrolled++ else containersDeclined++
-                carried -= delta
+                if (scrollBy(oriented.x, oriented.y)) {
+                    containersScrolled++
+                    carried -= delta
+                } else {
+                    containersDeclined++
+                }
             }
         }
         ancestor = ancestor.parent

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ScrollIntoView.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ScrollIntoView.kt
@@ -62,19 +62,43 @@ internal fun SemanticsNode.scrollIntoView(revealInHost: (boundsInRoot: Rect) -> 
     val hostScrolled = revealInHost(Rect(positionInRoot + carried, size.toSize()))
 
     return when {
+        containersDeclined > 0 -> NodeActionResult(
+            performed = false,
+            message = "a scrollable ancestor declined to scroll (it may be at its end, or scrolling may be disabled)" +
+                if (containersScrolled > 0 || hostScrolled) "; the containers outside it did scroll" else "",
+        )
+
         containersScrolled > 0 || hostScrolled -> NodeActionResult(
             performed = true,
             message = "scrolled ${containersScrolled + (if (hostScrolled) 1 else 0)} container(s); the scroll lands on the next frame, so capture the tree again to see the new bounds",
         )
 
-        containersDeclined > 0 -> NodeActionResult(
-            performed = false,
-            message = "a scrollable ancestor declined to scroll (it may be at its end, or scrolling may be disabled)",
-        )
+        isWhollyUnclipped -> NodeActionResult(performed = true, message = "the node is already in view")
 
-        else -> NodeActionResult(performed = true, message = "the node is already in view")
+        else -> NodeActionResult(
+            performed = false,
+            message = "the node is clipped by something on its path that cannot scroll — a non-scrollable clip, or the edge of the composition",
+        )
     }
 }
+
+/**
+ * Whether every pixel of the node is inside every ancestor's clip. [SemanticsNode.boundsInRoot] is
+ * clipped by the ancestors on the way up and the unclipped rectangle is not, so they agree only when
+ * nothing cuts the node off — which is the one case "already in view" may claim.
+ */
+private val SemanticsNode.isWhollyUnclipped: Boolean
+    get() {
+        if (!layoutInfo.isPlaced) return false
+        val unclipped = Rect(positionInRoot, size.toSize())
+        val clipped = boundsInRoot
+        return abs(clipped.left - unclipped.left) < CLIP_TOLERANCE_PX &&
+            abs(clipped.top - unclipped.top) < CLIP_TOLERANCE_PX &&
+            abs(clipped.right - unclipped.right) < CLIP_TOLERANCE_PX &&
+            abs(clipped.bottom - unclipped.bottom) < CLIP_TOLERANCE_PX
+    }
+
+private const val CLIP_TOLERANCE_PX = 0.5f
 
 /**
  * Where a scrollable's viewport sits in root coordinates. The clipping that matters is the

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsActionDispatch.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsActionDispatch.kt
@@ -1,5 +1,6 @@
 package com.kitakkun.jetwhale.plugins.semantics.agent
 
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.semantics.AccessibilityAction
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
@@ -20,8 +21,14 @@ import com.kitakkun.jetwhale.plugins.semantics.protocol.PerformNodeAction
  * meanwhile, and reports back whether the node actually handled it.
  *
  * Must be called on the thread that owns the composition.
+ *
+ * @param revealInHost how [NodeAction.BringIntoView] reaches past the composition, see
+ *   [scrollIntoView].
  */
-internal fun SemanticsNode.performSemanticsAction(request: PerformNodeAction): NodeActionResult {
+internal fun SemanticsNode.performSemanticsAction(
+    request: PerformNodeAction,
+    revealInHost: (boundsInRoot: Rect) -> Boolean,
+): NodeActionResult {
     val config = config
     if (request.action.requiresEnabled && config.getOrNull(SemanticsProperties.Disabled) != null) {
         return NodeActionResult(performed = false, message = "the node is disabled")
@@ -50,6 +57,19 @@ internal fun SemanticsNode.performSemanticsAction(request: PerformNodeAction): N
 
         NodeAction.ScrollBy -> config.invokeAction(SemanticsActions.ScrollBy) { it(request.scrollX, request.scrollY) }
 
+        NodeAction.ScrollToIndex -> {
+            val index = request.index
+                ?: return NodeActionResult(performed = false, message = "ScrollToIndex requires the 'index' argument")
+            // A lazy container throws on an index outside its item count instead of answering false.
+            try {
+                config.invokeAction(SemanticsActions.ScrollToIndex) { it(index) }
+            } catch (e: IllegalArgumentException) {
+                NodeActionResult(performed = false, message = e.message ?: "index $index is out of bounds")
+            }
+        }
+
+        NodeAction.BringIntoView -> scrollIntoView(revealInHost)
+
         NodeAction.RequestFocus -> config.invokeAction(SemanticsActions.RequestFocus) { it() }
 
         NodeAction.Dismiss -> config.invokeAction(SemanticsActions.Dismiss) { it() }
@@ -76,6 +96,8 @@ private val NodeAction.requiresEnabled: Boolean
         -> true
 
         NodeAction.ScrollBy,
+        NodeAction.ScrollToIndex,
+        NodeAction.BringIntoView,
         NodeAction.RequestFocus,
         NodeAction.Dismiss,
         -> false

--- a/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsOwnerNodeSource.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/SemanticsOwnerNodeSource.kt
@@ -68,7 +68,9 @@ class SemanticsOwnerNodeSource(
                 performed = false,
                 message = "unknown nodeId: ${request.nodeId} (the node may have left the composition; capture the tree again)",
             )
-        node.performSemanticsAction(request)
+        // An owner is the whole of what this source can see, so there is nothing around the
+        // composition for BringIntoView to scroll.
+        node.performSemanticsAction(request, revealInHost = { false })
     }
 }
 

--- a/jetwhale-plugins/semantics/agent/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ScrollDeltaToRevealTest.kt
+++ b/jetwhale-plugins/semantics/agent/src/commonTest/kotlin/com/kitakkun/jetwhale/plugins/semantics/agent/ScrollDeltaToRevealTest.kt
@@ -1,0 +1,40 @@
+package com.kitakkun.jetwhale.plugins.semantics.agent
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ScrollDeltaToRevealTest {
+    private val viewport = Rect(left = 0f, top = 100f, right = 400f, bottom = 500f)
+
+    @Test
+    fun `a target inside the viewport needs no scroll`() {
+        assertEquals(Offset.Zero, scrollDeltaToReveal(target = Rect(10f, 150f, 200f, 300f), viewport = viewport))
+    }
+
+    @Test
+    fun `a target below the viewport scrolls down just enough to show its bottom edge`() {
+        assertEquals(Offset(0f, 200f), scrollDeltaToReveal(target = Rect(10f, 600f, 200f, 700f), viewport = viewport))
+    }
+
+    @Test
+    fun `a target above the viewport scrolls up just enough to show its top edge`() {
+        assertEquals(Offset(0f, -80f), scrollDeltaToReveal(target = Rect(10f, 20f, 200f, 120f), viewport = viewport))
+    }
+
+    @Test
+    fun `a target to the right scrolls sideways and not vertically`() {
+        assertEquals(Offset(150f, 0f), scrollDeltaToReveal(target = Rect(450f, 150f, 550f, 300f), viewport = viewport))
+    }
+
+    @Test
+    fun `a target taller than the viewport that overlaps it is left where it is`() {
+        assertEquals(Offset.Zero, scrollDeltaToReveal(target = Rect(10f, 50f, 200f, 800f), viewport = viewport))
+    }
+
+    @Test
+    fun `a target partly past the bottom edge scrolls by the overhang only`() {
+        assertEquals(Offset(0f, 50f), scrollDeltaToReveal(target = Rect(10f, 400f, 200f, 550f), viewport = viewport))
+    }
+}

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorPluginFactory.kt
@@ -22,6 +22,7 @@ import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResponse
 import com.kitakkun.jetwhale.plugins.semantics.protocol.ViewAttributeResult
 import com.kitakkun.jetwhale.protocol.messaging.JetWhaleMessagingException
 import com.kitakkun.jetwhale.protocol.messaging.request
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -108,8 +109,11 @@ private class ComposeNodeInspectorHostPlugin :
                 pluginScope.launch {
                     actionStatus = try {
                         val result = performAction(request)
-                        // Re-read straight away: an action changes the very tree the user is
-                        // looking at, and a stale tree next to a "done" message reads as a failure.
+                        // Re-read once the app has drawn the result: an action changes the very tree
+                        // the user is looking at, and a stale tree next to a "done" message reads as a
+                        // failure. A scroll is applied on the app's next frame, so straight away is
+                        // too early.
+                        delay(ACTION_SETTLE_MS)
                         capture(snapshot?.options ?: NodeTreeCaptureOptions())
                         when {
                             result.performed -> "${request.action} on #${request.nodeId}: done"
@@ -152,3 +156,6 @@ private class ComposeNodeInspectorHostPlugin :
         )
     }
 }
+
+/** Comfortably more than one frame at 60 Hz, and still below what a user notices. */
+private const val ACTION_SETTLE_MS = 50L

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -384,8 +384,9 @@ private fun NodeDetail(
     }
 
     val clipboard = LocalClipboardManager.current
-    var textInput by remember(node.id) { mutableStateOf(node.editableText ?: "") }
-    var indexInput by remember(node.id) { mutableStateOf("") }
+    // Ids are per root, so the same id in another root is another node.
+    var textInput by remember(rootId, node.id) { mutableStateOf(node.editableText ?: "") }
+    var indexInput by remember(rootId, node.id) { mutableStateOf("") }
 
     Column(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(JwSpacing.large),
@@ -451,10 +452,11 @@ private fun NodeDetail(
             ActionButton("Dismiss", node, NodeAction.Dismiss, rootId, onPerformAction)
             ActionButton("Expand", node, NodeAction.Expand, rootId, onPerformAction)
             ActionButton("Collapse", node, NodeAction.Collapse, rootId, onPerformAction)
+            // Offered even for a node whose reported bounds are empty: those are the clipped bounds,
+            // and a node clipped away entirely is exactly the one this brings back.
             JwButton(
                 text = "Bring into view",
                 onClick = { onPerformAction(PerformNodeAction(rootId = rootId, nodeId = node.id, action = NodeAction.BringIntoView)) },
-                enabled = !node.bounds.isEmpty,
             )
         }
 

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/ComposeSemanticsInspectorScreen.kt
@@ -385,6 +385,7 @@ private fun NodeDetail(
 
     val clipboard = LocalClipboardManager.current
     var textInput by remember(node.id) { mutableStateOf(node.editableText ?: "") }
+    var indexInput by remember(node.id) { mutableStateOf("") }
 
     Column(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(JwSpacing.large),
@@ -450,6 +451,11 @@ private fun NodeDetail(
             ActionButton("Dismiss", node, NodeAction.Dismiss, rootId, onPerformAction)
             ActionButton("Expand", node, NodeAction.Expand, rootId, onPerformAction)
             ActionButton("Collapse", node, NodeAction.Collapse, rootId, onPerformAction)
+            JwButton(
+                text = "Bring into view",
+                onClick = { onPerformAction(PerformNodeAction(rootId = rootId, nodeId = node.id, action = NodeAction.BringIntoView)) },
+                enabled = !node.bounds.isEmpty,
+            )
         }
 
         if (node.actions.contains("SetText")) {
@@ -487,6 +493,26 @@ private fun NodeDetail(
             }
         }
 
+        if (node.actions.contains("ScrollToIndex")) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(JwSpacing.medium)) {
+                JwTextField(
+                    value = indexInput,
+                    onValueChange = { indexInput = it },
+                    placeholder = "Item index",
+                    modifier = Modifier.weight(1f),
+                )
+                JwButton(
+                    text = "Scroll to index",
+                    onClick = {
+                        indexInput.toIntOrNull()?.let { index ->
+                            onPerformAction(PerformNodeAction(rootId = rootId, nodeId = node.id, action = NodeAction.ScrollToIndex, index = index))
+                        }
+                    },
+                    enabled = indexInput.toIntOrNull() != null,
+                )
+            }
+        }
+
         JwButton(
             text = "Copy `adb shell input tap` for these bounds",
             onClick = { clipboard.setText(AnnotatedString(node.adbTapCommand())) },
@@ -517,7 +543,7 @@ private fun ActionButton(
 ) {
     // Only offer what the node actually advertises: a button for an action the node does not expose
     // would always come back "not exposed", which is noise rather than feedback.
-    val exposed = node.actions.contains(action.semanticsKeyName)
+    val exposed = action.semanticsKeyName?.let(node.actions::contains) ?: true
     if (!exposed) return
     JwButton(
         text = label,
@@ -526,8 +552,11 @@ private fun ActionButton(
     )
 }
 
-/** The semantics key an action arrives under in [UiNode.actions]. */
-private val NodeAction.semanticsKeyName: String
+/**
+ * The semantics key an action arrives under in [UiNode.actions], or `null` for an action that is
+ * not the node's own and so applies to every node.
+ */
+private val NodeAction.semanticsKeyName: String?
     get() = when (this) {
         NodeAction.Click -> "OnClick"
         NodeAction.LongClick -> "OnLongClick"
@@ -535,6 +564,8 @@ private val NodeAction.semanticsKeyName: String
         NodeAction.InsertText -> "InsertTextAtCursor"
         NodeAction.ImeAction -> "PerformImeAction"
         NodeAction.ScrollBy -> "ScrollBy"
+        NodeAction.ScrollToIndex -> "ScrollToIndex"
+        NodeAction.BringIntoView -> null
         NodeAction.RequestFocus -> "RequestFocus"
         NodeAction.Dismiss -> "Dismiss"
         NodeAction.Expand -> "Expand"

--- a/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/PerformNodeActionCommand.kt
+++ b/jetwhale-plugins/semantics/host/src/main/kotlin/com/kitakkun/jetwhale/plugins/semantics/host/PerformNodeActionCommand.kt
@@ -26,11 +26,14 @@ internal class PerformNodeActionCommand(
             "needs no coordinates and cannot land on something that moved in the meantime — prefer it over " +
             "`adb shell input tap`. Returns {\"performed\", \"rootId\", \"nodeId\", \"action\", \"message\"}; " +
             "performed=false with a message when the node does not expose the action or declined it. " +
-            "Capture the tree again afterwards to see the result."
+            "BringIntoView scrolls whatever surrounds the node — Compose scrollables and Android Views alike — " +
+            "by the least amount that shows it whole, and works on any node; ScrollToIndex scrolls a lazy " +
+            "list or RecyclerView to an item that may not be composed yet. Both land on the next frame: " +
+            "capture the tree again afterwards to see the result."
 
     private val nodeId by int("The node's id, as reported by findNodes or getNodeTree.")
     private val action by enum(
-        "The semantics action to invoke. Click is what a tap would do. SetText/InsertText require text; ScrollBy uses scrollX/scrollY.",
+        "The semantics action to invoke. Click is what a tap would do. SetText/InsertText require text; ScrollBy uses scrollX/scrollY; ScrollToIndex requires index; BringIntoView takes nothing.",
         NodeAction.entries,
     )
     private val rootId by stringOrNull(
@@ -39,6 +42,7 @@ internal class PerformNodeActionCommand(
     private val text by stringOrNull("The text for SetText or InsertText.")
     private val scrollX by intOrNull("Horizontal scroll distance in pixels for ScrollBy. Defaults to 0.")
     private val scrollY by intOrNull("Vertical scroll distance in pixels for ScrollBy. Defaults to 0.")
+    private val index by intOrNull("The item index for ScrollToIndex, counted from 0 over the container's items.")
 
     override suspend fun execute(arguments: JetWhaleMcpArguments): String {
         val nodeId = arguments[nodeId]
@@ -55,6 +59,7 @@ internal class PerformNodeActionCommand(
                     text = arguments[text],
                     scrollX = (arguments[scrollX] ?: 0).toFloat(),
                     scrollY = (arguments[scrollY] ?: 0).toFloat(),
+                    index = arguments[index],
                 ),
             )
         } catch (e: JetWhaleMessagingException) {

--- a/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
+++ b/jetwhale-plugins/semantics/protocol/api/jvm/protocol.api
@@ -165,6 +165,7 @@ public final class com/kitakkun/jetwhale/plugins/semantics/protocol/GetViewAttri
 }
 
 public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction : java/lang/Enum {
+	public static final field BringIntoView Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
 	public static final field Click Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
 	public static final field Collapse Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
 	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction$Companion;
@@ -175,6 +176,7 @@ public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction :
 	public static final field LongClick Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
 	public static final field RequestFocus Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
 	public static final field ScrollBy Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public static final field ScrollToIndex Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
 	public static final field SetText Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
@@ -359,18 +361,20 @@ public final class com/kitakkun/jetwhale/plugins/semantics/protocol/NodeTreeSnap
 
 public final class com/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction : com/kitakkun/jetwhale/protocol/messaging/JetWhaleRequest {
 	public static final field Companion Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction$Companion;
-	public fun <init> (Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FF)V
-	public synthetic fun <init> (Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FFLjava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FFLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()I
 	public final fun component3 ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()F
 	public final fun component6 ()F
-	public final fun copy (Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FF)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;
-	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FFILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FFLjava/lang/Integer;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;
+	public static synthetic fun copy$default (Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;Ljava/lang/String;ILcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;Ljava/lang/String;FFLjava/lang/Integer;ILjava/lang/Object;)Lcom/kitakkun/jetwhale/plugins/semantics/protocol/PerformNodeAction;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Lcom/kitakkun/jetwhale/plugins/semantics/protocol/NodeAction;
+	public final fun getIndex ()Ljava/lang/Integer;
 	public final fun getNodeId ()I
 	public final fun getRootId ()Ljava/lang/String;
 	public final fun getScrollX ()F

--- a/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
+++ b/jetwhale-plugins/semantics/protocol/api/protocol.klib.api
@@ -7,6 +7,7 @@
 
 // Library unique name: <com.kitakkun.jetwhale.plugins.semantics:protocol>
 final enum class com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction : kotlin/Enum<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction> { // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction|null[0]
+    enum entry BringIntoView // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.BringIntoView|null[0]
     enum entry Click // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.Click|null[0]
     enum entry Collapse // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.Collapse|null[0]
     enum entry Dismiss // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.Dismiss|null[0]
@@ -16,6 +17,7 @@ final enum class com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction : k
     enum entry LongClick // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.LongClick|null[0]
     enum entry RequestFocus // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.RequestFocus|null[0]
     enum entry ScrollBy // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.ScrollBy|null[0]
+    enum entry ScrollToIndex // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.ScrollToIndex|null[0]
     enum entry SetText // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.SetText|null[0]
 
     final val entries // com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction.entries|#static{}entries[0]
@@ -696,10 +698,12 @@ final class com.kitakkun.jetwhale.plugins.semantics.protocol/NodeTreeSnapshot { 
 }
 
 final class com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction : com.kitakkun.jetwhale.protocol.messaging/JetWhaleRequest<com.kitakkun.jetwhale.plugins.semantics.protocol/NodeActionResult> { // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction|null[0]
-    constructor <init>(kotlin/String, kotlin/Int, com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction, kotlin/String? = ..., kotlin/Float = ..., kotlin/Float = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.<init>|<init>(kotlin.String;kotlin.Int;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction;kotlin.String?;kotlin.Float;kotlin.Float){}[0]
+    constructor <init>(kotlin/String, kotlin/Int, com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction, kotlin/String? = ..., kotlin/Float = ..., kotlin/Float = ..., kotlin/Int? = ...) // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.<init>|<init>(kotlin.String;kotlin.Int;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction;kotlin.String?;kotlin.Float;kotlin.Float;kotlin.Int?){}[0]
 
     final val action // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.action|{}action[0]
         final fun <get-action>(): com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.action.<get-action>|<get-action>(){}[0]
+    final val index // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.index|{}index[0]
+        final fun <get-index>(): kotlin/Int? // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.index.<get-index>|<get-index>(){}[0]
     final val nodeId // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.nodeId|{}nodeId[0]
         final fun <get-nodeId>(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.nodeId.<get-nodeId>|<get-nodeId>(){}[0]
     final val rootId // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.rootId|{}rootId[0]
@@ -717,7 +721,8 @@ final class com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction :
     final fun component4(): kotlin/String? // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.component4|component4(){}[0]
     final fun component5(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.component5|component5(){}[0]
     final fun component6(): kotlin/Float // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.component6|component6(){}[0]
-    final fun copy(kotlin/String = ..., kotlin/Int = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction = ..., kotlin/String? = ..., kotlin/Float = ..., kotlin/Float = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.copy|copy(kotlin.String;kotlin.Int;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction;kotlin.String?;kotlin.Float;kotlin.Float){}[0]
+    final fun component7(): kotlin/Int? // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.component7|component7(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Int = ..., com.kitakkun.jetwhale.plugins.semantics.protocol/NodeAction = ..., kotlin/String? = ..., kotlin/Float = ..., kotlin/Float = ..., kotlin/Int? = ...): com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.copy|copy(kotlin.String;kotlin.Int;com.kitakkun.jetwhale.plugins.semantics.protocol.NodeAction;kotlin.String?;kotlin.Float;kotlin.Float;kotlin.Int?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.kitakkun.jetwhale.plugins.semantics.protocol/PerformNodeAction.toString|toString(){}[0]

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNodeMessages.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/ComposeNodeMessages.kt
@@ -39,4 +39,6 @@ data class PerformNodeAction(
     val scrollX: Float = 0f,
     /** Vertical scroll distance in pixels for [NodeAction.ScrollBy]; ignored otherwise. */
     val scrollY: Float = 0f,
+    /** Item index for [NodeAction.ScrollToIndex]; ignored otherwise. */
+    val index: Int? = null,
 ) : JetWhaleRequest<NodeActionResult>

--- a/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeModels.kt
+++ b/jetwhale-plugins/semantics/protocol/src/commonMain/kotlin/com/kitakkun/jetwhale/plugins/semantics/protocol/NodeModels.kt
@@ -266,6 +266,10 @@ data class NodeBounds(
  * On a [ComposeNode] it is the node's own semantics action. On a [ViewNode] it is the closest
  * equivalent the platform offers — [Click] calls `performClick()`, [SetText] sets an `EditText`'s
  * content — and [Dismiss], [Expand] and [Collapse] have none, so they report that they did not run.
+ *
+ * [BringIntoView] is the one action that is not the node's own: it drives the scrollable
+ * containers *around* the node, so it applies to any node with bounds rather than only to those
+ * that advertise it.
  */
 @Serializable
 enum class NodeAction {
@@ -286,6 +290,21 @@ enum class NodeAction {
 
     /** Scrolls a scrollable node by `scrollX`/`scrollY` pixels via `SemanticsActions.ScrollBy`. */
     ScrollBy,
+
+    /**
+     * Scrolls a lazy container (`LazyColumn`, `LazyRow`, a grid, a `Pager`; a `RecyclerView` or
+     * `ListView` on the View side) so that the item at `index` is at its start, via
+     * `SemanticsActions.ScrollToIndex`. Requires `index`. The way to reach an item that has no node
+     * yet because the container has not composed it.
+     */
+    ScrollToIndex,
+
+    /**
+     * Scrolls every scrollable ancestor by the least amount that shows the whole node, the way
+     * accessibility's "show on screen" does — no gesture, no coordinates. A node that is already
+     * fully visible reports `performed` with nothing moved.
+     */
+    BringIntoView,
 
     /** Gives the node keyboard focus via `SemanticsActions.RequestFocus`. */
     RequestFocus,


### PR DESCRIPTION
## Summary

Two new `performNodeAction` actions for the Compose Semantics Inspector, so an agent can get a node on screen without guessing `ScrollBy` distances:

- **`BringIntoView`** — works on any node. Walks the node's scrollable ancestors and scrolls each by the least amount that reveals the whole node, the way accessibility's "show on screen" does (ported from `AndroidComposeViewAccessibilityDelegateCompat.scrollOntoScreen`, which is private). On Android the projected bounds are then handed to the hosting `AndroidComposeView.requestRectangleOnScreen`, so the `View`s around the composition scroll too. On a `View` node it is `requestRectangleOnScreen` itself, which climbs through Compose's `AndroidViewHolder` — both directions of interop are covered in one call. A fully visible node reports `performed: true` with "the node is already in view".
- **`ScrollToIndex`** (`index` argument) — the step before `BringIntoView` for an item a lazy container has not composed yet. `SemanticsActions.ScrollToIndex` on Compose (`LazyColumn`/`LazyRow`, the grids, `Pager`); `RecyclerView.scrollToPosition` / `ListView.setSelection` on the View side. `RecyclerView` is a `compileOnly` dependency guarded by a class-presence check, so an app that does not ship it never resolves the class.

Both actions land on the container's next frame; the tool description and the guide say to capture again afterwards.

## Changes

- `protocol`: `NodeAction.ScrollToIndex`, `NodeAction.BringIntoView`, `PerformNodeAction.index`; ABI dumps updated.
- `agent`: `ScrollIntoView.kt` (common) with the scroll-delta math as a pure function plus tests; `performSemanticsAction` takes a `revealInHost` hook that the Android window source binds to `requestRectangleOnScreen` and the owner source answers `false`. View side in `ViewActionDispatch.kt`; `View` nodes now advertise `ScrollToIndex`.
- `host`: `index` argument on the MCP command, a **Bring into view** button on every node and a **Scroll to index** field on containers that expose it.
- `docs/guide/compose-semantics-inspector.md`: new "Getting a node on screen" section.

## Verification

- `compileKotlinJvm`, `compileAndroidMain`, `jvmTest`, `checkKotlinAbi`, spotless all pass.
- Live run against `:demo:desktop:run` through the headless host's MCP server: `ScrollToIndex 20` composed the rows; `BringIntoView` moved a row clipped at the top by 24 px and one overhanging the bottom by 8 px, both to full visibility; a fully visible row answered "already in view"; an out-of-range index and a missing `index` came back `performed: false` with a message.
- Not verified on a device: the Android `View` paths (`requestRectangleOnScreen`, `RecyclerView`).

## Breaking change

`PerformNodeAction` gains an `index` field, which changes the protocol data class's JVM constructor; a host and agent from different releases already fail to decode each other, and JetWhale is in alpha, so no compatibility overload is kept. `NodeAction` gains two entries an older agent cannot deserialize — same policy.

## Notes

- `SemanticsNode.unmergedConfig` is internal, so the ancestor walk reads `config`. A scrollable inside a merging container could be picked up off the node's path; rare, noted in the code.
- Follow-up: the per-action `when`s in the two dispatch files are growing; splitting actions into per-purpose classes is planned as a separate PR.


